### PR TITLE
Fix querysets with multiple versions of models

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ compilescss:
 node_modules:
 	@echo
 	@echo "> Installing Javascript dependencies..."
-	@npm ci
+	@npm install
 
 migrate:
 	@echo

--- a/common/jinja2.py
+++ b/common/jinja2.py
@@ -10,7 +10,7 @@ from govuk_frontend_jinja.templates import NunjucksExtension
 from webpack_loader.templatetags.webpack_loader import render_bundle
 from webpack_loader.templatetags.webpack_loader import webpack_static
 
-from workbaskets.views import get_current_workbasket
+from workbaskets.models import WorkBasket
 
 
 class GovukFrontendExtension(NunjucksExtension):
@@ -66,7 +66,7 @@ def environment(**kwargs):
         {
             "env": os.environ.get("ENV", "dev"),
             "get_messages": messages.get_messages,
-            "get_current_workbasket": get_current_workbasket,
+            "get_current_workbasket": WorkBasket.current,
             "pluralize": pluralize,
             "render_bundle": render_bundle,
             "static": static,

--- a/common/models.py
+++ b/common/models.py
@@ -101,7 +101,7 @@ class TrackedModelQuerySet(PolymorphicQuerySet):
         query = Q()
 
         # get models in the workbasket
-        in_workbasket = self.model.objects.filter(workbasket=workbasket)
+        in_workbasket = self.filter(workbasket=workbasket)
 
         # remove matching models from the queryset
         for instance in in_workbasket:
@@ -249,3 +249,10 @@ inherit TrackedModel must either:
 
     def validate_workbasket(self):
         pass
+
+    def add_to_workbasket(self, workbasket):
+        if workbasket == self.workbasket:
+            self.save()
+            return self
+
+        return self.new_draft(workbasket=workbasket)

--- a/common/models.py
+++ b/common/models.py
@@ -94,6 +94,10 @@ class TrackedModelQuerySet(PolymorphicQuerySet):
         """
         Add the latest versions of objects from the specified workbasket.
         """
+
+        if workbasket is None:
+            return self
+
         query = Q()
 
         # get models in the workbasket

--- a/footnotes/jinja2/footnotes/edit.jinja
+++ b/footnotes/jinja2/footnotes/edit.jinja
@@ -23,11 +23,13 @@
   </p>
   <p>
   Workbasket:
-  {% if request.session.workbasket -%}
-    <a href="{{ url("workbasket-ui-detail", args=[request.session.workbasket.id]) }}">{{ request.session.workbasket.title }}</a>
-  {%- else -%}
-    No current workbasket
-  {%- endif %}
+  {% with current_workbasket = get_current_workbasket(request) -%}
+    {% if current_workbasket -%}
+      <a href="{{ url("workbasket-ui-detail", args=[current_workbasket.id]) }}">{{ current_workbasket.title }}</a>
+    {%- else -%}
+      No current workbasket
+    {%- endif %}
+  {%- endwith %}
   </p>
 {% endblock %}
 

--- a/footnotes/tests/bdd/test_detail_footnotes.py
+++ b/footnotes/tests/bdd/test_detail_footnotes.py
@@ -13,7 +13,8 @@ scenarios("features/detail-footnotes.feature")
 
 @pytest.fixture
 @when("I select footnote NC000")
-def footnote_detail(client, footnote_NC000):
+def footnote_detail(client, footnote_NC000, freezer):
+    freezer.move_to("2021-01-01")
     return client.get(footnote_NC000.get_url())
 
 

--- a/footnotes/views.py
+++ b/footnotes/views.py
@@ -75,7 +75,7 @@ class FootnoteDetail(WithCurrentWorkBasket, FootnoteMixin, generic.DetailView):
 
     @property
     def queryset(self):
-        # laxy evaluation to allow freezegun to work
+        # lazy evaluation to allow freezegun to work
         return models.Footnote.objects.current()
 
 
@@ -83,7 +83,6 @@ class FootnoteUpdate(FootnoteMixin, DraftUpdateView):
     form_class = forms.FootnoteForm
     queryset = models.Footnote.objects.current()
     template_name = "footnotes/edit.jinja"
-    update_fields = ["valid_between"]
 
     def get_form(self, form_class=None):
         form = super().get_form(form_class)
@@ -128,7 +127,6 @@ class FootnoteDescriptionUpdate(FootnoteDescriptionMixin, DraftUpdateView):
     form_class = forms.FootnoteDescriptionForm
     queryset = models.FootnoteDescription.objects.current()
     template_name = "footnotes/edit_description.jinja"
-    update_fields = ["valid_between", "description"]
 
     def get_success_url(self):
         return self.object.get_url("confirm-update")

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,6 +23,7 @@ pytest
 pytest-bdd
 pytest-cov
 pytest-django
+pytest-freezegun
 pytest-mock
 sentry-sdk
 werkzeug

--- a/workbaskets/jinja2/workbaskets/choose-or-create.jinja
+++ b/workbaskets/jinja2/workbaskets/choose-or-create.jinja
@@ -36,7 +36,7 @@
     {% for workbasket in objects -%}
       {{ workbasket_options.append({
         "value": workbasket.pk,
-        "text": workbasket.title,
+        "text": workbasket.title|default("Workbasket " ~ workbasket.pk),
       }) or "" }}
     {%- endfor -%}
     {{ workbasket_options.append({

--- a/workbaskets/models.py
+++ b/workbaskets/models.py
@@ -179,6 +179,13 @@ class WorkBasket(TimestampedMixin):
             approver_id=int(data["approver_id"]) if data["approver_id"] else None,
         )
 
+    @classmethod
+    def current(cls, request):
+        """Get the current workbasket in the session"""
+
+        if "workbasket" in request.session:
+            return cls.from_json(request.session["workbasket"])
+
 
 class Transaction(TimestampedMixin):
     """A Transaction is created once the WorkBasket has been sent for approval"""

--- a/workbaskets/views/__init__.py
+++ b/workbaskets/views/__init__.py
@@ -1,7 +1,3 @@
-import json
-from functools import wraps
-
-from django.core.serializers.json import DjangoJSONEncoder
 from django.shortcuts import redirect
 from django.shortcuts import render
 from rest_framework import renderers
@@ -13,49 +9,6 @@ from common.renderers import TaricXMLRenderer
 from workbaskets.models import WorkBasket
 from workbaskets.models import WorkflowStatus
 from workbaskets.serializers import WorkBasketSerializer
-
-
-def get_current_workbasket(request):
-    workbasket_data = request.session.get("workbasket")
-    if workbasket_data is None:
-        return None
-    return WorkBasket.from_json(workbasket_data)
-
-
-def return_to_current_url(request):
-    request.session["return_to"] = f"{request.path_info}?{request.META['QUERY_STRING']}"
-
-
-def require_current_workbasket(view_func):
-    """
-    View decorator which redirects user to choose or create a workbasket before
-    continuing.
-    """
-
-    @wraps(view_func)
-    def check_for_current_workbasket(request, *args, **kwargs):
-        if get_current_workbasket(request) is None:
-            return_to_current_url(request)
-            return redirect(reverse("workbasket-ui-choose-or-create"))
-
-        return view_func(request, *args, **kwargs)
-
-    return check_for_current_workbasket
-
-
-class CurrentWorkBasketMixin:
-    """
-    Add models in the current workbasket to the modelview queryset
-    """
-
-    def get_queryset(self):
-        qs = super().get_queryset()
-
-        workbasket = get_current_workbasket(self.request)
-        if workbasket:
-            qs = qs.with_workbasket(workbasket)
-
-        return qs
 
 
 class WorkBasketViewSet(viewsets.ModelViewSet):

--- a/workbaskets/views/decorators.py
+++ b/workbaskets/views/decorators.py
@@ -1,0 +1,23 @@
+from functools import wraps
+
+from django.shortcuts import redirect
+from rest_framework.reverse import reverse
+
+from workbaskets.models import WorkBasket
+
+
+def require_current_workbasket(view_func):
+    """
+    View decorator which redirects user to choose or create a workbasket before
+    continuing.
+    """
+
+    @wraps(view_func)
+    def check_for_current_workbasket(request, *args, **kwargs):
+        if WorkBasket.current(request) is None:
+            request.session["return_to"] = request.build_absolute_uri()
+            return redirect(reverse("workbasket-ui-choose-or-create"))
+
+        return view_func(request, *args, **kwargs)
+
+    return check_for_current_workbasket

--- a/workbaskets/views/generic.py
+++ b/workbaskets/views/generic.py
@@ -1,0 +1,40 @@
+from django.http import HttpResponseRedirect
+from django.utils.decorators import method_decorator
+from django.views.generic import UpdateView
+
+from common.validators import UpdateType
+from workbaskets.models import WorkBasket
+from workbaskets.views.decorators import require_current_workbasket
+from workbaskets.views.mixins import WithCurrentWorkBasket
+
+
+@method_decorator(require_current_workbasket, name="dispatch")
+class DraftUpdateView(WithCurrentWorkBasket, UpdateView):
+    """
+    UpdateView which creates or modifies drafts of a model in the current workbasket.
+
+    Set `update_fields` to a list of field names to update on form submission.
+    """
+
+    def form_valid(self, form):
+        workbasket = WorkBasket.current(self.request)
+
+        # if there is already a draft in the workbasket, update it
+        if self.object.workbasket == workbasket:
+            self.object.update_type = UpdateType.UPDATE
+            for field_name in self.update_fields:
+                setattr(self.object, field_name, form.cleaned_data.get(field_name))
+            self.object.save(update_fields=self.update_fields)
+
+        # otherwise, create a new draft
+        else:
+            self.object = self.object.new_draft(
+                workbasket=workbasket,
+                update_type=UpdateType.UPDATE,
+                **{
+                    field_name: form.cleaned_data.get(field_name)
+                    for field_name in self.update_fields
+                },
+            )
+
+        return HttpResponseRedirect(self.get_success_url())

--- a/workbaskets/views/mixins.py
+++ b/workbaskets/views/mixins.py
@@ -1,0 +1,11 @@
+from workbaskets.models import WorkBasket
+
+
+class WithCurrentWorkBasket:
+    """
+    Add models in the current workbasket to the modelview queryset
+    """
+
+    def get_queryset(self):
+        qs = super().get_queryset()
+        return qs.with_workbasket(WorkBasket.current(self.request))


### PR DESCRIPTION
This change refactors the `CurrentWorkBasketMixin`, moving the queryset filtering code to
a new method `with_workbasket()` on the `TrackedModelQuerySet` class, and ensuring that only the latest version of models in
the workbasket are added to the queryset.

Additionally, if there is already a draft of an object in the current workbasket, this is now reused, rather
than creating a new draft.

This fixes the bug seen when editing the same footnote more than once. Multiple drafts
in the workbasket were added to the queryset, which caused an exception in the
`DetailView` which expects a single object.