### PR TITLE
Reformat some long lines using the latest version of `black`

### DIFF
--- a/additional_codes/migrations/0001_initial.py
+++ b/additional_codes/migrations/0001_initial.py
@@ -161,7 +161,10 @@ class Migration(migrations.Migration):
                     ),
                 ),
             ],
-            options={"abstract": False, "base_manager_name": "objects",},
+            options={
+                "abstract": False,
+                "base_manager_name": "objects",
+            },
             bases=("common.trackedmodel", models.Model),
         ),
         migrations.AddConstraint(

--- a/additional_codes/migrations/0003_use_common_fields.py
+++ b/additional_codes/migrations/0003_use_common_fields.py
@@ -12,7 +12,9 @@ class Migration(migrations.Migration):
 
     operations = [
         migrations.AlterField(
-            model_name="additionalcode", name="sid", field=common.models.NumericSID(),
+            model_name="additionalcode",
+            name="sid",
+            field=common.models.NumericSID(),
         ),
         migrations.AlterField(
             model_name="additionalcodedescription",

--- a/additional_codes/models.py
+++ b/additional_codes/models.py
@@ -24,7 +24,8 @@ class AdditionalCodeType(TrackedModel, ValidityMixin):
     description_subrecord_code = "05"
 
     sid = models.CharField(
-        max_length=1, validators=[validators.additional_code_type_sid_validator],
+        max_length=1,
+        validators=[validators.additional_code_type_sid_validator],
     )
     description = ShortDescription()
 

--- a/commodities/import_handlers.py
+++ b/commodities/import_handlers.py
@@ -112,7 +112,8 @@ class FootnoteAssociationGoodsNomenclature(ValidityMixin, Writable, ElementHandl
             footnote_type_id=self.data.pop("footnote_type_id")
         )
         footnote = Footnote.objects.get_latest_version(
-            footnote_id=self.data.pop("footnote_id"), footnote_type=footnote_type,
+            footnote_id=self.data.pop("footnote_id"),
+            footnote_type=footnote_type,
         )
 
         data.update(

--- a/commodities/migrations/0002_add_goods_nomenclature.py
+++ b/commodities/migrations/0002_add_goods_nomenclature.py
@@ -33,7 +33,10 @@ class Migration(migrations.Migration):
                     django.contrib.postgres.fields.ranges.DateTimeRangeField(),
                 ),
             ],
-            options={"abstract": False, "base_manager_name": "objects",},
+            options={
+                "abstract": False,
+                "base_manager_name": "objects",
+            },
             bases=("common.trackedmodel", models.Model),
         ),
         migrations.CreateModel(
@@ -145,5 +148,8 @@ class Migration(migrations.Migration):
             ],
             bases=("common.trackedmodel", models.Model),
         ),
-        migrations.RemoveField(model_name="commodity", name="trackedmodel_ptr",),
+        migrations.RemoveField(
+            model_name="commodity",
+            name="trackedmodel_ptr",
+        ),
     ]

--- a/commodities/migrations/0003_remove_commodities_and_add_relations.py
+++ b/commodities/migrations/0003_remove_commodities_and_add_relations.py
@@ -15,7 +15,9 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.DeleteModel(name="Commodity",),
+        migrations.DeleteModel(
+            name="Commodity",
+        ),
         migrations.AddField(
             model_name="goodsnomenclatureindent",
             name="indented_goods_nomenclature",

--- a/commodities/models.py
+++ b/commodities/models.py
@@ -187,7 +187,9 @@ class GoodsNomenclatureDescription(TrackedModel, ValidityMixin):
         validators=[MinValueValidator(1), MaxValueValidator(99999999)]
     )
     described_goods_nomenclature = models.ForeignKey(
-        GoodsNomenclature, on_delete=models.PROTECT, related_name="descriptions",
+        GoodsNomenclature,
+        on_delete=models.PROTECT,
+        related_name="descriptions",
     )
     description = models.TextField()
 

--- a/commodities/tests/test_business_rules.py
+++ b/commodities/tests/test_business_rules.py
@@ -29,7 +29,8 @@ def test_NIG2(date_ranges, normal_good):
     """
     parent = factories.GoodsNomenclatureIndentFactory(valid_between=date_ranges.big)
     generate_good(
-        origin=normal_good, valid_between=date_ranges.adjacent_later,
+        origin=normal_good,
+        valid_between=date_ranges.adjacent_later,
     )
     with pytest.raises(ValidationError):
         generate_good(

--- a/commodities/tests/test_importer.py
+++ b/commodities/tests/test_importer.py
@@ -94,7 +94,8 @@ def test_footnote_association_goods_nomenclature_importer_create(valid_user):
     import_taric(xml, valid_user.username, WorkflowStatus.PUBLISHED.value)
 
     db_association = models.FootnoteAssociationGoodsNomenclature.objects.get(
-        goods_nomenclature=good, associated_footnote=footnote,
+        goods_nomenclature=good,
+        associated_footnote=footnote,
     )
 
     assert db_association.valid_between.lower == association.valid_between.lower

--- a/common/forms.py
+++ b/common/forms.py
@@ -82,7 +82,8 @@ class GovukDateRangeField(DateTimeRangeField):
                 limit == "lower" or self.require_all_fields
             ):
                 error = ValidationError(
-                    self.error_messages[f"{limit}_required"], code=f"{limit}_required",
+                    self.error_messages[f"{limit}_required"],
+                    code=f"{limit}_required",
                 )
                 error.subfield = i
                 raise error

--- a/common/migrations/0001_initial.py
+++ b/common/migrations/0001_initial.py
@@ -57,6 +57,9 @@ class Migration(migrations.Migration):
                     ),
                 ),
             ],
-            options={"abstract": False, "base_manager_name": "objects",},
+            options={
+                "abstract": False,
+                "base_manager_name": "objects",
+            },
         ),
     ]

--- a/common/serializers.py
+++ b/common/serializers.py
@@ -7,7 +7,10 @@ from rest_polymorphic.serializers import PolymorphicSerializer
 
 class TARIC3DateTimeRangeField(DateTimeRangeField):
     child = serializers.DateTimeField(
-        input_formats=["iso-8601", "%Y-%m-%d",]  # default  # TARIC3 date format
+        input_formats=[
+            "iso-8601",
+            "%Y-%m-%d",
+        ]  # default  # TARIC3 date format
     )
 
 

--- a/common/tests/factories.py
+++ b/common/tests/factories.py
@@ -147,7 +147,8 @@ class GeographicalMembershipFactory(TrackedModelMixin, ValidityFactoryMixin):
 
     geo_group = factory.SubFactory(GeographicalAreaFactory, area_code=1)
     member = factory.SubFactory(
-        GeographicalAreaFactory, area_code=factory.fuzzy.FuzzyChoice([0, 2]),
+        GeographicalAreaFactory,
+        area_code=factory.fuzzy.FuzzyChoice([0, 2]),
     )
 
 

--- a/common/tests/migrations/0001_initial.py
+++ b/common/tests/migrations/0001_initial.py
@@ -35,7 +35,10 @@ class Migration(migrations.Migration):
                 ("sid", models.PositiveIntegerField()),
                 ("name", models.CharField(max_length=24, null=True)),
             ],
-            options={"abstract": False, "base_manager_name": "objects",},
+            options={
+                "abstract": False,
+                "base_manager_name": "objects",
+            },
             bases=("common.trackedmodel", models.Model),
         ),
         migrations.CreateModel(
@@ -59,7 +62,10 @@ class Migration(migrations.Migration):
                 ("custom_sid", models.PositiveIntegerField()),
                 ("description", models.CharField(max_length=24, null=True)),
             ],
-            options={"abstract": False, "base_manager_name": "objects",},
+            options={
+                "abstract": False,
+                "base_manager_name": "objects",
+            },
             bases=("common.trackedmodel", models.Model),
         ),
     ]

--- a/common/tests/test_util.py
+++ b/common/tests/test_util.py
@@ -36,17 +36,61 @@ def test_is_truthy(value, expected):
 @pytest.mark.parametrize(
     "overall,contained,expected",
     [
-        (Dates.big, Dates.normal, True,),
-        (Dates.normal, Dates.starts_with_normal, True,),
-        (Dates.normal, Dates.ends_with_normal, False,),
-        (Dates.normal, Dates.overlap_normal, False,),
-        (Dates.normal, Dates.overlap_normal_earlier, False,),
-        (Dates.normal, Dates.adjacent_earlier, False,),
-        (Dates.normal, Dates.adjacent_later, False,),
-        (Dates.normal, Dates.big, False,),
-        (Dates.normal, Dates.earlier, False,),
-        (Dates.normal, Dates.later, False,),
-        (Dates.normal, Dates.normal, False,),
+        (
+            Dates.big,
+            Dates.normal,
+            True,
+        ),
+        (
+            Dates.normal,
+            Dates.starts_with_normal,
+            True,
+        ),
+        (
+            Dates.normal,
+            Dates.ends_with_normal,
+            False,
+        ),
+        (
+            Dates.normal,
+            Dates.overlap_normal,
+            False,
+        ),
+        (
+            Dates.normal,
+            Dates.overlap_normal_earlier,
+            False,
+        ),
+        (
+            Dates.normal,
+            Dates.adjacent_earlier,
+            False,
+        ),
+        (
+            Dates.normal,
+            Dates.adjacent_later,
+            False,
+        ),
+        (
+            Dates.normal,
+            Dates.big,
+            False,
+        ),
+        (
+            Dates.normal,
+            Dates.earlier,
+            False,
+        ),
+        (
+            Dates.normal,
+            Dates.later,
+            False,
+        ),
+        (
+            Dates.normal,
+            Dates.normal,
+            False,
+        ),
     ],
 )
 def test_validity_range_contains_range(overall, contained, expected):

--- a/common/tests/util.py
+++ b/common/tests/util.py
@@ -21,15 +21,18 @@ INTERDEPENDENT_EXPORT_IMPLEMENTED = False
 UTC = timezone.utc
 
 requires_commodities = pytest.mark.skipif(
-    not COMMODITIES_IMPLEMENTED, reason="Commodities not implemented",
+    not COMMODITIES_IMPLEMENTED,
+    reason="Commodities not implemented",
 )
 
 requires_measures = pytest.mark.skipif(
-    not MEASURES_IMPLEMENTED, reason="Measures not implemented",
+    not MEASURES_IMPLEMENTED,
+    reason="Measures not implemented",
 )
 
 requires_meursing_tables = pytest.mark.skipif(
-    not MEURSING_TABLES_IMPLEMENTED, reason="Meursing tables not implemented",
+    not MEURSING_TABLES_IMPLEMENTED,
+    reason="Meursing tables not implemented",
 )
 
 requires_interdependent_export = pytest.mark.skipif(
@@ -102,46 +105,60 @@ def validate_taric_xml(factory=None, instance=None, factory_kwargs=None):
 
 class Dates:
     normal = DateTimeTZRange(
-        datetime(2021, 1, 1, tzinfo=UTC), datetime(2021, 2, 1, tzinfo=UTC),
+        datetime(2021, 1, 1, tzinfo=UTC),
+        datetime(2021, 2, 1, tzinfo=UTC),
     )
     earlier = DateTimeTZRange(
-        datetime(2020, 1, 1, tzinfo=UTC), datetime(2020, 2, 1, tzinfo=UTC),
+        datetime(2020, 1, 1, tzinfo=UTC),
+        datetime(2020, 2, 1, tzinfo=UTC),
     )
     later = DateTimeTZRange(
-        datetime(2022, 2, 2, tzinfo=UTC), datetime(2022, 3, 1, tzinfo=UTC),
+        datetime(2022, 2, 2, tzinfo=UTC),
+        datetime(2022, 3, 1, tzinfo=UTC),
     )
     big = DateTimeTZRange(
-        datetime(2019, 1, 1, tzinfo=UTC), datetime(2023, 1, 2, tzinfo=UTC),
+        datetime(2019, 1, 1, tzinfo=UTC),
+        datetime(2023, 1, 2, tzinfo=UTC),
     )
     adjacent_earlier = DateTimeTZRange(
-        datetime(2020, 12, 1, tzinfo=UTC), datetime(2020, 12, 31, tzinfo=UTC),
+        datetime(2020, 12, 1, tzinfo=UTC),
+        datetime(2020, 12, 31, tzinfo=UTC),
     )
     adjacent_later = DateTimeTZRange(
-        datetime(2021, 2, 1, tzinfo=UTC), datetime(2021, 3, 1, tzinfo=UTC),
+        datetime(2021, 2, 1, tzinfo=UTC),
+        datetime(2021, 3, 1, tzinfo=UTC),
     )
     adjacent_later_big = DateTimeTZRange(
-        datetime(2021, 2, 1, tzinfo=UTC), datetime(2023, 3, 1, tzinfo=UTC),
+        datetime(2021, 2, 1, tzinfo=UTC),
+        datetime(2023, 3, 1, tzinfo=UTC),
     )
     overlap_normal = DateTimeTZRange(
-        datetime(2021, 1, 15, tzinfo=UTC), datetime(2022, 2, 15, tzinfo=UTC),
+        datetime(2021, 1, 15, tzinfo=UTC),
+        datetime(2022, 2, 15, tzinfo=UTC),
     )
     overlap_normal_earlier = DateTimeTZRange(
-        datetime(2020, 12, 15, tzinfo=UTC), datetime(2021, 1, 15, tzinfo=UTC),
+        datetime(2020, 12, 15, tzinfo=UTC),
+        datetime(2021, 1, 15, tzinfo=UTC),
     )
     overlap_big = DateTimeTZRange(
-        datetime(2022, 1, 1, tzinfo=UTC), datetime(2024, 1, 3, tzinfo=UTC),
+        datetime(2022, 1, 1, tzinfo=UTC),
+        datetime(2024, 1, 3, tzinfo=UTC),
     )
     after_big = DateTimeTZRange(
-        datetime(2024, 2, 1, tzinfo=UTC), datetime(2024, 3, 1, tzinfo=UTC),
+        datetime(2024, 2, 1, tzinfo=UTC),
+        datetime(2024, 3, 1, tzinfo=UTC),
     )
     backwards = DateTimeTZRange(
-        datetime(2021, 2, 1, tzinfo=UTC), datetime(2021, 1, 2, tzinfo=UTC),
+        datetime(2021, 2, 1, tzinfo=UTC),
+        datetime(2021, 1, 2, tzinfo=UTC),
     )
     starts_with_normal = DateTimeTZRange(
-        datetime(2021, 1, 1, tzinfo=UTC), datetime(2021, 1, 15, tzinfo=UTC),
+        datetime(2021, 1, 1, tzinfo=UTC),
+        datetime(2021, 1, 15, tzinfo=UTC),
     )
     ends_with_normal = DateTimeTZRange(
-        datetime(2021, 1, 15, tzinfo=UTC), datetime(2021, 2, 1, tzinfo=UTC),
+        datetime(2021, 1, 15, tzinfo=UTC),
+        datetime(2021, 2, 1, tzinfo=UTC),
     )
     current = DateTimeTZRange(
         datetime(2020, 8, 1, tzinfo=UTC) - timedelta(weeks=4),
@@ -153,7 +170,8 @@ class Dates:
     )
     no_end = DateTimeTZRange(datetime(2021, 1, 1, tzinfo=UTC), None)
     normal_first_half = DateTimeTZRange(
-        datetime(2021, 1, 1, tzinfo=UTC), datetime(2021, 1, 15, tzinfo=UTC),
+        datetime(2021, 1, 1, tzinfo=UTC),
+        datetime(2021, 1, 15, tzinfo=UTC),
     )
 
 

--- a/common/views.py
+++ b/common/views.py
@@ -8,7 +8,13 @@ def index(request):
     workbaskets = []
     if request.user.is_authenticated:
         workbaskets = WorkBasket.objects.filter(author=request.user)
-    return render(request, "common/index.jinja", context={"workbaskets": workbaskets,})
+    return render(
+        request,
+        "common/index.jinja",
+        context={
+            "workbaskets": workbaskets,
+        },
+    )
 
 
 class LoginView(django.contrib.auth.views.LoginView):

--- a/footnotes/migrations/0001_initial.py
+++ b/footnotes/migrations/0001_initial.py
@@ -43,7 +43,9 @@ class Migration(migrations.Migration):
                     ),
                 ),
             ],
-            options={"ordering": ["footnote_type__footnote_type_id", "footnote_id"],},
+            options={
+                "ordering": ["footnote_type__footnote_type_id", "footnote_id"],
+            },
             bases=("common.trackedmodel", models.Model),
         ),
         migrations.CreateModel(
@@ -88,7 +90,10 @@ class Migration(migrations.Migration):
                     ),
                 ),
             ],
-            options={"abstract": False, "base_manager_name": "objects",},
+            options={
+                "abstract": False,
+                "base_manager_name": "objects",
+            },
             bases=("common.trackedmodel", models.Model),
         ),
         migrations.CreateModel(
@@ -114,7 +119,10 @@ class Migration(migrations.Migration):
                     ),
                 ),
             ],
-            options={"abstract": False, "base_manager_name": "objects",},
+            options={
+                "abstract": False,
+                "base_manager_name": "objects",
+            },
             bases=("common.trackedmodel",),
         ),
         migrations.CreateModel(

--- a/footnotes/migrations/0002_refactor_footnotes.py
+++ b/footnotes/migrations/0002_refactor_footnotes.py
@@ -16,14 +16,25 @@ class Migration(migrations.Migration):
 
     operations = [
         migrations.RemoveField(
-            model_name="footnotetypedescription", name="footnote_type",
+            model_name="footnotetypedescription",
+            name="footnote_type",
         ),
         migrations.RemoveField(
-            model_name="footnotetypedescription", name="trackedmodel_ptr",
+            model_name="footnotetypedescription",
+            name="trackedmodel_ptr",
         ),
-        migrations.AlterModelOptions(name="footnotetype", options={},),
-        migrations.RemoveConstraint(model_name="footnote", name="FO2",),
-        migrations.RemoveConstraint(model_name="footnotedescription", name="FO4",),
+        migrations.AlterModelOptions(
+            name="footnotetype",
+            options={},
+        ),
+        migrations.RemoveConstraint(
+            model_name="footnote",
+            name="FO2",
+        ),
+        migrations.RemoveConstraint(
+            model_name="footnotedescription",
+            name="FO4",
+        ),
         migrations.AddField(
             model_name="footnotedescription",
             name="description_period_sid",
@@ -90,5 +101,7 @@ class Migration(migrations.Migration):
                 name="exclude_overlapping_footnote_types",
             ),
         ),
-        migrations.DeleteModel(name="FootnoteTypeDescription",),
+        migrations.DeleteModel(
+            name="FootnoteTypeDescription",
+        ),
     ]

--- a/footnotes/migrations/0003_remove_exclusion_constraints.py
+++ b/footnotes/migrations/0003_remove_exclusion_constraints.py
@@ -12,10 +12,12 @@ class Migration(migrations.Migration):
 
     operations = [
         migrations.AlterModelOptions(
-            name="footnotedescription", options={"base_manager_name": "objects"},
+            name="footnotedescription",
+            options={"base_manager_name": "objects"},
         ),
         migrations.RemoveConstraint(
-            model_name="footnote", name="exclude_overlapping_footnotes_FO2",
+            model_name="footnote",
+            name="exclude_overlapping_footnotes_FO2",
         ),
         migrations.RemoveConstraint(
             model_name="footnotedescription",

--- a/footnotes/tests/test_business_rules.py
+++ b/footnotes/tests/test_business_rules.py
@@ -111,8 +111,7 @@ def test_FO4_start_dates_cannot_match():
 
 
 def test_FO4_description_start_before_footnote_end(date_ranges):
-    """The start date must be less than or equal to the end date of the footnote.
-    """
+    """The start date must be less than or equal to the end date of the footnote."""
 
     footnote = factories.FootnoteFactory(
         valid_between=date_ranges.normal,

--- a/footnotes/urls.py
+++ b/footnotes/urls.py
@@ -14,7 +14,11 @@ footnote_detail = r"^footnotes/(?P<footnote_type__footnote_type_id>[A-Z]{2,3})(?
 footnote_description_detail = r"^footnotes/(?P<described_footnote__footnote_type__footnote_type_id>[A-Z]{2,3})(?P<described_footnote__footnote_id>[0-9]{3}|[0-9]{5})/"
 
 urlpatterns = [
-    path("footnotes/", views.FootnoteList.as_view(), name="footnote-ui-list",),
+    path(
+        "footnotes/",
+        views.FootnoteList.as_view(),
+        name="footnote-ui-list",
+    ),
     re_path(
         (footnote_detail + r"$"),
         views.FootnoteDetail.as_view(),

--- a/footnotes/validators.py
+++ b/footnotes/validators.py
@@ -33,7 +33,9 @@ def validate_at_least_one_description(footnote):
         raise ValidationError("At least one description record is mandatory.")
 
 
-def validate_first_footnote_description_has_footnote_start_date(footnote_description,):
+def validate_first_footnote_description_has_footnote_start_date(
+    footnote_description,
+):
     """FO4"""
 
     footnote = footnote_description.described_footnote

--- a/geo_areas/migrations/0002_use_common_fields.py
+++ b/geo_areas/migrations/0002_use_common_fields.py
@@ -12,7 +12,9 @@ class Migration(migrations.Migration):
 
     operations = [
         migrations.AlterField(
-            model_name="geographicalarea", name="sid", field=common.models.NumericSID(),
+            model_name="geographicalarea",
+            name="sid",
+            field=common.models.NumericSID(),
         ),
         migrations.AlterField(
             model_name="geographicalareadescription",

--- a/importer/management/commands/import_taric.py
+++ b/importer/management/commands/import_taric.py
@@ -12,7 +12,10 @@ XML_CHUNK_SIZE = 4096
 
 def import_taric(taric3_file, username, status):
     xmlparser = etree.XMLPullParser(["start", "end", "start-ns"])
-    handler = Envelope(workbasket_status=status, tamato_username=username,)
+    handler = Envelope(
+        workbasket_status=status,
+        tamato_username=username,
+    )
 
     while True:
         buffer = taric3_file.read(XML_CHUNK_SIZE)
@@ -35,7 +38,9 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         parser.add_argument(
-            "taric3_file", help="The TARIC3 file to be parsed.", type=str,
+            "taric3_file",
+            help="The TARIC3 file to be parsed.",
+            type=str,
         )
         parser.add_argument(
             "-u",

--- a/importer/tests/test_handlers.py
+++ b/importer/tests/test_handlers.py
@@ -69,7 +69,11 @@ def test_element_handler_with_repeated_children():
     handler.end(el)
 
     assert handler.data == {
-        "foo": [{"id": 0}, {"id": 1}, {"id": 2},],
+        "foo": [
+            {"id": 0},
+            {"id": 1},
+            {"id": 2},
+        ],
     }
 
 
@@ -95,5 +99,8 @@ def test_validity_mixin():
     handler.end(el)
 
     assert handler.data == {
-        "valid_between": {"lower": "2020-01-01", "upper": "2020-01-02",},
+        "valid_between": {
+            "lower": "2020-01-01",
+            "upper": "2020-01-02",
+        },
     }

--- a/measures/migrations/0001_initial.py
+++ b/measures/migrations/0001_initial.py
@@ -43,7 +43,10 @@ class Migration(migrations.Migration):
                     ),
                 ),
             ],
-            options={"abstract": False, "base_manager_name": "objects",},
+            options={
+                "abstract": False,
+                "base_manager_name": "objects",
+            },
             bases=("common.trackedmodel", models.Model),
         ),
     ]

--- a/quotas/migrations/0001_initial.py
+++ b/quotas/migrations/0001_initial.py
@@ -57,7 +57,10 @@ class Migration(migrations.Migration):
                     ),
                 ),
             ],
-            options={"abstract": False, "base_manager_name": "objects",},
+            options={
+                "abstract": False,
+                "base_manager_name": "objects",
+            },
             bases=("common.trackedmodel",),
         ),
         migrations.CreateModel(
@@ -104,7 +107,10 @@ class Migration(migrations.Migration):
                     ),
                 ),
             ],
-            options={"abstract": False, "base_manager_name": "objects",},
+            options={
+                "abstract": False,
+                "base_manager_name": "objects",
+            },
             bases=("common.trackedmodel", models.Model),
         ),
         migrations.CreateModel(
@@ -153,7 +159,10 @@ class Migration(migrations.Migration):
                     ),
                 ),
             ],
-            options={"abstract": False, "base_manager_name": "objects",},
+            options={
+                "abstract": False,
+                "base_manager_name": "objects",
+            },
             bases=("common.trackedmodel", models.Model),
         ),
         migrations.CreateModel(
@@ -176,7 +185,10 @@ class Migration(migrations.Migration):
                 ),
                 ("sid", common.models.NumericSID()),
             ],
-            options={"abstract": False, "base_manager_name": "objects",},
+            options={
+                "abstract": False,
+                "base_manager_name": "objects",
+            },
             bases=("common.trackedmodel", models.Model),
         ),
         migrations.CreateModel(
@@ -212,7 +224,10 @@ class Migration(migrations.Migration):
                     ),
                 ),
             ],
-            options={"abstract": False, "base_manager_name": "objects",},
+            options={
+                "abstract": False,
+                "base_manager_name": "objects",
+            },
             bases=("common.trackedmodel", models.Model),
         ),
         migrations.CreateModel(
@@ -244,7 +259,10 @@ class Migration(migrations.Migration):
                     ),
                 ),
             ],
-            options={"abstract": False, "base_manager_name": "objects",},
+            options={
+                "abstract": False,
+                "base_manager_name": "objects",
+            },
             bases=("common.trackedmodel",),
         ),
         migrations.AddField(
@@ -326,7 +344,10 @@ class Migration(migrations.Migration):
                     ),
                 ),
             ],
-            options={"abstract": False, "base_manager_name": "objects",},
+            options={
+                "abstract": False,
+                "base_manager_name": "objects",
+            },
             bases=("common.trackedmodel",),
         ),
         migrations.AddField(
@@ -418,7 +439,10 @@ class Migration(migrations.Migration):
                     ),
                 ),
             ],
-            options={"abstract": False, "base_manager_name": "objects",},
+            options={
+                "abstract": False,
+                "base_manager_name": "objects",
+            },
             bases=("common.trackedmodel", models.Model),
         ),
         migrations.AddField(

--- a/quotas/tests/test_business_rules.py
+++ b/quotas/tests/test_business_rules.py
@@ -48,7 +48,8 @@ def test_ON2(date_ranges, published):
     )
 
     order_number = factories.QuotaOrderNumberFactory(
-        order_number=existing.order_number, valid_between=date_ranges.overlap_normal,
+        order_number=existing.order_number,
+        valid_between=date_ranges.overlap_normal,
     )
 
     with pytest.raises(ValidationError):
@@ -170,7 +171,11 @@ def test_ON12():
 
 @pytest.mark.parametrize(
     "area_code, expect_error",
-    [(AreaCode.COUNTRY, True), (AreaCode.GROUP, False), (AreaCode.REGION, True),],
+    [
+        (AreaCode.COUNTRY, True),
+        (AreaCode.GROUP, False),
+        (AreaCode.REGION, True),
+    ],
 )
 def test_ON13(date_ranges, published, area_code, expect_error):
     """An exclusion can only be entered if the order number origin is a geographical
@@ -181,14 +186,17 @@ def test_ON13(date_ranges, published, area_code, expect_error):
         area_code=area_code, workbasket=published
     )
     member_area = factories.GeographicalAreaFactory(
-        area_code=AreaCode.COUNTRY, workbasket=published,
+        area_code=AreaCode.COUNTRY,
+        workbasket=published,
     )
     if area_code == AreaCode.GROUP:
         factories.GeographicalMembershipFactory(
-            geo_group=geo_area, member=member_area,
+            geo_group=geo_area,
+            member=member_area,
         )
     origin = factories.QuotaOrderNumberOriginFactory(
-        geographical_area=geo_area, workbasket=published,
+        geographical_area=geo_area,
+        workbasket=published,
     )
     exclusion = factories.QuotaOrderNumberOriginExclusionFactory(
         origin=origin, excluded_geographical_area=member_area
@@ -255,7 +263,8 @@ def test_QD7(date_ranges, published):
         valid_between=date_ranges.normal, workbasket=published
     )
     definition = factories.QuotaDefinitionFactory(
-        order_number=order_number, valid_between=date_ranges.overlap_normal,
+        order_number=order_number,
+        valid_between=date_ranges.overlap_normal,
     )
 
     with pytest.raises(ValidationError):
@@ -359,7 +368,13 @@ def test_QA3():
 
 @pytest.mark.parametrize(
     "coefficient, expect_error",
-    [(None, False), (1.0, False), (2.0, False), (0.0, True), (-1.0, True),],
+    [
+        (None, False),
+        (1.0, False),
+        (2.0, False),
+        (0.0, True),
+        (-1.0, True),
+    ],
 )
 def test_QA4(coefficient, expect_error):
     """Whenever a sub-quota receives a coefficient, this has to be a strictly positive
@@ -414,7 +429,8 @@ def test_QA5_pt2(published):
     """
 
     assoc = factories.QuotaAssociationFactory(
-        coefficient=Decimal("1.00000"), sub_quota_relation_type=SubQuotaType.EQUIVALENT,
+        coefficient=Decimal("1.00000"),
+        sub_quota_relation_type=SubQuotaType.EQUIVALENT,
     )
 
     with pytest.raises(ValidationError):
@@ -425,7 +441,8 @@ def test_QA5_pt3(published):
     """A sub-quota defined with the 'normal' type must have a coefficient of 1"""
 
     assoc = factories.QuotaAssociationFactory(
-        coefficient=Decimal("1.20000"), sub_quota_relation_type=SubQuotaType.NORMAL,
+        coefficient=Decimal("1.20000"),
+        sub_quota_relation_type=SubQuotaType.NORMAL,
     )
 
     with pytest.raises(ValidationError):
@@ -455,9 +472,12 @@ def test_blocking_of_fcfs_quotas_only(published):
         mechanism=AdministrationMechanism.LICENSED, workbasket=published
     )
     definition = factories.QuotaDefinitionFactory(
-        workbasket=published, order_number=order_number,
+        workbasket=published,
+        order_number=order_number,
     )
-    blocking = factories.QuotaBlockingFactory(quota_definition=definition,)
+    blocking = factories.QuotaBlockingFactory(
+        quota_definition=definition,
+    )
 
     with pytest.raises(ValidationError):
         blocking.workbasket.submit_for_approval()
@@ -495,9 +515,12 @@ def test_suspension_of_fcfs_quotas_only(published):
         mechanism=AdministrationMechanism.LICENSED, workbasket=published
     )
     definition = factories.QuotaDefinitionFactory(
-        workbasket=published, order_number=order_number,
+        workbasket=published,
+        order_number=order_number,
     )
-    suspension = factories.QuotaSuspensionFactory(quota_definition=definition,)
+    suspension = factories.QuotaSuspensionFactory(
+        quota_definition=definition,
+    )
 
     with pytest.raises(ValidationError):
         suspension.workbasket.submit_for_approval()

--- a/quotas/tests/test_importer.py
+++ b/quotas/tests/test_importer.py
@@ -110,7 +110,8 @@ def test_quota_association_importer_create(valid_user):
     import_taric(xml, valid_user.username, WorkflowStatus.PUBLISHED)
 
     db_association = models.QuotaAssociation.objects.get(
-        main_quota=association.main_quota, sub_quota=association.sub_quota,
+        main_quota=association.main_quota,
+        sub_quota=association.sub_quota,
     )
 
     assert db_association.sub_quota_relation_type == association.sub_quota_relation_type

--- a/quotas/validators.py
+++ b/quotas/validators.py
@@ -234,7 +234,8 @@ def validate_sub_quota_validity_enclosed_by_main_quota_validity(association):
     """QA2"""
 
     if not validity_range_contains_range(
-        association.main_quota.valid_between, association.sub_quota.valid_between,
+        association.main_quota.valid_between,
+        association.sub_quota.valid_between,
     ):
         raise ValidationError(
             "The sub-quota's validity period must be entirely enclosed within the "

--- a/regulations/migrations/0001_initial.py
+++ b/regulations/migrations/0001_initial.py
@@ -30,7 +30,10 @@ class Migration(migrations.Migration):
                     ),
                 ),
             ],
-            options={"abstract": False, "base_manager_name": "objects",},
+            options={
+                "abstract": False,
+                "base_manager_name": "objects",
+            },
             bases=("common.trackedmodel",),
         ),
         migrations.CreateModel(
@@ -49,7 +52,10 @@ class Migration(migrations.Migration):
                 ),
                 ("effective_end_date", models.DateField(null=True)),
             ],
-            options={"abstract": False, "base_manager_name": "objects",},
+            options={
+                "abstract": False,
+                "base_manager_name": "objects",
+            },
             bases=("common.trackedmodel",),
         ),
         migrations.CreateModel(
@@ -82,7 +88,10 @@ class Migration(migrations.Migration):
                 ),
                 ("description", models.CharField(editable=False, max_length=500)),
             ],
-            options={"abstract": False, "base_manager_name": "objects",},
+            options={
+                "abstract": False,
+                "base_manager_name": "objects",
+            },
             bases=("common.trackedmodel", models.Model),
         ),
         migrations.CreateModel(
@@ -251,7 +260,10 @@ class Migration(migrations.Migration):
                     ),
                 ),
             ],
-            options={"abstract": False, "base_manager_name": "objects",},
+            options={
+                "abstract": False,
+                "base_manager_name": "objects",
+            },
             bases=("common.trackedmodel",),
         ),
         migrations.CreateModel(
@@ -286,7 +298,10 @@ class Migration(migrations.Migration):
                     ),
                 ),
             ],
-            options={"abstract": False, "base_manager_name": "objects",},
+            options={
+                "abstract": False,
+                "base_manager_name": "objects",
+            },
             bases=("common.trackedmodel",),
         ),
         migrations.CreateModel(
@@ -321,7 +336,10 @@ class Migration(migrations.Migration):
                     ),
                 ),
             ],
-            options={"abstract": False, "base_manager_name": "objects",},
+            options={
+                "abstract": False,
+                "base_manager_name": "objects",
+            },
             bases=("common.trackedmodel",),
         ),
         migrations.CreateModel(
@@ -358,7 +376,10 @@ class Migration(migrations.Migration):
                     ),
                 ),
             ],
-            options={"abstract": False, "base_manager_name": "objects",},
+            options={
+                "abstract": False,
+                "base_manager_name": "objects",
+            },
             bases=("common.trackedmodel",),
         ),
         migrations.AddField(

--- a/regulations/models.py
+++ b/regulations/models.py
@@ -28,7 +28,9 @@ class Group(TrackedModel, ValidityMixin):
     subrecord_code = "00"
 
     group_id = models.CharField(
-        max_length=3, editable=False, validators=[RegexValidator(r"[A-Z][A-Z][A-Z]")],
+        max_length=3,
+        editable=False,
+        validators=[RegexValidator(r"[A-Z][A-Z][A-Z]")],
     )
     # no need for a separate model as we don't support multiple languages
     description = ShortDescription()
@@ -41,7 +43,11 @@ class Group(TrackedModel, ValidityMixin):
 """The code which indicates whether or not a regulation has been replaced."""
 ReplacementIndicator = models.IntegerChoices(
     "ReplacementIndicator",
-    ["Not replaced", "Replaced", "Partially replaced",],
+    [
+        "Not replaced",
+        "Replaced",
+        "Partially replaced",
+    ],
     start=0,
 )
 
@@ -69,7 +75,9 @@ class Regulation(TrackedModel):
 
     """The regulation number"""
     regulation_id = models.CharField(
-        max_length=8, editable=False, validators=[validators.regulation_id_validator],
+        max_length=8,
+        editable=False,
+        validators=[validators.regulation_id_validator],
     )
 
     official_journal_number = models.CharField(
@@ -132,10 +140,15 @@ class Regulation(TrackedModel):
 
     # Base regulations have community_code and regulation_group
     community_code = models.PositiveIntegerField(
-        choices=CommunityCode.choices, blank=True, null=True,
+        choices=CommunityCode.choices,
+        blank=True,
+        null=True,
     )
     regulation_group = models.ForeignKey(
-        Group, on_delete=models.PROTECT, blank=True, null=True,
+        Group,
+        on_delete=models.PROTECT,
+        blank=True,
+        null=True,
     )
 
     amends = models.ManyToManyField(

--- a/regulations/tests/test_business_rules.py
+++ b/regulations/tests/test_business_rules.py
@@ -16,12 +16,14 @@ def test_ROIMB1():
     regulation_id = "C2000000"
     role_type = 1
     factories.RegulationFactory.create(
-        regulation_id=regulation_id, role_type=role_type,
+        regulation_id=regulation_id,
+        role_type=role_type,
     )
 
     with pytest.raises(django.core.exceptions.ValidationError):
         r = factories.RegulationFactory.build(
-            regulation_id=regulation_id, role_type=role_type,
+            regulation_id=regulation_id,
+            role_type=role_type,
         )
         r.full_clean()
 

--- a/regulations/validators.py
+++ b/regulations/validators.py
@@ -80,7 +80,9 @@ def validate_approved_from_not_approved(regulation):
 
     if not regulation.approved and regulation.values_from_db["approved"]:
         raise ValidationError(
-            {"approved": "Cannot change from Approved to Not Approved",}
+            {
+                "approved": "Cannot change from Approved to Not Approved",
+            }
         )
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 allure-pytest-bdd
-black
+black>=20.8b1
 dj-database-url
 django>=3.0,<3.1
 django-dotenv

--- a/settings/common.py
+++ b/settings/common.py
@@ -83,7 +83,9 @@ MIDDLEWARE = [
 TEMPLATES = [
     {
         "BACKEND": "django.template.backends.jinja2.Jinja2",
-        "DIRS": ["node_modules/govuk-frontend/govuk",],
+        "DIRS": [
+            "node_modules/govuk-frontend/govuk",
+        ],
         "APP_DIRS": True,
         "OPTIONS": {"environment": "common.jinja2.environment"},
     },

--- a/workbaskets/migrations/0001_initial.py
+++ b/workbaskets/migrations/0001_initial.py
@@ -91,7 +91,9 @@ class Migration(migrations.Migration):
                     ),
                 ),
             ],
-            options={"abstract": False,},
+            options={
+                "abstract": False,
+            },
         ),
         migrations.CreateModel(
             name="Transaction",
@@ -116,6 +118,8 @@ class Migration(migrations.Migration):
                     ),
                 ),
             ],
-            options={"abstract": False,},
+            options={
+                "abstract": False,
+            },
         ),
     ]

--- a/workbaskets/models.py
+++ b/workbaskets/models.py
@@ -24,7 +24,9 @@ class WorkBasket(TimestampedMixin):
         blank=True, help_text="Reason for the changes to the tariff"
     )
     author = models.ForeignKey(
-        settings.AUTH_USER_MODEL, on_delete=models.PROTECT, editable=False,
+        settings.AUTH_USER_MODEL,
+        on_delete=models.PROTECT,
+        editable=False,
     )
     approver = models.ForeignKey(
         settings.AUTH_USER_MODEL,
@@ -34,7 +36,8 @@ class WorkBasket(TimestampedMixin):
         related_name="approved_workbaskets",
     )
     status = FSMField(
-        default=WorkflowStatus.NEW_IN_PROGRESS, choices=WorkflowStatus.choices,
+        default=WorkflowStatus.NEW_IN_PROGRESS,
+        choices=WorkflowStatus.choices,
     )
 
     def __str__(self):
@@ -42,7 +45,10 @@ class WorkBasket(TimestampedMixin):
 
     @transition(
         field=status,
-        source=[WorkflowStatus.NEW_IN_PROGRESS, WorkflowStatus.EDITING,],
+        source=[
+            WorkflowStatus.NEW_IN_PROGRESS,
+            WorkflowStatus.EDITING,
+        ],
         target=WorkflowStatus.AWAITING_APPROVAL,
     )
     def submit_for_approval(self):
@@ -154,7 +160,9 @@ class Transaction(TimestampedMixin):
     """A Transaction is created once the WorkBasket has been sent for approval"""
 
     workbasket = models.OneToOneField(
-        WorkBasket, on_delete=models.PROTECT, editable=False,
+        WorkBasket,
+        on_delete=models.PROTECT,
+        editable=False,
     )
 
     def to_json(self):

--- a/workbaskets/views/__init__.py
+++ b/workbaskets/views/__init__.py
@@ -64,7 +64,10 @@ class WorkBasketUIViewSet(WorkBasketViewSet):
     @action(detail=False, methods=["get"])
     def choose_or_create(self, request):
         queryset = self.filter_queryset(self.get_queryset()).filter(
-            status__in=[WorkflowStatus.NEW_IN_PROGRESS, WorkflowStatus.EDITING,],
+            status__in=[
+                WorkflowStatus.NEW_IN_PROGRESS,
+                WorkflowStatus.EDITING,
+            ],
         )
         return render(
             request, "workbaskets/choose-or-create.jinja", context={"objects": queryset}


### PR DESCRIPTION
The latest `black` beta is more aggressive about
splitting across multiple lines.

We have chosen to stay updated to the latest
version for now so this commit applies those
reformats.

It also forces using the new version in our
requirements.txt so that there's no disparity
between what we run locally and in PR checks.