### PR TITLE
Enable deployment onto GOV.UK PaaS

### DIFF
--- a/.cfignore
+++ b/.cfignore
@@ -1,0 +1,131 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+
+.idea

--- a/.cfignore
+++ b/.cfignore
@@ -129,3 +129,8 @@ dmypy.json
 
 
 .idea
+node_modules/
+*.sw?
+docker/
+docs/
+run/

--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -1,7 +1,7 @@
-name: CI/CD
+name: Check PR
 
 on:
-  push:
+  pull_request:
     branches: [ master ]
 
 jobs:
@@ -66,33 +66,3 @@ jobs:
 
     - name: Report code coverage
       uses: codecov/codecov-action@v1
-
-    - name: Start deployment
-      uses: bobheadxi/deployments@v0.4.0
-      id: deployment
-      with:
-        step: start
-        token: ${{secrets.GITHUB_TOKEN}}
-        env: development
-
-    - name: Deploy to development environment
-      uses: d3sandoval/cloud-foundry-action@1.1.1
-      env:
-        CF_API: ${{secrets.CF_API}}
-        CF_PASSWORD: ${{secrets.CF_PASSWORD}}
-        CF_TARGET_ORG: ${{secrets.CF_TARGET_ORG}}
-        CF_TARGET_SPACE: ${{secrets.CF_TARGET_SPACE}}
-        CF_USERNAME: ${{secrets.CF_USERNAME}}
-      with:
-        args: push tamato-dev
-
-    - name: Update deployment status
-      uses: bobheadxi/deployments@v0.4.0
-      if: always()
-      with:
-        step: finish
-        token: ${{secrets.GITHUB_TOKEN}}
-        status: ${{job.status}}
-        deployment_id: ${{steps.deployment.outputs.deployment_id}}
-        env: ${{steps.deployment.outputs.env}}
-        env_url: https://tamato-dev.london.cloudapps.digital

--- a/.gitignore
+++ b/.gitignore
@@ -133,5 +133,5 @@ dmypy.json
 npm-debug.log*
 webpack-stats.json
 
-run/
-static/
+/run
+/static

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,95 @@
+PROJECT=tamato
+DEV=true
+
+-include .env
+export
+
+.PHONY: clean clean-bytecode clean-static collectstatic compilescss dependencies docker-image docker-test help node_modules run test
+
+
+clean-static:
+	@echo
+	@echo "> Removing collected static files..."
+	@rm -rf run/static static/*
+
+clean-bytecode:
+	@echo
+	@echo "> Removing compiled bytecode..."
+	@find . \( -name '__pycache__' -and -not -name "venv" \) -d -prune -exec rm -r {} +
+
+clean: clean-bytecode clean-static
+
+## dependencies: Install dependencies
+dependencies: requirements.txt
+	@echo
+	@echo "> Fetching dependencies..."
+	@pip install -r requirements.txt
+	@if [ ! "${DEV}" = "false" ]; then pip install -r requirements-dev.txt; fi
+
+## collectstatic: Collect assets into static folder
+collectstatic: compilescss
+	@echo
+	@echo "> Collecting static assets..."
+	@${BIN}python manage.py collectstatic --noinput
+
+compilescss:
+	@echo
+	@echo "> Compiling SCSS..."
+	@npm run build
+
+node_modules:
+	@echo
+	@echo "> Installing Javascript dependencies..."
+	@npm ci
+
+migrate:
+	@echo
+	@echo "> Running database migrations..."
+	@python manage.py migrate --noinput
+
+## run: Run webapp
+run: export DJANGO_SETTINGS_MODULE=settings.dev
+run: collectstatic migrate
+	@echo
+	@echo "> Running webapp..."
+	@python manage.py runserver
+
+run-cf: export DJANGO_SETTINGS_MODULE=settings
+run-cf: collectstatic migrate
+	@echo
+	@echo "> Running webapp..."
+	@gunicorn -b 0.0.0.0:8080 wsgi:application
+
+## test: Run tests
+test: export DJANGO_SETTINGS_MODULE=settings.test
+test:
+	@echo
+	@echo "> Running tests..."
+	python manage.py test
+
+## docker-image: Build docker image
+docker-image:
+	@echo
+	@echo "> Building docker image..."
+	@docker-compose build
+
+## docker-run: Run app in a Docker container
+docker-run:
+	@echo
+	@echo "> Run docker container..."
+	@docker-compose up
+
+## docker-test: Run tests in Docker container
+docker-test:
+	@echo
+	@echo "> Running tests in Docker..."
+	@docker-compose run \
+		-e DJANGO_SETTINGS_MODULE=settings.test \
+		${PROJECT} sh -c "docker/wait_for_db && python manage.py test -- --cov"
+
+help: Makefile
+	@echo
+	@echo " Commands in "$(PROJECT)":"
+	@echo
+	@sed -n 's/^##//p' $< | column -t -s ':' | sed -e 's/^/ /'
+	@echo

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: python manage.py migrate --noinput && gunicorn -b 0.0.0.0:8080 wsgi:application

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: python manage.py migrate --noinput && gunicorn -b 0.0.0.0:8080 wsgi:application
+web: make run-cf

--- a/common/static/common/js/application.js
+++ b/common/static/common/js/application.js
@@ -1,0 +1,6 @@
+const images = require.context('../../../../node_modules/govuk-frontend/govuk/assets/images', true)
+const imagePath = (name) => images(name, true)
+
+require.context('govuk-frontend/govuk/assets');
+import { initAll } from 'govuk-frontend';
+initAll();

--- a/common/static/common/scss/application.scss
+++ b/common/static/common/scss/application.scss
@@ -1,0 +1,12 @@
+@function frontend-font-url($filename) {
+  @return url("~govuk-frontend/govuk/assets/fonts/"+$filename);
+}
+
+@function frontend-image-url($filename) {
+  @return url("~govuk-frontend/govuk/assets/images/"+$filename);
+}
+
+$govuk-font-url-function: frontend-font-url;
+$govuk-image-url-function: frontend-image-url;
+
+@import "~govuk-frontend/govuk/all";

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,7 +1,8 @@
 ---
 applications:
-- name: tamato
-  memory: 64M
+- name: tamato-dev
+  memory: 128M
+  services:
+    - tamato-db
   buildpacks:
-  - python-buildpack
-  command: gunicorn -b 0.0.0.0:8000 -w 1 wsgi:application
+    - python_buildpack

--- a/manifest.yml
+++ b/manifest.yml
@@ -5,4 +5,5 @@ applications:
   services:
     - tamato-db
   buildpacks:
+    - nodejs_buildpack
     - python_buildpack

--- a/package.json
+++ b/package.json
@@ -6,6 +6,10 @@
   "description": "Tariff Management Tool",
   "repository": "https://github.com/uktrade/tamato.git",
   "licence": "MIT",
+  "engines": {
+    "node": "12.16.1",
+    "npm": "6.13.4"
+  },
   "dependencies": {
     "css-loader": "^3.3.0",
     "extract-loader": "^3.1.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 black
+dj-database-url
 django
 django-dotenv
 django-health-check
@@ -10,3 +11,5 @@ gunicorn
 jinja2
 psycopg2-binary
 sentry-sdk
+werkzeug
+whitenoise

--- a/settings/common.py
+++ b/settings/common.py
@@ -7,6 +7,8 @@ from os.path import abspath
 from os.path import dirname
 from os.path import join
 
+import dj_database_url
+
 from common.util import is_truthy
 
 
@@ -43,6 +45,7 @@ INSTALLED_APPS = [
     "django.contrib.contenttypes",
     "django.contrib.sessions",
     "django.contrib.messages",
+    "whitenoise.runserver_nostatic",
     "django.contrib.staticfiles",
     "django_extensions",
     # "health_check",
@@ -57,6 +60,7 @@ INSTALLED_APPS = [
 
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
+    "whitenoise.middleware.WhiteNoiseMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
@@ -139,14 +143,7 @@ DEBUG = is_truthy(os.environ.get("DEBUG", False))
 # -- Database
 
 DATABASES = {
-    "default": {
-        "ENGINE": "django.db.backends.postgresql",
-        "NAME": os.environ.get("DB_NAME", PROJECT_NAME),
-        "USER": os.environ.get("DB_USER", ""),
-        "PASSWORD": os.environ.get("DB_PASSWORD", ""),
-        "HOST": os.environ.get("DB_HOST", "127.0.0.1"),
-        "PORT": os.environ.get("DB_PORT", "5432"),
-    }
+    "default": dj_database_url.config(default="postgres://localhost:5432/tamato"),
 }
 
 # Wrap each request in a transaction

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,3 +18,16 @@ exclude_lines =
     # Don't complain if non-runnable code isn't run:
     if 0:
     if __name__ == .__main__.:
+
+[isort]
+line_length = 88
+force_single_line = True
+
+[flake8]
+exclude = .git,__pycache__,venv,*/migrations/*
+extend-ignore = E203
+max-line-length = 88
+
+[tool:pytest]
+norecursedirs = venv node_modules
+bdd_features_base_dir = docs/behaviour/ 


### PR DESCRIPTION
* Adds [`dj-database-url`](https://github.com/jacobian/dj-database-url) to get the connected database service credentials from the `DATABASE_URL` environment variable.
* Adds [`whitenoise`](http://whitenoise.evans.io/en/stable/) to serve static assets
* Adds a [`Procfile`](https://docs.cloudfoundry.org/buildpacks/prod-server.html) to run migrations and start the app on deployment
* Updates the Github Actions workflow to deploy to GOV.UK PaaS on passing tests
