### PR TITLE
Add a hook for validating models in a workbasket

### DIFF
--- a/additional_codes/models.py
+++ b/additional_codes/models.py
@@ -66,6 +66,9 @@ class AdditionalCode(TrackedModel, ValidityMixin):
             self
         )
 
+    def validate_workbasket(self):
+        validators.validate_at_least_one_description(self)
+
     def save(self, *args, **kwargs):
         self.full_clean()
         return super().save(*args, **kwargs)

--- a/additional_codes/tests/test_business_rules.py
+++ b/additional_codes/tests/test_business_rules.py
@@ -177,11 +177,14 @@ def test_ACN11():
 # Additional Code Description and Description Periods
 
 
-@pytest.mark.skip(reason="WorkBasket validation not implemented")
 def test_ACN5_one_description_mandatory():
     """At least one description is mandatory."""
 
-    # TODO this validation only makes sense when the workbasket is submitted
+    workbasket = factories.WorkBasketFactory()
+    ac = factories.AdditionalCodeFactory(workbasket=workbasket)
+
+    with pytest.raises(ValidationError):
+        workbasket.submit_for_approval()
 
 
 def test_ACN5_first_description_must_have_same_start_date(date_ranges):

--- a/additional_codes/validators.py
+++ b/additional_codes/validators.py
@@ -123,3 +123,8 @@ def validate_additional_code_description_start_date_before_additional_code_end_d
                 "date of the additional code."
             }
         )
+
+
+def validate_at_least_one_description(additional_code):
+    if additional_code.descriptions.count() < 1:
+        raise ValidationError("At least one description record is mandatory.")

--- a/certificates/models.py
+++ b/certificates/models.py
@@ -4,7 +4,8 @@ from django.core.validators import MaxValueValidator
 from django.db import models
 
 from certificates import validators
-from common.models import TrackedModel, ValidityMixin
+from common.models import TrackedModel
+from common.models import ValidityMixin
 
 
 class CertificateType(TrackedModel, ValidityMixin):
@@ -56,6 +57,9 @@ class Certificate(TrackedModel, ValidityMixin):
         validators.validate_certificate_type_validity_includes_certificate_validity(
             self
         )
+
+    def validate_workbasket(self):
+        validators.validate_at_least_one_description(self)
 
     def __str__(self):
         return f"Certificate {self.code}"

--- a/certificates/tests/test_business_rules.py
+++ b/certificates/tests/test_business_rules.py
@@ -1,11 +1,14 @@
-from datetime import datetime, timezone
+from datetime import datetime
+from datetime import timezone
 
-from django.core.exceptions import ValidationError
-from django.db import DataError, IntegrityError
 import pytest
+from django.core.exceptions import ValidationError
+from django.db import DataError
+from django.db import IntegrityError
 from psycopg2._range import DateTimeTZRange
 
 from common.tests import factories
+from common.tests.util import requires_measures
 
 
 pytestmark = pytest.mark.django_db
@@ -59,7 +62,7 @@ def test_ce3(date_ranges):
         factories.CertificateFactory.create(valid_between=date_ranges.backwards)
 
 
-@pytest.mark.skip(reason="Measures not implemented")
+@requires_measures
 def test_ce4():
     """
     If a certificate is used in a measure condition then the validity period of the certificate
@@ -68,7 +71,7 @@ def test_ce4():
     pass
 
 
-@pytest.mark.skip(reason="Measures not implemented")
+@requires_measures
 def test_ce5():
     """
     When a certificate cannot be deleted if it is used in a measure condition
@@ -76,14 +79,16 @@ def test_ce5():
     pass
 
 
-@pytest.mark.skip(
-    reason="description existence depends on certificate existence - this is a chicken and egg scenario"
-)
 def test_ce6_one_description_mandatory():
     """
     At least one description record is mandatory
     """
-    assert False
+
+    workbasket = factories.WorkBasketFactory()
+    c = factories.CertificateFactory(workbasket=workbasket)
+
+    with pytest.raises(ValidationError):
+        workbasket.submit_for_approval()
 
 
 def test_ce6_first_description_must_have_same_start_date(date_ranges):

--- a/certificates/validators.py
+++ b/certificates/validators.py
@@ -105,3 +105,8 @@ def validate_previous_certificate_description_is_adjacent(certificate_descriptio
                 "adjacent to the previous descriptions validity"
             }
         )
+
+
+def validate_at_least_one_description(certificate):
+    if certificate.descriptions.count() < 1:
+        raise ValidationError("At least one description record is mandatory.")

--- a/common/models.py
+++ b/common/models.py
@@ -6,7 +6,8 @@ from django.db.models import QuerySet
 from polymorphic.managers import PolymorphicManager
 from polymorphic.models import PolymorphicModel
 from polymorphic.query import PolymorphicQuerySet
-from treebeard.mp_tree import MP_Node, MP_NodeQuerySet
+from treebeard.mp_tree import MP_Node
+from treebeard.mp_tree import MP_NodeQuerySet
 
 from common import exceptions
 
@@ -166,3 +167,6 @@ class TrackedModel(PolymorphicModel):
             new_object.save()
 
         return new_object
+
+    def validate_workbasket(self):
+        pass

--- a/common/tests/factories.py
+++ b/common/tests/factories.py
@@ -35,6 +35,7 @@ class WorkBasketFactory(factory.django.DjangoModelFactory):
         model = "workbaskets.WorkBasket"
 
     author = factory.SubFactory(UserFactory)
+    title = factory.Faker("text", max_nb_chars=255)
 
 
 class ApprovedWorkBasketFactory(WorkBasketFactory):

--- a/footnotes/models.py
+++ b/footnotes/models.py
@@ -3,7 +3,8 @@ from django.contrib.postgres.fields import RangeOperators
 from django.db import models
 from django.db.models.functions import Lower
 
-from common.models import TrackedModel, ValidityMixin
+from common.models import TrackedModel
+from common.models import ValidityMixin
 from footnotes import validators
 
 

--- a/geo_areas/tests/test_business_rules.py
+++ b/geo_areas/tests/test_business_rules.py
@@ -1,12 +1,15 @@
-from datetime import datetime, timezone
+from datetime import datetime
+from datetime import timezone
 
 import pytest
 from django.core.exceptions import ValidationError
-from django.db import IntegrityError, DataError
+from django.db import DataError
+from django.db import IntegrityError
 from django.db.models import ProtectedError
 from psycopg2.extras import DateTimeTZRange
 
 from common.tests import factories
+from common.tests.util import requires_measures
 
 
 pytestmark = pytest.mark.django_db
@@ -96,13 +99,13 @@ def test_ga7(date_ranges):
         )
 
 
-@pytest.mark.skip(reason="Measures not yet implemented")
+@requires_measures
 def test_ga10():
     """ If referenced in a measure the geographical area validity range must span the measured validity range. """
     pass
 
 
-@pytest.mark.skip(reason="Measures not yet implemented")
+@requires_measures
 def test_ga11():
     """ If an area is excluded in a measure then the areas validity must span the measures. """
     pass
@@ -178,7 +181,7 @@ def test_ga19(child, country):
     factories.GeographicalMembershipFactory(geo_group=child, member=member)
 
 
-@pytest.mark.skip(reason="Measures not yet implemented")
+@requires_measures
 def test_ga21():
     """ If a geographical area is referenced in a measure then it may not be deleted1. """
     pass
@@ -190,7 +193,7 @@ def test_ga22(child):
         child.parent.delete()
 
 
-@pytest.mark.skip(reason="Measures not yet implemented")
+@requires_measures
 def test_ga23():
     """ If a geographical area is excluded in a measure, the area cannot be deleted. """
     pass


### PR DESCRIPTION
Some business rules require validating across models in a workbasket, for example,
Certificates must have at least one associated CertificateDescription. This cannot be
achieved with standard model validation.

This change adds a method to all TrackedModel objects, `validate_workbasket`, which may
be overridden to perform validation across all models in the same workbasket. When the
WorkBasket is validated, it calls this method on all its TrackedModels. Any
ValidationErrors raised are stored in the WorkBasket instance to enable error messaging
in the UI.