### PR TITLE
TP-166: Add frontend view to details of geographical areas.

### DIFF
--- a/common/static/common/scss/application.scss
+++ b/common/static/common/scss/application.scss
@@ -14,4 +14,5 @@ $govuk-image-url-function: frontend-image-url;
 @import "icon-action-list";
 @import "layout";
 @import "footnotes";
+@import "geo_areas";
 @import "regulations";

--- a/common/tests/factories.py
+++ b/common/tests/factories.py
@@ -2,6 +2,7 @@
 import random
 from datetime import datetime
 from datetime import timezone
+from itertools import product
 
 import factory
 from psycopg2.extras import DateTimeTZRange
@@ -98,12 +99,16 @@ class RegulationFactory(TrackedModelMixin):
     approved = True
 
 
+area_id_product_generator = product("ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789", repeat=4)
+
+
 class GeographicalAreaFactory(TrackedModelMixin, ValidityFactoryMixin):
     class Meta:
         model = "geo_areas.GeographicalArea"
 
     sid = factory.Sequence(lambda n: n)
-    area_id = factory.Sequence(lambda n: f"AB{n}" if n > 10 else f"ABC{n}")
+
+    area_id = factory.Sequence(lambda _: "".join(next(area_id_product_generator)))
     area_code = factory.LazyFunction(lambda: random.randint(0, 2))
 
 

--- a/conftest.py
+++ b/conftest.py
@@ -3,6 +3,9 @@ from datetime import timezone
 
 import pytest
 from psycopg2.extras import DateTimeTZRange
+from pytest_bdd import given
+
+from common.tests import factories
 
 
 @pytest.fixture(
@@ -67,3 +70,13 @@ def date_ranges():
         )
 
     return Dates
+
+
+@given('a valid user named "Alice"')
+def valid_user():
+    return factories.UserFactory.create(username="Alice")
+
+
+@given("I am logged in as Alice")
+def valid_user_login(client, valid_user):
+    client.force_login(valid_user)

--- a/geo_areas/jinja2/geo_areas/detail.jinja
+++ b/geo_areas/jinja2/geo_areas/detail.jinja
@@ -1,0 +1,194 @@
+{% extends "layouts/layout.jinja" %}
+
+{% from "components/tabs/macro.njk" import govukTabs %}
+{% from "components/input/macro.njk" import govukInput %}
+{% from "components/table/macro.njk" import govukTable %}
+
+{% set page_title = "Geographical area " ~ area.sid %}
+
+{% block beforeContent %}
+  {{ govukBreadcrumbs({
+    "items": [
+      {"text": "Home", "href": url("index")},
+      {"text": "Geographical areas", "href": url("geoarea-ui-list")},
+      {"text": page_title}
+    ]
+  }) }}
+{% endblock %}
+
+{% block content %}
+  <h1 class="govuk-heading-xl">{{ page_title }}</h1>
+  <p class="govuk-body">
+    You are viewing this geographical area in read-only mode.
+  </p>
+
+  {% set core_data_html %}
+    <div class="geo-area__core-data">
+      <div class="geo-area__core-data__content">
+        {{ govukTable({
+          "firstCellIsHeader": true,
+          "rows": [
+            [
+              {"text": "Geographical area ID"},
+              {"text": area.sid}
+            ],
+            [
+              {"text": "Current description"},
+              {"text": area.get_description().description}
+            ],
+            [
+              {"text": "Area code"},
+              {"text": "{} - {}".format(area.area_code, area.get_area_code_display())}
+            ],
+            [
+              {"text": "Start date"},
+              {"text": "{:%d %b %Y}".format(area.valid_between.lower)}
+            ],
+            [
+              {"text": "End date"},
+              {"text": "{:%d %b %Y}".format(area.valid_between.upper) if area.valid_between.upper else "-"}
+            ]
+          ]
+        }) }}
+      </div>
+      <div class="geo-area__core-data__actions">
+        <h2 class="govuk-heading-s">Actions</h2>
+        <ul class="icon-action-list govuk-list">
+          <li><a href="#" class="govuk-link govuk-!-font-size-16">Edit this geographical area</a></li>
+          <li><a href="#" class="govuk-link govuk-!-font-size-16">Delete this geographical area</a></li>
+        </ul>
+        <p class="govuk-body-s">
+          Please note that you are unable to modify descriptions on this tab.
+          Please select the "<a href="#descriptions">Descriptions</a>" tab to create and
+          modify descriptions.
+        </p>
+      </div>
+    </div>
+  {% endset %}
+
+  {% set description_data_html %}
+    {% set description_rows = [] %}
+    {% for description in area.geographicalareadescription_set.all() %}
+      {{ description_rows.append([
+        {"text": "{:%d %b %Y}".format(description.valid_between.lower)},
+        {"text": description.description},
+        {
+            "html": '<a href="#" class="govuk-link govuk-!-font-size-16">Edit description</a>'
+        }
+      ])}}
+    {% endfor %}
+    <div class="geo-area__description-data">
+      <div class="geo-area__description-data__content">
+        {{ govukTable({
+          "firstCellIsHeader": false,
+          "head": [
+            {
+              "text": "Start Date",
+              "classes": "govuk-!-width-one-quarter"
+            },
+            {
+              "text": "Description",
+              "classes": "govuk-!-width-two-thirds"
+            },
+            {
+              "text": "Actions"
+            },
+          ],
+          "rows": description_rows
+        }) }}
+      </div>
+      <div class="geo-area__description-data__actions">
+        <ul class="icon-action-list govuk-list">
+          <li><a href="#" class="govuk-link govuk-!-font-size-16">Create a new geographical area description</a></li>
+        </ul>
+      </div>
+    </div>
+  {% endset %}
+
+  {% set membership_data_html %}
+    {% set membership_rows = [] %}
+    {% for membership in members %}
+      {{ membership_rows.append([
+            {"text": "{:%d %b %Y}".format(membership.valid_between.lower)},
+            {
+                "text": "{:%d %b %Y}".format(membership.valid_between.upper)
+                if membership.valid_between.upper
+                else "-"
+            },
+            {
+                "text": membership.member.sid
+                if is_group
+                else membership.geo_group.sid
+            },
+            {
+                "text": membership.member.get_description().description
+                if is_group
+                else membership.geo_group.get_description().description
+            },
+            {
+                "html": '<a href="#" class="govuk-link govuk-!-font-size-16">Terminate</a>'
+            },
+      ]) or "" }}
+    {% endfor %}
+    <div class="geo-area__membership-data">
+      <div class="geo-area__membership-data__content">
+        {{ govukTable({
+          "firstCellIsHeader": false,
+          "head": [
+            {
+              "text": "Start Date"
+            },
+            {
+              "text": "End Date"
+            },
+            {
+              "text": "ID"
+            },
+            {
+              "text": "Description",
+              "classes": "govuk-!-width-one-half"
+            },
+            {
+              "text": "Actions"
+            }
+
+          ],
+          "rows": membership_rows
+        }) }}
+      </div>
+      {% if is_group %}
+      <div class="geo-area__membership-data__actions">
+        <ul class="icon-action-list govuk-list">
+          <li><a href="#" class="govuk-link govuk-!-font-size-16">Create a new membership</a></li>
+        </ul>
+      </div>
+      {% endif %}
+    </div>
+  {% endset %}
+
+  {{ govukTabs({
+    "items": [
+      {
+        "label": "Core geographical area data",
+        "id": "core-data",
+        "panel": {
+          "html": core_data_html
+        }
+      },
+      {
+        "label": "Descriptions",
+        "id": "descriptions",
+        "panel": {
+          "html": description_data_html
+        }
+      },
+      {
+        "label": "Members" if is_group else "Memberships",
+        "id": "members" if is_group else "memberships",
+        "panel": {
+          "html": membership_data_html
+        }
+      },
+    ]
+  }) }}
+{% endblock %}

--- a/geo_areas/models.py
+++ b/geo_areas/models.py
@@ -93,7 +93,7 @@ class GeographicalMembership(TrackedModel, ValidityMixin):
         validators.validate_members_of_child_group_are_in_parent_group(self)
 
     def __str__(self):
-        return f"<{self.member}> -> <{self.group}>"
+        return f"<{self.member}> -> <{self.geo_group}>"
 
     class Meta:
         constraints = (

--- a/geo_areas/static/geo_areas/scss/_geo_areas.scss
+++ b/geo_areas/static/geo_areas/scss/_geo_areas.scss
@@ -1,0 +1,16 @@
+.geo-area__core-data {
+  @extend .govuk-grid-row;
+}
+
+.geo-area__core-data__content {
+  @extend .govuk-grid-column-three-quarters;
+}
+
+.geo-area__core-data__actions {
+  @extend .govuk-grid-column-one-quarter;
+
+  h2 {
+    border-top: 2px solid $govuk-brand-colour;
+    padding-top: govuk-spacing(4);
+  }
+}

--- a/geo_areas/tests/bdd/conftest.py
+++ b/geo_areas/tests/bdd/conftest.py
@@ -1,0 +1,24 @@
+from pytest_bdd import given
+
+from common.tests import factories
+
+
+@given("geographical_area 1001 with a description and area_code 0")
+def geographical_area_1001():
+    area = factories.GeographicalAreaFactory(id=1001, area_code=0)
+    factories.GeographicalAreaDescriptionFactory(area=area, description="This is 1001")
+    factories.GeographicalAreaDescriptionFactory(
+        area=factories.GeographicalMembershipFactory(member=area).geo_group,
+        description="random group description",
+    )
+    return area
+
+
+@given("geographical_area 1002 with a description and area_code 1")
+def geographical_area_1002(geographical_area_1001):
+    area = factories.GeographicalAreaFactory(id=1002, area_code=1)
+    factories.GeographicalAreaDescriptionFactory(area=area, description="This is 1002")
+    factories.GeographicalMembershipFactory(
+        member=geographical_area_1001, geo_group=area
+    )
+    return area

--- a/geo_areas/tests/bdd/features/browse_geo_areas.feature
+++ b/geo_areas/tests/bdd/features/browse_geo_areas.feature
@@ -3,7 +3,7 @@ Feature: Geographical areas
 
 Background:
     Given a valid user named "Alice"
-    And geographical_area 1001 with a lorem ipsum description
+    And geographical_area 1001 with a description and area_code 0
 
 Scenario Outline: Searching for a geographical_area
     Given I am logged in as Alice
@@ -11,6 +11,7 @@ Scenario Outline: Searching for a geographical_area
     Then the search result should contain the geographical_area searched for
 
     Examples:
-    | search_term |
-    | 1001        |
-    | ipsum       |
+    | search_term  |
+    | 1001         |
+    | This is 1001 |
+

--- a/geo_areas/tests/bdd/features/detail_geo_areas.feature
+++ b/geo_areas/tests/bdd/features/detail_geo_areas.feature
@@ -1,0 +1,28 @@
+Feature: Geographical areas
+
+
+Background:
+    Given a valid user named "Alice"
+    And geographical_area 1001 with a description and area_code 0
+    And geographical_area 1002 with a description and area_code 1
+
+Scenario: Viewing a geographical_areas core data
+    Given I am logged in as Alice
+    When I view a geographical_area with id 1001
+    Then the core data of the geographical_area should be presented
+
+Scenario: Viewing a geographical_areas description data
+    Given I am logged in as Alice
+    When I view a geographical_area with id 1001
+    Then the descriptions against the geographical_area should be presented
+
+Scenario: Viewing a geographical_areas membership data
+    Given I am logged in as Alice
+    When I view a geographical_area with id 1001
+    Then the memberships against the geographical_area should be presented
+
+Scenario: Viewing a geographical_areas groups membership data
+    Given I am logged in as Alice
+    When I view a geographical_area with id 1002
+    Then the members against the geographical_area should be presented
+

--- a/geo_areas/tests/bdd/test_browse_geo_areas.py
+++ b/geo_areas/tests/bdd/test_browse_geo_areas.py
@@ -1,36 +1,14 @@
 """Tests for browse geographical area behaviours."""
 import pytest
-from pytest_bdd import given
 from pytest_bdd import scenarios
 from pytest_bdd import then
 from pytest_bdd import when
 from rest_framework.reverse import reverse
 
-from common.tests import factories
-
 pytestmark = pytest.mark.django_db
 
 
-scenarios("features/geo_areas.feature")
-
-
-@given('a valid user named "Alice"')
-def valid_user():
-    return factories.UserFactory.create(username="Alice")
-
-
-@given("I am logged in as Alice")
-def valid_user_login(client, valid_user):
-    client.force_login(valid_user)
-
-
-@given("geographical_area 1001 with a lorem ipsum description")
-def geographical_area_1001():
-    area = factories.GeographicalAreaFactory(id=1001)
-    factories.GeographicalAreaDescriptionFactory(
-        area=area, description="lorem ipsum dolor sit amet"
-    )
-    return area
+scenarios("features/browse_geo_areas.feature")
 
 
 @pytest.fixture

--- a/geo_areas/tests/bdd/test_detail_geo_areas.py
+++ b/geo_areas/tests/bdd/test_detail_geo_areas.py
@@ -1,0 +1,78 @@
+"""Tests for browse geographical area behaviours."""
+import pytest
+from pytest_bdd import scenarios
+from pytest_bdd import then
+from pytest_bdd import when
+from rest_framework.reverse import reverse
+
+from geo_areas import models
+
+pytestmark = pytest.mark.django_db
+
+
+scenarios("features/detail_geo_areas.feature")
+
+
+@pytest.fixture
+@when("I view a geographical_area with id 1001")
+def geo_area_detail(client):
+    return client.get(reverse("geoarea-ui-detail", args=(1001,)))
+
+
+@pytest.fixture
+@when("I view a geographical_area with id 1002")
+def geo_area_group_detail(client):
+    return client.get(reverse("geoarea-ui-detail", args=(1002,)))
+
+
+@then("the core data of the geographical_area should be presented")
+def geo_area_core_data(geo_area_detail, geographical_area_1001):
+    content = geo_area_detail.content.decode()
+
+    assert str(geographical_area_1001.sid) in content
+    assert geographical_area_1001.get_description().description in content
+    assert (
+        f"{geographical_area_1001.area_code} - {geographical_area_1001.get_area_code_display()}"
+        in content
+    )
+
+    assert "{:%d %b %Y}".format(geographical_area_1001.valid_between.lower) in content
+
+
+@then("the descriptions against the geographical_area should be presented")
+def geo_area_description_data(geo_area_detail, geographical_area_1001):
+    descriptions = geographical_area_1001.geographicalareadescription_set.all()
+
+    content = geo_area_detail.content.decode()
+
+    for description in descriptions:
+        assert description.description in content
+        assert "{:%d %b %Y}".format(description.valid_between.lower) in content
+
+
+def compare_members_to_html(members, html, is_group):
+    for member in members:
+        obj = member.geo_group if is_group else member.member
+        assert "{:%d %b %Y}".format(member.valid_between.lower) in html
+        assert str(obj.sid) in html
+        assert obj.get_description().description in html
+
+
+@then("the memberships against the geographical_area should be presented")
+def geo_area_membership_data(geo_area_detail, geographical_area_1001):
+    memberships = models.GeographicalMembership.objects.filter(
+        member=geographical_area_1001
+    )
+    compare_members_to_html(
+        memberships, geo_area_detail.content.decode(), is_group=True
+    )
+
+
+@then("the members against the geographical_area should be presented")
+def geo_area_group_members_data(geo_area_group_detail, geographical_area_1002):
+    members = models.GeographicalMembership.objects.filter(
+        geo_group=geographical_area_1002
+    )
+    compare_members_to_html(
+        members, geo_area_group_detail.content.decode(), is_group=False
+    )

--- a/geo_areas/views.py
+++ b/geo_areas/views.py
@@ -1,10 +1,10 @@
 from django.shortcuts import render
 from rest_framework import permissions
-from rest_framework import renderers
 from rest_framework import viewsets
 
 from geo_areas.filters import GeographicalAreaFilter
 from geo_areas.models import GeographicalArea
+from geo_areas.models import GeographicalMembership
 from geo_areas.serializers import GeographicalAreaSerializer
 
 
@@ -27,8 +27,24 @@ class GeoAreaUIViewSet(GeoAreaViewSet):
     UI endpoint that allows geographical areas to be viewed.
     """
 
-    def list(self, request):
+    def list(self, request, **kwargs):
         queryset = self.filter_queryset(self.get_queryset())
         return render(
             request, "geo_areas/list.jinja", context={"object_list": queryset}
+        )
+
+    def retrieve(self, request, *args, **kwargs):
+        area = self.get_object()
+
+        is_group = area.area_code == 1
+        kwargs = {"geo_group": area} if is_group else {"member": area}
+
+        return render(
+            request,
+            "geo_areas/detail.jinja",
+            context={
+                "area": area,
+                "is_group": is_group,
+                "members": GeographicalMembership.objects.filter(**kwargs),
+            },
         )

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -62,6 +62,7 @@ module.exports = {
               sassOptions: {
                 includePaths: [
                   'footnotes/static/footnotes/scss',
+                  'geo_areas/static/geo_areas/scss',
                   'regulations/static/regulations/scss',
                 ],
               },


### PR DESCRIPTION
It is required for tariff managers to be able to view, individual
geographical areas in order to edit ad update them.

This commit introduces a frontend page for viewing individual
geographical areas. This includes a tabbed view for core data,
descriptions, as well as a members/memberships tab.

The members/memberships tab changes based on the area_code. i.e.
if a geographical area is a group then it has members and so
displays the members tab. If a geographical area is not a group then it
does not have members but may have memberships - in which case these
are displayed in a memberships tab.