### PR TITLE
Start using ADRs to record architecture decisions

### DIFF
--- a/docs/adr/0001-record-architecture-decisions.md
+++ b/docs/adr/0001-record-architecture-decisions.md
@@ -1,0 +1,19 @@
+# 1. Record architecture decisions
+
+Date: 2020-04-01
+
+## Status
+
+Accepted
+
+## Context
+
+We need to record the architectural decisions made on this project.
+
+## Decision
+
+We will use Architecture Decision Records, as [described by Michael Nygard](http://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions).
+
+## Consequences
+
+See Michael Nygard's article, linked above. For a lightweight ADR toolset, see Nat Pryce's [adr-tools](https://github.com/npryce/adr-tools).


### PR DESCRIPTION
Decisions affecting the technical architecture of the TAMATO project should be recorded
in the docs/adr folder in Markdown format so that the reasons for decisions and the
alternatives considered are documented and kept alongside the code, for ease of
maintenance and future development.

See:
 * http://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions
 * [adr-tools](https://github.com/npryce/adr-tools)