### PR TITLE
Refactor range contains check function

### DIFF
--- a/common/tests/test_util.py
+++ b/common/tests/test_util.py
@@ -50,7 +50,7 @@ def test_is_truthy(value, expected):
         (
             Dates.normal,
             Dates.ends_with_normal,
-            False,
+            True,
         ),
         (
             Dates.normal,
@@ -90,7 +90,7 @@ def test_is_truthy(value, expected):
         (
             Dates.normal,
             Dates.normal,
-            False,
+            True,
         ),
     ],
 )

--- a/common/util.py
+++ b/common/util.py
@@ -17,13 +17,34 @@ def validity_range_contains_range(
 
     If either end is unbounded in the contained range,it must also be unbounded in the overall range.
     """
-    if contained_range.upper and contained_range.lower:
-        return (
-            contained_range.lower in overall_range
-            and contained_range.upper in overall_range
-        )
+    # XXX assumes both ranges are [) (inclusive-lower, exclusive-upper)
 
-    return not (
-        (contained_range.upper_inf and overall_range.upper)
-        or (contained_range.lower_inf and contained_range.lower)
-    )
+    if overall_range.lower_inf and overall_range.upper_inf:
+        return True
+
+    if (contained_range.lower_inf and not overall_range.lower_inf) or (
+        contained_range.upper_inf and not overall_range.upper_inf
+    ):
+        return False
+
+    if not overall_range.lower_inf:
+        if (
+            not contained_range.upper_inf
+            and contained_range.upper <= overall_range.lower
+        ):
+            return False
+
+        if contained_range.lower < overall_range.lower:
+            return False
+
+    if not overall_range.upper_inf:
+        if (
+            not contained_range.lower_inf
+            and contained_range.lower >= overall_range.upper
+        ):
+            return False
+
+        if contained_range.upper > overall_range.upper:
+            return False
+
+    return True

--- a/measures/tests/test_business_rules.py
+++ b/measures/tests/test_business_rules.py
@@ -1234,6 +1234,9 @@ def test_ME116(date_ranges):
         goods_nomenclature__valid_between=date_ranges.no_end_before(cutoff),
         measure_type__valid_between=date_ranges.no_end_before(cutoff),
         measure_type__order_number_capture_code=OrderNumberCaptureCode.MANDATORY,
+        measure_type__measure_type_series__valid_between=date_ranges.no_end_before(
+            cutoff
+        ),
     )
 
 
@@ -1305,4 +1308,7 @@ def test_ME119(approved_workbasket, date_ranges):
         geographical_area__valid_between=date_ranges.no_end_before(cutoff),
         goods_nomenclature__valid_between=date_ranges.no_end_before(cutoff),
         measure_type__valid_between=date_ranges.no_end_before(cutoff),
+        measure_type__measure_type_series__valid_between=date_ranges.no_end_before(
+            cutoff
+        ),
     )


### PR DESCRIPTION
The `validity_range_contains_range` function incorrectly returned `False` when a contained
range had the same end date as the containing range.

This commit fixes that by checking that the contained range bounds are within or equal
to the containing range bounds.

Also, a few fixes to tests that failed after this change
 - the tests for this function, natch
 - the footnotes editing test was submitting an empty start date when editing the end date
 - the measures tests were missing the measure_type_series validity period (probably only passed before because of the bug this commit fixes)