### PR TITLE
TP-300: Apply importer to certificates models.py

### DIFF
--- a/additional_codes/import_parsers.py
+++ b/additional_codes/import_parsers.py
@@ -1,5 +1,6 @@
 from importer.namespaces import Tag
 from importer.parsers import ElementParser
+from importer.parsers import IntElement
 from importer.parsers import TextElement
 from importer.parsers import ValidityMixin
 from importer.parsers import Writable
@@ -24,15 +25,11 @@ class AdditionalCodeParser(ValidityMixin, Writable, ElementParser):
 
     tag = Tag("additional.code")
 
-    sid = TextElement(Tag("additional.code.sid"))
+    sid = IntElement(Tag("additional.code.sid"))
     type__sid = TextElement(Tag("additional.code.type.id"))
     code = TextElement(Tag("additional.code"))
     valid_between_lower = TextElement(Tag("validity.start.date"))
     valid_between_upper = TextElement(Tag("validity.end.date"))
-
-    def clean(self):
-        self.data["sid"] = int(self.data["sid"])
-        return super().clean()
 
 
 @Record.register_child("additional_code_description_period")

--- a/certificates/import_handlers.py
+++ b/certificates/import_handlers.py
@@ -1,4 +1,5 @@
 from certificates import import_parsers as parsers
+from certificates import models
 from certificates import serializers
 from importer.handlers import BaseHandler
 
@@ -8,21 +9,57 @@ class CertificateTypeHandler(BaseHandler):
     tag = parsers.CertificateTypeParser.tag.name
 
 
+@CertificateTypeHandler.register_dependant
 class CertificateTypeDescriptionHandler(BaseHandler):
+    dependencies = [
+        CertificateTypeHandler,
+    ]
     serializer_class = serializers.CertificateTypeSerializer
     tag = parsers.CertificateTypeDescriptionParser.tag.name
 
 
 class CertificateHandler(BaseHandler):
+    links = (
+        {
+            "model": models.CertificateType,
+            "name": "certificate_type",
+        },
+    )
+
     serializer_class = serializers.CertificateSerializer
     tag = parsers.CertificateParser.tag.name
 
 
-class CertificateDescriptionHandler(BaseHandler):
+class BaseCertificateDescriptionHandler(BaseHandler):
+    links = (
+        {
+            "identifying_fields": ("sid", "certificate_type__sid"),
+            "model": models.Certificate,
+            "name": "described_certificate",
+        },
+    )
+    serializer_class = serializers.CertificateDescriptionSerializer
+    tag = "BaseCertificateDescriptionHandler"
+
+    def get_described_certificate_link(self, model, kwargs):
+        certificate_type = models.CertificateType.objects.get_latest_version(
+            sid=kwargs.pop("certificate_type__sid")
+        )
+        obj = model.objects.get_latest_version(
+            certificate_type=certificate_type, **kwargs
+        )
+        return obj
+
+
+class CertificateDescriptionHandler(BaseCertificateDescriptionHandler):
     serializer_class = serializers.CertificateDescriptionSerializer
     tag = parsers.CertificateDescriptionParser.tag.name
 
 
-class CertificateDescriptionPeriodHandler(BaseHandler):
+@CertificateDescriptionHandler.register_dependant
+class CertificateDescriptionPeriodHandler(BaseCertificateDescriptionHandler):
+    dependencies = [
+        CertificateDescriptionHandler,
+    ]
     serializer_class = serializers.CertificateDescriptionSerializer
     tag = parsers.CertificateDescriptionPeriodParser.tag.name

--- a/certificates/import_parsers.py
+++ b/certificates/import_parsers.py
@@ -1,43 +1,115 @@
 from importer.namespaces import Tag
 from importer.parsers import ElementParser
+from importer.parsers import IntElement
 from importer.parsers import TextElement
 from importer.parsers import ValidityMixin
 from importer.parsers import Writable
+from importer.taric import Record
 
 
+@Record.register_child("certificate_type")
 class CertificateTypeParser(ValidityMixin, Writable, ElementParser):
+    """
+    <xs:element name="certificate.type" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="certificate.type.code" type="CertificateTypeCode"/>
+                <xs:element name="validity.start.date" type="Date"/>
+                <xs:element name="validity.end.date" type="Date" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    """
+
     tag = Tag("certificate.type")
 
     sid = TextElement(Tag("certificate.type.code"))
-    valid_between_lower = TextElement(Tag("validity.start.date"))
-    valid_between_upper = TextElement(Tag("validity.end.date"))
 
 
+@Record.register_child("certificate_type_description")
 class CertificateTypeDescriptionParser(Writable, ElementParser):
+    """
+    <xs:element name="certificate.type.description" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="certificate.type.code" type="CertificateTypeCode"/>
+                <xs:element name="language.id" type="LanguageId"/>
+                <xs:element name="description" type="ShortDescription" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    """
+
     tag = Tag("certificate.type.description")
 
     sid = TextElement(Tag("certificate.type.code"))
     description = TextElement(Tag("description"))
 
 
+@Record.register_child("certificate")
 class CertificateParser(ValidityMixin, Writable, ElementParser):
+    """
+    <xs:element name="certificate" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="certificate.type.code" type="CertificateTypeCode"/>
+                <xs:element name="certificate.code" type="CertificateCode"/>
+                <xs:element name="validity.start.date" type="Date"/>
+                <xs:element name="validity.end.date" type="Date" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    """
+
     tag = Tag("certificate")
 
-    sid = TextElement(Tag("certificate.type.code"))
+    sid = TextElement(Tag("certificate.code"))
+    certificate_type__sid = TextElement(Tag("certificate.type.code"))
 
 
+@Record.register_child("certificate_description")
 class CertificateDescriptionParser(Writable, ElementParser):
+    """
+    <xs:element name="certificate.description" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="certificate.description.period.sid" type="SID"/>
+                <xs:element name="language.id" type="LanguageId"/>
+                <xs:element name="certificate.type.code" type="CertificateTypeCode"/>
+                <xs:element name="certificate.code" type="CertificateCode"/>
+                <xs:element name="description" type="ShortDescription" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    """
+
     tag = Tag("certificate.description")
 
-    sid = TextElement(Tag("certificate.description.period.sid"))
+    sid = IntElement(Tag("certificate.description.period.sid"))
     description = TextElement(Tag("description"))
-    certificate_sid = TextElement(Tag("certificate.code"))
-    certificate_type_sid = TextElement(Tag("certificate.code"))
+    described_certificate__sid = TextElement(Tag("certificate.code"))
+    described_certificate__type__sid = TextElement(Tag("certificate.type.code"))
 
 
+@Record.register_child("certificate_description_period")
 class CertificateDescriptionPeriodParser(ValidityMixin, Writable, ElementParser):
+    """
+    <xs:element name="certificate.description.period" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="certificate.description.period.sid" type="SID"/>
+                <xs:element name="certificate.type.code" type="CertificateTypeCode"/>
+                <xs:element name="certificate.code" type="CertificateCode"/>
+                <xs:element name="validity.start.date" type="Date"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    """
+
     tag = Tag("certificate.description.period")
 
-    sid = TextElement(Tag("certificate.description.period.sid"))
-    valid_between_lower = TextElement(Tag("validity.start.date"))
-    valid_between_upper = TextElement(Tag("validity.end.date"))
+    sid = IntElement(Tag("certificate.description.period.sid"))
+    described_certificate__sid = TextElement(Tag("certificate.code"))
+    described_certificate__certificate_type__sid = TextElement(
+        Tag("certificate.type.code")
+    )

--- a/certificates/models.py
+++ b/certificates/models.py
@@ -1,6 +1,5 @@
 from django.contrib.postgres.constraints import ExclusionConstraint
 from django.contrib.postgres.fields import RangeOperators
-from django.core.validators import MaxValueValidator
 from django.db import models
 
 from certificates import validators

--- a/certificates/serializers.py
+++ b/certificates/serializers.py
@@ -1,7 +1,10 @@
+from rest_framework import serializers
+
 from certificates import models
 from common.serializers import TrackedModelSerializer
 from common.serializers import TrackedModelSerializerMixin
 from common.serializers import ValiditySerializerMixin
+from common.validators import NumericSIDValidator
 
 
 @TrackedModelSerializer.register_polymorphic_model
@@ -19,6 +22,7 @@ class CertificateTypeSerializer(TrackedModelSerializerMixin, ValiditySerializerM
             "taric_template",
             "start_date",
             "end_date",
+            "valid_between",
         ]
 
 
@@ -37,6 +41,7 @@ class CertificateSerializer(TrackedModelSerializerMixin, ValiditySerializerMixin
             "taric_template",
             "start_date",
             "end_date",
+            "valid_between",
         ]
 
 
@@ -45,6 +50,7 @@ class CertificateDescriptionSerializer(
     TrackedModelSerializerMixin, ValiditySerializerMixin
 ):
     described_certificate = CertificateSerializer(read_only=True)
+    sid = serializers.IntegerField(validators=[NumericSIDValidator()])
 
     class Meta:
         model = models.CertificateDescription
@@ -60,4 +66,5 @@ class CertificateDescriptionSerializer(
             "taric_template",
             "start_date",
             "end_date",
+            "valid_between",
         ]

--- a/certificates/tests/test_importer.py
+++ b/certificates/tests/test_importer.py
@@ -1,3 +1,40 @@
 import pytest
 
+from certificates import serializers
+from common.tests import factories
+from common.tests.util import validate_taric_import
+
 pytestmark = pytest.mark.django_db
+
+
+@validate_taric_import(
+    serializers.CertificateTypeSerializer, factories.CertificateTypeFactory
+)
+def test_certificate_type_importer_create(valid_user, test_object, db_object):
+    assert db_object.sid == test_object.sid
+    assert db_object.description == test_object.description
+    assert db_object.valid_between.lower == test_object.valid_between.lower
+    assert db_object.valid_between.upper == test_object.valid_between.upper
+
+
+@validate_taric_import(
+    serializers.CertificateSerializer,
+    factories.CertificateFactory,
+    dependencies={"certificate_type": factories.CertificateTypeFactory},
+)
+def test_certificate_importer_create(valid_user, test_object, db_object):
+    assert db_object.sid == test_object.sid
+    assert db_object.certificate_type == test_object.certificate_type
+
+
+@validate_taric_import(
+    serializers.CertificateDescriptionSerializer,
+    factories.CertificateDescriptionFactory,
+    dependencies={"described_certificate": factories.CertificateFactory},
+)
+def test_certificate_description_importer_create(valid_user, test_object, db_object):
+    assert db_object.sid == test_object.sid
+    assert db_object.description == test_object.description
+    assert db_object.described_certificate == test_object.described_certificate
+    assert db_object.valid_between.lower == test_object.valid_between.lower
+    assert db_object.valid_between.upper == test_object.valid_between.upper

--- a/commodities/models.py
+++ b/commodities/models.py
@@ -221,6 +221,8 @@ class FootnoteAssociationGoodsNomenclature(TrackedModel, ValidityMixin):
         "footnotes.Footnote", on_delete=models.PROTECT
     )
 
+    identifying_fields = "goods_nomenclature", "associated_footnote"
+
     def clean(self):
         validators.validate_goods_validity_includes_footnote_association(self)
         validators.validate_footnote_validity_includes_footnote_association(self)

--- a/common/assets/taric3.xsd
+++ b/common/assets/taric3.xsd
@@ -1,1803 +1,1803 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Implementation of TARIC3-TMES v5.10 (18/05/2015) -->
 <xs:schema xmlns="urn:publicid:-:DGTAXUD:TARIC:MESSAGE:1.0" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:envelope="urn:publicid:-:DGTAXUD:GENERAL:ENVELOPE:1.0" xmlns:xml="http://www.w3.org/XML/1998/namespace" targetNamespace="urn:publicid:-:DGTAXUD:TARIC:MESSAGE:1.0" elementFormDefault="qualified" attributeFormDefault="unqualified">
-	<xs:import namespace="http://www.w3.org/XML/1998/namespace" schemaLocation="xml.xsd">
-		<xs:annotation>
-			<xs:documentation>Get access to the xml: attribute groups for xml:lang as declared on
+    <xs:import namespace="http://www.w3.org/XML/1998/namespace" schemaLocation="xml.xsd">
+        <xs:annotation>
+            <xs:documentation>Get access to the xml: attribute groups for xml:lang as declared on
         &apos;schema&apos; and &apos;documentation&apos;
       below</xs:documentation>
-		</xs:annotation>
-	</xs:import>
-	<xs:import namespace="urn:publicid:-:DGTAXUD:GENERAL:ENVELOPE:1.0" schemaLocation="envelope.xsd"/>
-	<!-- Technical data -->
-	<xs:simpleType name="RecordCode">
-		<xs:restriction base="xs:string">
-			<xs:pattern value="\d\d\d"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:simpleType name="RecordSequenceNumber">
-		<xs:restriction base="xs:int">
-			<xs:minInclusive value="1"/>
-			<xs:maxInclusive value="99999999"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:simpleType name="SubRecordCode">
-		<xs:restriction base="xs:string">
-			<xs:pattern value="\d\d"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:simpleType name="TransactionId">
-		<xs:restriction base="xs:integer">
-			<xs:minInclusive value="1"/>
-			<xs:maxInclusive value="9999999999"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:simpleType name="UpdateType">
-		<xs:restriction base="xs:string">
-			<xs:annotation>
-				<xs:documentation>1-Update, 2-Delete, 3-Insert</xs:documentation>
-			</xs:annotation>
-			<xs:length value="1"/>
-			<xs:enumeration value="1">
-				<xs:annotation>
-					<xs:documentation>Update</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="2">
-				<xs:annotation>
-					<xs:documentation>Delete</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="3">
-				<xs:annotation>
-					<xs:documentation>Insert</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-		</xs:restriction>
-	</xs:simpleType>
-	<!-- Technical elements -->
-	<xs:element name="abstract.record" abstract="true"/>
-	<xs:element name="transmission" substitutionGroup="envelope:abstract.message">
-		<xs:annotation>
-			<xs:documentation>Contains a transmission</xs:documentation>
-		</xs:annotation>
-		<xs:complexType>
-			<xs:sequence>
-				<xs:element name="record">
-					<xs:complexType>
-						<xs:sequence>
-							<xs:element name="transaction.id" type="TransactionId"/>
-							<xs:element name="record.code" type="RecordCode"/>
-							<xs:element name="subrecord.code" type="SubRecordCode"/>
-							<xs:element name="record.sequence.number" type="RecordSequenceNumber"/>
-							<xs:element name="update.type" type="UpdateType"/>
-							<xs:element ref="abstract.record"/>
-						</xs:sequence>
-					</xs:complexType>
-				</xs:element>
-			</xs:sequence>
-			<xs:attribute ref="xml:lang" default="en-GB"/>
-		</xs:complexType>
-	</xs:element>
-	<xs:element name="transmission.comment" substitutionGroup="abstract.record">
-		<xs:complexType>
-			<xs:sequence>
-				<xs:element name="comment.sid" type="SID"/>
-				<xs:element name="language.id" type="LanguageId"/>
-				<xs:element name="comment.text" type="LongDescription" minOccurs="0"/>
-			</xs:sequence>
-		</xs:complexType>
-	</xs:element>
-	<!-- Business data -->
-	<xs:simpleType name="ActionCode">
-		<xs:restriction base="xs:string">
-			<xs:pattern value="\d\d\d?"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:simpleType name="AdditionalCode">
-		<xs:restriction base="xs:string">
-			<xs:length value="3"/>
-			<xs:pattern value="[A-Z0-9][A-Z0-9][A-Z0-9]"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:simpleType name="AdditionalCodeTypeId">
-		<xs:restriction base="xs:string">
-			<xs:length value="1"/>
-			<xs:pattern value="[A-Z0-9]"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:simpleType name="ApplicationCodeAdditionalCode">
-		<xs:restriction base="xs:string">
-			<xs:length value="1"/>
-			<xs:enumeration value="0"/>
-			<xs:enumeration value="1"/>
-			<xs:enumeration value="3"/>
-			<xs:enumeration value="4"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:simpleType name="ApplicationCodeFootnote">
-		<xs:restriction base="xs:string">
-			<xs:length value="1"/>
-			<xs:enumeration value="1"/>
-			<xs:enumeration value="2"/>
-			<xs:enumeration value="3"/>
-			<xs:enumeration value="4"/>
-			<xs:enumeration value="5"/>
-			<xs:enumeration value="6"/>
-			<xs:enumeration value="7"/>
-			<xs:enumeration value="8"/>
-			<xs:enumeration value="9"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:simpleType name="ApprovedFlag">
-		<xs:restriction base="xs:string">
-			<xs:length value="1"/>
-			<xs:enumeration value="0"/>
-			<xs:enumeration value="1"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:simpleType name="AreaCode">
-		<xs:restriction base="xs:string">
-			<xs:length value="1"/>
-			<xs:enumeration value="0"/>
-			<xs:enumeration value="1"/>
-			<xs:enumeration value="2"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:simpleType name="CertificateCode">
-		<xs:restriction base="xs:string">
-			<xs:length value="3"/>
-			<xs:pattern value="[A-Z0-9][A-Z0-9][A-Z0-9]"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:simpleType name="CertificateTypeCode">
-		<xs:restriction base="xs:string">
-			<xs:length value="1"/>
-			<xs:pattern value="[A-Z0-9]"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:simpleType name="ChapterHeading">
-		<xs:restriction base="xs:string">
-			<xs:length value="2"/>
-			<xs:pattern value="[0-9][0-9]"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:simpleType name="Code">
-		<xs:restriction base="xs:string">
-			<xs:maxLength value="10"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:simpleType name="CodeTypeId">
-		<xs:restriction base="xs:string">
-			<xs:maxLength value="4"/>
-			<xs:enumeration value="ACT"/>
-			<xs:enumeration value="COND"/>
-			<xs:enumeration value="DE"/>
-			<xs:enumeration value="GA"/>
-			<xs:enumeration value="MOU"/>
-			<xs:enumeration value="MQC"/>
-			<xs:enumeration value="MT"/>
-			<xs:enumeration value="NG"/>
-			<xs:enumeration value="RLTP"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:simpleType name="CommunityCode">
-		<xs:restriction base="xs:string">
-			<xs:length value="1"/>
-			<xs:enumeration value="1"/>
-			<xs:enumeration value="2"/>
-			<xs:enumeration value="3"/>
-			<xs:enumeration value="4"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:simpleType name="ComponentSequenceNumber">
-		<xs:restriction base="xs:int">
-			<xs:minInclusive value="1"/>
-			<xs:maxInclusive value="999"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:simpleType name="ConditionCode">
-		<xs:restriction base="xs:string">
-			<xs:pattern value="[A-Z][A-Z]?"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:simpleType name="Date">
-		<xs:annotation>
-			<xs:documentation>Date format</xs:documentation>
-		</xs:annotation>
-		<xs:restriction base="xs:date">
-			<xs:pattern value="\d{4}-\d{2}-\d{2}"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:simpleType name="DutyAmount">
-		<xs:restriction base="xs:decimal">
-			<xs:maxInclusive value="9999999.999"/>
-			<xs:fractionDigits value="3"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:simpleType name="DutyAmountApplicabilityCode">
-		<xs:restriction base="xs:int">
-			<xs:enumeration value="0"/>
-			<xs:enumeration value="1"/>
-			<xs:enumeration value="2"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:simpleType name="DutyExpressionId">
-		<xs:restriction base="xs:string">
-			<xs:length value="2"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:simpleType name="ExchangeRate">
-		<xs:restriction base="xs:decimal">
-			<xs:maxInclusive value="99999999.99999999"/>
-			<xs:fractionDigits value="8"/>
-			<xs:minExclusive value="0"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:simpleType name="ExportRefundCode">
-		<xs:restriction base="xs:string">
-			<xs:length value="3"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:simpleType name="FootnoteId">
-		<xs:restriction base="xs:string">
-			<xs:pattern value="[0-9]{5}|[0-9]{3}"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:simpleType name="FootnoteTypeId">
-		<xs:restriction base="xs:string">
-			<xs:pattern value="[A-Z]{2}|[A-Z]{3}|[0-9]{2}"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:simpleType name="GeographicalAreaId">
-		<xs:restriction base="xs:string">
-			<xs:maxLength value="4"/>
-			<xs:pattern value="[A-Z0-9]{2}|[A-Z0-9]{4}"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:simpleType name="GoodsNomenclatureItemId">
-		<xs:restriction base="xs:string">
-			<xs:length value="10"/>
-			<xs:pattern value="[0-9]{10}"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:simpleType name="GoodsNomenclatureGroupId">
-		<xs:restriction base="xs:string">
-			<xs:maxLength value="6"/>
-			<xs:pattern value="[0-9]{6}"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:simpleType name="GoodsNomenclatureGroupType">
-		<xs:restriction base="xs:string">
-			<xs:length value="1"/>
-			<xs:pattern value="[A-Z]"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:simpleType name="LanguageId">
-		<xs:restriction base="xs:string">
-			<xs:length value="2"/>
-			<xs:pattern value="[A-Z][A-Z]"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:simpleType name="LongDescription">
-		<xs:restriction base="xs:string">
-			<xs:maxLength value="20000"/>
-		<!-- RTC 14311 -->
+        </xs:annotation>
+    </xs:import>
+    <xs:import namespace="urn:publicid:-:DGTAXUD:GENERAL:ENVELOPE:1.0" schemaLocation="envelope.xsd"/>
+    <!-- Technical data -->
+    <xs:simpleType name="RecordCode">
+        <xs:restriction base="xs:string">
+            <xs:pattern value="\d\d\d"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="RecordSequenceNumber">
+        <xs:restriction base="xs:int">
+            <xs:minInclusive value="1"/>
+            <xs:maxInclusive value="99999999"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="SubRecordCode">
+        <xs:restriction base="xs:string">
+            <xs:pattern value="\d\d"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="TransactionId">
+        <xs:restriction base="xs:integer">
+            <xs:minInclusive value="1"/>
+            <xs:maxInclusive value="9999999999"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="UpdateType">
+        <xs:restriction base="xs:string">
+            <xs:annotation>
+                <xs:documentation>1-Update, 2-Delete, 3-Insert</xs:documentation>
+            </xs:annotation>
+            <xs:length value="1"/>
+            <xs:enumeration value="1">
+                <xs:annotation>
+                    <xs:documentation>Update</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="2">
+                <xs:annotation>
+                    <xs:documentation>Delete</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="3">
+                <xs:annotation>
+                    <xs:documentation>Insert</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+        </xs:restriction>
+    </xs:simpleType>
+    <!-- Technical elements -->
+    <xs:element name="abstract.record" abstract="true"/>
+    <xs:element name="transmission" substitutionGroup="envelope:abstract.message">
+        <xs:annotation>
+            <xs:documentation>Contains a transmission</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="record">
+                    <xs:complexType>
+                        <xs:sequence>
+                            <xs:element name="transaction.id" type="TransactionId"/>
+                            <xs:element name="record.code" type="RecordCode"/>
+                            <xs:element name="subrecord.code" type="SubRecordCode"/>
+                            <xs:element name="record.sequence.number" type="RecordSequenceNumber"/>
+                            <xs:element name="update.type" type="UpdateType"/>
+                            <xs:element ref="abstract.record"/>
+                        </xs:sequence>
+                    </xs:complexType>
+                </xs:element>
+            </xs:sequence>
+            <xs:attribute ref="xml:lang" default="en-GB"/>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="transmission.comment" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="comment.sid" type="SID"/>
+                <xs:element name="language.id" type="LanguageId"/>
+                <xs:element name="comment.text" type="LongDescription" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <!-- Business data -->
+    <xs:simpleType name="ActionCode">
+        <xs:restriction base="xs:string">
+            <xs:pattern value="\d\d\d?"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="AdditionalCode">
+        <xs:restriction base="xs:string">
+            <xs:length value="3"/>
+            <xs:pattern value="[A-Z0-9][A-Z0-9][A-Z0-9]"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="AdditionalCodeTypeId">
+        <xs:restriction base="xs:string">
+            <xs:length value="1"/>
+            <xs:pattern value="[A-Z0-9]"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="ApplicationCodeAdditionalCode">
+        <xs:restriction base="xs:string">
+            <xs:length value="1"/>
+            <xs:enumeration value="0"/>
+            <xs:enumeration value="1"/>
+            <xs:enumeration value="3"/>
+            <xs:enumeration value="4"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="ApplicationCodeFootnote">
+        <xs:restriction base="xs:string">
+            <xs:length value="1"/>
+            <xs:enumeration value="1"/>
+            <xs:enumeration value="2"/>
+            <xs:enumeration value="3"/>
+            <xs:enumeration value="4"/>
+            <xs:enumeration value="5"/>
+            <xs:enumeration value="6"/>
+            <xs:enumeration value="7"/>
+            <xs:enumeration value="8"/>
+            <xs:enumeration value="9"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="ApprovedFlag">
+        <xs:restriction base="xs:string">
+            <xs:length value="1"/>
+            <xs:enumeration value="0"/>
+            <xs:enumeration value="1"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="AreaCode">
+        <xs:restriction base="xs:string">
+            <xs:length value="1"/>
+            <xs:enumeration value="0"/>
+            <xs:enumeration value="1"/>
+            <xs:enumeration value="2"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="CertificateCode">
+        <xs:restriction base="xs:string">
+            <xs:length value="3"/>
+            <xs:pattern value="[A-Z0-9][A-Z0-9][A-Z0-9]"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="CertificateTypeCode">
+        <xs:restriction base="xs:string">
+            <xs:length value="1"/>
+            <xs:pattern value="[A-Z0-9]"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="ChapterHeading">
+        <xs:restriction base="xs:string">
+            <xs:length value="2"/>
+            <xs:pattern value="[0-9][0-9]"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="Code">
+        <xs:restriction base="xs:string">
+            <xs:maxLength value="10"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="CodeTypeId">
+        <xs:restriction base="xs:string">
+            <xs:maxLength value="4"/>
+            <xs:enumeration value="ACT"/>
+            <xs:enumeration value="COND"/>
+            <xs:enumeration value="DE"/>
+            <xs:enumeration value="GA"/>
+            <xs:enumeration value="MOU"/>
+            <xs:enumeration value="MQC"/>
+            <xs:enumeration value="MT"/>
+            <xs:enumeration value="NG"/>
+            <xs:enumeration value="RLTP"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="CommunityCode">
+        <xs:restriction base="xs:string">
+            <xs:length value="1"/>
+            <xs:enumeration value="1"/>
+            <xs:enumeration value="2"/>
+            <xs:enumeration value="3"/>
+            <xs:enumeration value="4"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="ComponentSequenceNumber">
+        <xs:restriction base="xs:int">
+            <xs:minInclusive value="1"/>
+            <xs:maxInclusive value="999"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="ConditionCode">
+        <xs:restriction base="xs:string">
+            <xs:pattern value="[A-Z][A-Z]?"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="Date">
+        <xs:annotation>
+            <xs:documentation>Date format</xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:date">
+            <xs:pattern value="\d{4}-\d{2}-\d{2}"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="DutyAmount">
+        <xs:restriction base="xs:decimal">
+            <xs:maxInclusive value="9999999.999"/>
+            <xs:fractionDigits value="3"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="DutyAmountApplicabilityCode">
+        <xs:restriction base="xs:int">
+            <xs:enumeration value="0"/>
+            <xs:enumeration value="1"/>
+            <xs:enumeration value="2"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="DutyExpressionId">
+        <xs:restriction base="xs:string">
+            <xs:length value="2"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="ExchangeRate">
+        <xs:restriction base="xs:decimal">
+            <xs:maxInclusive value="99999999.99999999"/>
+            <xs:fractionDigits value="8"/>
+            <xs:minExclusive value="0"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="ExportRefundCode">
+        <xs:restriction base="xs:string">
+            <xs:length value="3"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="FootnoteId">
+        <xs:restriction base="xs:string">
+            <xs:pattern value="[0-9]{5}|[0-9]{3}"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="FootnoteTypeId">
+        <xs:restriction base="xs:string">
+            <xs:pattern value="[A-Z]{2}|[A-Z]{3}|[0-9]{2}"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="GeographicalAreaId">
+        <xs:restriction base="xs:string">
+            <xs:maxLength value="4"/>
+            <xs:pattern value="[A-Z0-9]{2}|[A-Z0-9]{4}"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="GoodsNomenclatureItemId">
+        <xs:restriction base="xs:string">
+            <xs:length value="10"/>
+            <xs:pattern value="[0-9]{10}"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="GoodsNomenclatureGroupId">
+        <xs:restriction base="xs:string">
+            <xs:maxLength value="6"/>
+            <xs:pattern value="[0-9]{6}"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="GoodsNomenclatureGroupType">
+        <xs:restriction base="xs:string">
+            <xs:length value="1"/>
+            <xs:pattern value="[A-Z]"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="LanguageId">
+        <xs:restriction base="xs:string">
+            <xs:length value="2"/>
+            <xs:pattern value="[A-Z][A-Z]"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="LongDescription">
+        <xs:restriction base="xs:string">
+            <xs:maxLength value="20000"/>
+        <!-- RTC 14311 -->
     </xs:restriction>
    </xs:simpleType>
-	<xs:simpleType name="MeasureExplosionLevel">
-		<xs:restriction base="xs:int">
-			<xs:enumeration value="2"/>
-			<xs:enumeration value="4"/>
-			<xs:enumeration value="6"/>
-			<xs:enumeration value="8"/>
-			<xs:enumeration value="10"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:simpleType name="MeasurementUnitApplicabilityCode">
-		<xs:restriction base="xs:string">
-			<xs:length value="1"/>
-			<xs:enumeration value="0"/>
-			<xs:enumeration value="1"/>
-			<xs:enumeration value="2"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:simpleType name="MeasurementUnitCode">
-		<xs:restriction base="xs:string">
-			<xs:length value="3"/>
-			<xs:pattern value="[A-Z][A-Z][A-Z]"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:simpleType name="MeasurementUnitQualifierCode">
-		<xs:restriction base="xs:string">
-			<xs:length value="1"/>
-			<xs:pattern value="[A-Z]"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:simpleType name="MeasureTypeId">
-		<xs:restriction base="xs:string">
-			<xs:pattern value="[0-9]{3}|[0-9]{6}"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:simpleType name="MeasureTypeCombination">
-		<xs:restriction base="xs:string">
-			<xs:length value="1"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:simpleType name="MeasureTypeSeriesId">
-		<xs:restriction base="xs:string">
-			<xs:pattern value="[A-Z][A-Z]?"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:simpleType name="MeursingHeadingNumber">
-		<xs:restriction base="xs:string">
-			<xs:pattern value="\d{1,3}"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:simpleType name="MeursingTablePlanId">
-		<xs:restriction base="xs:string">
-			<xs:length value="2"/>
-			<xs:pattern value="\d\d"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:simpleType name="MonetaryUnitApplicabilityCode">
-		<xs:restriction base="xs:string">
-			<xs:length value="1"/>
-			<xs:enumeration value="0"/>
-			<xs:enumeration value="1"/>
-			<xs:enumeration value="2"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:simpleType name="MonetaryUnitCode">
-		<xs:restriction base="xs:string">
-			<xs:length value="3"/>
-			<xs:pattern value="[A-Z]{3}">
-				<xs:annotation>
-					<xs:appinfo>
-						<format xmlns="taric-format">AAA</format>
-					</xs:appinfo>
-				</xs:annotation>
-			</xs:pattern>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:simpleType name="NomenclatureGroupFacilityCode">
-		<xs:restriction base="xs:string">
-			<xs:length value="1"/>
-			<xs:enumeration value="0"/>
-			<xs:enumeration value="2"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:simpleType name="NumberOf">
-		<xs:restriction base="xs:string">
-			<xs:length value="2"/>
-			<xs:pattern value="\d\d"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:simpleType name="OfficialJournalNumber">
-		<xs:restriction base="xs:string">
-			<xs:maxLength value="5"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:simpleType name="OfficialJournalPage">
-		<xs:restriction base="xs:int">
-			<xs:minInclusive value="1"/>
-			<xs:maxInclusive value="9999"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:simpleType name="OrderNumber">
-		<xs:restriction base="xs:string">
-			<xs:length value="6"/>
-			<xs:pattern value="[0-9]{6}"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:simpleType name="OrderNumberCaptureCode">
-		<xs:restriction base="xs:string">
-			<xs:length value="1"/>
-			<xs:enumeration value="1"/>
-			<xs:enumeration value="2"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:simpleType name="OriginCode">
-		<xs:restriction base="xs:string">
-			<xs:length value="1"/>
-			<xs:enumeration value="0"/>
-			<xs:enumeration value="1"/>
-			<xs:enumeration value="2"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:simpleType name="PriorityCode">
-		<xs:restriction base="xs:string">
-			<xs:length value="1"/>
-			<xs:enumeration value="1"/>
-			<xs:enumeration value="2"/>
-			<xs:enumeration value="3"/>
-			<xs:enumeration value="4"/>
-			<xs:enumeration value="5"/>
-			<xs:enumeration value="6"/>
-			<xs:enumeration value="7"/>
-			<xs:enumeration value="8"/>
-			<xs:enumeration value="9"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:simpleType name="ProductLineSuffix">
-		<xs:restriction base="xs:string">
-			<xs:length value="2"/>
-			<xs:pattern value="[0-9][0-9]"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:simpleType name="PublicationCode">
-		<xs:restriction base="xs:string">
-			<xs:length value="1"/>
-			<xs:enumeration value="0"/>
-			<xs:enumeration value="1"/>
-			<xs:enumeration value="2"/>
-			<xs:enumeration value="3"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:simpleType name="PublicationSigle">
-		<xs:restriction base="xs:string">
-			<xs:maxLength value="20"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:simpleType name="QuotaAmount">
-		<xs:restriction base="xs:decimal">
-			<xs:maxInclusive value="99999999999.999"/>
-			<xs:fractionDigits value="3"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:simpleType name="QuotaCoefficient">
-		<xs:restriction base="xs:decimal">
-			<xs:maxInclusive value="99999999999.99999"/>
-			<xs:fractionDigits value="5"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:simpleType name="QuotaBlockingPeriodType">
-		<xs:restriction base="xs:string">
-			<xs:length value="1"/>
-			<xs:pattern value="[0-9]"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:simpleType name="QuotaCriticalStateCode">
-		<xs:restriction base="xs:string">
-			<xs:length value="1"/>
-			<xs:enumeration value="Y"/>
-			<xs:enumeration value="N"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:simpleType name="QuotaCriticalTreshold">
-		<xs:restriction base="xs:int">
-			<xs:minInclusive value="0"/>
-			<xs:maxInclusive value="100"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:simpleType name="QuotaPrecision">
-		<xs:restriction base="xs:string">
-			<xs:length value="1"/>
-			<xs:enumeration value="0"/>
-			<xs:enumeration value="1"/>
-			<xs:enumeration value="2"/>
-			<xs:enumeration value="3"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:simpleType name="QuotaBlockedStateCode">
-		<xs:restriction base="xs:string">
-			<xs:length value="1"/>
-			<xs:enumeration value="Y"/>
-			<xs:enumeration value="N"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:simpleType name="QuotaExhaustedStateCode">
-		<xs:restriction base="xs:string">
-			<xs:length value="1"/>
-			<xs:enumeration value="Y"/>
-			<xs:enumeration value="N"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:simpleType name="QuotaSuspendedStateCode">
-		<xs:restriction base="xs:string">
-			<xs:length value="1"/>
-			<xs:enumeration value="Y"/>
-			<xs:enumeration value="N"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<!-- QTM148 CUSTD00029679 03/08/2013 CUST-DEV2  -->
-	<xs:simpleType name="QuotaClosedCode">
-		<xs:restriction base="xs:string">
-			<xs:length value="1"/>
-			<xs:enumeration value="Y"/>
-			<xs:enumeration value="N"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<!-- CUSTD00029679 - end  -->
-	<xs:simpleType name="QuotaAllocatedPercentage">
-		<xs:restriction base="xs:decimal">
-			<xs:maxInclusive value="999.999"/>
-			<xs:fractionDigits value="3"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:simpleType name="ReductionIndicator">
-		<xs:restriction base="xs:string">
-			<xs:length value="1"/>
-			<xs:enumeration value="1"/>
-			<xs:enumeration value="2"/>
-			<xs:enumeration value="3"/>
-  		<xs:enumeration value="4"/>
+    <xs:simpleType name="MeasureExplosionLevel">
+        <xs:restriction base="xs:int">
+            <xs:enumeration value="2"/>
+            <xs:enumeration value="4"/>
+            <xs:enumeration value="6"/>
+            <xs:enumeration value="8"/>
+            <xs:enumeration value="10"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="MeasurementUnitApplicabilityCode">
+        <xs:restriction base="xs:string">
+            <xs:length value="1"/>
+            <xs:enumeration value="0"/>
+            <xs:enumeration value="1"/>
+            <xs:enumeration value="2"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="MeasurementUnitCode">
+        <xs:restriction base="xs:string">
+            <xs:length value="3"/>
+            <xs:pattern value="[A-Z][A-Z][A-Z]"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="MeasurementUnitQualifierCode">
+        <xs:restriction base="xs:string">
+            <xs:length value="1"/>
+            <xs:pattern value="[A-Z]"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="MeasureTypeId">
+        <xs:restriction base="xs:string">
+            <xs:pattern value="[0-9]{3}|[0-9]{6}"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="MeasureTypeCombination">
+        <xs:restriction base="xs:string">
+            <xs:length value="1"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="MeasureTypeSeriesId">
+        <xs:restriction base="xs:string">
+            <xs:pattern value="[A-Z][A-Z]?"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="MeursingHeadingNumber">
+        <xs:restriction base="xs:string">
+            <xs:pattern value="\d{1,3}"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="MeursingTablePlanId">
+        <xs:restriction base="xs:string">
+            <xs:length value="2"/>
+            <xs:pattern value="\d\d"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="MonetaryUnitApplicabilityCode">
+        <xs:restriction base="xs:string">
+            <xs:length value="1"/>
+            <xs:enumeration value="0"/>
+            <xs:enumeration value="1"/>
+            <xs:enumeration value="2"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="MonetaryUnitCode">
+        <xs:restriction base="xs:string">
+            <xs:length value="3"/>
+            <xs:pattern value="[A-Z]{3}">
+                <xs:annotation>
+                    <xs:appinfo>
+                        <format xmlns="taric-format">AAA</format>
+                    </xs:appinfo>
+                </xs:annotation>
+            </xs:pattern>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="NomenclatureGroupFacilityCode">
+        <xs:restriction base="xs:string">
+            <xs:length value="1"/>
+            <xs:enumeration value="0"/>
+            <xs:enumeration value="2"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="NumberOf">
+        <xs:restriction base="xs:string">
+            <xs:length value="2"/>
+            <xs:pattern value="\d\d"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="OfficialJournalNumber">
+        <xs:restriction base="xs:string">
+            <xs:maxLength value="5"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="OfficialJournalPage">
+        <xs:restriction base="xs:int">
+            <xs:minInclusive value="1"/>
+            <xs:maxInclusive value="9999"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="OrderNumber">
+        <xs:restriction base="xs:string">
+            <xs:length value="6"/>
+            <xs:pattern value="[0-9]{6}"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="OrderNumberCaptureCode">
+        <xs:restriction base="xs:string">
+            <xs:length value="1"/>
+            <xs:enumeration value="1"/>
+            <xs:enumeration value="2"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="OriginCode">
+        <xs:restriction base="xs:string">
+            <xs:length value="1"/>
+            <xs:enumeration value="0"/>
+            <xs:enumeration value="1"/>
+            <xs:enumeration value="2"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="PriorityCode">
+        <xs:restriction base="xs:string">
+            <xs:length value="1"/>
+            <xs:enumeration value="1"/>
+            <xs:enumeration value="2"/>
+            <xs:enumeration value="3"/>
+            <xs:enumeration value="4"/>
+            <xs:enumeration value="5"/>
+            <xs:enumeration value="6"/>
+            <xs:enumeration value="7"/>
+            <xs:enumeration value="8"/>
+            <xs:enumeration value="9"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="ProductLineSuffix">
+        <xs:restriction base="xs:string">
+            <xs:length value="2"/>
+            <xs:pattern value="[0-9][0-9]"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="PublicationCode">
+        <xs:restriction base="xs:string">
+            <xs:length value="1"/>
+            <xs:enumeration value="0"/>
+            <xs:enumeration value="1"/>
+            <xs:enumeration value="2"/>
+            <xs:enumeration value="3"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="PublicationSigle">
+        <xs:restriction base="xs:string">
+            <xs:maxLength value="20"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="QuotaAmount">
+        <xs:restriction base="xs:decimal">
+            <xs:maxInclusive value="99999999999.999"/>
+            <xs:fractionDigits value="3"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="QuotaCoefficient">
+        <xs:restriction base="xs:decimal">
+            <xs:maxInclusive value="99999999999.99999"/>
+            <xs:fractionDigits value="5"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="QuotaBlockingPeriodType">
+        <xs:restriction base="xs:string">
+            <xs:length value="1"/>
+            <xs:pattern value="[0-9]"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="QuotaCriticalStateCode">
+        <xs:restriction base="xs:string">
+            <xs:length value="1"/>
+            <xs:enumeration value="Y"/>
+            <xs:enumeration value="N"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="QuotaCriticalTreshold">
+        <xs:restriction base="xs:int">
+            <xs:minInclusive value="0"/>
+            <xs:maxInclusive value="100"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="QuotaPrecision">
+        <xs:restriction base="xs:string">
+            <xs:length value="1"/>
+            <xs:enumeration value="0"/>
+            <xs:enumeration value="1"/>
+            <xs:enumeration value="2"/>
+            <xs:enumeration value="3"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="QuotaBlockedStateCode">
+        <xs:restriction base="xs:string">
+            <xs:length value="1"/>
+            <xs:enumeration value="Y"/>
+            <xs:enumeration value="N"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="QuotaExhaustedStateCode">
+        <xs:restriction base="xs:string">
+            <xs:length value="1"/>
+            <xs:enumeration value="Y"/>
+            <xs:enumeration value="N"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="QuotaSuspendedStateCode">
+        <xs:restriction base="xs:string">
+            <xs:length value="1"/>
+            <xs:enumeration value="Y"/>
+            <xs:enumeration value="N"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <!-- QTM148 CUSTD00029679 03/08/2013 CUST-DEV2  -->
+    <xs:simpleType name="QuotaClosedCode">
+        <xs:restriction base="xs:string">
+            <xs:length value="1"/>
+            <xs:enumeration value="Y"/>
+            <xs:enumeration value="N"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <!-- CUSTD00029679 - end  -->
+    <xs:simpleType name="QuotaAllocatedPercentage">
+        <xs:restriction base="xs:decimal">
+            <xs:maxInclusive value="999.999"/>
+            <xs:fractionDigits value="3"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="ReductionIndicator">
+        <xs:restriction base="xs:string">
+            <xs:length value="1"/>
+            <xs:enumeration value="1"/>
+            <xs:enumeration value="2"/>
+            <xs:enumeration value="3"/>
+          <xs:enumeration value="4"/>
       <xs:enumeration value="5"/>
       <xs:enumeration value="6"/>
       <xs:enumeration value="7"/>
       <xs:enumeration value="8"/>
       <xs:enumeration value="9"/>
     </xs:restriction>
-	</xs:simpleType>
-	<xs:simpleType name="RelationType">
-		<xs:restriction base="xs:string">
-			<xs:length value="2"/>
-			<xs:enumeration value="EQ"/>
-			<xs:enumeration value="NM"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:simpleType name="RegulationGroupId">
-		<xs:restriction base="xs:string">
-			<xs:length value="3"/>
-			<xs:pattern value="[A-Z][A-Z][A-Z]"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:simpleType name="RegulationId">
-		<xs:restriction base="xs:string">
-			<xs:length value="8"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:simpleType name="RegulationRoleTypeId">
-		<xs:restriction base="xs:string">
-			<xs:length value="1"/>
-			<xs:enumeration value="1"/>
-			<xs:enumeration value="2"/>
-			<xs:enumeration value="3"/>
-			<xs:enumeration value="4"/>
-			<xs:enumeration value="5"/>
-			<xs:enumeration value="6"/>
-			<xs:enumeration value="7"/>
-			<xs:enumeration value="8"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:simpleType name="ReplacementIndicator">
-		<xs:restriction base="xs:string">
-			<xs:length value="1"/>
-			<xs:enumeration value="0"/>
-			<xs:enumeration value="1"/>
-			<xs:enumeration value="2"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:simpleType name="RowColumnCode">
-		<xs:restriction base="xs:string">
-			<xs:length value="1"/>
-			<xs:enumeration value="0"/>
-			<xs:enumeration value="1"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:simpleType name="ShortDescription">
-		<xs:restriction base="xs:string">
-			<xs:maxLength value="500"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:simpleType name="StoppedFlag">
-		<xs:restriction base="xs:string">
-			<xs:length value="1"/>
-			<xs:enumeration value="0"/>
-			<xs:enumeration value="1"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:simpleType name="SID">
-		<xs:restriction base="xs:int">
-			<xs:minInclusive value="1"/>
-			<xs:maxInclusive value="99999999"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:simpleType name="StatisticalIndicator">
-		<xs:restriction base="xs:string">
-			<xs:length value="1"/>
-			<xs:enumeration value="0"/>
-			<xs:enumeration value="1"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:simpleType name="SubHeadingSequenceNumber">
-		<xs:restriction base="xs:string">
-			<xs:pattern value="\d{1,4}"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:simpleType name="SurveillanceNumber">
-		<xs:restriction base="xs:string">
-			<xs:length value="6"/>
-			<xs:pattern value="[0-9]{6}"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:simpleType name="TableLineSequenceNumber">
-		<xs:restriction base="xs:int">
-			<xs:minInclusive value="1"/>
-			<xs:maxInclusive value="99999"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:simpleType name="Timestamp">
-		<xs:annotation>
-			<xs:documentation>Timestamp format</xs:documentation>
-		</xs:annotation>
-		<xs:restriction base="xs:dateTime">
-			<xs:pattern value="\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:simpleType name="TradeMovementCode">
-		<xs:restriction base="xs:string">
-			<xs:length value="1"/>
-			<xs:enumeration value="0"/>
-			<xs:enumeration value="1"/>
-			<xs:enumeration value="2"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<!--Data elements -->
-	<xs:element name="additional.code" substitutionGroup="abstract.record">
-		<xs:complexType>
-			<xs:sequence>
-				<xs:element name="additional.code.sid" type="SID"/>
-				<xs:element name="additional.code.type.id" type="AdditionalCodeTypeId"/>
-				<xs:element name="additional.code" type="AdditionalCode"/>
-				<xs:element name="validity.start.date" type="Date"/>
-				<xs:element name="validity.end.date" type="Date" minOccurs="0"/>
-			</xs:sequence>
-		</xs:complexType>
-	</xs:element>
-	<xs:element name="additional.code.description.period" substitutionGroup="abstract.record">
-		<xs:complexType>
-			<xs:sequence>
-				<xs:element name="additional.code.description.period.sid" type="SID"/>
-				<xs:element name="additional.code.sid" type="SID"/>
-				<xs:element name="additional.code.type.id" type="AdditionalCodeTypeId"/>
-				<xs:element name="additional.code" type="AdditionalCode"/>
-				<xs:element name="validity.start.date" type="Date"/>
-			</xs:sequence>
-		</xs:complexType>
-	</xs:element>
-	<xs:element name="additional.code.description" substitutionGroup="abstract.record">
-		<xs:complexType>
-			<xs:sequence>
-				<xs:element name="additional.code.description.period.sid" type="SID"/>
-				<xs:element name="language.id" type="LanguageId"/>
-				<xs:element name="additional.code.sid" type="SID"/>
-				<xs:element name="additional.code.type.id" type="AdditionalCodeTypeId"/>
-				<xs:element name="additional.code" type="AdditionalCode"/>
-				<xs:element name="description" type="LongDescription" minOccurs="0"/>
-			</xs:sequence>
-		</xs:complexType>
-	</xs:element>
-	<xs:element name="additional.code.type" substitutionGroup="abstract.record">
-		<xs:complexType>
-			<xs:sequence>
-				<xs:element name="additional.code.type.id" type="AdditionalCodeTypeId"/>
-				<xs:element name="validity.start.date" type="Date"/>
-				<xs:element name="validity.end.date" type="Date" minOccurs="0"/>
-				<xs:element name="application.code" type="ApplicationCodeAdditionalCode"/>
-				<xs:element name="meursing.table.plan.id" type="MeursingTablePlanId" minOccurs="0"/>
-			</xs:sequence>
-		</xs:complexType>
-	</xs:element>
-	<xs:element name="additional.code.type.description" substitutionGroup="abstract.record">
-		<xs:complexType>
-			<xs:sequence>
-				<xs:element name="additional.code.type.id" type="AdditionalCodeTypeId"/>
-				<xs:element name="language.id" type="LanguageId"/>
-				<xs:element name="description" type="ShortDescription" minOccurs="0"/>
-			</xs:sequence>
-		</xs:complexType>
-	</xs:element>
-	<xs:element name="additional.code.type.measure.type" substitutionGroup="abstract.record">
-		<xs:complexType>
-			<xs:sequence>
-				<xs:element name="measure.type.id" type="MeasureTypeId"/>
-				<xs:element name="additional.code.type.id" type="AdditionalCodeTypeId"/>
-				<xs:element name="validity.start.date" type="Date"/>
-				<xs:element name="validity.end.date" type="Date" minOccurs="0"/>
-			</xs:sequence>
-		</xs:complexType>
-	</xs:element>
-	<xs:element name="base.regulation" substitutionGroup="abstract.record">
-		<xs:complexType>
-			<xs:sequence>
-				<xs:element name="base.regulation.role" type="RegulationRoleTypeId"/>
-				<xs:element name="base.regulation.id" type="RegulationId"/>
-				<xs:element name="published.date" type="Date" minOccurs="0"/>
-				<xs:element name="officialjournal.number" type="OfficialJournalNumber" minOccurs="0"/>
-				<xs:element name="officialjournal.page" type="OfficialJournalPage" minOccurs="0"/>
-				<xs:element name="validity.start.date" type="Date"/>
-				<xs:element name="validity.end.date" type="Date" minOccurs="0"/>
-				<xs:element name="effective.end.date" type="Date" minOccurs="0"/>
-				<xs:element name="community.code" type="CommunityCode"/>
-				<xs:element name="regulation.group.id" type="RegulationGroupId"/>
-				<xs:element name="antidumping.regulation.role" type="RegulationRoleTypeId" minOccurs="0"/>
-				<xs:element name="related.antidumping.regulation.id" type="RegulationId" minOccurs="0"/>
-				<xs:element name="complete.abrogation.regulation.role" type="RegulationRoleTypeId" minOccurs="0"/>
-				<xs:element name="complete.abrogation.regulation.id" type="RegulationId" minOccurs="0"/>
-				<xs:element name="explicit.abrogation.regulation.role" type="RegulationRoleTypeId" minOccurs="0"/>
-				<xs:element name="explicit.abrogation.regulation.id" type="RegulationId" minOccurs="0"/>
-				<xs:element name="replacement.indicator" type="ReplacementIndicator"/>
-				<xs:element name="stopped.flag" type="StoppedFlag"/>
-				<xs:element name="information.text" type="ShortDescription" minOccurs="0"/>
-				<xs:element name="approved.flag" type="ApprovedFlag"/>
-			</xs:sequence>
-		</xs:complexType>
-	</xs:element>
-	<xs:element name="ceiling" substitutionGroup="abstract.record">
-		<xs:complexType>
-			<xs:sequence>
-				<xs:element name="surveillance.number" type="SurveillanceNumber"/>
-				<xs:element name="validity.start.date" type="Date"/>
-				<xs:element name="validity.end.date" type="Date" minOccurs="0"/>
-				<xs:element name="ceiling.reached.date" type="Date"/>
-			</xs:sequence>
-		</xs:complexType>
-	</xs:element>
-	<xs:element name="certificate" substitutionGroup="abstract.record">
-		<xs:complexType>
-			<xs:sequence>
-				<xs:element name="certificate.type.code" type="CertificateTypeCode"/>
-				<xs:element name="certificate.code" type="CertificateCode"/>
-				<xs:element name="validity.start.date" type="Date"/>
-				<xs:element name="validity.end.date" type="Date" minOccurs="0"/>
-			</xs:sequence>
-		</xs:complexType>
-	</xs:element>
-	<xs:element name="certificate.description.period" substitutionGroup="abstract.record">
-		<xs:complexType>
-			<xs:sequence>
-				<xs:element name="certificate.description.period.sid" type="SID"/>
-				<xs:element name="certificate.type.code" type="CertificateTypeCode"/>
-				<xs:element name="certificate.code" type="CertificateCode"/>
-				<xs:element name="validity.start.date" type="Date"/>
-			</xs:sequence>
-		</xs:complexType>
-	</xs:element>
-	<xs:element name="certificate.description" substitutionGroup="abstract.record">
-		<xs:complexType>
-			<xs:sequence>
-				<xs:element name="certificate.description.period.sid" type="SID"/>
-				<xs:element name="language.id" type="LanguageId"/>
-				<xs:element name="certificate.type.code" type="CertificateTypeCode"/>
-				<xs:element name="certificate.code" type="CertificateCode"/>
-				<xs:element name="description" type="ShortDescription" minOccurs="0"/>
-			</xs:sequence>
-		</xs:complexType>
-	</xs:element>
-	<xs:element name="certificate.type" substitutionGroup="abstract.record">
-		<xs:complexType>
-			<xs:sequence>
-				<xs:element name="certificate.type.code" type="CertificateTypeCode"/>
-				<xs:element name="validity.start.date" type="Date"/>
-				<xs:element name="validity.end.date" type="Date" minOccurs="0"/>
-			</xs:sequence>
-		</xs:complexType>
-	</xs:element>
-	<xs:element name="certificate.type.description" substitutionGroup="abstract.record">
-		<xs:complexType>
-			<xs:sequence>
-				<xs:element name="certificate.type.code" type="CertificateTypeCode"/>
-				<xs:element name="language.id" type="LanguageId"/>
-				<xs:element name="description" type="ShortDescription" minOccurs="0"/>
-			</xs:sequence>
-		</xs:complexType>
-	</xs:element>
-	<xs:element name="complete.abrogation.regulation" substitutionGroup="abstract.record">
-		<xs:complexType>
-			<xs:sequence>
-				<xs:element name="complete.abrogation.regulation.role" type="RegulationRoleTypeId"/>
-				<xs:element name="complete.abrogation.regulation.id" type="RegulationId"/>
-				<xs:element name="published.date" type="Date" minOccurs="0"/>
-				<xs:element name="officialjournal.number" type="OfficialJournalNumber" minOccurs="0"/>
-				<xs:element name="officialjournal.page" type="OfficialJournalPage" minOccurs="0"/>
-				<xs:element name="replacement.indicator" type="ReplacementIndicator"/>
-				<xs:element name="information.text" type="ShortDescription" minOccurs="0"/>
-				<xs:element name="approved.flag" type="ApprovedFlag"/>
-			</xs:sequence>
-		</xs:complexType>
-	</xs:element>
-	<xs:element name="duty.expression" substitutionGroup="abstract.record">
-		<xs:complexType>
-			<xs:sequence>
-				<xs:element name="duty.expression.id" type="DutyExpressionId"/>
-				<xs:element name="validity.start.date" type="Date"/>
-				<xs:element name="validity.end.date" type="Date" minOccurs="0"/>
-				<xs:element name="duty.amount.applicability.code" type="DutyAmountApplicabilityCode"/>
-				<xs:element name="measurement.unit.applicability.code" type="MeasurementUnitApplicabilityCode"/>
-				<xs:element name="monetary.unit.applicability.code" type="MonetaryUnitApplicabilityCode"/>
-			</xs:sequence>
-		</xs:complexType>
-	</xs:element>
-	<xs:element name="duty.expression.description" substitutionGroup="abstract.record">
-		<xs:complexType>
-			<xs:sequence>
-				<xs:element name="duty.expression.id" type="DutyExpressionId"/>
-				<xs:element name="language.id" type="LanguageId"/>
-				<xs:element name="description" type="ShortDescription" minOccurs="0"/>
-			</xs:sequence>
-		</xs:complexType>
-	</xs:element>
-	<xs:element name="explicit.abrogation.regulation" substitutionGroup="abstract.record">
-		<xs:complexType>
-			<xs:sequence>
-				<xs:element name="explicit.abrogation.regulation.role" type="RegulationRoleTypeId"/>
-				<xs:element name="explicit.abrogation.regulation.id" type="RegulationId"/>
-				<xs:element name="published.date" type="Date" minOccurs="0"/>
-				<xs:element name="officialjournal.number" type="OfficialJournalNumber" minOccurs="0"/>
-				<xs:element name="officialjournal.page" type="OfficialJournalPage" minOccurs="0"/>
-				<xs:element name="replacement.indicator" type="ReplacementIndicator"/>
-				<xs:element name="abrogation.date" type="Date"/>
-				<xs:element name="information.text" type="ShortDescription" minOccurs="0"/>
-				<xs:element name="approved.flag" type="ApprovedFlag"/>
-			</xs:sequence>
-		</xs:complexType>
-	</xs:element>
-	<xs:element name="export.refund.nomenclature" substitutionGroup="abstract.record">
-		<xs:complexType>
-			<xs:sequence>
-				<xs:element name="export.refund.nomenclature.sid" type="SID"/>
-				<xs:element name="goods.nomenclature.item.id" type="GoodsNomenclatureItemId"/>
-				<xs:element name="additional.code.type" type="AdditionalCodeTypeId"/>
-				<xs:element name="export.refund.code" type="ExportRefundCode"/>
-				<xs:element name="productline.suffix" type="ProductLineSuffix"/>
-				<xs:element name="validity.start.date" type="Date"/>
-				<xs:element name="validity.end.date" type="Date" minOccurs="0"/>
-				<xs:element name="goods.nomenclature.sid" type="SID"/>
-			</xs:sequence>
-		</xs:complexType>
-	</xs:element>
-	<xs:element name="export.refund.nomenclature.indents" substitutionGroup="abstract.record">
-		<xs:complexType>
-			<xs:sequence>
-				<xs:element name="export.refund.nomenclature.indents.sid" type="SID"/>
-				<xs:element name="export.refund.nomenclature.sid" type="SID"/>
-				<xs:element name="validity.start.date" type="Date"/>
-				<xs:element name="number.export.refund.nomenclature.indents" type="NumberOf"/>
-				<xs:element name="goods.nomenclature.item.id" type="GoodsNomenclatureItemId"/>
-				<xs:element name="additional.code.type" type="AdditionalCodeTypeId"/>
-				<xs:element name="export.refund.code" type="ExportRefundCode"/>
-				<xs:element name="productline.suffix" type="ProductLineSuffix"/>
-			</xs:sequence>
-		</xs:complexType>
-	</xs:element>
-	<xs:element name="export.refund.nomenclature.description.period" substitutionGroup="abstract.record">
-		<xs:complexType>
-			<xs:sequence>
-				<xs:element name="export.refund.nomenclature.description.period.sid" type="SID"/>
-				<xs:element name="export.refund.nomenclature.sid" type="SID"/>
-				<xs:element name="validity.start.date" type="Date"/>
-				<xs:element name="goods.nomenclature.item.id" type="GoodsNomenclatureItemId"/>
-				<xs:element name="additional.code.type" type="AdditionalCodeTypeId"/>
-				<xs:element name="export.refund.code" type="ExportRefundCode"/>
-				<xs:element name="productline.suffix" type="ProductLineSuffix"/>
-			</xs:sequence>
-		</xs:complexType>
-	</xs:element>
-	<xs:element name="export.refund.nomenclature.description" substitutionGroup="abstract.record">
-		<xs:complexType>
-			<xs:sequence>
-				<xs:element name="export.refund.nomenclature.description.period.sid" type="SID"/>
-				<xs:element name="language.id" type="LanguageId"/>
-				<xs:element name="export.refund.nomenclature.sid" type="SID"/>
-				<xs:element name="goods.nomenclature.item.id" type="GoodsNomenclatureItemId"/>
-				<xs:element name="additional.code.type" type="AdditionalCodeTypeId"/>
-				<xs:element name="export.refund.code" type="ExportRefundCode"/>
-				<xs:element name="productline.suffix" type="ProductLineSuffix"/>
-				<xs:element name="description" type="LongDescription" minOccurs="0"/>
-			</xs:sequence>
-		</xs:complexType>
-	</xs:element>
-	<xs:element name="footnote" substitutionGroup="abstract.record">
-		<xs:complexType>
-			<xs:sequence>
-				<xs:element name="footnote.type.id" type="FootnoteTypeId"/>
-				<xs:element name="footnote.id" type="FootnoteId"/>
-				<xs:element name="validity.start.date" type="Date"/>
-				<xs:element name="validity.end.date" type="Date" minOccurs="0"/>
-			</xs:sequence>
-		</xs:complexType>
-	</xs:element>
-	<xs:element name="footnote.association.additional.code" substitutionGroup="abstract.record">
-		<xs:complexType>
-			<xs:sequence>
-				<xs:element name="additional.code.sid" type="SID"/>
-				<xs:element name="footnote.type.id" type="FootnoteTypeId"/>
-				<xs:element name="footnote.id" type="FootnoteId"/>
-				<xs:element name="validity.start.date" type="Date"/>
-				<xs:element name="validity.end.date" type="Date" minOccurs="0"/>
-				<xs:element name="additional.code.type.id" type="AdditionalCodeTypeId"/>
-				<xs:element name="additional.code" type="AdditionalCode"/>
-			</xs:sequence>
-		</xs:complexType>
-	</xs:element>
-	<xs:element name="footnote.association.ern" substitutionGroup="abstract.record">
-		<xs:complexType>
-			<xs:sequence>
-				<xs:element name="export.refund.nomenclature.sid" type="SID"/>
-				<xs:element name="footnote.type" type="FootnoteTypeId"/>
-				<xs:element name="footnote.id" type="FootnoteId"/>
-				<xs:element name="validity.start.date" type="Date"/>
-				<xs:element name="validity.end.date" type="Date" minOccurs="0"/>
-				<xs:element name="goods.nomenclature.item.id" type="GoodsNomenclatureItemId"/>
-				<xs:element name="additional.code.type" type="AdditionalCodeTypeId"/>
-				<xs:element name="export.refund.code" type="ExportRefundCode"/>
-				<xs:element name="productline.suffix" type="ProductLineSuffix"/>
-			</xs:sequence>
-		</xs:complexType>
-	</xs:element>
-	<xs:element name="footnote.association.goods.nomenclature" substitutionGroup="abstract.record">
-		<xs:complexType>
-			<xs:sequence>
-				<xs:element name="goods.nomenclature.sid" type="SID"/>
-				<xs:element name="footnote.type" type="FootnoteTypeId"/>
-				<xs:element name="footnote.id" type="FootnoteId"/>
-				<xs:element name="validity.start.date" type="Date"/>
-				<xs:element name="validity.end.date" type="Date" minOccurs="0"/>
-				<xs:element name="goods.nomenclature.item.id" type="GoodsNomenclatureItemId"/>
-				<xs:element name="productline.suffix" type="ProductLineSuffix"/>
-			</xs:sequence>
-		</xs:complexType>
-	</xs:element>
-	<xs:element name="footnote.association.meursing.heading" substitutionGroup="abstract.record">
-		<xs:complexType>
-			<xs:sequence>
-				<xs:element name="meursing.table.plan.id" type="MeursingTablePlanId"/>
-				<xs:element name="meursing.heading.number" type="MeursingHeadingNumber"/>
-				<xs:element name="row.column.code" type="RowColumnCode"/>
-				<xs:element name="footnote.type" type="FootnoteTypeId"/>
-				<xs:element name="footnote.id" type="FootnoteId"/>
-				<xs:element name="validity.start.date" type="Date"/>
-				<xs:element name="validity.end.date" type="Date" minOccurs="0"/>
-			</xs:sequence>
-		</xs:complexType>
-	</xs:element>
-	<xs:element name="footnote.description.period" substitutionGroup="abstract.record">
-		<xs:complexType>
-			<xs:sequence>
-				<xs:element name="footnote.description.period.sid" type="SID"/>
-				<xs:element name="footnote.type.id" type="FootnoteTypeId"/>
-				<xs:element name="footnote.id" type="FootnoteId"/>
-				<xs:element name="validity.start.date" type="Date"/>
-			</xs:sequence>
-		</xs:complexType>
-	</xs:element>
-	<xs:element name="footnote.description" substitutionGroup="abstract.record">
-		<xs:complexType>
-			<xs:sequence>
-				<xs:element name="footnote.description.period.sid" type="SID"/>
-				<xs:element name="language.id" type="LanguageId"/>
-				<xs:element name="footnote.type.id" type="FootnoteTypeId"/>
-				<xs:element name="footnote.id" type="FootnoteId"/>
-				<xs:element name="description" type="LongDescription" minOccurs="0"/>
-			</xs:sequence>
-		</xs:complexType>
-	</xs:element>
-	<xs:element name="footnote.type" substitutionGroup="abstract.record">
-		<xs:complexType>
-			<xs:sequence>
-				<xs:element name="footnote.type.id" type="FootnoteTypeId"/>
-				<xs:element name="validity.start.date" type="Date"/>
-				<xs:element name="validity.end.date" type="Date" minOccurs="0"/>
-				<xs:element name="application.code" type="ApplicationCodeFootnote"/>
-			</xs:sequence>
-		</xs:complexType>
-	</xs:element>
-	<xs:element name="footnote.type.description" substitutionGroup="abstract.record">
-		<xs:complexType>
-			<xs:sequence>
-				<xs:element name="footnote.type.id" type="FootnoteTypeId"/>
-				<xs:element name="language.id" type="LanguageId"/>
-				<xs:element name="description" type="ShortDescription" minOccurs="0"/>
-			</xs:sequence>
-		</xs:complexType>
-	</xs:element>
-	<xs:element name="fts.regulation.action" substitutionGroup="abstract.record">
-		<xs:complexType>
-			<xs:sequence>
-				<xs:element name="fts.regulation.role" type="RegulationRoleTypeId"/>
-				<xs:element name="fts.regulation.id" type="RegulationId"/>
-				<xs:element name="stopped.regulation.role" type="RegulationRoleTypeId"/>
-				<xs:element name="stopped.regulation.id" type="RegulationId"/>
-			</xs:sequence>
-		</xs:complexType>
-	</xs:element>
-	<xs:element name="full.temporary.stop.regulation" substitutionGroup="abstract.record">
-		<xs:complexType>
-			<xs:sequence>
-				<xs:element name="full.temporary.stop.regulation.role" type="RegulationRoleTypeId"/>
-				<xs:element name="full.temporary.stop.regulation.id" type="RegulationId"/>
-				<xs:element name="published.date" type="Date" minOccurs="0"/>
-				<xs:element name="officialjournal.number" type="OfficialJournalNumber" minOccurs="0"/>
-				<xs:element name="officialjournal.page" type="OfficialJournalPage" minOccurs="0"/>
-				<xs:element name="validity.start.date" type="Date"/>
-				<xs:element name="validity.end.date" type="Date" minOccurs="0"/>
-				<xs:element name="effective.enddate" type="Date" minOccurs="0"/>
-				<xs:element name="complete.abrogation.regulation.role" type="RegulationRoleTypeId" minOccurs="0"/>
-				<xs:element name="complete.abrogation.regulation.id" type="RegulationId" minOccurs="0"/>
-				<xs:element name="explicit.abrogation.regulation.role" type="RegulationRoleTypeId" minOccurs="0"/>
-				<xs:element name="explicit.abrogation.regulation.id" type="RegulationId" minOccurs="0"/>
-				<xs:element name="replacement.indicator" type="ReplacementIndicator"/>
-				<xs:element name="information.text" type="ShortDescription" minOccurs="0"/>
-				<xs:element name="approved.flag" type="ApprovedFlag"/>
-			</xs:sequence>
-		</xs:complexType>
-	</xs:element>
-	<xs:element name="geographical.area" substitutionGroup="abstract.record">
-		<xs:complexType>
-			<xs:sequence>
-				<xs:element name="geographical.area.sid" type="SID"/>
-				<xs:element name="geographical.area.id" type="GeographicalAreaId"/>
-				<xs:element name="validity.start.date" type="Date"/>
-				<xs:element name="validity.end.date" type="Date" minOccurs="0"/>
-				<xs:element name="geographical.code" type="AreaCode"/>
-				<xs:element name="parent.geographical.area.group.sid" type="SID" minOccurs="0"/>
-			</xs:sequence>
-		</xs:complexType>
-	</xs:element>
-	<xs:element name="geographical.area.description.period" substitutionGroup="abstract.record">
-		<xs:complexType>
-			<xs:sequence>
-				<xs:element name="geographical.area.description.period.sid" type="SID"/>
-				<xs:element name="geographical.area.sid" type="SID"/>
-				<xs:element name="validity.start.date" type="Date"/>
-				<xs:element name="geographical.area.id" type="GeographicalAreaId"/>
-			</xs:sequence>
-		</xs:complexType>
-	</xs:element>
-	<xs:element name="geographical.area.description" substitutionGroup="abstract.record">
-		<xs:complexType>
-			<xs:sequence>
-				<xs:element name="geographical.area.description.period.sid" type="SID"/>
-				<xs:element name="language.id" type="LanguageId"/>
-				<xs:element name="geographical.area.sid" type="SID"/>
-				<xs:element name="geographical.area.id" type="GeographicalAreaId"/>
-				<xs:element name="description" type="ShortDescription" minOccurs="0"/>
-			</xs:sequence>
-		</xs:complexType>
-	</xs:element>
-	<xs:element name="geographical.area.membership" substitutionGroup="abstract.record">
-		<xs:complexType>
-			<xs:sequence>
-				<xs:element name="geographical.area.sid" type="SID"/>
-				<xs:element name="geographical.area.group.sid" type="SID"/>
-				<xs:element name="validity.start.date" type="Date"/>
-				<xs:element name="validity.end.date" type="Date" minOccurs="0"/>
-			</xs:sequence>
-		</xs:complexType>
-	</xs:element>
-	<xs:element name="goods.nomenclature" substitutionGroup="abstract.record">
-		<xs:complexType>
-			<xs:sequence>
-				<xs:element name="goods.nomenclature.sid" type="SID"/>
-				<xs:element name="goods.nomenclature.item.id" type="GoodsNomenclatureItemId"/>
-				<xs:element name="producline.suffix" type="ProductLineSuffix"/>
-				<xs:element name="validity.start.date" type="Date"/>
-				<xs:element name="validity.end.date" type="Date" minOccurs="0"/>
-				<xs:element name="statistical.indicator" type="StatisticalIndicator"/>
-			</xs:sequence>
-		</xs:complexType>
-	</xs:element>
-	<xs:element name="goods.nomenclature.indents" substitutionGroup="abstract.record">
-		<xs:complexType>
-			<xs:sequence>
-				<xs:element name="goods.nomenclature.indent.sid" type="SID"/>
-				<xs:element name="goods.nomenclature.sid" type="SID"/>
-				<xs:element name="validity.start.date" type="Date"/>
-				<xs:element name="number.indents" type="NumberOf"/>
-				<xs:element name="goods.nomenclature.item.id" type="GoodsNomenclatureItemId"/>
-				<xs:element name="productline.suffix" type="ProductLineSuffix"/>
-			</xs:sequence>
-		</xs:complexType>
-	</xs:element>
-	<xs:element name="goods.nomenclature.description.period" substitutionGroup="abstract.record">
-		<xs:complexType>
-			<xs:sequence>
-				<xs:element name="goods.nomenclature.description.period.sid" type="SID"/>
-				<xs:element name="goods.nomenclature.sid" type="SID"/>
-				<xs:element name="validity.start.date" type="Date"/>
-				<xs:element name="goods.nomenclature.item.id" type="GoodsNomenclatureItemId"/>
-				<xs:element name="productline.suffix" type="ProductLineSuffix"/>
-			</xs:sequence>
-		</xs:complexType>
-	</xs:element>
-	<xs:element name="goods.nomenclature.description" substitutionGroup="abstract.record">
-		<xs:complexType>
-			<xs:sequence>
-				<xs:element name="goods.nomenclature.description.period.sid" type="SID"/>
-				<xs:element name="language.id" type="LanguageId"/>
-				<xs:element name="goods.nomenclature.sid" type="SID"/>
-				<xs:element name="goods.nomenclature.item.id" type="GoodsNomenclatureItemId"/>
-				<xs:element name="productline.suffix" type="ProductLineSuffix"/>
-				<xs:element name="description" type="LongDescription" minOccurs="0"/>
-			</xs:sequence>
-		</xs:complexType>
-	</xs:element>
-	<xs:element name="goods.nomenclature.group" substitutionGroup="abstract.record">
-		<xs:complexType>
-			<xs:sequence>
-				<xs:element name="goods.nomenclature.group.type" type="GoodsNomenclatureGroupType"/>
-				<xs:element name="goods.nomenclature.group.id" type="GoodsNomenclatureGroupId"/>
-				<xs:element name="validity.start.date" type="Date"/>
-				<xs:element name="validity.end.date" type="Date" minOccurs="0"/>
-				<xs:element name="nomenclature.group.facility.code" type="NomenclatureGroupFacilityCode"/>
-			</xs:sequence>
-		</xs:complexType>
-	</xs:element>
-	<xs:element name="goods.nomenclature.group.description" substitutionGroup="abstract.record">
-		<xs:complexType>
-			<xs:sequence>
-				<xs:element name="goods.nomenclature.group.type" type="GoodsNomenclatureGroupType"/>
-				<xs:element name="goods.nomenclature.group.id" type="GoodsNomenclatureGroupId"/>
-				<xs:element name="language.id" type="LanguageId"/>
-				<xs:element name="description" type="ShortDescription" minOccurs="0"/>
-			</xs:sequence>
-		</xs:complexType>
-	</xs:element>
-	<xs:element name="goods.nomenclature.origin" substitutionGroup="abstract.record">
-		<xs:complexType>
-			<xs:sequence>
-				<xs:element name="goods.nomenclature.sid" type="SID"/>
-				<xs:element name="derived.goods.nomenclature.item.id" type="GoodsNomenclatureItemId"/>
-				<xs:element name="derived.productline.suffix" type="ProductLineSuffix"/>
-				<xs:element name="goods.nomenclature.item.id" type="GoodsNomenclatureItemId"/>
-				<xs:element name="productline.suffix" type="ProductLineSuffix"/>
-			</xs:sequence>
-		</xs:complexType>
-	</xs:element>
-	<xs:element name="goods.nomenclature.successor" substitutionGroup="abstract.record">
-		<xs:complexType>
-			<xs:sequence>
-				<xs:element name="goods.nomenclature.sid" type="SID"/>
-				<xs:element name="absorbed.goods.nomenclature.item.id" type="GoodsNomenclatureItemId"/>
-				<xs:element name="absorbed.productline.suffix" type="ProductLineSuffix"/>
-				<xs:element name="goods.nomenclature.item.id" type="GoodsNomenclatureItemId"/>
-				<xs:element name="productline.suffix" type="ProductLineSuffix"/>
-			</xs:sequence>
-		</xs:complexType>
-	</xs:element>
-	<xs:element name="language" substitutionGroup="abstract.record">
-		<xs:complexType>
-			<xs:sequence>
-				<xs:element name="language.id" type="LanguageId"/>
-				<xs:element name="validity.start.date" type="Date"/>
-				<xs:element name="validity.end.date" type="Date" minOccurs="0"/>
-			</xs:sequence>
-		</xs:complexType>
-	</xs:element>
-	<xs:element name="language.description" substitutionGroup="abstract.record">
-		<xs:complexType>
-			<xs:sequence>
-				<xs:element name="language.code.id" type="LanguageId"/>
-				<xs:element name="language.id" type="LanguageId"/>
-				<xs:element name="description" type="ShortDescription" minOccurs="0"/>
-			</xs:sequence>
-		</xs:complexType>
-	</xs:element>
-	<xs:element name="measure" substitutionGroup="abstract.record">
-		<xs:complexType>
-			<xs:sequence>
-				<xs:element name="measure.sid" type="SID"/>
-				<xs:element name="measure.type" type="MeasureTypeId"/>
-				<xs:element name="geographical.area" type="GeographicalAreaId"/>
-				<xs:element name="goods.nomenclature.item.id" type="GoodsNomenclatureItemId" minOccurs="0"/>
-				<xs:element name="additional.code.type" type="AdditionalCodeTypeId" minOccurs="0"/>
-				<xs:element name="additional.code" type="AdditionalCode" minOccurs="0"/>
-				<xs:element name="ordernumber" type="OrderNumber" minOccurs="0"/>
-				<xs:element name="reduction.indicator" type="ReductionIndicator" minOccurs="0"/>
-				<xs:element name="validity.start.date" type="Date"/>
-				<xs:element name="measure.generating.regulation.role" type="RegulationRoleTypeId"/>
-				<xs:element name="measure.generating.regulation.id" type="RegulationId"/>
-				<xs:element name="validity.end.date" type="Date" minOccurs="0"/>
-				<xs:element name="justification.regulation.role" type="RegulationRoleTypeId" minOccurs="0"/>
-				<xs:element name="justification.regulation.id" type="RegulationId" minOccurs="0"/>
-				<xs:element name="stopped.flag" type="StoppedFlag"/>
-				<xs:element name="geographical.area.sid" type="SID" minOccurs="0"/>
-				<xs:element name="goods.nomenclature.sid" type="SID" minOccurs="0"/>
-				<xs:element name="additional.code.sid" type="SID" minOccurs="0"/>
-				<xs:element name="export.refund.nomenclature.sid" type="SID" minOccurs="0"/>
-			</xs:sequence>
-		</xs:complexType>
-	</xs:element>
-	<xs:element name="measure.component" substitutionGroup="abstract.record">
-		<xs:complexType>
-			<xs:sequence>
-				<xs:element name="measure.sid" type="SID"/>
-				<xs:element name="duty.expression.id" type="DutyExpressionId"/>
-				<xs:element name="duty.amount" type="DutyAmount" minOccurs="0"/>
-				<xs:element name="monetary.unit.code" type="MonetaryUnitCode" minOccurs="0"/>
-				<xs:element name="measurement.unit.code" type="MeasurementUnitCode" minOccurs="0"/>
-				<xs:element name="measurement.unit.qualifier.code" type="MeasurementUnitQualifierCode" minOccurs="0"/>
-			</xs:sequence>
-		</xs:complexType>
-	</xs:element>
-	<xs:element name="measure.condition" substitutionGroup="abstract.record">
-		<xs:complexType>
-			<xs:sequence>
-				<xs:element name="measure.condition.sid" type="SID"/>
-				<xs:element name="measure.sid" type="SID"/>
-				<xs:element name="condition.code" type="ConditionCode"/>
-				<xs:element name="component.sequence.number" type="ComponentSequenceNumber"/>
-				<xs:element name="condition.duty.amount" type="DutyAmount" minOccurs="0"/>
-				<xs:element name="condition.monetary.unit.code" type="MonetaryUnitCode" minOccurs="0"/>
-				<xs:element name="condition.measurement.unit.code" type="MeasurementUnitCode" minOccurs="0"/>
-				<xs:element name="condition.measurement.unit.qualifier.code" type="MeasurementUnitQualifierCode" minOccurs="0"/>
-				<xs:element name="action.code" type="ActionCode" minOccurs="0"/>
-				<xs:element name="certificate.type.code" type="CertificateTypeCode" minOccurs="0"/>
-				<xs:element name="certificate.code" type="CertificateCode" minOccurs="0"/>
-			</xs:sequence>
-		</xs:complexType>
-	</xs:element>
-	<xs:element name="measure.condition.component" substitutionGroup="abstract.record">
-		<xs:complexType>
-			<xs:sequence>
-				<xs:element name="measure.condition.sid" type="SID"/>
-				<xs:element name="duty.expression.id" type="DutyExpressionId"/>
-				<xs:element name="duty.amount" type="DutyAmount" minOccurs="0"/>
-				<xs:element name="monetary.unit.code" type="MonetaryUnitCode" minOccurs="0"/>
-				<xs:element name="measurement.unit.code" type="MeasurementUnitCode" minOccurs="0"/>
-				<xs:element name="measurement.unit.qualifier.code" type="MeasurementUnitQualifierCode" minOccurs="0"/>
-			</xs:sequence>
-		</xs:complexType>
-	</xs:element>
-	<xs:element name="measure.excluded.geographical.area" substitutionGroup="abstract.record">
-		<xs:complexType>
-			<xs:sequence>
-				<xs:element name="measure.sid" type="SID"/>
-				<xs:element name="excluded.geographical.area" type="GeographicalAreaId"/>
-				<xs:element name="geographical.area.sid" type="SID"/>
-			</xs:sequence>
-		</xs:complexType>
-	</xs:element>
-	<xs:element name="footnote.association.measure" substitutionGroup="abstract.record">
-		<xs:complexType>
-			<xs:sequence>
-				<xs:element name="measure.sid" type="SID"/>
-				<xs:element name="footnote.type.id" type="FootnoteTypeId"/>
-				<xs:element name="footnote.id" type="FootnoteId"/>
-			</xs:sequence>
-		</xs:complexType>
-	</xs:element>
-	<xs:element name="measure.partial.temporary.stop" substitutionGroup="abstract.record">
-		<xs:complexType>
-			<xs:sequence>
-				<xs:element name="measure.sid" type="SID"/>
-				<xs:element name="validity.start.date" type="Date"/>
-				<xs:element name="validity.end.date" type="Date" minOccurs="0"/>
-				<xs:element name="partial.temporary.stop.regulation.id" type="RegulationId"/>
-				<xs:element name="partial.temporary.stop.regulation.officialjournal.number" type="OfficialJournalNumber" minOccurs="0"/>
-				<xs:element name="partial.temporary.stop.regulation.officialjournal.page" type="OfficialJournalPage" minOccurs="0"/>
-				<xs:element name="abrogation.regulation.id" type="RegulationId" minOccurs="0"/>
-				<xs:element name="abrogation.regulation.officialjournal.number" type="OfficialJournalNumber" minOccurs="0"/>
-				<xs:element name="abrogation.regulation.officialjournal.page" type="OfficialJournalPage" minOccurs="0"/>
-			</xs:sequence>
-		</xs:complexType>
-	</xs:element>
-	<xs:element name="measure.condition.code" substitutionGroup="abstract.record">
-		<xs:complexType>
-			<xs:sequence>
-				<xs:element name="condition.code" type="ConditionCode"/>
-				<xs:element name="validity.start.date" type="Date"/>
-				<xs:element name="validity.end.date" type="Date" minOccurs="0"/>
-			</xs:sequence>
-		</xs:complexType>
-	</xs:element>
-	<xs:element name="measure.condition.code.description" substitutionGroup="abstract.record">
-		<xs:complexType>
-			<xs:sequence>
-				<xs:element name="condition.code" type="ConditionCode"/>
-				<xs:element name="language.id" type="LanguageId"/>
-				<xs:element name="description" type="ShortDescription" minOccurs="0"/>
-			</xs:sequence>
-		</xs:complexType>
-	</xs:element>
-	<xs:element name="measure.action" substitutionGroup="abstract.record">
-		<xs:complexType>
-			<xs:sequence>
-				<xs:element name="action.code" type="ActionCode"/>
-				<xs:element name="validity.start.date" type="Date"/>
-				<xs:element name="validity.end.date" type="Date" minOccurs="0"/>
-			</xs:sequence>
-		</xs:complexType>
-	</xs:element>
-	<xs:element name="measure.action.description" substitutionGroup="abstract.record">
-		<xs:complexType>
-			<xs:sequence>
-				<xs:element name="action.code" type="ActionCode"/>
-				<xs:element name="language.id" type="LanguageId"/>
-				<xs:element name="description" type="ShortDescription" minOccurs="0"/>
-			</xs:sequence>
-		</xs:complexType>
-	</xs:element>
-	<xs:element name="measure.type" substitutionGroup="abstract.record">
-		<xs:complexType>
-			<xs:sequence>
-				<xs:element name="measure.type.id" type="MeasureTypeId"/>
-				<xs:element name="validity.start.date" type="Date"/>
-				<xs:element name="validity.end.date" type="Date" minOccurs="0"/>
-				<xs:element name="trade.movement.code" type="TradeMovementCode"/>
-				<xs:element name="priority.code" type="PriorityCode"/>
-				<xs:element name="measure.component.applicable.code" type="MeasurementUnitApplicabilityCode"/>
-				<xs:element name="origin.dest.code" type="OriginCode"/>
-				<xs:element name="order.number.capture.code" type="OrderNumberCaptureCode"/>
-				<xs:element name="measure.explosion.level" type="MeasureExplosionLevel"/>
-				<xs:element name="measure.type.series.id" type="MeasureTypeSeriesId"/>
-			</xs:sequence>
-		</xs:complexType>
-	</xs:element>
-	<xs:element name="measure.type.description" substitutionGroup="abstract.record">
-		<xs:complexType>
-			<xs:sequence>
-				<xs:element name="measure.type.id" type="MeasureTypeId"/>
-				<xs:element name="language.id" type="LanguageId"/>
-				<xs:element name="description" type="ShortDescription" minOccurs="0"/>
-			</xs:sequence>
-		</xs:complexType>
-	</xs:element>
-	<xs:element name="measure.type.series" substitutionGroup="abstract.record">
-		<xs:complexType>
-			<xs:sequence>
-				<xs:element name="measure.type.series.id" type="MeasureTypeSeriesId"/>
-				<xs:element name="validity.start.date" type="Date"/>
-				<xs:element name="validity.end.date" type="Date" minOccurs="0"/>
-				<xs:element name="measure.type.combination" type="MeasureTypeCombination"/>
-			</xs:sequence>
-		</xs:complexType>
-	</xs:element>
-	<xs:element name="measure.type.series.description" substitutionGroup="abstract.record">
-		<xs:complexType>
-			<xs:sequence>
-				<xs:element name="measure.type.series.id" type="MeasureTypeSeriesId"/>
-				<xs:element name="language.id" type="LanguageId"/>
-				<xs:element name="description" type="ShortDescription" minOccurs="0"/>
-			</xs:sequence>
-		</xs:complexType>
-	</xs:element>
-	<xs:element name="measurement.unit" substitutionGroup="abstract.record">
-		<xs:complexType>
-			<xs:sequence>
-				<xs:element name="measurement.unit.code" type="MeasurementUnitCode"/>
-				<xs:element name="validity.start.date" type="Date"/>
-				<xs:element name="validity.end.date" type="Date" minOccurs="0"/>
-			</xs:sequence>
-		</xs:complexType>
-	</xs:element>
-	<xs:element name="measurement.unit.description" substitutionGroup="abstract.record">
-		<xs:complexType>
-			<xs:sequence>
-				<xs:element name="measurement.unit.code" type="MeasurementUnitCode"/>
-				<xs:element name="language.id" type="LanguageId"/>
-				<xs:element name="description" type="ShortDescription" minOccurs="0"/>
-			</xs:sequence>
-		</xs:complexType>
-	</xs:element>
-	<xs:element name="measurement.unit.qualifier" substitutionGroup="abstract.record">
-		<xs:complexType>
-			<xs:sequence>
-				<xs:element name="measurement.unit.qualifier.code" type="MeasurementUnitQualifierCode"/>
-				<xs:element name="validity.start.date" type="Date"/>
-				<xs:element name="validity.end.date" type="Date" minOccurs="0"/>
-			</xs:sequence>
-		</xs:complexType>
-	</xs:element>
-	<xs:element name="measurement.unit.qualifier.description" substitutionGroup="abstract.record">
-		<xs:complexType>
-			<xs:sequence>
-				<xs:element name="measurement.unit.qualifier.code" type="MeasurementUnitQualifierCode"/>
-				<xs:element name="language.id" type="LanguageId"/>
-				<xs:element name="description" type="ShortDescription" minOccurs="0"/>
-			</xs:sequence>
-		</xs:complexType>
-	</xs:element>
-	<xs:element name="measurement" substitutionGroup="abstract.record">
-		<xs:complexType>
-			<xs:sequence>
-				<xs:element name="measurement.unit.code" type="MeasurementUnitCode"/>
-				<xs:element name="measurement.unit.qualifier.code" type="MeasurementUnitQualifierCode"/>
-				<xs:element name="validity.start.date" type="Date"/>
-				<xs:element name="validity.end.date" type="Date" minOccurs="0"/>
-			</xs:sequence>
-		</xs:complexType>
-	</xs:element>
-	<xs:element name="meursing.table.plan" substitutionGroup="abstract.record">
-		<xs:complexType>
-			<xs:sequence>
-				<xs:element name="meursing.table.plan.id" type="MeursingTablePlanId"/>
-				<xs:element name="validity.start.date" type="Date"/>
-				<xs:element name="validity.end.date" type="Date" minOccurs="0"/>
-			</xs:sequence>
-		</xs:complexType>
-	</xs:element>
-	<xs:element name="meursing.heading" substitutionGroup="abstract.record">
-		<xs:complexType>
-			<xs:sequence>
-				<xs:element name="meursing.table.plan.id" type="MeursingTablePlanId"/>
-				<xs:element name="meursing.heading.number" type="MeursingHeadingNumber"/>
-				<xs:element name="row.column.code" type="RowColumnCode"/>
-				<xs:element name="validity.start.date" type="Date"/>
-				<xs:element name="validity.end.date" type="Date" minOccurs="0"/>
-			</xs:sequence>
-		</xs:complexType>
-	</xs:element>
-	<xs:element name="meursing.heading.text" substitutionGroup="abstract.record">
-		<xs:complexType>
-			<xs:sequence>
-				<xs:element name="meursing.table.plan.id" type="MeursingTablePlanId"/>
-				<xs:element name="meursing.heading.number" type="MeursingHeadingNumber"/>
-				<xs:element name="row.column.code" type="RowColumnCode"/>
-				<xs:element name="language.id" type="LanguageId"/>
-				<xs:element name="description" type="ShortDescription" minOccurs="0"/>
-			</xs:sequence>
-		</xs:complexType>
-	</xs:element>
-	<xs:element name="meursing.subheading" substitutionGroup="abstract.record">
-		<xs:complexType>
-			<xs:sequence>
-				<xs:element name="meursing.table.plan.id" type="MeursingTablePlanId"/>
-				<xs:element name="meursing.heading.number" type="MeursingHeadingNumber"/>
-				<xs:element name="row.column.code" type="RowColumnCode"/>
-				<xs:element name="subheading.sequence.number" type="SubHeadingSequenceNumber"/>
-				<xs:element name="validity.start.date" type="Date"/>
-				<xs:element name="validity.end.date" type="Date" minOccurs="0"/>
-				<xs:element name="description" type="ShortDescription" minOccurs="0"/>
-			</xs:sequence>
-		</xs:complexType>
-	</xs:element>
-	<xs:element name="meursing.additional.code" substitutionGroup="abstract.record">
-		<xs:complexType>
-			<xs:sequence>
-				<xs:element name="meursing.additional.code.sid" type="SID"/>
-				<xs:element name="validity.end.date" type="Date" minOccurs="0"/>
-				<xs:element name="additional.code" type="AdditionalCode"/>
-				<xs:element name="validity.start.date" type="Date"/>
-			</xs:sequence>
-		</xs:complexType>
-	</xs:element>
-	<xs:element name="meursing.table.cell.component" substitutionGroup="abstract.record">
-		<xs:complexType>
-			<xs:sequence>
-				<xs:element name="meursing.additional.code.sid" type="SID"/>
-				<xs:element name="meursing.table.plan.id" type="MeursingTablePlanId"/>
-				<xs:element name="heading.number" type="MeursingHeadingNumber"/>
-				<xs:element name="row.column.code" type="RowColumnCode"/>
-				<xs:element name="subheading.sequence.number" type="SubHeadingSequenceNumber"/>
-				<xs:element name="validity.start.date" type="Date"/>
-				<xs:element name="validity.end.date" type="Date" minOccurs="0"/>
-				<xs:element name="additional.code" type="AdditionalCode"/>
-			</xs:sequence>
-		</xs:complexType>
-	</xs:element>
-	<xs:element name="modification.regulation" substitutionGroup="abstract.record">
-		<xs:complexType>
-			<xs:sequence>
-				<xs:element name="modification.regulation.role" type="RegulationRoleTypeId"/>
-				<xs:element name="modification.regulation.id" type="RegulationId"/>
-				<xs:element name="published.date" type="Date" minOccurs="0"/>
-				<xs:element name="officialjournal.number" type="OfficialJournalNumber" minOccurs="0"/>
-				<xs:element name="officialjournal.page" type="OfficialJournalPage" minOccurs="0"/>
-				<xs:element name="validity.start.date" type="Date"/>
-				<xs:element name="validity.end.date" type="Date" minOccurs="0"/>
-				<xs:element name="effective.end.date" type="Date" minOccurs="0"/>
-				<xs:element name="base.regulation.role" type="RegulationRoleTypeId"/>
-				<xs:element name="base.regulation.id" type="RegulationId"/>
-				<xs:element name="complete.abrogation.regulation.role" type="RegulationRoleTypeId" minOccurs="0"/>
-				<xs:element name="complete.abrogation.regulation.id" type="RegulationId" minOccurs="0"/>
-				<xs:element name="explicit.abrogation.regulation.role" type="RegulationRoleTypeId" minOccurs="0"/>
-				<xs:element name="explicit.abrogation.regulation.id" type="RegulationId" minOccurs="0"/>
-				<xs:element name="replacement.indicator" type="ReplacementIndicator"/>
-				<xs:element name="stopped.flag" type="StoppedFlag"/>
-				<xs:element name="information.text" type="ShortDescription" minOccurs="0"/>
-				<xs:element name="approved.flag" type="ApprovedFlag"/>
-			</xs:sequence>
-		</xs:complexType>
-	</xs:element>
-	<xs:element name="monetary.exchange.period" substitutionGroup="abstract.record">
-		<xs:complexType>
-			<xs:sequence>
-				<xs:element name="monetary.exchange.period.sid" type="SID"/>
-				<xs:element name="parent.monetary.unit.code" type="MonetaryUnitCode"/>
-				<xs:element name="validity.start.date" type="Date"/>
-				<xs:element name="validity.end.date" type="Date" minOccurs="0"/>
-			</xs:sequence>
-		</xs:complexType>
-	</xs:element>
-	<xs:element name="monetary.exchange.rate" substitutionGroup="abstract.record">
-		<xs:complexType>
-			<xs:sequence>
-				<xs:element name="monetary.exchange.period.sid" type="SID"/>
-				<xs:element name="child.monetary.unit.code" type="MonetaryUnitCode"/>
-				<xs:element name="exchange.rate" type="ExchangeRate"/>
-			</xs:sequence>
-		</xs:complexType>
-	</xs:element>
-	<xs:element name="monetary.unit" substitutionGroup="abstract.record">
-		<xs:complexType>
-			<xs:sequence>
-				<xs:element name="monetary.unit.code" type="MonetaryUnitCode"/>
-				<xs:element name="validity.start.date" type="Date"/>
-				<xs:element name="validity.end.date" type="Date" minOccurs="0"/>
-			</xs:sequence>
-		</xs:complexType>
-	</xs:element>
-	<xs:element name="monetary.unit.description" substitutionGroup="abstract.record">
-		<xs:complexType>
-			<xs:sequence>
-				<xs:element name="monetary.unit.code" type="MonetaryUnitCode"/>
-				<xs:element name="language.id" type="LanguageId"/>
-				<xs:element name="description" type="ShortDescription" minOccurs="0"/>
-			</xs:sequence>
-		</xs:complexType>
-	</xs:element>
-	<xs:element name="nomenclature.group.membership" substitutionGroup="abstract.record">
-		<xs:complexType>
-			<xs:sequence>
-				<xs:element name="goods.nomenclature.sid" type="SID"/>
-				<xs:element name="goods.nomenclature.group.type" type="GoodsNomenclatureGroupType"/>
-				<xs:element name="goods.nomenclature.group.id" type="GoodsNomenclatureGroupId"/>
-				<xs:element name="validity.start.date" type="Date"/>
-				<xs:element name="validity.end.date" type="Date" minOccurs="0"/>
-				<xs:element name="goods.nomenclature.item.id" type="GoodsNomenclatureItemId"/>
-				<xs:element name="productline.suffix" type="ProductLineSuffix"/>
-			</xs:sequence>
-		</xs:complexType>
-	</xs:element>
-	<xs:element name="prorogation.regulation" substitutionGroup="abstract.record">
-		<xs:complexType>
-			<xs:sequence>
-				<xs:element name="prorogation.regulation.role" type="RegulationRoleTypeId"/>
-				<xs:element name="prorogation.regulation.id" type="RegulationId"/>
-				<xs:element name="published.date" type="Date" minOccurs="0"/>
-				<xs:element name="officialjournal.number" type="OfficialJournalNumber" minOccurs="0"/>
-				<xs:element name="officialjournal.page" type="OfficialJournalPage" minOccurs="0"/>
-				<xs:element name="replacement.indicator" type="ReplacementIndicator"/>
-				<xs:element name="information.text" type="ShortDescription" minOccurs="0"/>
-				<xs:element name="approved.flag" type="ApprovedFlag"/>
-			</xs:sequence>
-		</xs:complexType>
-	</xs:element>
-	<xs:element name="prorogation.regulation.action" substitutionGroup="abstract.record">
-		<xs:complexType>
-			<xs:sequence>
-				<xs:element name="prorogation.regulation.role" type="RegulationRoleTypeId"/>
-				<xs:element name="prorogation.regulation.id" type="RegulationId"/>
-				<xs:element name="prorogated.regulation.role" type="RegulationRoleTypeId"/>
-				<xs:element name="prorogated.regulation.id" type="RegulationId"/>
-				<xs:element name="prorogated.date" type="Date" minOccurs="0"/>
-			</xs:sequence>
-		</xs:complexType>
-	</xs:element>
-	<xs:element name="publication.sigle" substitutionGroup="abstract.record">
-		<xs:complexType>
-			<xs:sequence>
-				<xs:element name="code.type.id" type="CodeTypeId"/>
-				<xs:element name="code" type="Code"/>
-				<xs:element name="validity.start.date" type="Date"/>
-				<xs:element name="validity.end.date" type="Date" minOccurs="0"/>
-				<xs:element name="publication.code" type="PublicationCode"/>
-				<xs:element name="publication.sigle" type="PublicationSigle" minOccurs="0"/>
-			</xs:sequence>
-		</xs:complexType>
-	</xs:element>
-	<xs:element name="quota.order.number" substitutionGroup="abstract.record">
-		<xs:complexType>
-			<xs:sequence>
-				<xs:element name="quota.order.number.sid" type="SID"/>
-				<xs:element name="quota.order.number.id" type="OrderNumber"/>
-				<xs:element name="validity.start.date" type="Date"/>
-				<xs:element name="validity.end.date" type="Date" minOccurs="0"/>
-			</xs:sequence>
-		</xs:complexType>
-	</xs:element>
-	<xs:element name="quota.order.number.origin" substitutionGroup="abstract.record">
-		<xs:complexType>
-			<xs:sequence>
-				<xs:element name="quota.order.number.origin.sid" type="SID"/>
-				<xs:element name="quota.order.number.sid" type="SID"/>
-				<xs:element name="geographical.area.id" type="GeographicalAreaId"/>
-				<xs:element name="validity.start.date" type="Date"/>
-				<xs:element name="validity.end.date" type="Date" minOccurs="0"/>
-				<xs:element name="geographical.area.sid" type="SID"/>
-			</xs:sequence>
-		</xs:complexType>
-	</xs:element>
-	<xs:element name="quota.order.number.origin.exclusions" substitutionGroup="abstract.record">
-		<xs:complexType>
-			<xs:sequence>
-				<xs:element name="quota.order.number.origin.sid" type="SID"/>
-				<xs:element name="excluded.geographical.area.sid" type="SID"/>
-			</xs:sequence>
-		</xs:complexType>
-	</xs:element>
-	<xs:element name="quota.definition" substitutionGroup="abstract.record">
-		<xs:complexType>
-			<xs:sequence>
-				<xs:element name="quota.definition.sid" type="SID"/>
-				<xs:element name="quota.order.number.id" type="OrderNumber"/>
-				<xs:element name="validity.start.date" type="Date"/>
-				<xs:element name="validity.end.date" type="Date" minOccurs="0"/>
-				<xs:element name="quota.order.number.sid" type="SID"/>
-				<xs:element name="volume" type="QuotaAmount"/>
-				<xs:element name="initial.volume" type="QuotaAmount"/>
-				<xs:element name="monetary.unit.code" type="MonetaryUnitCode" minOccurs="0"/>
-				<xs:element name="measurement.unit.code" type="MeasurementUnitCode" minOccurs="0"/>
-				<xs:element name="measurement.unit.qualifier.code" type="MeasurementUnitQualifierCode" minOccurs="0"/>
-				<xs:element name="maximum.precision" type="QuotaPrecision"/>
-				<xs:element name="critical.state" type="QuotaCriticalStateCode"/>
-				<xs:element name="critical.threshold" type="QuotaCriticalTreshold"/>
-				<xs:element name="description" type="ShortDescription" minOccurs="0"/>
-			</xs:sequence>
-		</xs:complexType>
-	</xs:element>
-	<xs:element name="quota.association" substitutionGroup="abstract.record">
-		<xs:complexType>
-			<xs:sequence>
-				<xs:element name="main.quota.definition.sid" type="SID"/>
-				<xs:element name="sub.quota.definition.sid" type="SID"/>
-				<xs:element name="relation.type" type="RelationType"/>
-				<xs:element name="coefficient" type="QuotaCoefficient" minOccurs="0"/>
-			</xs:sequence>
-		</xs:complexType>
-	</xs:element>
-	<xs:element name="quota.blocking.period" substitutionGroup="abstract.record">
-		<xs:complexType>
-			<xs:sequence>
-				<xs:element name="quota.blocking.period.sid" type="SID"/>
-				<xs:element name="quota.definition.sid" type="SID"/>
-				<xs:element name="blocking.start.date" type="Date"/>
-				<xs:element name="blocking.end.date" type="Date"/>
-				<xs:element name="blocking.period.type" type="QuotaBlockingPeriodType"/>
-				<xs:element name="description" type="ShortDescription" minOccurs="0"/>
-			</xs:sequence>
-		</xs:complexType>
-	</xs:element>
-	<xs:element name="quota.suspension.period" substitutionGroup="abstract.record">
-		<xs:complexType>
-			<xs:sequence>
-				<xs:element name="quota.suspension.period.sid" type="SID"/>
-				<xs:element name="quota.definition.sid" type="SID"/>
-				<xs:element name="suspension.start.date" type="Date"/>
-				<xs:element name="suspension.end.date" type="Date"/>
-				<xs:element name="description" type="ShortDescription" minOccurs="0"/>
-			</xs:sequence>
-		</xs:complexType>
-	</xs:element>
-	<xs:element name="quota.extended.information" substitutionGroup="abstract.record">
-		<xs:complexType>
-			<xs:sequence>
-				<xs:element name="quota.definition.sid" type="SID"/>
-				<xs:element name="balance" type="QuotaAmount"/>
-				<xs:element name="imported.amount" type="QuotaAmount"/>
-				<xs:element name="last.allocation.date" type="Date" minOccurs="0"/>
-				<xs:element name="allocated.percentage" type="QuotaAllocatedPercentage" minOccurs="0"/>
-				<xs:element name="last.import.date" type="Date" minOccurs="0"/>
-				<xs:element name="quota.exhaustion.state" type="QuotaExhaustedStateCode"/>
-				<xs:element name="exhaustion.date" type="Date" minOccurs="0"/>
-				<xs:element name="quota.blocked.state" type="QuotaBlockedStateCode"/>
-				<xs:element name="quota.suspended.state" type="QuotaSuspendedStateCode"/>
-				<xs:element name="total.awaiting.allocation" type="QuotaAmount"/>
-			</xs:sequence>
-		</xs:complexType>
-	</xs:element>
-	<xs:element name="quota.balance.event" substitutionGroup="abstract.record">
-		<xs:complexType>
-			<xs:sequence>
-				<xs:element name="quota.definition.sid" type="SID"/>
-				<xs:element name="occurrence.timestamp" type="Timestamp"/>
-				<xs:element name="old.balance" type="QuotaAmount"/>
-				<xs:element name="new.balance" type="QuotaAmount"/>
-				<xs:element name="imported.amount" type="QuotaAmount"/>
-				<xs:element name="last.import.date.in.allocation" type="Date" minOccurs="0"/>
-			</xs:sequence>
-		</xs:complexType>
-	</xs:element>
-	<xs:element name="quota.unblocking.event" substitutionGroup="abstract.record">
-		<xs:complexType>
-			<xs:sequence>
-				<xs:element name="quota.definition.sid" type="SID"/>
-				<xs:element name="occurrence.timestamp" type="Timestamp"/>
-				<xs:element name="unblocking.date" type="Date"/>
-			</xs:sequence>
-		</xs:complexType>
-	</xs:element>
-	<xs:element name="quota.critical.event" substitutionGroup="abstract.record">
-		<xs:complexType>
-			<xs:sequence>
-				<xs:element name="quota.definition.sid" type="SID"/>
-				<xs:element name="occurrence.timestamp" type="Timestamp"/>
-				<xs:element name="critical.state" type="QuotaCriticalStateCode"/>
-				<xs:element name="critical.state.change.date" type="Date" minOccurs="0"/>
-			</xs:sequence>
-		</xs:complexType>
-	</xs:element>
-	<xs:element name="quota.exhaustion.event" substitutionGroup="abstract.record">
-		<xs:complexType>
-			<xs:sequence>
-				<xs:element name="quota.definition.sid" type="SID"/>
-				<xs:element name="occurrence.timestamp" type="Timestamp"/>
-				<xs:element name="exhaustion.date" type="Date"/>
-			</xs:sequence>
-		</xs:complexType>
-	</xs:element>
-	<xs:element name="quota.reopening.event" substitutionGroup="abstract.record">
-		<xs:complexType>
-			<xs:sequence>
-				<xs:element name="quota.definition.sid" type="SID"/>
-				<xs:element name="occurrence.timestamp" type="Timestamp"/>
-				<xs:element name="reopening.date" type="Date"/>
-			</xs:sequence>
-		</xs:complexType>
-	</xs:element>
-	<xs:element name="quota.unsuspension.event" substitutionGroup="abstract.record">
-		<xs:complexType>
-			<xs:sequence>
-				<xs:element name="quota.definition.sid" type="SID"/>
-				<xs:element name="occurrence.timestamp" type="Timestamp"/>
-				<xs:element name="unsuspension.date" type="Date"/>
-			</xs:sequence>
-		</xs:complexType>
-	</xs:element>
-	<xs:element name="quota.closed.and.transferred.event" substitutionGroup="abstract.record">
-		<xs:complexType>
-			<xs:sequence>
-				<xs:element name="quota.definition.sid" type="SID"/>
-				<xs:element name="occurrence.timestamp" type="Timestamp"/>
-				<!-- QTM148 CUSTD00029679 03/08/2013 CUST-DEV2  -->
-				<!--    <xs:element name="closing.date" type="Date"/> -->
-				<xs:element name="transfer.date" type="Date"/>
-				<xs:element name="quota.closed" type="QuotaClosedCode"/>
-				<!-- CUSTD00029679 - end -->
-				<xs:element name="transferred.amount" type="QuotaAmount"/>
-				<xs:element name="target.quota.definition.sid" type="SID"/>
-			</xs:sequence>
-		</xs:complexType>
-	</xs:element>
-	<xs:element name="regulation.group" substitutionGroup="abstract.record">
-		<xs:complexType>
-			<xs:sequence>
-				<xs:element name="regulation.group.id" type="RegulationGroupId"/>
-				<xs:element name="validity.start.date" type="Date"/>
-				<xs:element name="validity.end.date" type="Date" minOccurs="0"/>
-			</xs:sequence>
-		</xs:complexType>
-	</xs:element>
-	<xs:element name="regulation.group.description" substitutionGroup="abstract.record">
-		<xs:complexType>
-			<xs:sequence>
-				<xs:element name="regulation.group.id" type="RegulationGroupId"/>
-				<xs:element name="language.id" type="LanguageId"/>
-				<xs:element name="description" type="ShortDescription" minOccurs="0"/>
-			</xs:sequence>
-		</xs:complexType>
-	</xs:element>
-	<xs:element name="regulation.role.type" substitutionGroup="abstract.record">
-		<xs:complexType>
-			<xs:sequence>
-				<xs:element name="regulation.role.type.id" type="RegulationRoleTypeId"/>
-				<xs:element name="validity.start.date" type="Date"/>
-				<xs:element name="validity.end.date" type="Date" minOccurs="0"/>
-			</xs:sequence>
-		</xs:complexType>
-	</xs:element>
-	<xs:element name="regulation.role.type.description" substitutionGroup="abstract.record">
-		<xs:complexType>
-			<xs:sequence>
-				<xs:element name="regulation.role.type.id" type="RegulationRoleTypeId"/>
-				<xs:element name="language.id" type="LanguageId"/>
-				<xs:element name="description" type="ShortDescription" minOccurs="0"/>
-			</xs:sequence>
-		</xs:complexType>
-	</xs:element>
-	<xs:element name="regulation.replacement" substitutionGroup="abstract.record">
-		<xs:complexType>
-			<xs:sequence>
-				<xs:element name="replacing.regulation.role" type="RegulationRoleTypeId"/>
-				<xs:element name="replacing.regulation.id" type="RegulationId"/>
-				<xs:element name="replaced.regulation.role" type="RegulationRoleTypeId"/>
-				<xs:element name="replaced.regulation.id" type="RegulationId"/>
-				<xs:element name="measure.type.id" type="MeasureTypeId" minOccurs="0"/>
-				<xs:element name="geographical.area.id" type="GeographicalAreaId" minOccurs="0"/>
-				<xs:element name="chapter.heading" type="ChapterHeading" minOccurs="0"/>
-			</xs:sequence>
-		</xs:complexType>
-	</xs:element>
+    </xs:simpleType>
+    <xs:simpleType name="RelationType">
+        <xs:restriction base="xs:string">
+            <xs:length value="2"/>
+            <xs:enumeration value="EQ"/>
+            <xs:enumeration value="NM"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="RegulationGroupId">
+        <xs:restriction base="xs:string">
+            <xs:length value="3"/>
+            <xs:pattern value="[A-Z][A-Z][A-Z]"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="RegulationId">
+        <xs:restriction base="xs:string">
+            <xs:length value="8"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="RegulationRoleTypeId">
+        <xs:restriction base="xs:string">
+            <xs:length value="1"/>
+            <xs:enumeration value="1"/>
+            <xs:enumeration value="2"/>
+            <xs:enumeration value="3"/>
+            <xs:enumeration value="4"/>
+            <xs:enumeration value="5"/>
+            <xs:enumeration value="6"/>
+            <xs:enumeration value="7"/>
+            <xs:enumeration value="8"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="ReplacementIndicator">
+        <xs:restriction base="xs:string">
+            <xs:length value="1"/>
+            <xs:enumeration value="0"/>
+            <xs:enumeration value="1"/>
+            <xs:enumeration value="2"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="RowColumnCode">
+        <xs:restriction base="xs:string">
+            <xs:length value="1"/>
+            <xs:enumeration value="0"/>
+            <xs:enumeration value="1"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="ShortDescription">
+        <xs:restriction base="xs:string">
+            <xs:maxLength value="500"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="StoppedFlag">
+        <xs:restriction base="xs:string">
+            <xs:length value="1"/>
+            <xs:enumeration value="0"/>
+            <xs:enumeration value="1"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="SID">
+        <xs:restriction base="xs:int">
+            <xs:minInclusive value="1"/>
+            <xs:maxInclusive value="99999999"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="StatisticalIndicator">
+        <xs:restriction base="xs:string">
+            <xs:length value="1"/>
+            <xs:enumeration value="0"/>
+            <xs:enumeration value="1"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="SubHeadingSequenceNumber">
+        <xs:restriction base="xs:string">
+            <xs:pattern value="\d{1,4}"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="SurveillanceNumber">
+        <xs:restriction base="xs:string">
+            <xs:length value="6"/>
+            <xs:pattern value="[0-9]{6}"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="TableLineSequenceNumber">
+        <xs:restriction base="xs:int">
+            <xs:minInclusive value="1"/>
+            <xs:maxInclusive value="99999"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="Timestamp">
+        <xs:annotation>
+            <xs:documentation>Timestamp format</xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:dateTime">
+            <xs:pattern value="\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="TradeMovementCode">
+        <xs:restriction base="xs:string">
+            <xs:length value="1"/>
+            <xs:enumeration value="0"/>
+            <xs:enumeration value="1"/>
+            <xs:enumeration value="2"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <!--Data elements -->
+    <xs:element name="additional.code" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="additional.code.sid" type="SID"/>
+                <xs:element name="additional.code.type.id" type="AdditionalCodeTypeId"/>
+                <xs:element name="additional.code" type="AdditionalCode"/>
+                <xs:element name="validity.start.date" type="Date"/>
+                <xs:element name="validity.end.date" type="Date" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="additional.code.description.period" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="additional.code.description.period.sid" type="SID"/>
+                <xs:element name="additional.code.sid" type="SID"/>
+                <xs:element name="additional.code.type.id" type="AdditionalCodeTypeId"/>
+                <xs:element name="additional.code" type="AdditionalCode"/>
+                <xs:element name="validity.start.date" type="Date"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="additional.code.description" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="additional.code.description.period.sid" type="SID"/>
+                <xs:element name="language.id" type="LanguageId"/>
+                <xs:element name="additional.code.sid" type="SID"/>
+                <xs:element name="additional.code.type.id" type="AdditionalCodeTypeId"/>
+                <xs:element name="additional.code" type="AdditionalCode"/>
+                <xs:element name="description" type="LongDescription" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="additional.code.type" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="additional.code.type.id" type="AdditionalCodeTypeId"/>
+                <xs:element name="validity.start.date" type="Date"/>
+                <xs:element name="validity.end.date" type="Date" minOccurs="0"/>
+                <xs:element name="application.code" type="ApplicationCodeAdditionalCode"/>
+                <xs:element name="meursing.table.plan.id" type="MeursingTablePlanId" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="additional.code.type.description" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="additional.code.type.id" type="AdditionalCodeTypeId"/>
+                <xs:element name="language.id" type="LanguageId"/>
+                <xs:element name="description" type="ShortDescription" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="additional.code.type.measure.type" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="measure.type.id" type="MeasureTypeId"/>
+                <xs:element name="additional.code.type.id" type="AdditionalCodeTypeId"/>
+                <xs:element name="validity.start.date" type="Date"/>
+                <xs:element name="validity.end.date" type="Date" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="base.regulation" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="base.regulation.role" type="RegulationRoleTypeId"/>
+                <xs:element name="base.regulation.id" type="RegulationId"/>
+                <xs:element name="published.date" type="Date" minOccurs="0"/>
+                <xs:element name="officialjournal.number" type="OfficialJournalNumber" minOccurs="0"/>
+                <xs:element name="officialjournal.page" type="OfficialJournalPage" minOccurs="0"/>
+                <xs:element name="validity.start.date" type="Date"/>
+                <xs:element name="validity.end.date" type="Date" minOccurs="0"/>
+                <xs:element name="effective.end.date" type="Date" minOccurs="0"/>
+                <xs:element name="community.code" type="CommunityCode"/>
+                <xs:element name="regulation.group.id" type="RegulationGroupId"/>
+                <xs:element name="antidumping.regulation.role" type="RegulationRoleTypeId" minOccurs="0"/>
+                <xs:element name="related.antidumping.regulation.id" type="RegulationId" minOccurs="0"/>
+                <xs:element name="complete.abrogation.regulation.role" type="RegulationRoleTypeId" minOccurs="0"/>
+                <xs:element name="complete.abrogation.regulation.id" type="RegulationId" minOccurs="0"/>
+                <xs:element name="explicit.abrogation.regulation.role" type="RegulationRoleTypeId" minOccurs="0"/>
+                <xs:element name="explicit.abrogation.regulation.id" type="RegulationId" minOccurs="0"/>
+                <xs:element name="replacement.indicator" type="ReplacementIndicator"/>
+                <xs:element name="stopped.flag" type="StoppedFlag"/>
+                <xs:element name="information.text" type="ShortDescription" minOccurs="0"/>
+                <xs:element name="approved.flag" type="ApprovedFlag"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="ceiling" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="surveillance.number" type="SurveillanceNumber"/>
+                <xs:element name="validity.start.date" type="Date"/>
+                <xs:element name="validity.end.date" type="Date" minOccurs="0"/>
+                <xs:element name="ceiling.reached.date" type="Date"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="certificate" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="certificate.type.code" type="CertificateTypeCode"/>
+                <xs:element name="certificate.code" type="CertificateCode"/>
+                <xs:element name="validity.start.date" type="Date"/>
+                <xs:element name="validity.end.date" type="Date" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="certificate.description.period" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="certificate.description.period.sid" type="SID"/>
+                <xs:element name="certificate.type.code" type="CertificateTypeCode"/>
+                <xs:element name="certificate.code" type="CertificateCode"/>
+                <xs:element name="validity.start.date" type="Date"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="certificate.description" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="certificate.description.period.sid" type="SID"/>
+                <xs:element name="language.id" type="LanguageId"/>
+                <xs:element name="certificate.type.code" type="CertificateTypeCode"/>
+                <xs:element name="certificate.code" type="CertificateCode"/>
+                <xs:element name="description" type="ShortDescription" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="certificate.type" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="certificate.type.code" type="CertificateTypeCode"/>
+                <xs:element name="validity.start.date" type="Date"/>
+                <xs:element name="validity.end.date" type="Date" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="certificate.type.description" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="certificate.type.code" type="CertificateTypeCode"/>
+                <xs:element name="language.id" type="LanguageId"/>
+                <xs:element name="description" type="ShortDescription" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="complete.abrogation.regulation" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="complete.abrogation.regulation.role" type="RegulationRoleTypeId"/>
+                <xs:element name="complete.abrogation.regulation.id" type="RegulationId"/>
+                <xs:element name="published.date" type="Date" minOccurs="0"/>
+                <xs:element name="officialjournal.number" type="OfficialJournalNumber" minOccurs="0"/>
+                <xs:element name="officialjournal.page" type="OfficialJournalPage" minOccurs="0"/>
+                <xs:element name="replacement.indicator" type="ReplacementIndicator"/>
+                <xs:element name="information.text" type="ShortDescription" minOccurs="0"/>
+                <xs:element name="approved.flag" type="ApprovedFlag"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="duty.expression" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="duty.expression.id" type="DutyExpressionId"/>
+                <xs:element name="validity.start.date" type="Date"/>
+                <xs:element name="validity.end.date" type="Date" minOccurs="0"/>
+                <xs:element name="duty.amount.applicability.code" type="DutyAmountApplicabilityCode"/>
+                <xs:element name="measurement.unit.applicability.code" type="MeasurementUnitApplicabilityCode"/>
+                <xs:element name="monetary.unit.applicability.code" type="MonetaryUnitApplicabilityCode"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="duty.expression.description" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="duty.expression.id" type="DutyExpressionId"/>
+                <xs:element name="language.id" type="LanguageId"/>
+                <xs:element name="description" type="ShortDescription" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="explicit.abrogation.regulation" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="explicit.abrogation.regulation.role" type="RegulationRoleTypeId"/>
+                <xs:element name="explicit.abrogation.regulation.id" type="RegulationId"/>
+                <xs:element name="published.date" type="Date" minOccurs="0"/>
+                <xs:element name="officialjournal.number" type="OfficialJournalNumber" minOccurs="0"/>
+                <xs:element name="officialjournal.page" type="OfficialJournalPage" minOccurs="0"/>
+                <xs:element name="replacement.indicator" type="ReplacementIndicator"/>
+                <xs:element name="abrogation.date" type="Date"/>
+                <xs:element name="information.text" type="ShortDescription" minOccurs="0"/>
+                <xs:element name="approved.flag" type="ApprovedFlag"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="export.refund.nomenclature" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="export.refund.nomenclature.sid" type="SID"/>
+                <xs:element name="goods.nomenclature.item.id" type="GoodsNomenclatureItemId"/>
+                <xs:element name="additional.code.type" type="AdditionalCodeTypeId"/>
+                <xs:element name="export.refund.code" type="ExportRefundCode"/>
+                <xs:element name="productline.suffix" type="ProductLineSuffix"/>
+                <xs:element name="validity.start.date" type="Date"/>
+                <xs:element name="validity.end.date" type="Date" minOccurs="0"/>
+                <xs:element name="goods.nomenclature.sid" type="SID"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="export.refund.nomenclature.indents" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="export.refund.nomenclature.indents.sid" type="SID"/>
+                <xs:element name="export.refund.nomenclature.sid" type="SID"/>
+                <xs:element name="validity.start.date" type="Date"/>
+                <xs:element name="number.export.refund.nomenclature.indents" type="NumberOf"/>
+                <xs:element name="goods.nomenclature.item.id" type="GoodsNomenclatureItemId"/>
+                <xs:element name="additional.code.type" type="AdditionalCodeTypeId"/>
+                <xs:element name="export.refund.code" type="ExportRefundCode"/>
+                <xs:element name="productline.suffix" type="ProductLineSuffix"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="export.refund.nomenclature.description.period" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="export.refund.nomenclature.description.period.sid" type="SID"/>
+                <xs:element name="export.refund.nomenclature.sid" type="SID"/>
+                <xs:element name="validity.start.date" type="Date"/>
+                <xs:element name="goods.nomenclature.item.id" type="GoodsNomenclatureItemId"/>
+                <xs:element name="additional.code.type" type="AdditionalCodeTypeId"/>
+                <xs:element name="export.refund.code" type="ExportRefundCode"/>
+                <xs:element name="productline.suffix" type="ProductLineSuffix"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="export.refund.nomenclature.description" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="export.refund.nomenclature.description.period.sid" type="SID"/>
+                <xs:element name="language.id" type="LanguageId"/>
+                <xs:element name="export.refund.nomenclature.sid" type="SID"/>
+                <xs:element name="goods.nomenclature.item.id" type="GoodsNomenclatureItemId"/>
+                <xs:element name="additional.code.type" type="AdditionalCodeTypeId"/>
+                <xs:element name="export.refund.code" type="ExportRefundCode"/>
+                <xs:element name="productline.suffix" type="ProductLineSuffix"/>
+                <xs:element name="description" type="LongDescription" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="footnote" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="footnote.type.id" type="FootnoteTypeId"/>
+                <xs:element name="footnote.id" type="FootnoteId"/>
+                <xs:element name="validity.start.date" type="Date"/>
+                <xs:element name="validity.end.date" type="Date" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="footnote.association.additional.code" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="additional.code.sid" type="SID"/>
+                <xs:element name="footnote.type.id" type="FootnoteTypeId"/>
+                <xs:element name="footnote.id" type="FootnoteId"/>
+                <xs:element name="validity.start.date" type="Date"/>
+                <xs:element name="validity.end.date" type="Date" minOccurs="0"/>
+                <xs:element name="additional.code.type.id" type="AdditionalCodeTypeId"/>
+                <xs:element name="additional.code" type="AdditionalCode"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="footnote.association.ern" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="export.refund.nomenclature.sid" type="SID"/>
+                <xs:element name="footnote.type" type="FootnoteTypeId"/>
+                <xs:element name="footnote.id" type="FootnoteId"/>
+                <xs:element name="validity.start.date" type="Date"/>
+                <xs:element name="validity.end.date" type="Date" minOccurs="0"/>
+                <xs:element name="goods.nomenclature.item.id" type="GoodsNomenclatureItemId"/>
+                <xs:element name="additional.code.type" type="AdditionalCodeTypeId"/>
+                <xs:element name="export.refund.code" type="ExportRefundCode"/>
+                <xs:element name="productline.suffix" type="ProductLineSuffix"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="footnote.association.goods.nomenclature" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="goods.nomenclature.sid" type="SID"/>
+                <xs:element name="footnote.type" type="FootnoteTypeId"/>
+                <xs:element name="footnote.id" type="FootnoteId"/>
+                <xs:element name="validity.start.date" type="Date"/>
+                <xs:element name="validity.end.date" type="Date" minOccurs="0"/>
+                <xs:element name="goods.nomenclature.item.id" type="GoodsNomenclatureItemId"/>
+                <xs:element name="productline.suffix" type="ProductLineSuffix"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="footnote.association.meursing.heading" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="meursing.table.plan.id" type="MeursingTablePlanId"/>
+                <xs:element name="meursing.heading.number" type="MeursingHeadingNumber"/>
+                <xs:element name="row.column.code" type="RowColumnCode"/>
+                <xs:element name="footnote.type" type="FootnoteTypeId"/>
+                <xs:element name="footnote.id" type="FootnoteId"/>
+                <xs:element name="validity.start.date" type="Date"/>
+                <xs:element name="validity.end.date" type="Date" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="footnote.description.period" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="footnote.description.period.sid" type="SID"/>
+                <xs:element name="footnote.type.id" type="FootnoteTypeId"/>
+                <xs:element name="footnote.id" type="FootnoteId"/>
+                <xs:element name="validity.start.date" type="Date"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="footnote.description" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="footnote.description.period.sid" type="SID"/>
+                <xs:element name="language.id" type="LanguageId"/>
+                <xs:element name="footnote.type.id" type="FootnoteTypeId"/>
+                <xs:element name="footnote.id" type="FootnoteId"/>
+                <xs:element name="description" type="LongDescription" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="footnote.type" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="footnote.type.id" type="FootnoteTypeId"/>
+                <xs:element name="validity.start.date" type="Date"/>
+                <xs:element name="validity.end.date" type="Date" minOccurs="0"/>
+                <xs:element name="application.code" type="ApplicationCodeFootnote"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="footnote.type.description" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="footnote.type.id" type="FootnoteTypeId"/>
+                <xs:element name="language.id" type="LanguageId"/>
+                <xs:element name="description" type="ShortDescription" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="fts.regulation.action" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="fts.regulation.role" type="RegulationRoleTypeId"/>
+                <xs:element name="fts.regulation.id" type="RegulationId"/>
+                <xs:element name="stopped.regulation.role" type="RegulationRoleTypeId"/>
+                <xs:element name="stopped.regulation.id" type="RegulationId"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="full.temporary.stop.regulation" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="full.temporary.stop.regulation.role" type="RegulationRoleTypeId"/>
+                <xs:element name="full.temporary.stop.regulation.id" type="RegulationId"/>
+                <xs:element name="published.date" type="Date" minOccurs="0"/>
+                <xs:element name="officialjournal.number" type="OfficialJournalNumber" minOccurs="0"/>
+                <xs:element name="officialjournal.page" type="OfficialJournalPage" minOccurs="0"/>
+                <xs:element name="validity.start.date" type="Date"/>
+                <xs:element name="validity.end.date" type="Date" minOccurs="0"/>
+                <xs:element name="effective.enddate" type="Date" minOccurs="0"/>
+                <xs:element name="complete.abrogation.regulation.role" type="RegulationRoleTypeId" minOccurs="0"/>
+                <xs:element name="complete.abrogation.regulation.id" type="RegulationId" minOccurs="0"/>
+                <xs:element name="explicit.abrogation.regulation.role" type="RegulationRoleTypeId" minOccurs="0"/>
+                <xs:element name="explicit.abrogation.regulation.id" type="RegulationId" minOccurs="0"/>
+                <xs:element name="replacement.indicator" type="ReplacementIndicator"/>
+                <xs:element name="information.text" type="ShortDescription" minOccurs="0"/>
+                <xs:element name="approved.flag" type="ApprovedFlag"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="geographical.area" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="geographical.area.sid" type="SID"/>
+                <xs:element name="geographical.area.id" type="GeographicalAreaId"/>
+                <xs:element name="validity.start.date" type="Date"/>
+                <xs:element name="validity.end.date" type="Date" minOccurs="0"/>
+                <xs:element name="geographical.code" type="AreaCode"/>
+                <xs:element name="parent.geographical.area.group.sid" type="SID" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="geographical.area.description.period" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="geographical.area.description.period.sid" type="SID"/>
+                <xs:element name="geographical.area.sid" type="SID"/>
+                <xs:element name="validity.start.date" type="Date"/>
+                <xs:element name="geographical.area.id" type="GeographicalAreaId"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="geographical.area.description" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="geographical.area.description.period.sid" type="SID"/>
+                <xs:element name="language.id" type="LanguageId"/>
+                <xs:element name="geographical.area.sid" type="SID"/>
+                <xs:element name="geographical.area.id" type="GeographicalAreaId"/>
+                <xs:element name="description" type="ShortDescription" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="geographical.area.membership" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="geographical.area.sid" type="SID"/>
+                <xs:element name="geographical.area.group.sid" type="SID"/>
+                <xs:element name="validity.start.date" type="Date"/>
+                <xs:element name="validity.end.date" type="Date" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="goods.nomenclature" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="goods.nomenclature.sid" type="SID"/>
+                <xs:element name="goods.nomenclature.item.id" type="GoodsNomenclatureItemId"/>
+                <xs:element name="producline.suffix" type="ProductLineSuffix"/>
+                <xs:element name="validity.start.date" type="Date"/>
+                <xs:element name="validity.end.date" type="Date" minOccurs="0"/>
+                <xs:element name="statistical.indicator" type="StatisticalIndicator"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="goods.nomenclature.indents" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="goods.nomenclature.indent.sid" type="SID"/>
+                <xs:element name="goods.nomenclature.sid" type="SID"/>
+                <xs:element name="validity.start.date" type="Date"/>
+                <xs:element name="number.indents" type="NumberOf"/>
+                <xs:element name="goods.nomenclature.item.id" type="GoodsNomenclatureItemId"/>
+                <xs:element name="productline.suffix" type="ProductLineSuffix"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="goods.nomenclature.description.period" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="goods.nomenclature.description.period.sid" type="SID"/>
+                <xs:element name="goods.nomenclature.sid" type="SID"/>
+                <xs:element name="validity.start.date" type="Date"/>
+                <xs:element name="goods.nomenclature.item.id" type="GoodsNomenclatureItemId"/>
+                <xs:element name="productline.suffix" type="ProductLineSuffix"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="goods.nomenclature.description" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="goods.nomenclature.description.period.sid" type="SID"/>
+                <xs:element name="language.id" type="LanguageId"/>
+                <xs:element name="goods.nomenclature.sid" type="SID"/>
+                <xs:element name="goods.nomenclature.item.id" type="GoodsNomenclatureItemId"/>
+                <xs:element name="productline.suffix" type="ProductLineSuffix"/>
+                <xs:element name="description" type="LongDescription" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="goods.nomenclature.group" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="goods.nomenclature.group.type" type="GoodsNomenclatureGroupType"/>
+                <xs:element name="goods.nomenclature.group.id" type="GoodsNomenclatureGroupId"/>
+                <xs:element name="validity.start.date" type="Date"/>
+                <xs:element name="validity.end.date" type="Date" minOccurs="0"/>
+                <xs:element name="nomenclature.group.facility.code" type="NomenclatureGroupFacilityCode"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="goods.nomenclature.group.description" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="goods.nomenclature.group.type" type="GoodsNomenclatureGroupType"/>
+                <xs:element name="goods.nomenclature.group.id" type="GoodsNomenclatureGroupId"/>
+                <xs:element name="language.id" type="LanguageId"/>
+                <xs:element name="description" type="ShortDescription" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="goods.nomenclature.origin" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="goods.nomenclature.sid" type="SID"/>
+                <xs:element name="derived.goods.nomenclature.item.id" type="GoodsNomenclatureItemId"/>
+                <xs:element name="derived.productline.suffix" type="ProductLineSuffix"/>
+                <xs:element name="goods.nomenclature.item.id" type="GoodsNomenclatureItemId"/>
+                <xs:element name="productline.suffix" type="ProductLineSuffix"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="goods.nomenclature.successor" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="goods.nomenclature.sid" type="SID"/>
+                <xs:element name="absorbed.goods.nomenclature.item.id" type="GoodsNomenclatureItemId"/>
+                <xs:element name="absorbed.productline.suffix" type="ProductLineSuffix"/>
+                <xs:element name="goods.nomenclature.item.id" type="GoodsNomenclatureItemId"/>
+                <xs:element name="productline.suffix" type="ProductLineSuffix"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="language" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="language.id" type="LanguageId"/>
+                <xs:element name="validity.start.date" type="Date"/>
+                <xs:element name="validity.end.date" type="Date" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="language.description" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="language.code.id" type="LanguageId"/>
+                <xs:element name="language.id" type="LanguageId"/>
+                <xs:element name="description" type="ShortDescription" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="measure" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="measure.sid" type="SID"/>
+                <xs:element name="measure.type" type="MeasureTypeId"/>
+                <xs:element name="geographical.area" type="GeographicalAreaId"/>
+                <xs:element name="goods.nomenclature.item.id" type="GoodsNomenclatureItemId" minOccurs="0"/>
+                <xs:element name="additional.code.type" type="AdditionalCodeTypeId" minOccurs="0"/>
+                <xs:element name="additional.code" type="AdditionalCode" minOccurs="0"/>
+                <xs:element name="ordernumber" type="OrderNumber" minOccurs="0"/>
+                <xs:element name="reduction.indicator" type="ReductionIndicator" minOccurs="0"/>
+                <xs:element name="validity.start.date" type="Date"/>
+                <xs:element name="measure.generating.regulation.role" type="RegulationRoleTypeId"/>
+                <xs:element name="measure.generating.regulation.id" type="RegulationId"/>
+                <xs:element name="validity.end.date" type="Date" minOccurs="0"/>
+                <xs:element name="justification.regulation.role" type="RegulationRoleTypeId" minOccurs="0"/>
+                <xs:element name="justification.regulation.id" type="RegulationId" minOccurs="0"/>
+                <xs:element name="stopped.flag" type="StoppedFlag"/>
+                <xs:element name="geographical.area.sid" type="SID" minOccurs="0"/>
+                <xs:element name="goods.nomenclature.sid" type="SID" minOccurs="0"/>
+                <xs:element name="additional.code.sid" type="SID" minOccurs="0"/>
+                <xs:element name="export.refund.nomenclature.sid" type="SID" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="measure.component" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="measure.sid" type="SID"/>
+                <xs:element name="duty.expression.id" type="DutyExpressionId"/>
+                <xs:element name="duty.amount" type="DutyAmount" minOccurs="0"/>
+                <xs:element name="monetary.unit.code" type="MonetaryUnitCode" minOccurs="0"/>
+                <xs:element name="measurement.unit.code" type="MeasurementUnitCode" minOccurs="0"/>
+                <xs:element name="measurement.unit.qualifier.code" type="MeasurementUnitQualifierCode" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="measure.condition" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="measure.condition.sid" type="SID"/>
+                <xs:element name="measure.sid" type="SID"/>
+                <xs:element name="condition.code" type="ConditionCode"/>
+                <xs:element name="component.sequence.number" type="ComponentSequenceNumber"/>
+                <xs:element name="condition.duty.amount" type="DutyAmount" minOccurs="0"/>
+                <xs:element name="condition.monetary.unit.code" type="MonetaryUnitCode" minOccurs="0"/>
+                <xs:element name="condition.measurement.unit.code" type="MeasurementUnitCode" minOccurs="0"/>
+                <xs:element name="condition.measurement.unit.qualifier.code" type="MeasurementUnitQualifierCode" minOccurs="0"/>
+                <xs:element name="action.code" type="ActionCode" minOccurs="0"/>
+                <xs:element name="certificate.type.code" type="CertificateTypeCode" minOccurs="0"/>
+                <xs:element name="certificate.code" type="CertificateCode" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="measure.condition.component" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="measure.condition.sid" type="SID"/>
+                <xs:element name="duty.expression.id" type="DutyExpressionId"/>
+                <xs:element name="duty.amount" type="DutyAmount" minOccurs="0"/>
+                <xs:element name="monetary.unit.code" type="MonetaryUnitCode" minOccurs="0"/>
+                <xs:element name="measurement.unit.code" type="MeasurementUnitCode" minOccurs="0"/>
+                <xs:element name="measurement.unit.qualifier.code" type="MeasurementUnitQualifierCode" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="measure.excluded.geographical.area" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="measure.sid" type="SID"/>
+                <xs:element name="excluded.geographical.area" type="GeographicalAreaId"/>
+                <xs:element name="geographical.area.sid" type="SID"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="footnote.association.measure" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="measure.sid" type="SID"/>
+                <xs:element name="footnote.type.id" type="FootnoteTypeId"/>
+                <xs:element name="footnote.id" type="FootnoteId"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="measure.partial.temporary.stop" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="measure.sid" type="SID"/>
+                <xs:element name="validity.start.date" type="Date"/>
+                <xs:element name="validity.end.date" type="Date" minOccurs="0"/>
+                <xs:element name="partial.temporary.stop.regulation.id" type="RegulationId"/>
+                <xs:element name="partial.temporary.stop.regulation.officialjournal.number" type="OfficialJournalNumber" minOccurs="0"/>
+                <xs:element name="partial.temporary.stop.regulation.officialjournal.page" type="OfficialJournalPage" minOccurs="0"/>
+                <xs:element name="abrogation.regulation.id" type="RegulationId" minOccurs="0"/>
+                <xs:element name="abrogation.regulation.officialjournal.number" type="OfficialJournalNumber" minOccurs="0"/>
+                <xs:element name="abrogation.regulation.officialjournal.page" type="OfficialJournalPage" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="measure.condition.code" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="condition.code" type="ConditionCode"/>
+                <xs:element name="validity.start.date" type="Date"/>
+                <xs:element name="validity.end.date" type="Date" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="measure.condition.code.description" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="condition.code" type="ConditionCode"/>
+                <xs:element name="language.id" type="LanguageId"/>
+                <xs:element name="description" type="ShortDescription" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="measure.action" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="action.code" type="ActionCode"/>
+                <xs:element name="validity.start.date" type="Date"/>
+                <xs:element name="validity.end.date" type="Date" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="measure.action.description" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="action.code" type="ActionCode"/>
+                <xs:element name="language.id" type="LanguageId"/>
+                <xs:element name="description" type="ShortDescription" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="measure.type" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="measure.type.id" type="MeasureTypeId"/>
+                <xs:element name="validity.start.date" type="Date"/>
+                <xs:element name="validity.end.date" type="Date" minOccurs="0"/>
+                <xs:element name="trade.movement.code" type="TradeMovementCode"/>
+                <xs:element name="priority.code" type="PriorityCode"/>
+                <xs:element name="measure.component.applicable.code" type="MeasurementUnitApplicabilityCode"/>
+                <xs:element name="origin.dest.code" type="OriginCode"/>
+                <xs:element name="order.number.capture.code" type="OrderNumberCaptureCode"/>
+                <xs:element name="measure.explosion.level" type="MeasureExplosionLevel"/>
+                <xs:element name="measure.type.series.id" type="MeasureTypeSeriesId"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="measure.type.description" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="measure.type.id" type="MeasureTypeId"/>
+                <xs:element name="language.id" type="LanguageId"/>
+                <xs:element name="description" type="ShortDescription" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="measure.type.series" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="measure.type.series.id" type="MeasureTypeSeriesId"/>
+                <xs:element name="validity.start.date" type="Date"/>
+                <xs:element name="validity.end.date" type="Date" minOccurs="0"/>
+                <xs:element name="measure.type.combination" type="MeasureTypeCombination"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="measure.type.series.description" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="measure.type.series.id" type="MeasureTypeSeriesId"/>
+                <xs:element name="language.id" type="LanguageId"/>
+                <xs:element name="description" type="ShortDescription" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="measurement.unit" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="measurement.unit.code" type="MeasurementUnitCode"/>
+                <xs:element name="validity.start.date" type="Date"/>
+                <xs:element name="validity.end.date" type="Date" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="measurement.unit.description" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="measurement.unit.code" type="MeasurementUnitCode"/>
+                <xs:element name="language.id" type="LanguageId"/>
+                <xs:element name="description" type="ShortDescription" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="measurement.unit.qualifier" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="measurement.unit.qualifier.code" type="MeasurementUnitQualifierCode"/>
+                <xs:element name="validity.start.date" type="Date"/>
+                <xs:element name="validity.end.date" type="Date" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="measurement.unit.qualifier.description" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="measurement.unit.qualifier.code" type="MeasurementUnitQualifierCode"/>
+                <xs:element name="language.id" type="LanguageId"/>
+                <xs:element name="description" type="ShortDescription" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="measurement" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="measurement.unit.code" type="MeasurementUnitCode"/>
+                <xs:element name="measurement.unit.qualifier.code" type="MeasurementUnitQualifierCode"/>
+                <xs:element name="validity.start.date" type="Date"/>
+                <xs:element name="validity.end.date" type="Date" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="meursing.table.plan" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="meursing.table.plan.id" type="MeursingTablePlanId"/>
+                <xs:element name="validity.start.date" type="Date"/>
+                <xs:element name="validity.end.date" type="Date" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="meursing.heading" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="meursing.table.plan.id" type="MeursingTablePlanId"/>
+                <xs:element name="meursing.heading.number" type="MeursingHeadingNumber"/>
+                <xs:element name="row.column.code" type="RowColumnCode"/>
+                <xs:element name="validity.start.date" type="Date"/>
+                <xs:element name="validity.end.date" type="Date" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="meursing.heading.text" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="meursing.table.plan.id" type="MeursingTablePlanId"/>
+                <xs:element name="meursing.heading.number" type="MeursingHeadingNumber"/>
+                <xs:element name="row.column.code" type="RowColumnCode"/>
+                <xs:element name="language.id" type="LanguageId"/>
+                <xs:element name="description" type="ShortDescription" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="meursing.subheading" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="meursing.table.plan.id" type="MeursingTablePlanId"/>
+                <xs:element name="meursing.heading.number" type="MeursingHeadingNumber"/>
+                <xs:element name="row.column.code" type="RowColumnCode"/>
+                <xs:element name="subheading.sequence.number" type="SubHeadingSequenceNumber"/>
+                <xs:element name="validity.start.date" type="Date"/>
+                <xs:element name="validity.end.date" type="Date" minOccurs="0"/>
+                <xs:element name="description" type="ShortDescription" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="meursing.additional.code" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="meursing.additional.code.sid" type="SID"/>
+                <xs:element name="validity.end.date" type="Date" minOccurs="0"/>
+                <xs:element name="additional.code" type="AdditionalCode"/>
+                <xs:element name="validity.start.date" type="Date"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="meursing.table.cell.component" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="meursing.additional.code.sid" type="SID"/>
+                <xs:element name="meursing.table.plan.id" type="MeursingTablePlanId"/>
+                <xs:element name="heading.number" type="MeursingHeadingNumber"/>
+                <xs:element name="row.column.code" type="RowColumnCode"/>
+                <xs:element name="subheading.sequence.number" type="SubHeadingSequenceNumber"/>
+                <xs:element name="validity.start.date" type="Date"/>
+                <xs:element name="validity.end.date" type="Date" minOccurs="0"/>
+                <xs:element name="additional.code" type="AdditionalCode"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="modification.regulation" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="modification.regulation.role" type="RegulationRoleTypeId"/>
+                <xs:element name="modification.regulation.id" type="RegulationId"/>
+                <xs:element name="published.date" type="Date" minOccurs="0"/>
+                <xs:element name="officialjournal.number" type="OfficialJournalNumber" minOccurs="0"/>
+                <xs:element name="officialjournal.page" type="OfficialJournalPage" minOccurs="0"/>
+                <xs:element name="validity.start.date" type="Date"/>
+                <xs:element name="validity.end.date" type="Date" minOccurs="0"/>
+                <xs:element name="effective.end.date" type="Date" minOccurs="0"/>
+                <xs:element name="base.regulation.role" type="RegulationRoleTypeId"/>
+                <xs:element name="base.regulation.id" type="RegulationId"/>
+                <xs:element name="complete.abrogation.regulation.role" type="RegulationRoleTypeId" minOccurs="0"/>
+                <xs:element name="complete.abrogation.regulation.id" type="RegulationId" minOccurs="0"/>
+                <xs:element name="explicit.abrogation.regulation.role" type="RegulationRoleTypeId" minOccurs="0"/>
+                <xs:element name="explicit.abrogation.regulation.id" type="RegulationId" minOccurs="0"/>
+                <xs:element name="replacement.indicator" type="ReplacementIndicator"/>
+                <xs:element name="stopped.flag" type="StoppedFlag"/>
+                <xs:element name="information.text" type="ShortDescription" minOccurs="0"/>
+                <xs:element name="approved.flag" type="ApprovedFlag"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="monetary.exchange.period" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="monetary.exchange.period.sid" type="SID"/>
+                <xs:element name="parent.monetary.unit.code" type="MonetaryUnitCode"/>
+                <xs:element name="validity.start.date" type="Date"/>
+                <xs:element name="validity.end.date" type="Date" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="monetary.exchange.rate" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="monetary.exchange.period.sid" type="SID"/>
+                <xs:element name="child.monetary.unit.code" type="MonetaryUnitCode"/>
+                <xs:element name="exchange.rate" type="ExchangeRate"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="monetary.unit" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="monetary.unit.code" type="MonetaryUnitCode"/>
+                <xs:element name="validity.start.date" type="Date"/>
+                <xs:element name="validity.end.date" type="Date" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="monetary.unit.description" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="monetary.unit.code" type="MonetaryUnitCode"/>
+                <xs:element name="language.id" type="LanguageId"/>
+                <xs:element name="description" type="ShortDescription" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="nomenclature.group.membership" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="goods.nomenclature.sid" type="SID"/>
+                <xs:element name="goods.nomenclature.group.type" type="GoodsNomenclatureGroupType"/>
+                <xs:element name="goods.nomenclature.group.id" type="GoodsNomenclatureGroupId"/>
+                <xs:element name="validity.start.date" type="Date"/>
+                <xs:element name="validity.end.date" type="Date" minOccurs="0"/>
+                <xs:element name="goods.nomenclature.item.id" type="GoodsNomenclatureItemId"/>
+                <xs:element name="productline.suffix" type="ProductLineSuffix"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="prorogation.regulation" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="prorogation.regulation.role" type="RegulationRoleTypeId"/>
+                <xs:element name="prorogation.regulation.id" type="RegulationId"/>
+                <xs:element name="published.date" type="Date" minOccurs="0"/>
+                <xs:element name="officialjournal.number" type="OfficialJournalNumber" minOccurs="0"/>
+                <xs:element name="officialjournal.page" type="OfficialJournalPage" minOccurs="0"/>
+                <xs:element name="replacement.indicator" type="ReplacementIndicator"/>
+                <xs:element name="information.text" type="ShortDescription" minOccurs="0"/>
+                <xs:element name="approved.flag" type="ApprovedFlag"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="prorogation.regulation.action" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="prorogation.regulation.role" type="RegulationRoleTypeId"/>
+                <xs:element name="prorogation.regulation.id" type="RegulationId"/>
+                <xs:element name="prorogated.regulation.role" type="RegulationRoleTypeId"/>
+                <xs:element name="prorogated.regulation.id" type="RegulationId"/>
+                <xs:element name="prorogated.date" type="Date" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="publication.sigle" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="code.type.id" type="CodeTypeId"/>
+                <xs:element name="code" type="Code"/>
+                <xs:element name="validity.start.date" type="Date"/>
+                <xs:element name="validity.end.date" type="Date" minOccurs="0"/>
+                <xs:element name="publication.code" type="PublicationCode"/>
+                <xs:element name="publication.sigle" type="PublicationSigle" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="quota.order.number" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="quota.order.number.sid" type="SID"/>
+                <xs:element name="quota.order.number.id" type="OrderNumber"/>
+                <xs:element name="validity.start.date" type="Date"/>
+                <xs:element name="validity.end.date" type="Date" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="quota.order.number.origin" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="quota.order.number.origin.sid" type="SID"/>
+                <xs:element name="quota.order.number.sid" type="SID"/>
+                <xs:element name="geographical.area.id" type="GeographicalAreaId"/>
+                <xs:element name="validity.start.date" type="Date"/>
+                <xs:element name="validity.end.date" type="Date" minOccurs="0"/>
+                <xs:element name="geographical.area.sid" type="SID"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="quota.order.number.origin.exclusions" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="quota.order.number.origin.sid" type="SID"/>
+                <xs:element name="excluded.geographical.area.sid" type="SID"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="quota.definition" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="quota.definition.sid" type="SID"/>
+                <xs:element name="quota.order.number.id" type="OrderNumber"/>
+                <xs:element name="validity.start.date" type="Date"/>
+                <xs:element name="validity.end.date" type="Date" minOccurs="0"/>
+                <xs:element name="quota.order.number.sid" type="SID"/>
+                <xs:element name="volume" type="QuotaAmount"/>
+                <xs:element name="initial.volume" type="QuotaAmount"/>
+                <xs:element name="monetary.unit.code" type="MonetaryUnitCode" minOccurs="0"/>
+                <xs:element name="measurement.unit.code" type="MeasurementUnitCode" minOccurs="0"/>
+                <xs:element name="measurement.unit.qualifier.code" type="MeasurementUnitQualifierCode" minOccurs="0"/>
+                <xs:element name="maximum.precision" type="QuotaPrecision"/>
+                <xs:element name="critical.state" type="QuotaCriticalStateCode"/>
+                <xs:element name="critical.threshold" type="QuotaCriticalTreshold"/>
+                <xs:element name="description" type="ShortDescription" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="quota.association" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="main.quota.definition.sid" type="SID"/>
+                <xs:element name="sub.quota.definition.sid" type="SID"/>
+                <xs:element name="relation.type" type="RelationType"/>
+                <xs:element name="coefficient" type="QuotaCoefficient" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="quota.blocking.period" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="quota.blocking.period.sid" type="SID"/>
+                <xs:element name="quota.definition.sid" type="SID"/>
+                <xs:element name="blocking.start.date" type="Date"/>
+                <xs:element name="blocking.end.date" type="Date"/>
+                <xs:element name="blocking.period.type" type="QuotaBlockingPeriodType"/>
+                <xs:element name="description" type="ShortDescription" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="quota.suspension.period" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="quota.suspension.period.sid" type="SID"/>
+                <xs:element name="quota.definition.sid" type="SID"/>
+                <xs:element name="suspension.start.date" type="Date"/>
+                <xs:element name="suspension.end.date" type="Date"/>
+                <xs:element name="description" type="ShortDescription" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="quota.extended.information" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="quota.definition.sid" type="SID"/>
+                <xs:element name="balance" type="QuotaAmount"/>
+                <xs:element name="imported.amount" type="QuotaAmount"/>
+                <xs:element name="last.allocation.date" type="Date" minOccurs="0"/>
+                <xs:element name="allocated.percentage" type="QuotaAllocatedPercentage" minOccurs="0"/>
+                <xs:element name="last.import.date" type="Date" minOccurs="0"/>
+                <xs:element name="quota.exhaustion.state" type="QuotaExhaustedStateCode"/>
+                <xs:element name="exhaustion.date" type="Date" minOccurs="0"/>
+                <xs:element name="quota.blocked.state" type="QuotaBlockedStateCode"/>
+                <xs:element name="quota.suspended.state" type="QuotaSuspendedStateCode"/>
+                <xs:element name="total.awaiting.allocation" type="QuotaAmount"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="quota.balance.event" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="quota.definition.sid" type="SID"/>
+                <xs:element name="occurrence.timestamp" type="Timestamp"/>
+                <xs:element name="old.balance" type="QuotaAmount"/>
+                <xs:element name="new.balance" type="QuotaAmount"/>
+                <xs:element name="imported.amount" type="QuotaAmount"/>
+                <xs:element name="last.import.date.in.allocation" type="Date" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="quota.unblocking.event" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="quota.definition.sid" type="SID"/>
+                <xs:element name="occurrence.timestamp" type="Timestamp"/>
+                <xs:element name="unblocking.date" type="Date"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="quota.critical.event" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="quota.definition.sid" type="SID"/>
+                <xs:element name="occurrence.timestamp" type="Timestamp"/>
+                <xs:element name="critical.state" type="QuotaCriticalStateCode"/>
+                <xs:element name="critical.state.change.date" type="Date" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="quota.exhaustion.event" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="quota.definition.sid" type="SID"/>
+                <xs:element name="occurrence.timestamp" type="Timestamp"/>
+                <xs:element name="exhaustion.date" type="Date"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="quota.reopening.event" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="quota.definition.sid" type="SID"/>
+                <xs:element name="occurrence.timestamp" type="Timestamp"/>
+                <xs:element name="reopening.date" type="Date"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="quota.unsuspension.event" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="quota.definition.sid" type="SID"/>
+                <xs:element name="occurrence.timestamp" type="Timestamp"/>
+                <xs:element name="unsuspension.date" type="Date"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="quota.closed.and.transferred.event" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="quota.definition.sid" type="SID"/>
+                <xs:element name="occurrence.timestamp" type="Timestamp"/>
+                <!-- QTM148 CUSTD00029679 03/08/2013 CUST-DEV2  -->
+                <!--    <xs:element name="closing.date" type="Date"/> -->
+                <xs:element name="transfer.date" type="Date"/>
+                <xs:element name="quota.closed" type="QuotaClosedCode"/>
+                <!-- CUSTD00029679 - end -->
+                <xs:element name="transferred.amount" type="QuotaAmount"/>
+                <xs:element name="target.quota.definition.sid" type="SID"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="regulation.group" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="regulation.group.id" type="RegulationGroupId"/>
+                <xs:element name="validity.start.date" type="Date"/>
+                <xs:element name="validity.end.date" type="Date" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="regulation.group.description" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="regulation.group.id" type="RegulationGroupId"/>
+                <xs:element name="language.id" type="LanguageId"/>
+                <xs:element name="description" type="ShortDescription" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="regulation.role.type" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="regulation.role.type.id" type="RegulationRoleTypeId"/>
+                <xs:element name="validity.start.date" type="Date"/>
+                <xs:element name="validity.end.date" type="Date" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="regulation.role.type.description" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="regulation.role.type.id" type="RegulationRoleTypeId"/>
+                <xs:element name="language.id" type="LanguageId"/>
+                <xs:element name="description" type="ShortDescription" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="regulation.replacement" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="replacing.regulation.role" type="RegulationRoleTypeId"/>
+                <xs:element name="replacing.regulation.id" type="RegulationId"/>
+                <xs:element name="replaced.regulation.role" type="RegulationRoleTypeId"/>
+                <xs:element name="replaced.regulation.id" type="RegulationId"/>
+                <xs:element name="measure.type.id" type="MeasureTypeId" minOccurs="0"/>
+                <xs:element name="geographical.area.id" type="GeographicalAreaId" minOccurs="0"/>
+                <xs:element name="chapter.heading" type="ChapterHeading" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
 </xs:schema>

--- a/common/tests/factories.py
+++ b/common/tests/factories.py
@@ -180,7 +180,7 @@ class CertificateDescriptionFactory(TrackedModelMixin, ValidityFactoryMixin):
     class Meta:
         model = "certificates.CertificateDescription"
 
-    sid = numeric_sid()
+    sid = factory.Sequence(lambda x: x + 1)
 
     described_certificate = factory.SubFactory(CertificateFactory)
     description = short_description()
@@ -219,7 +219,7 @@ class AdditionalCodeFactory(TrackedModelMixin, ValidityFactoryMixin):
     class Meta:
         model = "additional_codes.AdditionalCode"
 
-    sid = numeric_sid()
+    sid = factory.Sequence(lambda x: x + 1)
     type = factory.SubFactory(AdditionalCodeTypeFactory)
     code = string_sequence(3)
 

--- a/footnotes/tests/test_importer.py
+++ b/footnotes/tests/test_importer.py
@@ -1,33 +1,17 @@
 import pytest
 
 from common.tests import factories
-from common.tests.util import generate_test_import_xml
-from common.validators import UpdateType
-from footnotes import models
+from common.tests.util import validate_taric_import
 from footnotes import serializers
-from importer.management.commands.import_taric import import_taric
-from workbaskets.models import WorkflowStatus
 
 pytestmark = pytest.mark.django_db
 
 
-def test_footnote_type_importer_create(valid_user):
-    footnote_type = factories.FootnoteTypeFactory.build(
-        update_type=UpdateType.CREATE.value
-    )
-    xml = generate_test_import_xml(
-        serializers.FootnoteTypeSerializer(
-            footnote_type, context={"format": "xml"}
-        ).data
-    )
-
-    import_taric(xml, valid_user.username, WorkflowStatus.PUBLISHED.value)
-
-    db_footnote_type = models.FootnoteType.objects.get(
-        footnote_type_id=footnote_type.footnote_type_id
-    )
-
-    assert db_footnote_type.footnote_type_id == footnote_type.footnote_type_id
-    assert db_footnote_type.application_code == footnote_type.application_code
-    assert db_footnote_type.valid_between.lower == footnote_type.valid_between.lower
-    assert db_footnote_type.valid_between.upper == footnote_type.valid_between.upper
+@validate_taric_import(
+    serializers.FootnoteTypeSerializer, factories.FootnoteTypeFactory
+)
+def test_footnote_type_importer_create(valid_user, test_object, db_object):
+    assert db_object.footnote_type_id == test_object.footnote_type_id
+    assert db_object.application_code == test_object.application_code
+    assert db_object.valid_between.lower == test_object.valid_between.lower
+    assert db_object.valid_between.upper == test_object.valid_between.upper

--- a/importer/handlers.py
+++ b/importer/handlers.py
@@ -267,7 +267,7 @@ class BaseHandler(metaclass=BaseHandlerMeta):
         a dependency is not found the method returns False - to signify the object cannot be resolved.
         If all dependencies are found the method returns True.
         """
-        dependencies = self.dependency_keys
+        dependencies = self.dependency_keys.copy()
         resolved_dependencies = {self.key}
 
         while dependencies:
@@ -361,6 +361,7 @@ class BaseHandler(metaclass=BaseHandlerMeta):
         if not self.dependency_keys and not self.links:
             self.dispatch()
             return {self.key}
+
         if not self.resolve_dependencies() or not self.resolve_links():
             return set()
 
@@ -379,6 +380,7 @@ class BaseHandler(metaclass=BaseHandlerMeta):
         data.update(workbasket_id=self.workbasket_id)
         logger.debug(f"Creating {self.serializer_class.Meta.model}: {data}")
         data = self.pre_save(data, self.resolved_links)
+        print(data)
         obj = self.serializer_class().create(data)
         self.post_save(obj)
         return obj

--- a/importer/parsers.py
+++ b/importer/parsers.py
@@ -175,13 +175,29 @@ class TextElement(ElementParser):
     This class provides a convenient way to define a parser for elements that contain
     only a text value and have no attributes or children, eg:
 
-        <msg:record.code>430</msg:record.code>
+        <msg:record.code>Example Text</msg:record.code>
 
     """
 
     def clean(self):
         super().clean()
         self.data = self.text
+
+
+class IntElement(ElementParser):
+    """
+    Parse elements which contain an integer value.
+
+    This class provides a convenient way to define a parser for elements that contain
+    only an integer value and have no attributes or children, eg:
+
+        <msg:record.code>430</msg:record.code>
+
+    """
+
+    def clean(self):
+        super().clean()
+        self.data = int(self.text)
 
 
 class ValidityMixin:


### PR DESCRIPTION
All certificates models now work with the importer.

Tests have been simplified as the majority of importer tests would include
significant amounts of boilerplate. To handle this a new test utility has
been added and applied to older importer tests.

Also replaced tabs in the taric3.xsd with spaces. Because copying the XML
definitions for the parser docstrings was upsetting the PyCharm linter.