### PR TITLE
Make compatible with tamato-taric-import

### DIFF
--- a/commodities/serializers.py
+++ b/commodities/serializers.py
@@ -1,0 +1,9 @@
+from rest_framework import serializers
+
+from commodities import models
+
+
+class CommoditySerializer(serializers.HyperlinkedModelSerializer):
+    class Meta:
+        model = models.Commodity
+        fields = ["code"]

--- a/common/serializers.py
+++ b/common/serializers.py
@@ -4,8 +4,14 @@ from drf_extra_fields.fields import DateTimeRangeField
 from rest_framework import serializers
 
 
+class TARIC3DateTimeRangeField(DateTimeRangeField):
+    child = serializers.DateTimeField(
+        input_formats=["iso-8601", "%Y-%m-%d",]  # default  # TARIC3 date format
+    )
+
+
 class ValiditySerializerMixin(serializers.ModelSerializer):
-    valid_between = DateTimeRangeField()
+    valid_between = TARIC3DateTimeRangeField()
 
 
 class UserSerializer(serializers.ModelSerializer):

--- a/measures/serializers.py
+++ b/measures/serializers.py
@@ -1,0 +1,20 @@
+from rest_framework import serializers
+
+from commodities.models import Commodity
+from commodities.serializers import CommoditySerializer
+from common.serializers import ValiditySerializerMixin
+from measures import models
+
+
+class MeasureSerializer(ValiditySerializerMixin):
+    commodity_code = CommoditySerializer()
+
+    class Meta:
+        model = models.Measure
+        fields = ["commodity_code", "valid_between"]
+
+    def create(self, validated_data):
+        commodity_code = Commodity.objects.get(
+            **validated_data.pop("commodity_code", {})
+        )
+        models.Measure.objects.create(commodity_code=commodity_code, **validated_data)

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python
+from distutils.core import setup
+
+import setuptools
+
+setup(
+    name="tamato",
+    version="0.0.1",
+    description="UK Tariff Management Tool",
+    maintainer="Department for International Trade",
+    maintainer_email="webops@digital.trade.gov.uk",
+    url="https://github.com/uktrade/tamato",
+    packages=setuptools.find_packages(),
+    install_requires=[
+        "dj-database-url",
+        "django",
+        "django-dotenv",
+        "django-extra-fields",
+        "django-filter",
+        "django-fsm",
+        "django-health-check",
+        "django-polymorphic",
+        "django-treebeard",
+        "django-webpack-loader",
+        "django_extensions",
+        "djangorestframework",
+        "gunicorn",
+        "jinja2",
+        "psycopg2-binary",
+        "sentry-sdk",
+        "werkzeug",
+        "whitenoise",
+    ],
+    dependency_links=[
+        "https://github.com/alphagov/govuk-frontend-jinja/tarball/master#egg=govuk-frontend-jinja",
+    ],
+)


### PR DESCRIPTION
The TAMATO TARIC importer script has a dependency on TAMATO's serializers and models to
validate and modify the TAMATO DB.

This change adds a `setup.py` to allow TAMATO to be added as a pip dependency

It also adds preliminary serializers for Commodity and Measure models, to allow the
importer to deserialize these models.

Finally, the ValiditySerializerMixin is modified to handle TARIC date format strings
(YYYY-MM-DD) as well as ISO 8601 format (the default), for convenience.