### PR TITLE
Bump nodejs version 12.18.2

### DIFF
--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -38,7 +38,7 @@ jobs:
     - name: Set up Node
       uses: actions/setup-node@v1
       with:
-        node-version: "12.16.1"
+        node-version: "12.18.2"
 
     - name: Install Dependencies
       run: |

--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -38,7 +38,7 @@ jobs:
     - name: Set up Node
       uses: actions/setup-node@v1
       with:
-        node-version: "12.16.3"
+        node-version: "12.18.2"
 
     - name: Install Dependencies
       run: |

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Then you can browse to http://localhost:8000/ to view the app
 
 ### Running locally
 
-This app requires Python 3.8.x and Node 12.16.x
+This app requires Python 3.8.x and Node 12.18.x
 
 Create a Python virtualenv and install the dependencies:
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "repository": "https://github.com/uktrade/tamato.git",
   "licence": "MIT",
   "engines": {
-    "node": "12.16.3",
+    "node": "12.18.2",
     "npm": "6.13.4"
   },
   "dependencies": {


### PR DESCRIPTION
PaaS no longer supports 12.16, which causes deployment to fail