### PR TITLE
Add footnote detail view [TP-88]

### DIFF
--- a/common/jinja2/common/logged_out.jinja
+++ b/common/jinja2/common/logged_out.jinja
@@ -1,6 +1,6 @@
 {% extends "layouts/layout.jinja" %}
 
-{% set page_title = "Logged Out" %}
+{% set page_title = "Signed Out" %}
 
 {% block content %}
   <h1 class="govuk-heading-xl">{{ page_title }}</h1>

--- a/common/static/common/scss/_icon-action-list.scss
+++ b/common/static/common/scss/_icon-action-list.scss
@@ -1,0 +1,3 @@
+.icon-action-list {
+  // icon precedes text
+}

--- a/common/static/common/scss/application.scss
+++ b/common/static/common/scss/application.scss
@@ -11,4 +11,6 @@ $govuk-image-url-function: frontend-image-url;
 
 @import "~govuk-frontend/govuk/all";
 
+@import "icon-action-list";
 @import "layout";
+@import "footnotes";

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,10 +16,14 @@ services:
       - db
     env_file: .env
     environment:
-      DB_HOST: "db"
-      DB_NAME: "postgres"
-      DB_USER: "postgres"
-      DEBUG: "True"
+      DATABASE_URL: "postgres://postgres@db/postgres"
+      DJANGO_SETTINGS_MODULE: "settings.dev"
+      ENABLE_DJANGO_DEBUG_TOOLBAR: "False"
       PYTHONUNBUFFERED: "1"
-    command: ["python", "manage.py", "runserver", "0.0.0.0:8000"]
-
+    command:
+      - sh
+      - -c
+      - |
+        python manage.py migrate
+        python manage.py loaddata test-footnotes-fixtures test-user-fixtures
+        python manage.py runserver 0.0.0.0:8000

--- a/footnotes/fixtures/test-footnotes-fixtures.json
+++ b/footnotes/fixtures/test-footnotes-fixtures.json
@@ -6,7 +6,17 @@
       "footnote_type_id": "NC",
       "valid_between": "{\"bounds\": \"[)\", \"lower\": \"2020-04-22T16:31:01.872514+00:00\", \"upper\": \"9999-12-31T23:59:59.999999+00:00\"}",
       "live": false,
-      "description": "Foo"
+      "description": "A test footnote type"
+    }
+  },
+  {
+    "model": "footnotes.footnotetype",
+    "pk": 2,
+    "fields": {
+      "footnote_type_id": "01",
+      "valid_between": "{\"bounds\": \"[)\", \"lower\": \"2020-04-23T16:31:01.872514+00:00\", \"upper\": \"9999-12-31T23:59:59.999999+00:00\"}",
+      "live": false,
+      "description": "Another test footnote type"
     }
   },
   {
@@ -16,8 +26,19 @@
       "footnote_id": "000",
       "valid_between": "{\"bounds\": \"[)\", \"lower\": \"2020-04-22T16:34:36.161120+00:00\", \"upper\": null}",
       "live": false,
-      "footnote_type_id": 1,
-      "description": "Bar"
+      "footnote_type": 1,
+      "description": "A test footnote"
+    }
+  },
+  {
+    "model": "footnotes.footnote",
+    "pk": 2,
+    "fields": {
+      "footnote_id": "001",
+      "valid_between": "{\"bounds\": \"[)\", \"lower\": \"2020-04-23T16:34:36.161120+00:00\", \"upper\": null}",
+      "live": false,
+      "footnote_type": 2,
+      "description": "Another test footnote"
     }
   }
 ]

--- a/footnotes/jinja2/footnotes/detail.jinja
+++ b/footnotes/jinja2/footnotes/detail.jinja
@@ -1,0 +1,85 @@
+{% extends "layouts/layout.jinja" %}
+
+{% from "components/tabs/macro.njk" import govukTabs %}
+{% from "components/input/macro.njk" import govukInput %}
+{% from "components/table/macro.njk" import govukTable %}
+
+{% set footnote_id = footnote.footnote_type.footnote_type_id ~ footnote.footnote_id %}
+{% set page_title = "Footnote " ~ footnote_id %}
+
+{% block beforeContent %}
+  {{ govukBreadcrumbs({
+    "items": [
+      {"text": "Home", "href": url("index")},
+      {"text": "Footnotes", "href": url("footnote-ui-list")},
+      {"text": page_title}
+    ]
+  }) }}
+{% endblock %}
+
+{% block content %}
+  <h1 class="govuk-heading-xl">{{ page_title }}</h1>
+  <p class="govuk-body">
+    You are viewing this footnote in read-only mode.
+  </p>
+
+  {% set core_data_html %}
+    <div class="footnote__core-data">
+      <div class="footnote__core-data__content">
+        {{ govukTable({
+          "firstCellIsHeader": true,
+          "rows": [
+            [
+              {"text": "Footnote type"},
+              {"text": footnote.footnote_type.footnote_type_id ~ " - " ~ footnote.footnote_type.description}
+            ],
+            [
+              {"text": "Application code"},
+              {"text": ""},
+            ],
+            [
+              {"text": "Footnote ID"},
+              {"text": footnote_id}
+            ],
+            [
+              {"text": "Current description"},
+              {"text": footnote.description}
+            ],
+            [
+              {"text": "Start date"},
+              {"text": "{:%d %b %Y}".format(footnote.valid_between.lower)}
+            ],
+            [
+              {"text": "End date"},
+              {"text": "{:%d %b %Y}".format(footnote.valid_between.upper) if footnote.valid_between.upper else "-"}
+            ]
+          ]
+        }) }}
+      </div>
+      <div class="footnote__core-data__actions">
+        <h2 class="govuk-heading-s">Actions</h2>
+        <ul class="icon-action-list govuk-list">
+          <li><a href="#" class="govuk-link govuk-!-font-size-16">Edit this footnote</a></li>
+          <li><a href="#" class="govuk-link govuk-!-font-size-16">Delete this footnote</a></li>
+        </ul>
+        <p class="govuk-body-s">
+          Please note that you are unable to modify descriptions on this tab.
+          Please select the "<a href="#descriptions">Descriptions</a>" tab to create and
+          modify descriptions.
+        </p>
+      </div>
+    </div>
+  {% endset %}
+
+  {{ govukTabs({
+    "items": [
+      {
+        "label": "Core footnote data",
+        "id": "core-data",
+        "panel": {
+          "html": core_data_html
+        }
+      }
+    ]
+  }) }}
+{% endblock %}

--- a/footnotes/jinja2/footnotes/list.jinja
+++ b/footnotes/jinja2/footnotes/list.jinja
@@ -41,8 +41,11 @@
     <div class="filter-layout__content">
       {% set table_rows = [] %}
       {% for footnote in footnotes %}
+        {% set footnote_link -%}
+        <a href="{{ url("footnote-ui-detail", kwargs={"pk": footnote.pk}) }}">{{ footnote.footnote_type.footnote_type_id ~ footnote.footnote_id }}</a>
+        {%- endset %}
         {{ table_rows.append([
-          {"text": footnote.footnote_type.footnote_type_id ~ footnote.footnote_id},
+          {"html": footnote_link},
           {"text": footnote.description},
           {"text": footnote.footnote_type.description},
           {"text": ""},

--- a/footnotes/static/footnotes/scss/_footnotes.scss
+++ b/footnotes/static/footnotes/scss/_footnotes.scss
@@ -1,0 +1,16 @@
+.footnote__core-data {
+  @extend .govuk-grid-row;
+}
+
+.footnote__core-data__content {
+  @extend .govuk-grid-column-three-quarters;
+}
+
+.footnote__core-data__actions {
+  @extend .govuk-grid-column-one-quarter;
+
+  h2 {
+    border-top: 2px solid $govuk-brand-colour;
+    padding-top: govuk-spacing(4);
+  }
+}

--- a/footnotes/tests/bdd/features/footnotes.feature
+++ b/footnotes/tests/bdd/features/footnotes.feature
@@ -11,3 +11,9 @@ Scenario: Searching by footnote ID
     Given I am logged in as Alice
     When I search for a footnote using a footnote ID
     Then the search result should contain the footnote searched for
+
+
+Scenario: View footnote core data
+    Given I am logged in as Alice
+    When I select footnote NC000
+    Then a summary of the core information should be presented

--- a/footnotes/tests/bdd/test_browse_footnotes.py
+++ b/footnotes/tests/bdd/test_browse_footnotes.py
@@ -27,7 +27,7 @@ def valid_user_login(client, valid_user):
 @given("footnote NC000")
 def footnote_NC000():
     footnote_type = factories.FootnoteTypeFactory(footnote_type_id="NC")
-    factories.FootnoteFactory(footnote_id="000", footnote_type=footnote_type)
+    return factories.FootnoteFactory(footnote_id="000", footnote_type=footnote_type)
 
 
 @pytest.fixture
@@ -42,3 +42,17 @@ def footnotes_list(footnotes_search):
     assert len(results) == 1
     result = results[0]
     assert result["footnote_type"]["id"] == "NC" and result["id"] == "000"
+
+
+@pytest.fixture
+@when("I select footnote NC000")
+def footnote_details(client, footnote_NC000):
+    return client.get(reverse("footnote-detail", kwargs={"pk": footnote_NC000.pk}))
+
+
+@then("a summary of the core information should be presented")
+def footnote_core_data(footnote_details):
+    result = footnote_details.json()
+    assert {"description", "id", "valid_between"} <= set(result.keys())
+    assert "footnote_type" in result
+    assert {"description", "id", "valid_between"} <= set(result["footnote_type"].keys())

--- a/footnotes/urls.py
+++ b/footnotes/urls.py
@@ -7,6 +7,7 @@ from footnotes import views
 
 api_router = routers.DefaultRouter()
 api_router.register(r"footnotes", views.FootnoteViewSet)
+api_router.register(r"footnote_types", views.FootnoteTypeViewSet)
 
 ui_router = routers.DefaultRouter()
 ui_router.register(r"footnotes", views.FootnoteUIViewSet, basename="footnote-ui")

--- a/footnotes/views.py
+++ b/footnotes/views.py
@@ -34,3 +34,18 @@ class FootnoteUIViewSet(FootnoteViewSet):
     def list(self, request):
         queryset = self.filter_queryset(self.get_queryset())
         return render(request, "footnotes/list.jinja", context={"footnotes": queryset})
+
+    def retrieve(self, request, *args, **kwargs):
+        return render(
+            request, "footnotes/detail.jinja", context={"footnote": self.get_object()}
+        )
+
+
+class FootnoteTypeViewSet(viewsets.ReadOnlyModelViewSet):
+    """
+    API endpoint that allows footnote types to be viewed or edited.
+    """
+
+    queryset = FootnoteType.objects.all()
+    serializer_class = FootnoteTypeSerializer
+    permission_classes = [permissions.IsAuthenticated]

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -56,7 +56,16 @@ module.exports = {
             loader: MiniCssExtractPlugin.loader
           },
           'css-loader',
-          'sass-loader'
+          {
+            loader: 'sass-loader',
+            options: {
+              sassOptions: {
+                includePaths: [
+                  'footnotes/static/footnotes/scss',
+                ],
+              },
+            },
+          },
         ]
       }
     ]


### PR DESCRIPTION
As a Tariff manager
I want to view the summary of a footnote
So that core information is visible at a glance

This change overrides the FootnoteViewSet to return a rendered Jinja template, which
uses GOV.UK Frontend Tabs and Table components to display the footnote core data.

The footnotes list is updated to make the footnote ID a link to the detail view.

This also adds a couple of test footnotes and footnote types in fixtures to be loaded
into the database with `python manage.py loaddata test-footnotes-fixtures`.