### PR TITLE
Stop "None" from showing in the geo area description tab.

### DIFF
--- a/geo_areas/jinja2/geo_areas/detail.jinja
+++ b/geo_areas/jinja2/geo_areas/detail.jinja
@@ -75,7 +75,7 @@
         {
             "html": '<a href="#" class="govuk-link govuk-!-font-size-16">Edit description</a>'
         }
-      ])}}
+      ]) or ""}}
     {% endfor %}
     <div class="geo-area__description-data">
       <div class="geo-area__description-data__content">


### PR DESCRIPTION
Currently when appending to a list within a Jinja2 `set` tag "None"
is always returned and rendered on the page. By adding an `or ""` after
the append python will automatically inject the blank string into the
page instead - which is the equivalent to adding nothing to the page.