### PR TITLE
TP-333: Allow fetching of "latest" versions of a relation.

### DIFF
--- a/additional_codes/tests/test_business_rules.py
+++ b/additional_codes/tests/test_business_rules.py
@@ -59,20 +59,22 @@ def test_ACN1():
         )
 
 
-def test_ACN2():
+def test_ACN2(must_exist):
     """
     The referenced additional code type must exist and have as application code "non-
     Meursing" or "Export Refund for Processed Agricultural Goods”.
     """
 
-    wb = factories.WorkBasketFactory.create()
-    ac = factories.AdditionalCodeFactory.build(type=None, workbasket=wb)
-    with pytest.raises(ObjectDoesNotExist):
-        ac.save()
+    assert must_exist(
+        "type",
+        factories.AdditionalCodeTypeFactory,
+        factories.AdditionalCodeFactory,
+    )
 
-    ac.type = factories.AdditionalCodeTypeFactory.create(application_code=0)
     with pytest.raises(ValidationError):
-        ac.save()
+        factories.AdditionalCodeFactory(
+            type__application_code=0,
+        )
 
 
 def test_ACN3(date_ranges):

--- a/additional_codes/validators.py
+++ b/additional_codes/validators.py
@@ -1,3 +1,4 @@
+from django.core.exceptions import ObjectDoesNotExist
 from django.core.exceptions import ValidationError
 from django.core.validators import RegexValidator
 from django.db.models import IntegerChoices
@@ -37,6 +38,12 @@ def validate_additional_code_type(obj):
     The referenced additional code type must exist and have as application code
     "non-Meursing" or "Export refund for processed agricultural good".
     """
+
+    try:
+        if obj.type is None:
+            return
+    except ObjectDoesNotExist as e:
+        raise ValidationError("The referenced additional code type must exist.") from e
 
     permitted_codes = [
         ApplicationCode.ADDITIONAL_CODES,

--- a/common/tests/factories.py
+++ b/common/tests/factories.py
@@ -8,6 +8,7 @@ import factory.fuzzy
 
 from common.tests.models import TestModel1
 from common.tests.models import TestModel2
+from common.tests.models import TestModel3
 from common.tests.util import Dates
 from common.validators import ApplicabilityCode
 from common.validators import UpdateType
@@ -78,6 +79,11 @@ class TransactionFactory(factory.django.DjangoModelFactory):
 
 class TrackedModelMixin(factory.django.DjangoModelFactory):
     workbasket = factory.SubFactory(WorkBasketFactory)
+    update_type = UpdateType.UPDATE.value
+
+
+class ApprovedTrackedModelMixin(factory.django.DjangoModelFactory):
+    workbasket = factory.SubFactory(ApprovedWorkBasketFactory)
     update_type = UpdateType.UPDATE.value
 
 
@@ -203,7 +209,7 @@ class CertificateDescriptionFactory(TrackedModelMixin, ValidityFactoryMixin):
     description = short_description()
 
 
-class TestModel1Factory(TrackedModelMixin, ValidityFactoryMixin):
+class TestModel1Factory(ApprovedTrackedModelMixin, ValidityFactoryMixin):
     class Meta:
         model = TestModel1
 
@@ -211,12 +217,20 @@ class TestModel1Factory(TrackedModelMixin, ValidityFactoryMixin):
     sid = numeric_sid()
 
 
-class TestModel2Factory(TrackedModelMixin, ValidityFactoryMixin):
+class TestModel2Factory(ApprovedTrackedModelMixin, ValidityFactoryMixin):
     class Meta:
         model = TestModel2
 
     description = factory.Faker("text", max_nb_chars=24)
     custom_sid = numeric_sid()
+
+
+class TestModel3Factory(ApprovedTrackedModelMixin, ValidityFactoryMixin):
+    class Meta:
+        model = TestModel3
+
+    linked_model = factory.SubFactory(TestModel1Factory)
+    sid = numeric_sid()
 
 
 class AdditionalCodeTypeFactory(TrackedModelMixin, ValidityFactoryMixin):

--- a/common/tests/migrations/0001_initial.py
+++ b/common/tests/migrations/0001_initial.py
@@ -68,4 +68,37 @@ class Migration(migrations.Migration):
             },
             bases=("common.trackedmodel", models.Model),
         ),
+        migrations.CreateModel(
+            name="TestModel3",
+            fields=[
+                (
+                    "trackedmodel_ptr",
+                    models.OneToOneField(
+                        auto_created=True,
+                        on_delete=django.db.models.deletion.CASCADE,
+                        parent_link=True,
+                        primary_key=True,
+                        serialize=False,
+                        to="common.trackedmodel",
+                    ),
+                ),
+                (
+                    "valid_between",
+                    django.contrib.postgres.fields.ranges.DateTimeRangeField(),
+                ),
+                ("sid", models.PositiveIntegerField()),
+                (
+                    "linked_model",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.PROTECT,
+                        to="tests.testmodel1",
+                    ),
+                ),
+            ],
+            options={
+                "abstract": False,
+                "base_manager_name": "objects",
+            },
+            bases=("common.trackedmodel", models.Model),
+        ),
     ]

--- a/common/tests/models.py
+++ b/common/tests/models.py
@@ -20,3 +20,10 @@ class TestModel2(TrackedModel, ValidityMixin):
     description = models.CharField(max_length=24, null=True)
 
     identifying_fields = ("custom_sid",)
+
+
+class TestModel3(TrackedModel, ValidityMixin):
+    __test__ = False
+
+    sid = models.PositiveIntegerField()
+    linked_model = models.ForeignKey(TestModel1, on_delete=models.PROTECT)

--- a/package-lock.json
+++ b/package-lock.json
@@ -4426,7 +4426,8 @@
     "picomatch": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
-      "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg=="
+      "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
+      "optional": true
     },
     "pify": {
       "version": "2.3.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 allure-pytest-bdd
 black>=20.8b1
 dj-database-url
-django>=3.0,<3.1
+django>=3.1,<3.2
 django-dotenv
 django-extra-fields
 django-filter


### PR DESCRIPTION
The data model within TaMaTo is intended to be versioned. That is to say
that any row within a table derived from TrackedModel holds some identifying
columns which are non-unique. If multiple rows have the same data within these
identifying columns they are seen as multiple versions of the same object.

However foreign keys must be made on the primary key field of a table. With
this being the case it is possible to create a row on one table and link it
to a row in another table. This row in another table can then be "updated" -
adding a new row to the table and a new version of the object. In this case
the foreign key may be considered stale, but only within the date range of
the new row that has been added.

To solve this problem a mechanism has been added to allow fetching of the
"latest" row representing the latest version of an object for all
relations pertaining to derivatives of TrackedModels.

In python this allows us to define a model like so:

```python3
class ExampleModel(TrackedModel):
    # must be a TrackedModel
    other_model = models.ForeignKey(OtherModel, on_delete=models.PROTECT)
```

And then access the latest version of the relation by simply adding `_latest`
to the attribute name like so:

```python3
example_model = ExampleModel.objects.first()
example_model.other_model_latest  # Gets the latest version
```

If done like in the above example, a query is generated specifically to fetch
this latest version of the row. However another mechanism has been added at
the queryset level which enable this to be done in a single query. This is
the `with_latest_links` QuerySet method.

This method finds all the relations of a model and for each one adds a column
populated by a SQL subquery that looks roughly like so:

```sql
SELECT Row_to_json({relation_table}) AS "json_data"
  FROM  {relation_table}
 INNER JOIN "common_trackedmodel" U1
    ON {relation_table}."trackedmodel_ptr_id" = U1."id"
 INNER JOIN "workbaskets_workbasket" U2
    ON U1."workbasket_id" = U2."id"
 WHERE {relation_table}.{identifying_field} = {outer_relation_join}.{identifying_field}
   AND U2."status" IN ({approved_statuses})
 ORDER BY {relation_table}."trackedmodel_ptr_id" DESC
 LIMIT 1
```

This caches the data for each row on the object instances in a dictionary
which is then used to create the related object in python when called upon.

To facilitate this a new `RowToJson` Func has been added, adding the ability
to call the postgres specific `row_to_json` function. This must be used in
conjunction with the `RowToJsonSubquery` which adds the proper arguments to
the function.