### PR TITLE
Show correct activity date on footnote versions list

### DIFF
--- a/footnotes/jinja2/footnotes/detail.jinja
+++ b/footnotes/jinja2/footnotes/detail.jinja
@@ -118,7 +118,7 @@
     {% for version in object.get_versions() %}
       {{ version_rows.append([
         {"text": version.get_update_type_display()},
-        {"text": "{:%d %b %Y}".format(version.workbasket.created_at)},
+        {"text": "{:%d %b %Y}".format(version.updated_at)},
         {"text": "{:%d %b %Y}".format(version.valid_between.lower)},
         {"text": "{:%d %b %Y}".format(version.valid_between.upper) if version.valid_between.upper else "-"},
         {"html": status(version.workbasket)},


### PR DESCRIPTION
Was showing workbasket creation date, rather than the footnote draft
update timestamp.