### PR TITLE
Check code standards with Black

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -28,3 +28,6 @@ jobs:
     - name: Run Tests
       run: |
         python manage.py test
+    - name: Run Linter
+      run: |
+        black --check .

--- a/commodities/migrations/0001_initial.py
+++ b/commodities/migrations/0001_initial.py
@@ -11,30 +11,52 @@ class Migration(migrations.Migration):
 
     initial = True
 
-    dependencies = [
-    ]
+    dependencies = []
 
     operations = [
         BtreeGistExtension(),
         migrations.CreateModel(
-            name='Commodity',
+            name="Commodity",
             fields=[
-                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
-                ('path', models.CharField(max_length=255, unique=True)),
-                ('depth', models.PositiveIntegerField()),
-                ('numchild', models.PositiveIntegerField(default=0)),
-                ('created_at', models.DateTimeField(auto_now_add=True)),
-                ('updated_at', models.DateTimeField(auto_now=True)),
-                ('valid_between', django.contrib.postgres.fields.ranges.DateTimeRangeField()),
-                ('live', models.BooleanField(default=False)),
-                ('code', models.CharField(max_length=12)),
-                ('description', models.TextField()),
-                ('version', models.PositiveIntegerField()),
-                ('predecessor', models.OneToOneField(blank=True, null=True, on_delete=django.db.models.deletion.PROTECT, related_name='successor', to='commodities.Commodity')),
+                (
+                    "id",
+                    models.AutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("path", models.CharField(max_length=255, unique=True)),
+                ("depth", models.PositiveIntegerField()),
+                ("numchild", models.PositiveIntegerField(default=0)),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+                ("updated_at", models.DateTimeField(auto_now=True)),
+                (
+                    "valid_between",
+                    django.contrib.postgres.fields.ranges.DateTimeRangeField(),
+                ),
+                ("live", models.BooleanField(default=False)),
+                ("code", models.CharField(max_length=12)),
+                ("description", models.TextField()),
+                ("version", models.PositiveIntegerField()),
+                (
+                    "predecessor",
+                    models.OneToOneField(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.PROTECT,
+                        related_name="successor",
+                        to="commodities.Commodity",
+                    ),
+                ),
             ],
         ),
         migrations.AddConstraint(
-            model_name='commodity',
-            constraint=django.contrib.postgres.constraints.ExclusionConstraint(expressions=[('valid_between', '&&'), ('code', '=')], name='exclude_overlapping_commodities'),
+            model_name="commodity",
+            constraint=django.contrib.postgres.constraints.ExclusionConstraint(
+                expressions=[("valid_between", "&&"), ("code", "=")],
+                name="exclude_overlapping_commodities",
+            ),
         ),
     ]

--- a/commodities/models.py
+++ b/commodities/models.py
@@ -15,7 +15,7 @@ class Commodity(MP_Node, TimestampedMixin, ValidityMixin):
         on_delete=models.PROTECT,
         null=True,
         blank=True,
-        related_name='successor'
+        related_name="successor",
     )
     version = models.PositiveIntegerField()
 
@@ -34,15 +34,19 @@ class Commodity(MP_Node, TimestampedMixin, ValidityMixin):
     def has_measure_in_tree(self):
         ascendant_measures = self.get_ancestors().filter(measures__isnull=False)
         descendant_measures = self.get_descendants().filter(measures__isnull=False)
-        return self.measures.exists() or ascendant_measures.exists() or descendant_measures.exists()
+        return (
+            self.measures.exists()
+            or ascendant_measures.exists()
+            or descendant_measures.exists()
+        )
 
     class Meta:
         constraints = (
             ExclusionConstraint(
                 name="exclude_overlapping_commodities",
                 expressions=[
-                    ('valid_between', RangeOperators.OVERLAPS),
-                    ('code', RangeOperators.EQUAL),
+                    ("valid_between", RangeOperators.OVERLAPS),
+                    ("code", RangeOperators.EQUAL),
                 ],
             ),
         )

--- a/measures/migrations/0001_initial.py
+++ b/measures/migrations/0001_initial.py
@@ -9,16 +9,31 @@ class Migration(migrations.Migration):
     initial = True
 
     dependencies = [
-        ('commodities', '0001_initial'),
+        ("commodities", "0001_initial"),
     ]
 
     operations = [
         migrations.CreateModel(
-            name='Measure',
+            name="Measure",
             fields=[
-                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
-                ('duty', models.CharField(max_length=512)),
-                ('commodity', models.ForeignKey(on_delete=django.db.models.deletion.PROTECT, related_name='measures', to='commodities.Commodity')),
+                (
+                    "id",
+                    models.AutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("duty", models.CharField(max_length=512)),
+                (
+                    "commodity",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.PROTECT,
+                        related_name="measures",
+                        to="commodities.Commodity",
+                    ),
+                ),
             ],
         ),
     ]

--- a/measures/models.py
+++ b/measures/models.py
@@ -4,5 +4,7 @@ from commodities.models import Commodity
 
 
 class Measure(models.Model):
-    commodity = models.ForeignKey(Commodity, on_delete=models.PROTECT, related_name='measures')
+    commodity = models.ForeignKey(
+        Commodity, on_delete=models.PROTECT, related_name="measures"
+    )
     duty = models.CharField(max_length=512)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,12 @@
+black
 django
-django_extensions
 django-dotenv
 django-health-check
 django-treebeard
+django-webpack-loader
+django_extensions
+git+https://github.com/alphagov/govuk-frontend-jinja.git
 gunicorn
 jinja2
 psycopg2-binary
 sentry-sdk
-git+https://github.com/alphagov/govuk-frontend-jinja.git
-django-webpack-loader


### PR DESCRIPTION
Because we want to keep the Python codebase maintainable, we should keep to a consistent code standard. Black checks code for violations of that standard and Github will show a failed check if there are any violations.