### PR TITLE
Compile SCSS and Javascript assets in Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,7 @@
 .env
-.git
-.github
-venv
-.projectrc
+.git/
+.github/
 .python-version
+node_modules/
+venv/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,21 @@
+FROM node:13.12-buster-slim AS jsdeps
+
+COPY . .
+
+RUN npm install && npm run build
+
+
 FROM python:3.8-slim-buster
 
 LABEL maintainer="webops@digital.trade.gov.uk"
 
 ENV DJANGO_SETTINGS_MODULE "settings"
+
+# add git client
+RUN apt-get -qq update && apt-get install --no-install-recommends -qqy \
+    curl \
+    ca-certificates \
+    git
 
 # don't run as root
 RUN groupadd -g 1000 tamato && \
@@ -16,7 +29,10 @@ COPY requirements.txt ./
 RUN pip install -U pip && \
     pip install -r requirements.txt --no-warn-script-location
 
-COPY . .
+COPY --chown=tamato:tamato . .
+COPY --chown=tamato:tamato --from=jsdeps node_modules node_modules
+COPY --chown=tamato:tamato --from=jsdeps static/webpack_bundles static/webpack_bundles
+COPY --chown=tamato:tamato --from=jsdeps webpack-stats.json ./
 
 # empty .env file to prevent warning messages
 RUN touch .env

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ RUN pip install -U pip && \
     pip install -r requirements.txt --no-warn-script-location
 
 COPY --chown=tamato:tamato . .
-COPY --chown=tamato:tamato --from=jsdeps node_modules node_modules
+COPY --chown=tamato:tamato --from=jsdeps node_modules/govuk-frontend/govuk node_modules/govuk-frontend/govuk
 COPY --chown=tamato:tamato --from=jsdeps static/webpack_bundles static/webpack_bundles
 COPY --chown=tamato:tamato --from=jsdeps webpack-stats.json ./
 

--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@
 
 Run the following command to build the docker image:
 
-    docker build -t tamato .
+    docker-compose build
 
 Then to run the app:
 
-    docker run -p 8000:8000 tamato
+    docker-compose up
 
 Then you can browse to http://localhost:8000/ to view the app
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,25 @@
+version: '3'
+services:
+  db:
+    image: "postgres:12.2"
+    environment:
+      POSTGRES_HOST_AUTH_METHOD: "trust"
+
+  tamato:
+    build: .
+    image: tamato
+    ports:
+      - "8000:8000"
+    depends_on:
+      - db
+    links:
+      - db
+    env_file: .env
+    environment:
+      DB_HOST: "db"
+      DB_NAME: "postgres"
+      DB_USER: "postgres"
+      DEBUG: "True"
+      PYTHONUNBUFFERED: "1"
+    command: ["python", "manage.py", "runserver", "0.0.0.0:8000"]
+

--- a/urls.py
+++ b/urls.py
@@ -25,7 +25,7 @@ urlpatterns = [
     path("admin/", admin.site.urls),
 ]
 
-if settings.DEBUG:
+if "debug_toolbar" in settings.INSTALLED_APPS:
     import debug_toolbar
 
     urlpatterns = [path("__debug__/", include(debug_toolbar.urls)), *urlpatterns]


### PR DESCRIPTION
The webapp now depends on NodeJS to fetch and compile GOV.UK Frontend and its dependencies.

This change introduces a multi-stage build, which first uses a NodeJS image to install GOV.UK Frontend, then passes the compiled assets to the Python image.

The container is now run with docker-compose, as it depends on a Postgres database.