### PR TITLE
TP-148: Add frontend view to browse geographical areas.

### DIFF
--- a/common/jinja2/common/index.jinja
+++ b/common/jinja2/common/index.jinja
@@ -18,6 +18,9 @@
         footnotes</a>
     </div>
     <div class="govuk-grid-column-one-third">
+      <h2 class="govuk-heading-m">Manage geographical areas</h2>
+      <a class="govuk-link" href="{{ url('geoarea-ui-list') }}">Find and edit
+        geographical areas</a>
     </div>
   </div>
   <p class="govuk-body govuk-!-margin-bottom-9"></p>

--- a/common/tests/factories.py
+++ b/common/tests/factories.py
@@ -118,7 +118,7 @@ class GeographicalMembershipFactory(TrackedModelMixin, ValidityFactoryMixin):
     )
 
 
-class GeographicalAreaDescriptionFactory(TrackedModelMixin):
+class GeographicalAreaDescriptionFactory(TrackedModelMixin, ValidityFactoryMixin):
     class Meta:
         model = "geo_areas.GeographicalAreaDescription"
 

--- a/footnotes/models.py
+++ b/footnotes/models.py
@@ -1,6 +1,5 @@
 from django.contrib.postgres.constraints import ExclusionConstraint
 from django.contrib.postgres.fields import RangeOperators
-from django.core.exceptions import ValidationError
 from django.db import models
 from django.db.models.functions import Lower
 

--- a/geo_areas/filters.py
+++ b/geo_areas/filters.py
@@ -1,0 +1,27 @@
+import logging
+
+from django.contrib.postgres.search import SearchVector
+from django_filters import rest_framework as filters
+
+from geo_areas.models import GeographicalArea
+from geo_areas.validators import AreaCode
+
+log = logging.getLogger(__name__)
+
+
+class GeographicalAreaFilter(filters.FilterSet):
+    area_code = filters.TypedMultipleChoiceFilter(choices=AreaCode.choices, coerce=int)
+
+    class Meta:
+        model = GeographicalArea
+        fields = ["id", "sid", "area_code"]
+
+    @property
+    def qs(self):
+        queryset = super().qs
+        search_term = self.request.query_params.get("search", "")
+        log.debug(f"Search term: {search_term}")
+        if search_term:
+            vector = SearchVector("id", "geographicalareadescription__description")
+            queryset = queryset.annotate(search=vector).filter(search=search_term)
+        return queryset

--- a/geo_areas/jinja2/geo_areas/list.jinja
+++ b/geo_areas/jinja2/geo_areas/list.jinja
@@ -1,0 +1,120 @@
+{% extends "layouts/layout.jinja" %}
+
+{% from "components/button/macro.njk" import govukButton %}
+{% from "components/checkboxes/macro.njk" import govukCheckboxes %}
+{% from "components/input/macro.njk" import govukInput %}
+{% from "components/table/macro.njk" import govukTable %}
+
+{% set page_title = "Find and edit geographical areas" %}
+
+{% block beforeContent %}
+  {{ govukBreadcrumbs({
+    "items": [
+      {"text": "Home", "href": url("index")},
+      {"text": page_title}
+    ]
+  }) }}
+{% endblock %}
+
+{% block content %}
+  <h1 class="govuk-heading-xl">{{ page_title }}</h1>
+  <p class="govuk-body">
+    Enter criteria to help find a geographical area.
+    Alternatively, <a href="">create a new geographical area</a>.
+  </p>
+
+  <div class="filter-layout">
+    <form class="filter-layout__filters" method="get" action="{{ url("geoarea-ui-list") }}">
+
+      {% set area_code_list = request.GET.getlist("area_code") %}
+      {% set active_list = request.GET.getlist("active") %}
+
+      {{ govukInput({
+        "id": "search",
+        "name": "search",
+        "label": {
+          "text": "Search",
+          "classes": "govuk-label--m",
+          "attributes": {}
+        },
+        "formGroup": {}
+      }) }}
+
+      {{ govukCheckboxes({
+        "name": "area_code",
+        "fieldset": {
+          "legend": {
+            "text": "Area code",
+            "classes": "govuk-label--m",
+          },
+          "attributes": {},
+        },
+        "items": [
+          {
+            "value": 0,
+            "text": "Country",
+            "checked": "0" in area_code_list,
+            "conditional": {"html": False},
+            "hint": {},
+            "label": {"attributes": {},},
+          },
+          {
+            "value": 1,
+            "text": "Geographical area group",
+            "checked": "1" in area_code_list,
+            "conditional": {"html": False},
+            "hint": {},
+            "label": {"attributes": {},},
+          },
+          {
+            "value": 2,
+            "text": "Region",
+            "checked": "2" in area_code_list,
+            "conditional": {"html": False},
+            "hint": {},
+            "label": {"attributes": {},},
+          },
+        ],
+        "formGroup": {},
+
+      }) }}
+
+      {{ govukCheckboxes({
+        "name": "active",
+        "fieldset": {
+          "legend": {
+            "text": "Active state",
+            "classes": "govuk-label--m",
+          },
+          "attributes": {},
+        },
+        "items": [
+          {
+            "value": "active",
+            "text": "Active",
+            "checked": "active" in active_list,
+            "conditional": {"html": False},
+            "hint": {},
+            "label": {"attributes": {},},
+          },
+          {
+            "value": "terminated",
+            "text": "Terminated",
+            "checked": "terminated" in active_list,
+            "conditional": {"html": False},
+            "hint": {},
+            "label": {"attributes": {},},
+          }
+        ],
+        "formGroup": {},
+
+      }) }}
+
+      {{ govukButton({"text": "Filter"}) }}
+    </form>
+
+    <div class="filter-layout__content">
+      {% include "includes/geo_areas_list.jinja" %}
+    </div>
+  </div>
+{% endblock %}

--- a/geo_areas/jinja2/includes/geo_areas_list.jinja
+++ b/geo_areas/jinja2/includes/geo_areas_list.jinja
@@ -1,0 +1,28 @@
+
+      {% set table_rows = [] %}
+      {% for geo_area in object_list %}
+        {% set geo_area_link -%}
+        <a href="{{ url("geoarea-ui-detail", kwargs={"pk": geo_area.pk}) }}">{{ geo_area.sid }}</a>
+        {%- endset %}
+        {{ table_rows.append([
+          {"text": geo_area.pk},
+          {"html": geo_area_link},
+          {"text": geo_area.get_description().description},
+          {"text": "{} {}".format(geo_area.area_code, geo_area.get_area_code_display())},
+          {"text": "{:%d %b %Y}".format(geo_area.valid_between.lower)},
+          {"text": "{:%d %b %Y}".format(geo_area.valid_between.upper) if geo_area.valid_between.upper else "-"},
+          {"text": ""},
+        ]) or "" }}
+      {% endfor %}
+      {{ govukTable({
+        "head": [
+          {"text": "ID"},
+          {"text": "SID"},
+          {"text": "Description"},
+          {"text": "Area code"},
+          {"text": "Start date"},
+          {"text": "End date"},
+          {"text": "Status"}
+        ],
+        "rows": table_rows
+      }) }}

--- a/geo_areas/models.py
+++ b/geo_areas/models.py
@@ -37,6 +37,9 @@ class GeographicalArea(TrackedModel, ValidityMixin):
     # This deals with subgroups of other groups
     parent = models.ForeignKey("self", on_delete=models.PROTECT, null=True, blank=True)
 
+    def get_description(self):
+        return self.geographicalareadescription_set.last()
+
     def save(self, *args, **kwargs):
         self.full_clean()
         return super().save(*args, **kwargs)
@@ -129,4 +132,4 @@ class GeographicalAreaDescription(TrackedModel, ValidityMixin):
         validators.validate_description_is_not_null(self)
 
     def __str__(self):
-        return f'description - "{self.description}" for {self.area}>'
+        return f'description - "{self.description}" for {self.area}'

--- a/geo_areas/serializers.py
+++ b/geo_areas/serializers.py
@@ -1,0 +1,24 @@
+from common.serializers import ValiditySerializerMixin
+from geo_areas import models
+
+
+class GeographicalMembershipSerializer(ValiditySerializerMixin):
+    class Meta:
+        model = models.GeographicalMembership
+        fields = "__all__"
+
+
+class GeographicalAreaDescriptionSerializer(ValiditySerializerMixin):
+    class Meta:
+        model = models.GeographicalAreaDescription
+        fields = ["id", "description", "valid_between"]
+
+
+class GeographicalAreaSerializer(ValiditySerializerMixin):
+    descriptions = GeographicalAreaDescriptionSerializer(
+        many=True, source="geographicalareadescription_set"
+    )
+
+    class Meta:
+        model = models.GeographicalArea
+        fields = ["id", "sid", "area_code", "descriptions", "valid_between"]

--- a/geo_areas/tests/bdd/features/geo_areas.feature
+++ b/geo_areas/tests/bdd/features/geo_areas.feature
@@ -1,0 +1,16 @@
+Feature: Geographical areas
+
+
+Background:
+    Given a valid user named "Alice"
+    And geographical_area 1001 with a lorem ipsum description
+
+Scenario Outline: Searching for a geographical_area
+    Given I am logged in as Alice
+    When I search for a geographical_area using a <search_term>
+    Then the search result should contain the geographical_area searched for
+
+    Examples:
+    | search_term |
+    | 1001        |
+    | ipsum       |

--- a/geo_areas/tests/bdd/test_browse_geo_areas.py
+++ b/geo_areas/tests/bdd/test_browse_geo_areas.py
@@ -1,0 +1,47 @@
+"""Tests for browse geographical area behaviours."""
+import pytest
+from pytest_bdd import given
+from pytest_bdd import scenarios
+from pytest_bdd import then
+from pytest_bdd import when
+from rest_framework.reverse import reverse
+
+from common.tests import factories
+
+pytestmark = pytest.mark.django_db
+
+
+scenarios("features/geo_areas.feature")
+
+
+@given('a valid user named "Alice"')
+def valid_user():
+    return factories.UserFactory.create(username="Alice")
+
+
+@given("I am logged in as Alice")
+def valid_user_login(client, valid_user):
+    client.force_login(valid_user)
+
+
+@given("geographical_area 1001 with a lorem ipsum description")
+def geographical_area_1001():
+    area = factories.GeographicalAreaFactory(id=1001)
+    factories.GeographicalAreaDescriptionFactory(
+        area=area, description="lorem ipsum dolor sit amet"
+    )
+    return area
+
+
+@pytest.fixture
+@when("I search for a geographical_area using a <search_term>")
+def geo_area_search(search_term, client):
+    return client.get(reverse("geoarea-list"), {"search": search_term})
+
+
+@then("the search result should contain the geographical_area searched for")
+def geo_area_list(geo_area_search):
+    results = geo_area_search.json()
+    assert len(results) == 1
+    result = results[0]
+    assert result["id"] == 1001

--- a/geo_areas/urls.py
+++ b/geo_areas/urls.py
@@ -1,0 +1,17 @@
+from django.urls import include
+from django.urls import path
+from rest_framework import routers
+
+from geo_areas import views
+
+
+api_router = routers.DefaultRouter()
+api_router.register(r"geographical_areas", views.GeoAreaViewSet, basename="geoarea")
+
+ui_router = routers.DefaultRouter()
+ui_router.register(r"geographical_areas", views.GeoAreaUIViewSet, basename="geoarea-ui")
+
+urlpatterns = [
+    path("", include(ui_router.urls)),
+    path("api/", include(api_router.urls)),
+]

--- a/geo_areas/views.py
+++ b/geo_areas/views.py
@@ -1,0 +1,34 @@
+from django.shortcuts import render
+from rest_framework import permissions
+from rest_framework import renderers
+from rest_framework import viewsets
+
+from geo_areas.filters import GeographicalAreaFilter
+from geo_areas.models import GeographicalArea
+from geo_areas.serializers import GeographicalAreaSerializer
+
+
+class GeoAreaViewSet(viewsets.ReadOnlyModelViewSet):
+    """
+    API endpoint that allows geographical areas to be viewed.
+    """
+
+    queryset = GeographicalArea.objects.all().prefetch_related(
+        "geographicalareadescription_set"
+    )
+    serializer_class = GeographicalAreaSerializer
+    permission_classes = [permissions.IsAuthenticated]
+    filterset_class = GeographicalAreaFilter
+    search_fields = ["sid", "area_code"]
+
+
+class GeoAreaUIViewSet(GeoAreaViewSet):
+    """
+    UI endpoint that allows geographical areas to be viewed.
+    """
+
+    def list(self, request):
+        queryset = self.filter_queryset(self.get_queryset())
+        return render(
+            request, "geo_areas/list.jinja", context={"object_list": queryset}
+        )

--- a/urls.py
+++ b/urls.py
@@ -22,6 +22,7 @@ urlpatterns = [
     path("", include("common.urls")),
     path("commodities/", include("commodities.urls")),
     path("", include("footnotes.urls")),
+    path("", include("geo_areas.urls")),
     path("measures/", include("measures.urls")),
     path("", include("regulations.urls")),
     path("", include("workbaskets.urls")),


### PR DESCRIPTION
# What

It is required for tariff managers to be able to view, browse and search
for geographical areas in order to edit and update them.

# Why

This commit introduces a frontend page for viewing and searching lists
of geographical areas. The search input utilises postgreSQLs full-text
search features and so can run a search over both the geographical areas
ID and its description set.