### PR TITLE
Add config file for pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,10 @@
+repos:
+  - repo: https://github.com/asottile/reorder_python_imports
+    rev: v2.3.5
+    hooks:
+      - id: reorder-python-imports
+        args: [--py3-plus]
+  - repo: https://github.com/psf/black
+    rev: 19.10b0
+    hooks:
+      - id: black


### PR DESCRIPTION
We use the pre-commit (https://pre-commit.com/) tool to automatically run the Black
Python linter on our code before commits. This change adds the
`reorder-python-imports` formatter and shares the config, so that all
developers on the project can use it.