### PR TITLE
Correct build path for Sphinx docs

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -115,4 +115,4 @@ jobs:
       uses: peaceiris/actions-gh-pages@v3
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
-        publish_dir: docs/_build
+        publish_dir: _build


### PR DESCRIPTION
Publishing to Github pages fails because the path to the Sphinx build is wrong