### PR TITLE
Fix additional code search

### DIFF
--- a/additional_codes/filters.py
+++ b/additional_codes/filters.py
@@ -1,0 +1,23 @@
+import re
+
+from common.filters import TamatoFilterBackend
+
+
+COMBINED_ADDITIONAL_CODE_AND_TYPE_ID = re.compile(
+    r"^(?P<additional_code_type_id>[A-Z0-9])(?P<additional_code_id>[A-Z0-9]{3})$"
+)
+
+
+class AdditionalCodeFilterBackend(TamatoFilterBackend):
+    """
+    Filter that combines additional code type ID and additional code ID
+    """
+
+    search_fields = "type__sid", "code"  # XXX order is significant
+
+    def get_search_term(self, request):
+        search_term = super().get_search_term(request)
+        match = COMBINED_ADDITIONAL_CODE_AND_TYPE_ID.match(search_term.strip())
+        if match:
+            return " ".join(match.groups())
+        return search_term

--- a/additional_codes/views.py
+++ b/additional_codes/views.py
@@ -2,6 +2,7 @@ from django.shortcuts import render
 from rest_framework import permissions
 from rest_framework import viewsets
 
+from additional_codes.filters import AdditionalCodeFilterBackend
 from additional_codes.models import AdditionalCode
 from additional_codes.models import AdditionalCodeType
 from additional_codes.serializers import AdditionalCodeSerializer
@@ -16,7 +17,14 @@ class AdditionalCodeViewSet(viewsets.ReadOnlyModelViewSet):
     queryset = AdditionalCode.objects.all().prefetch_related("descriptions")
     serializer_class = AdditionalCodeSerializer
     permission_classes = [permissions.IsAuthenticated]
-    search_fields = ["sid", "code"]
+    filter_backends = [AdditionalCodeFilterBackend]
+    search_fields = [
+        "sid",
+        "code",
+        "descriptions__description",
+        "type__sid",
+        "type__description",
+    ]
 
 
 class AdditionalCodeUIViewSet(AdditionalCodeViewSet):

--- a/common/filters.py
+++ b/common/filters.py
@@ -1,0 +1,18 @@
+from django.contrib.postgres.search import SearchVector
+from rest_framework import filters
+from rest_framework.settings import api_settings
+
+
+class TamatoFilterBackend(filters.BaseFilterBackend):
+    search_fields = ("sid",)
+
+    def get_search_term(self, request):
+        return request.query_params.get(api_settings.SEARCH_PARAM, "")
+
+    def filter_queryset(self, request, queryset, view):
+        search_term = self.get_search_term(request)
+        if search_term:
+            return queryset.annotate(search=SearchVector(*self.search_fields)).filter(
+                search=search_term
+            )
+        return filters.SearchFilter().filter_queryset(request, queryset, view)


### PR DESCRIPTION
All additional codes were returned regardless of search terms.

This change adds a custom DRF filter backend, which searches for exact Additional Code
Type SID + Additional Code matches (eg: X001), and falls back to full-text search on
sid, code, type, description and type description.