### PR TITLE
Remove dependency on freezegun

### DIFF
--- a/additional_codes/tests/test_business_rules.py
+++ b/additional_codes/tests/test_business_rules.py
@@ -225,7 +225,7 @@ def test_ACN5_(date_ranges):
         type=factories.AdditionalCodeTypeFactory(valid_between=date_ranges.big),
     )
     factories.AdditionalCodeDescriptionFactory(
-        described_additional_code=ac, valid_between=date_ranges.normal_first_half
+        described_additional_code=ac, valid_between=date_ranges.starts_with_normal
     )
 
     with pytest.raises(ValidationError):

--- a/certificates/tests/test_business_rules.py
+++ b/certificates/tests/test_business_rules.py
@@ -169,18 +169,12 @@ def test_certificate_description_period_must_be_adjacent_to_predecessor(date_ran
         sid=predecessor.sid,
         predecessor=predecessor,
         described_certificate=predecessor.described_certificate,
-        valid_between=DateTimeTZRange(
-            datetime(2021, 2, 1, tzinfo=timezone.utc),
-            datetime(2021, 3, 1, tzinfo=timezone.utc),
-        ),
+        valid_between=date_ranges.adjacent_later,
     )
     with pytest.raises(ValidationError):
         factories.CertificateDescriptionFactory(
             sid=predecessor.sid,
             predecessor=predecessor,
             described_certificate=predecessor.described_certificate,
-            valid_between=DateTimeTZRange(
-                datetime(2021, 3, 2, tzinfo=timezone.utc),
-                datetime(2021, 4, 1, tzinfo=timezone.utc),
-            ),
+            valid_between=date_ranges.adjacent_even_later,
         )

--- a/common/tests/test_models.py
+++ b/common/tests/test_models.py
@@ -67,7 +67,6 @@ def model2_with_history(date_ranges):
     return model_with_history(factories.TestModel2Factory, date_ranges, custom_sid=1)
 
 
-@pytest.mark.freeze_time("2020-08-01")
 def test_get_current(model1_with_history, model2_with_history):
     """
     Ensure only the most recent records are fetched.
@@ -119,7 +118,6 @@ def test_as_at(model1_with_history, date_ranges):
     assert set(queryset.values_list("pk", flat=True)) == pks
 
 
-@pytest.mark.freeze_time("2020-08-01")
 def test_active(model1_with_history, date_ranges):
     """
     Ensure only the currently active records are fetched.
@@ -142,7 +140,6 @@ def test_get_version_raises_error():
         TestModel2.objects.get_version(sid=1)
 
 
-@pytest.mark.freeze_time("2020-08-01")
 def test_get_current_version(date_ranges, model1_with_history):
     """
     Ensure getting the current version works with a standard sid identifier.
@@ -152,7 +149,6 @@ def test_get_current_version(date_ranges, model1_with_history):
     assert TestModel1.objects.get_current_version(sid=model.sid) == model
 
 
-@pytest.mark.freeze_time("2020-08-01")
 def test_get_current_version_custom_identifier(date_ranges, model2_with_history):
     """
     Ensure getting the current version works with a custom identifier.

--- a/common/tests/util.py
+++ b/common/tests/util.py
@@ -8,6 +8,7 @@ from typing import Dict
 from typing import Type
 
 import pytest
+from dateutil.relativedelta import relativedelta
 from django.core.exceptions import ValidationError
 from django.template.loader import render_to_string
 from django.urls import reverse
@@ -186,73 +187,101 @@ def validate_taric_import(
     return decorator
 
 
+NOW = datetime.now(tz=UTC).replace(hour=0, minute=0, second=0, microsecond=0)
+
+
 class Dates:
     normal = DateTimeTZRange(
-        datetime(2021, 1, 1, tzinfo=UTC),
-        datetime(2021, 2, 1, tzinfo=UTC),
+        NOW,
+        NOW + relativedelta(months=+1),
     )
     earlier = DateTimeTZRange(
-        datetime(2020, 1, 1, tzinfo=UTC),
-        datetime(2020, 2, 1, tzinfo=UTC),
+        NOW + relativedelta(years=-1),
+        NOW + relativedelta(years=-1, months=+1),
     )
     later = DateTimeTZRange(
-        datetime(2022, 2, 2, tzinfo=UTC),
-        datetime(2022, 3, 1, tzinfo=UTC),
+        NOW + relativedelta(years=+1, months=+1, days=+1),
+        NOW + relativedelta(years=+1, months=+2),
     )
     big = DateTimeTZRange(
-        datetime(2019, 1, 1, tzinfo=UTC),
-        datetime(2023, 1, 2, tzinfo=UTC),
+        NOW + relativedelta(years=-2),
+        NOW + relativedelta(years=+2, days=+1),
     )
     adjacent_earlier = DateTimeTZRange(
-        datetime(2020, 12, 1, tzinfo=UTC),
-        datetime(2020, 12, 31, tzinfo=UTC),
+        NOW + relativedelta(months=-1),
+        NOW + relativedelta(days=-1),
     )
     adjacent_later = DateTimeTZRange(
-        datetime(2021, 2, 1, tzinfo=UTC),
-        datetime(2021, 3, 1, tzinfo=UTC),
+        NOW + relativedelta(months=+1),
+        NOW + relativedelta(months=+2),
+    )
+    adjacent_even_later = DateTimeTZRange(
+        NOW + relativedelta(months=+2, days=+1),
+        NOW + relativedelta(months=+3),
     )
     adjacent_later_big = DateTimeTZRange(
-        datetime(2021, 2, 1, tzinfo=UTC),
-        datetime(2023, 3, 1, tzinfo=UTC),
+        NOW + relativedelta(months=+1),
+        NOW + relativedelta(years=+2, months=+2),
     )
     overlap_normal = DateTimeTZRange(
-        datetime(2021, 1, 15, tzinfo=UTC),
-        datetime(2022, 2, 15, tzinfo=UTC),
+        NOW + relativedelta(days=+14),
+        NOW + relativedelta(days=+14, months=+1, years=+1),
     )
     overlap_normal_earlier = DateTimeTZRange(
-        datetime(2020, 12, 15, tzinfo=UTC),
-        datetime(2021, 1, 15, tzinfo=UTC),
+        NOW + relativedelta(months=-1, days=+14),
+        NOW + relativedelta(days=+14),
     )
     overlap_big = DateTimeTZRange(
-        datetime(2022, 1, 1, tzinfo=UTC),
-        datetime(2024, 1, 3, tzinfo=UTC),
+        NOW + relativedelta(years=+1),
+        NOW + relativedelta(years=+3, days=+2),
     )
     after_big = DateTimeTZRange(
-        datetime(2024, 2, 1, tzinfo=UTC),
-        datetime(2024, 3, 1, tzinfo=UTC),
+        NOW + relativedelta(years=+3, months=+1),
+        NOW + relativedelta(years=+3, months=+2),
     )
     backwards = DateTimeTZRange(
-        datetime(2021, 2, 1, tzinfo=UTC),
-        datetime(2021, 1, 2, tzinfo=UTC),
+        NOW + relativedelta(months=+1),
+        NOW + relativedelta(days=+1),
     )
     starts_with_normal = DateTimeTZRange(
-        datetime(2021, 1, 1, tzinfo=UTC),
-        datetime(2021, 1, 15, tzinfo=UTC),
+        NOW,
+        NOW + relativedelta(days=+14),
     )
     ends_with_normal = DateTimeTZRange(
-        datetime(2021, 1, 15, tzinfo=UTC),
-        datetime(2021, 2, 1, tzinfo=UTC),
+        NOW + relativedelta(days=+14),
+        NOW + relativedelta(months=+1),
     )
     current = DateTimeTZRange(
-        datetime(2020, 8, 1, tzinfo=UTC) - timedelta(weeks=4),
-        datetime(2020, 8, 1, tzinfo=UTC) + timedelta(weeks=4),
+        NOW + relativedelta(weeks=-4),
+        NOW + relativedelta(weeks=+4),
     )
     future = DateTimeTZRange(
-        datetime(2020, 8, 1, tzinfo=UTC) + timedelta(weeks=10),
-        datetime(2020, 8, 1, tzinfo=UTC) + timedelta(weeks=20),
+        NOW + relativedelta(weeks=+10),
+        NOW + relativedelta(weeks=+20),
     )
-    no_end = DateTimeTZRange(datetime(2021, 1, 1, tzinfo=UTC), None)
+    no_end = DateTimeTZRange(NOW, None)
     normal_first_half = DateTimeTZRange(
-        datetime(2021, 1, 1, tzinfo=UTC),
-        datetime(2021, 1, 15, tzinfo=UTC),
+        NOW,
+        NOW + relativedelta(days=+14),
     )
+
+    @classmethod
+    def short_before(cls, dt):
+        return DateTimeTZRange(
+            dt + relativedelta(months=-1),
+            dt + relativedelta(days=-14),
+        )
+
+    @classmethod
+    def medium_before(cls, dt):
+        return DateTimeTZRange(
+            dt + relativedelta(months=-1),
+            dt + relativedelta(days=-1),
+        )
+
+    @classmethod
+    def no_end_before(cls, dt):
+        return DateTimeTZRange(
+            dt + relativedelta(months=-1),
+            None,
+        )

--- a/common/util.py
+++ b/common/util.py
@@ -1,13 +1,7 @@
 """
 Miscellaneous utility functions
 """
-from datetime import datetime
-from datetime import timezone
-
 from psycopg2.extras import DateTimeTZRange
-
-
-BREXIT_DATE = datetime(2021, 1, 1, tzinfo=timezone.utc)
 
 
 def is_truthy(value: str) -> bool:

--- a/footnotes/tests/bdd/test_detail_footnotes.py
+++ b/footnotes/tests/bdd/test_detail_footnotes.py
@@ -13,8 +13,7 @@ scenarios("features/detail-footnotes.feature")
 
 @pytest.fixture
 @when("I select footnote NC000")
-def footnote_detail(client, footnote_NC000, freezer):
-    freezer.move_to("2021-01-01")
+def footnote_detail(client, footnote_NC000):
     return client.get(footnote_NC000.get_url())
 
 

--- a/footnotes/tests/test_business_rules.py
+++ b/footnotes/tests/test_business_rules.py
@@ -118,7 +118,7 @@ def test_FO4_description_start_before_footnote_end(date_ranges):
         footnote_type=factories.FootnoteTypeFactory(valid_between=date_ranges.big),
     )
     factories.FootnoteDescriptionFactory(
-        described_footnote=footnote, valid_between=date_ranges.normal_first_half
+        described_footnote=footnote, valid_between=date_ranges.starts_with_normal
     )
 
     with pytest.raises(ValidationError):

--- a/footnotes/views.py
+++ b/footnotes/views.py
@@ -72,11 +72,7 @@ class FootnoteMixin:
 
 class FootnoteDetail(WithCurrentWorkBasket, FootnoteMixin, generic.DetailView):
     template_name = "footnotes/detail.jinja"
-
-    @property
-    def queryset(self):
-        # lazy evaluation to allow freezegun to work
-        return models.Footnote.objects.current()
+    queryset = models.Footnote.objects.current()
 
 
 class FootnoteUpdate(FootnoteMixin, DraftUpdateView):

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,6 @@ pytest
 pytest-bdd
 pytest-cov
 pytest-django
-pytest-freezegun
 pytest-mock
 sentry-sdk
 sphinx


### PR DESCRIPTION
We are currently using a set of fixed dates for testing purposes.  Eventually the
current date will no longer fall within those date ranges.  This commit replaces the
fixed dates with relative dates, based on the current date at runtime.  This also
removes our dependency on freezegun for the few tests that needed it.

This change has been separated out from TP-240 (measures data model), because I need it for another PR.