### PR TITLE
TP-272: Implement importer for Goods Nomenclature and Indents.

### DIFF
--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -77,6 +77,6 @@ jobs:
     - name: Build documentation
       uses: ammaraskar/sphinx-action@0.4
       with:
-        pre-build-command: "apt-get update -y && apt-get install -y git-core"
+        pre-build-command: "apt-get update -y && apt-get install -y git-core python-dev build-essential libxml2-dev libxslt1-dev libz-dev"
         docs-folder: "."
         build-command: "sphinx-build -b html -c docs/ . _build"

--- a/commodities/import_handlers.py
+++ b/commodities/import_handlers.py
@@ -11,6 +11,10 @@ from importer.handlers import BaseHandler
 logger = logging.getLogger(__name__)
 
 
+class InvalidIndentError(Exception):
+    pass
+
+
 class GoodsNomenclatureHandler(BaseHandler):
     serializer_class = serializers.GoodsNomenclatureSerializer
     tag = parsers.GoodsNomenclatureParser.tag.name
@@ -21,19 +25,93 @@ class GoodsNomenclatureOriginHandler(BaseHandler):
     tag = parsers.GoodsNomenclatureOriginParser.tag.name
 
 
-class GoodsNomenclatureDescriptionHandler(BaseHandler):
+class BaseGoodsNomenclatureDescriptionHandler(BaseHandler):
+    links = (
+        {
+            "identifying_fields": ("sid", "item_id"),
+            "model": models.GoodsNomenclature,
+            "name": "described_goods_nomenclature",
+        },
+    )
+    serializer_class = serializers.GoodsNomenclatureDescriptionSerializer
+    tag = "BaseGoodsNomenclatureDescriptionHandler"
+
+
+class GoodsNomenclatureDescriptionHandler(BaseGoodsNomenclatureDescriptionHandler):
     serializer_class = serializers.GoodsNomenclatureDescriptionSerializer
     tag = parsers.GoodsNomenclatureDescriptionParser.tag.name
 
 
-class GoodsNomenclatureDescriptionPeriodHandler(BaseHandler):
+@GoodsNomenclatureDescriptionHandler.register_dependant
+class GoodsNomenclatureDescriptionPeriodHandler(
+    BaseGoodsNomenclatureDescriptionHandler
+):
+    dependencies = [GoodsNomenclatureDescriptionHandler]
     serializer_class = serializers.GoodsNomenclatureDescriptionSerializer
     tag = parsers.GoodsNomenclatureDescriptionPeriodParser.tag.name
 
 
-class GoodsNomenclatureIndentsHandler(BaseHandler):
+class GoodsNomenclatureIndentHandler(BaseHandler):
+    links = (
+        {"model": models.GoodsNomenclature, "name": "indented_goods_nomenclature"},
+    )
     serializer_class = serializers.GoodsNomenclatureIndentSerializer
     tag = parsers.GoodsNomenclatureIndentsParser.tag.name
+
+    def __init__(self, *args, **kwargs):
+        super(GoodsNomenclatureIndentHandler, self).__init__(*args, **kwargs)
+        self.extra_data = {}
+
+    def clean(self, data: dict) -> dict:
+        self.extra_data["indent"] = int(data["indent"])
+        return super(GoodsNomenclatureIndentHandler, self).clean(data)
+
+    def save(self, data: dict):
+        indent = self.extra_data.pop("indent")
+        data.update(**self.extra_data)
+
+        item_id = data["indented_goods_nomenclature"].item_id
+
+        if (
+            indent == 0 and item_id[2:] == "00000000"
+        ):  # This is a root indent (i.e. a chapter heading)
+            return models.GoodsNomenclatureIndent.add_root(**data)
+
+        chapter_heading = item_id[:2]
+
+        parent_indent = indent + 1
+
+        # TODO: Parents may change over an indents lifetime, need to check for all parents over the lifetime of
+        # an indent and create a series of updates to match them all.
+        # Updates aren't setup yet, do once they are.
+        parent = max(
+            models.GoodsNomenclatureIndent.objects.filter(
+                indented_goods_nomenclature__item_id__startswith=chapter_heading,
+                indented_goods_nomenclature__item_id__lte=item_id,
+                depth=parent_indent,
+                valid_between__contains=data["valid_between"],
+            ).current(),
+            key=lambda x: x.indented_goods_nomenclature.item_id,
+        )
+
+        return parent.add_child(**data)
+
+    def post_save(self, obj):
+        """
+        There is a possible (albeit unlikely) scenario when introducing an indent that the
+        new indent is put between an existing indent and it's children (i.e. it becomes the
+        new parent for those children).
+
+        As the old system had no real materialized tree behind the system it is not
+        unreasonable to suggest this as a possibility.
+
+        This method handles this by checking for any children which need to be moved
+        in case this happens.
+        """
+
+        # TODO: Implement this scenario (requires updating to be implemented first).
+
+        return super(GoodsNomenclatureIndentHandler, self).post_save(obj)
 
 
 class FootnoteAssociationGoodsNomenclatureHandler(BaseHandler):

--- a/commodities/import_parsers.py
+++ b/commodities/import_parsers.py
@@ -1,6 +1,5 @@
 import logging
 
-from commodities import models
 from importer.namespaces import Tag
 from importer.parsers import ElementParser
 from importer.parsers import TextElement
@@ -14,6 +13,21 @@ logger = logging.getLogger(__name__)
 
 @Record.register_child("goods_nomenclature")
 class GoodsNomenclatureParser(ValidityMixin, Writable, ElementParser):
+    """
+    <xs:element name="goods.nomenclature" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="goods.nomenclature.sid" type="SID"/>
+                <xs:element name="goods.nomenclature.item.id" type="GoodsNomenclatureItemId"/>
+                <xs:element name="producline.suffix" type="ProductLineSuffix"/>
+                <xs:element name="validity.start.date" type="Date"/>
+                <xs:element name="validity.end.date" type="Date" minOccurs="0"/>
+                <xs:element name="statistical.indicator" type="StatisticalIndicator"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    """
+
     tag = Tag("goods.nomenclature")
 
     sid = TextElement(Tag("goods.nomenclature.sid"))
@@ -26,6 +40,20 @@ class GoodsNomenclatureParser(ValidityMixin, Writable, ElementParser):
 
 @Record.register_child("goods_nomenclature_origin")
 class GoodsNomenclatureOriginParser(Writable, ElementParser):
+    """
+    <xs:element name="goods.nomenclature.origin" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="goods.nomenclature.sid" type="SID"/>
+                <xs:element name="derived.goods.nomenclature.item.id" type="GoodsNomenclatureItemId"/>
+                <xs:element name="derived.productline.suffix" type="ProductLineSuffix"/>
+                <xs:element name="goods.nomenclature.item.id" type="GoodsNomenclatureItemId"/>
+                <xs:element name="productline.suffix" type="ProductLineSuffix"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    """
+
     tag = Tag("goods.nomenclature.origin")
 
     sid = TextElement(Tag("goods.nomenclature.sid"))
@@ -37,59 +65,113 @@ class GoodsNomenclatureOriginParser(Writable, ElementParser):
 
 @Record.register_child("goods_nomenclature_description")
 class GoodsNomenclatureDescriptionParser(Writable, ElementParser):
+    """
+    <xs:element name="goods.nomenclature.description" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="goods.nomenclature.description.period.sid" type="SID"/>
+                <xs:element name="language.id" type="LanguageId"/>
+                <xs:element name="goods.nomenclature.sid" type="SID"/>
+                <xs:element name="goods.nomenclature.item.id" type="GoodsNomenclatureItemId"/>
+                <xs:element name="productline.suffix" type="ProductLineSuffix"/>
+                <xs:element name="description" type="LongDescription" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    """
+
     tag = Tag("goods.nomenclature.description")
 
-    goods_nomenclature_description_period_sid = TextElement(
-        "goods.nomenclature.description.period.sid"
-    )
+    sid = TextElement(Tag("goods.nomenclature.description.period.sid"))
     language_id = TextElement(Tag("language.id"))
-    goods_nomenclature_sid = TextElement(Tag("goods.nomenclature.sid"))
-    goods_nomenclature_item_id = TextElement(Tag("goods.nomenclature.item.id"))
-    productline_suffix = TextElement(Tag("productline.suffix"))
+    described_goods_nomenclature__sid = TextElement(Tag("goods.nomenclature.sid"))
+    described_goods_nomenclature__item_id = TextElement(
+        Tag("goods.nomenclature.item.id")
+    )
+    described_goods_nomenclature__productline_suffix = TextElement(
+        Tag("productline.suffix")
+    )
     description = TextElement(Tag("description"))
 
 
 @Record.register_child("goods_nomenclature_description_period")
-class GoodsNomenclatureDescriptionPeriodParser(Writable, ElementParser):
+class GoodsNomenclatureDescriptionPeriodParser(ValidityMixin, Writable, ElementParser):
+    """
+    <xs:element name="goods.nomenclature.description.period" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="goods.nomenclature.description.period.sid" type="SID"/>
+                <xs:element name="goods.nomenclature.sid" type="SID"/>
+                <xs:element name="validity.start.date" type="Date"/>
+                <xs:element name="goods.nomenclature.item.id" type="GoodsNomenclatureItemId"/>
+                <xs:element name="productline.suffix" type="ProductLineSuffix"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    """
+
     tag = Tag("goods.nomenclature.description.period")
 
-    goods_nomenclature_description_period_sid = TextElement(
-        "goods.nomenclature.description.period.sid"
+    sid = TextElement(Tag("goods.nomenclature.description.period.sid"))
+    described_goods_nomenclature__sid = TextElement(Tag("goods.nomenclature.sid"))
+    described_goods_nomenclature__item_id = TextElement(
+        Tag("goods.nomenclature.item.id")
     )
-    goods_nomenclature_sid = TextElement(Tag("goods.nomenclature.sid"))
-    valid_between_lower = TextElement(Tag("validity.start.date"))
-    goods_nomenclature_item_id = TextElement(Tag("goods.nomenclature.item.id"))
-    productline_suffix = TextElement(Tag("productline.suffix"))
+    described_goods_nomenclature__productline_suffix = TextElement(
+        Tag("productline.suffix")
+    )
 
 
 @Record.register_child("goods_nomenclature_indent")
 class GoodsNomenclatureIndentsParser(ValidityMixin, Writable, ElementParser):
+    """
+    <xs:element name="goods.nomenclature.indents" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="goods.nomenclature.indent.sid" type="SID"/>
+                <xs:element name="goods.nomenclature.sid" type="SID"/>
+                <xs:element name="validity.start.date" type="Date"/>
+                <xs:element name="number.indents" type="NumberOf"/>
+                <xs:element name="goods.nomenclature.item.id" type="GoodsNomenclatureItemId"/>
+                <xs:element name="productline.suffix" type="ProductLineSuffix"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    """
+
     tag = Tag("goods.nomenclature.indents")
 
     sid = TextElement(Tag("goods.nomenclature.indent.sid"))
-    goods_nomenclature_sid = TextElement(Tag("goods.nomenclature.sid"))
-    valid_between_lower = TextElement(Tag("validity.start.date"))
-    number_indents = TextElement(Tag("number.indents"))
-    goods_nomenclature_item_id = TextElement(Tag("goods.nomenclature.item.id"))
-    productline_suffix = TextElement(Tag("productline.suffix"))
-
-    def clean(self):
-        super().clean()
-        good = models.GoodsNomenclature.objects.get_latest_version(
-            sid=self.data.pop("goods_nomenclature_sid")
-        )
-        self.data["indented_goods_nomenclature"] = good
+    indented_goods_nomenclature__sid = TextElement(Tag("goods.nomenclature.sid"))
+    indent = TextElement(Tag("number.indents"))
+    indented_goods_nomenclature__item_id = TextElement(
+        Tag("goods.nomenclature.item.id")
+    )
+    indented_goods_nomenclature__suffix = TextElement(Tag("productline.suffix"))
 
 
 @Record.register_child("footnote_association_goods_nomenclature")
 class FootnoteAssociationGoodsNomenclatureParser(
     ValidityMixin, Writable, ElementParser
 ):
+    """
+    <xs:element name="footnote.association.goods.nomenclature" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="goods.nomenclature.sid" type="SID"/>
+                <xs:element name="footnote.type" type="FootnoteTypeId"/>
+                <xs:element name="footnote.id" type="FootnoteId"/>
+                <xs:element name="validity.start.date" type="Date"/>
+                <xs:element name="validity.end.date" type="Date" minOccurs="0"/>
+                <xs:element name="goods.nomenclature.item.id" type="GoodsNomenclatureItemId"/>
+                <xs:element name="productline.suffix" type="ProductLineSuffix"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    """
+
     tag = Tag("footnote.association.goods.nomenclature")
 
     goods_nomenclature__sid = TextElement(Tag("goods.nomenclature.sid"))
     associated_footnote__footnote_id = TextElement(Tag("footnote.id"))
     associated_footnote__footnote_type_id = TextElement(Tag("footnote.type"))
-
-    # valid_between_lower = TextElement(Tag("validity.start.date"))
-    # valid_between_upper = TextElement(Tag("validity.end.date"))

--- a/commodities/serializers.py
+++ b/commodities/serializers.py
@@ -59,7 +59,8 @@ class GoodsNomenclatureIndentSerializer(
     indented_goods_nomenclature = SimpleGoodsNomenclatureSerializer(read_only=True)
 
     def get_indent(self, object: models.GoodsNomenclature):
-        return str(object.depth).zfill(2)
+        indent = 0 if object.depth < 3 else object.depth - 2
+        return str(indent).zfill(2)
 
     class Meta:
         model = models.GoodsNomenclatureIndent
@@ -73,6 +74,7 @@ class GoodsNomenclatureIndentSerializer(
             "taric_template",
             "start_date",
             "end_date",
+            "valid_between",
         ]
 
 
@@ -96,6 +98,7 @@ class GoodsNomenclatureDescriptionSerializer(
             "taric_template",
             "start_date",
             "end_date",
+            "valid_between",
         ]
 
 

--- a/commodities/tests/test_business_rules.py
+++ b/commodities/tests/test_business_rules.py
@@ -30,13 +30,16 @@ def test_NIG2(date_ranges, normal_good):
 
     Also covers NIG3
     """
-    parent = factories.GoodsNomenclatureIndentFactory(valid_between=date_ranges.big)
-    factories.GoodsNomenclatureFactory(
+    parent = factories.GoodsNomenclatureIndentFactory.create(
+        valid_between=date_ranges.big,
+        indented_goods_nomenclature__valid_between=date_ranges.big,
+    )
+    factories.GoodsNomenclatureFactory.create(
         origin=normal_good,
         valid_between=date_ranges.adjacent_later,
     )
     with pytest.raises(ValidationError):
-        factories.GoodsNomenclatureFactory(
+        factories.GoodsNomenclatureFactory.create(
             valid_between=date_ranges.adjacent_later_big,
             origin=normal_good,
             indent__parent=parent,

--- a/commodities/tests/test_importer.py
+++ b/commodities/tests/test_importer.py
@@ -2,9 +2,10 @@ import pytest
 
 from commodities import models
 from commodities import serializers
+from commodities.import_handlers import InvalidIndentError
 from common.tests import factories
 from common.tests.util import generate_test_import_xml
-from common.tests.util import requires_interdependent_export
+from common.tests.util import requires_update_importer
 from common.tests.util import validate_taric_import
 from common.validators import UpdateType
 from importer.management.commands.import_taric import import_taric
@@ -25,7 +26,25 @@ def test_goods_nomenclature_importer_create(valid_user, test_object, db_object):
     assert db_object.valid_between.upper == test_object.valid_between.upper
 
 
-@requires_interdependent_export
+@validate_taric_import(
+    serializers.GoodsNomenclatureDescriptionSerializer,
+    factories.GoodsNomenclatureDescriptionFactory,
+    dependencies={"described_goods_nomenclature": factories.GoodsNomenclatureFactory},
+)
+def test_goods_nomenclature_description_importer_create(
+    valid_user, test_object, db_object
+):
+    assert (
+        db_object.described_goods_nomenclature
+        == test_object.described_goods_nomenclature
+    )
+    assert db_object.sid == test_object.sid
+    assert db_object.description == test_object.description
+    assert db_object.valid_between.lower == test_object.valid_between.lower
+    assert db_object.valid_between.upper == test_object.valid_between.upper
+
+
+@requires_update_importer
 def test_goods_nomenclature_importer_create_with_origin(valid_user):
     origin = factories.GoodsNomenclatureFactory(update_type=UpdateType.CREATE.value)
     good = factories.GoodsNomenclatureFactory.build(
@@ -43,31 +62,101 @@ def test_goods_nomenclature_importer_create_with_origin(valid_user):
     assert db_good.origin == origin
 
 
-@pytest.mark.skip(
-    "Requires specific commodity code hierarchical importer implementation."
-)
 def test_goods_nomenclature_indent_importer_create(valid_user):
-    good = factories.GoodsNomenclatureFactory()
-    indent = factories.GoodsNomenclatureIndentFactory.build(
-        update_type=UpdateType.CREATE.value, indented_goods_nomenclature=good
-    )
-    xml = generate_test_import_xml(
-        serializers.GoodsNomenclatureIndentSerializer(
-            indent, context={"format": "xml"}
-        ).data
+    test_object = factories.GoodsNomenclatureIndentFactory.build(
+        update_type=UpdateType.CREATE.value,
+        indented_goods_nomenclature=factories.GoodsNomenclatureFactory.create(
+            item_id="1100000000"
+        ),
     )
 
-    import_taric(xml, valid_user.username, WorkflowStatus.PUBLISHED.value)
-
-    db_indent = models.GoodsNomenclatureIndent.objects.get(sid=indent.sid)
-
-    assert db_indent.sid == indent.sid
-    assert db_indent.depth == indent.depth
-    assert (
-        db_indent.indented_goods_nomenclature.sid
-        == indent.indented_goods_nomenclature.sid
+    @validate_taric_import(
+        serializers.GoodsNomenclatureIndentSerializer, instance=test_object
     )
-    assert db_indent.valid_between.lower == indent.valid_between.lower
+    def assert_func(valid_user, test_object, db_object):
+        assert db_object.sid == test_object.sid
+        assert db_object.depth == test_object.depth
+        assert (
+            db_object.indented_goods_nomenclature.sid
+            == test_object.indented_goods_nomenclature.sid
+        )
+        assert db_object.valid_between.lower == test_object.valid_between.lower
+
+    assert_func(valid_user)
+
+
+def test_goods_nomenclature_indent_importer_create_with_parent_low_indent(valid_user):
+    parent_indent = factories.GoodsNomenclatureIndentFactory.create(
+        indented_goods_nomenclature__item_id="1200000000"
+    )
+
+    test_object = factories.GoodsNomenclatureIndentFactory.build(
+        update_type=UpdateType.CREATE.value,
+        indented_goods_nomenclature=factories.SimpleGoodsNomenclatureFactory.create(
+            item_id="1201000000"
+        ),
+        parent=parent_indent,
+    )
+
+    @validate_taric_import(
+        serializers.GoodsNomenclatureIndentSerializer, instance=test_object
+    )
+    def assert_func(valid_user, test_object, db_object):
+        assert db_object.sid == test_object.sid
+        assert db_object.depth == test_object.depth
+        assert db_object.depth == 2
+        assert (
+            db_object.indented_goods_nomenclature.sid
+            == test_object.indented_goods_nomenclature.sid
+        )
+        assert db_object.get_parent() == parent_indent
+        assert db_object.valid_between.lower == test_object.valid_between.lower
+
+    assert_func(valid_user)
+
+
+def test_goods_nomenclature_indent_importer_create_with_parent_high_indent(valid_user):
+    parent_indent = None
+    for idx in range(1, 6):
+        parent_indent = factories.GoodsNomenclatureIndentFactory.create(
+            indented_goods_nomenclature__item_id=("12" * idx).ljust(10, "0"),
+            parent=parent_indent,
+        )
+
+    test_object = factories.GoodsNomenclatureIndentFactory.build(
+        update_type=UpdateType.CREATE.value,
+        indented_goods_nomenclature=factories.GoodsNomenclatureFactory.create(
+            item_id="1212121215"
+        ),
+        parent=parent_indent,
+    )
+
+    @validate_taric_import(
+        serializers.GoodsNomenclatureIndentSerializer, instance=test_object
+    )
+    def assert_func(valid_user, test_object, db_object):
+        assert db_object.sid == test_object.sid
+        assert db_object.depth == test_object.depth
+        assert db_object.depth == 6
+        assert (
+            db_object.indented_goods_nomenclature.sid
+            == test_object.indented_goods_nomenclature.sid
+        )
+        assert db_object.get_parent() == parent_indent
+        assert db_object.valid_between.lower == test_object.valid_between.lower
+
+    assert_func(valid_user)
+
+
+@requires_update_importer
+def test_goods_nomenclature_indent_importer_create_with_branch_shift(valid_user):
+    """
+    There is an unlikely (query impossible) scenario where a new indent could
+    manage to step in between an existing Goods Nomenclature and its parent.
+
+    This would require the tree to be updated once ingested.
+    """
+    assert False
 
 
 @validate_taric_import(

--- a/commodities/validators.py
+++ b/commodities/validators.py
@@ -27,7 +27,7 @@ def validate_goods_parent_validity_includes_good(goods_nomenclature_indent):
 
     if not parent:
         return
-    parent_validity = parent.valid_between
+    parent_validity = parent.indented_goods_nomenclature.valid_between
 
     if not validity_range_contains_range(parent_validity, goods_validity):
         raise ValidationError(

--- a/common/tests/factories.py
+++ b/common/tests/factories.py
@@ -235,6 +235,16 @@ class AdditionalCodeDescriptionFactory(TrackedModelMixin, ValidityFactoryMixin):
     description = short_description()
 
 
+class SimpleGoodsNomenclatureFactory(TrackedModelMixin, ValidityFactoryMixin):
+    class Meta:
+        model = "commodities.GoodsNomenclature"
+
+    sid = numeric_sid()
+    item_id = string_sequence(10, characters=string.digits)
+    suffix = "80"
+    statistical = False
+
+
 class GoodsNomenclatureFactory(TrackedModelMixin, ValidityFactoryMixin):
     class Meta:
         model = "commodities.GoodsNomenclature"
@@ -280,7 +290,7 @@ class GoodsNomenclatureIndentFactory(TrackedModelMixin, ValidityFactoryMixin):
     depth = factory.LazyAttribute(lambda o: len(o.path) // 4)
 
     sid = numeric_sid()
-    indented_goods_nomenclature = factory.SubFactory(GoodsNomenclatureFactory)
+    indented_goods_nomenclature = factory.SubFactory(SimpleGoodsNomenclatureFactory)
 
 
 class GoodsNomenclatureDescriptionFactory(TrackedModelMixin, ValidityFactoryMixin):

--- a/common/tests/util.py
+++ b/common/tests/util.py
@@ -23,10 +23,11 @@ from common.validators import UpdateType
 from importer.management.commands.import_taric import import_taric
 from workbaskets.validators import WorkflowStatus
 
-COMMODITIES_IMPLEMENTED = False
+INTERDEPENDENT_IMPORT_IMPLEMENTED = True
+UPDATE_IMPORTER_IMPLEMENTED = False
 EXPORT_REFUND_NOMENCLATURE_IMPLEMENTED = False
-INTERDEPENDENT_EXPORT_IMPLEMENTED = False
 MEASURES_IMPLEMENTED = True
+COMMODITIES_IMPLEMENTED = True
 MEURSING_TABLES_IMPLEMENTED = False
 PARTIAL_TEMPORARY_STOP_IMPLEMENTED = False
 UTC = timezone.utc
@@ -56,9 +57,14 @@ requires_partial_temporary_stop = pytest.mark.skipif(
     reason="Partial temporary stop not implemented",
 )
 
-requires_interdependent_export = pytest.mark.skipif(
-    not INTERDEPENDENT_EXPORT_IMPLEMENTED,
-    reason="Interdependent exports not implemented",
+requires_interdependent_import = pytest.mark.skipif(
+    not INTERDEPENDENT_IMPORT_IMPLEMENTED,
+    reason="Interdependent imports not implemented",
+)
+
+requires_update_importer = pytest.mark.skipif(
+    not UPDATE_IMPORTER_IMPLEMENTED,
+    reason="Requires Updating importers to be implemented",
 )
 
 


### PR DESCRIPTION
It is a requirement for the project to be able to import Goods Nomenclature,
Goods Nomenclature descriptions and Indents from legacy TARIC3 XML data.

This commit introduces the import parsers and handlers for these models.
Most of the models are straightforward and follow the predefined patterns
set out in other importers. However indents, being a materialized path in the
new data models but only a pseudo materialized path in the old data models,
has some divergence.

It has been necessary to find the appropriate parent of any new indents
coming in using only the limited dataset given. To this end the following
algorithm has been used:

- If top level indent, assign indent as root with no parents.
- If 1 < indent < 6, the parent item ID can be ascertained from the given
  data, use this to find the parent indent and assign the current indent
  as its child.
- if indent >= 6, the parent item ID can not be immediately ascertained
  from the given data. Find the indent that:
    1) has an item ID starting with the first 8 chars of the current item ID.
    2) has an item ID that is less than the current item ID.
    3) has an indent level of the current one - 1.
    4) has the largest item ID of those that satisfy criteria 1-3.

There is at least one corner case not currently handled. This is where an indent
is introduced that should be the parent of a pre-existing indent. This could
reasonably be handled in the post_save method of the handler - but would require
the update system to be implemented for the append only log on Goods Nomenclature
first.