### PR TITLE
Fix double `.items()`

### DIFF
--- a/common/jinja2.py
+++ b/common/jinja2.py
@@ -25,7 +25,7 @@ class GovukFrontendExtension(NunjucksExtension):
             ]
             source = re.sub(
                 r"(for attribute, value in )(" + r"|".join(iterated_objects) + r")",
-                r"\1(\2|default({})).items()",
+                r"\1(\2|default({}))",
                 source,
             )
 


### PR DESCRIPTION
The v0.5.5-alpha release of govuk-frontend-jinja fixes a bug which we had patched locally.

When Nunjucks iterates over an object, it does `for key, value in object`. This is fails in Jinja, and govuk-frontend-jinja now corrects this to `for key, value in object.items()`. However, we were already applying this patch, in addition to inserting a guard for iterating an undefined attribute (eg: `for key, value in (object.attribute|default({})).items()`) which results in `.items().items()` in the processed template, causing an error.