### PR TITLE
TP-242: Importer for measures

### DIFF
--- a/common/models.py
+++ b/common/models.py
@@ -269,6 +269,11 @@ inherit TrackedModel must either:
             query &= Q(**{field: getattr(self, field)})
         return self.__class__.objects.filter(query).order_by("-created_at")
 
+    def get_latest_version(self):
+        return self.__class__.objects.get_latest_version(
+            **{field: getattr(self, field) for field in self.identifying_fields}
+        )
+
     def validate_workbasket(self):
         pass
 

--- a/common/tests/factories.py
+++ b/common/tests/factories.py
@@ -571,7 +571,7 @@ class MeasureActionFactory(TrackedModelMixin, ValidityFactoryMixin):
     class Meta:
         model = "measures.MeasureAction"
 
-    code = factory.Faker("random_int", min=1, max=999)
+    code = factory.Sequence(lambda x: "{0:02d}".format(x + 1))
     description = short_description()
 
 

--- a/common/tests/util.py
+++ b/common/tests/util.py
@@ -143,7 +143,10 @@ def validate_taric_xml(
                         ".//subrecord.code", namespaces=xml.nsmap
                     )
                     full_code = record_code + subrecord_code
-                    assert full_code > last_code, "Elements out of order in XML"
+                    if full_code < last_code:
+                        raise Exception(
+                            f"Elements out of order in XML: {last_code}, {full_code}"
+                        )
                     last_code = full_code
 
             func(

--- a/measures/import_handlers.py
+++ b/measures/import_handlers.py
@@ -1,77 +1,427 @@
-import logging
-
-from importer.namespaces import Tag
-from importer.parsers import ElementParser
-from importer.parsers import TextElement
-from importer.parsers import ValidityMixin
-from importer.parsers import Writable
-from importer.taric import Record
+from additional_codes.models import AdditionalCode
+from additional_codes.models import AdditionalCodeType
+from certificates.models import Certificate
+from commodities.models import GoodsNomenclature
+from footnotes.models import Footnote
+from footnotes.models import FootnoteType
+from geo_areas.models import GeographicalArea
+from importer.handlers import BaseHandler
+from measures import import_parsers as parsers
+from measures import models
 from measures import serializers
+from quotas.models import QuotaOrderNumber
+from regulations.models import Regulation
 
 
-@Record.register_child("measure")
-class Measure(Writable, ValidityMixin, ElementParser):
+class MeasureTypeSeriesHandler(BaseHandler):
+    serializer_class = serializers.MeasureTypeSeriesSerializer
+    tag = parsers.MeasureTypeSeriesParser.tag.name
+
+
+@MeasureTypeSeriesHandler.register_dependant
+class MeasureTypeSeriesDescriptionHandler(BaseHandler):
+    dependencies = [MeasureTypeSeriesHandler]
+    serializer_class = serializers.MeasureTypeSeriesSerializer
+    tag = parsers.MeasureTypeSeriesDescriptionParser.tag.name
+
+
+class MeasurementUnitHandler(BaseHandler):
+    serializer_class = serializers.MeasurementUnitSerializer
+    tag = parsers.MeasurementUnitParser.tag.name
+
+
+@MeasurementUnitHandler.register_dependant
+class MeasurementUnitDescriptionHandler(BaseHandler):
+    dependencies = [MeasurementUnitHandler]
+    serializer_class = serializers.MeasurementUnitSerializer
+    tag = parsers.MeasurementUnitDescriptionParser.tag.name
+
+
+class MeasurementUnitQualifierHandler(BaseHandler):
+    serializer_class = serializers.MeasurementUnitQualifierSerializer
+    tag = parsers.MeasurementUnitQualifierParser.tag.name
+
+
+@MeasurementUnitQualifierHandler.register_dependant
+class MeasurementUnitQualifierDescriptionHandler(BaseHandler):
+    dependencies = [MeasurementUnitQualifierHandler]
+    serializer_class = serializers.MeasurementUnitQualifierSerializer
+    tag = parsers.MeasurementUnitQualifierDescriptionParser.tag.name
+
+
+class MeasurementHandler(BaseHandler):
+    identifying_fields = ("measurement_unit__code", "measurement_unit_qualifier__code")
+    links = (
+        {
+            "model": models.MeasurementUnit,
+            "name": "measurement_unit",
+        },
+        {
+            "model": models.MeasurementUnitQualifier,
+            "name": "measurement_unit_qualifier",
+        },
+    )
+    serializer_class = serializers.MeasurementSerializer
+    tag = parsers.MeasurementParser.tag.name
+
+
+class MonetaryUnitHandler(BaseHandler):
+    serializer_class = serializers.MonetaryUnitSerializer
+    tag = parsers.MonetaryUnitParser.tag.name
+
+
+@MonetaryUnitHandler.register_dependant
+class MonetaryUnitDescriptionHandler(BaseHandler):
+    dependencies = [MonetaryUnitHandler]
+    serializer_class = serializers.MonetaryUnitSerializer
+    tag = parsers.MonetaryUnitDescriptionParser.tag.name
+
+
+class DutyExpressionHandler(BaseHandler):
+    serializer_class = serializers.DutyExpressionSerializer
+    tag = parsers.DutyExpressionParser.tag.name
+
+
+@DutyExpressionHandler.register_dependant
+class DutyExpressionDescriptionHandler(BaseHandler):
+    dependencies = [DutyExpressionHandler]
+    serializer_class = serializers.DutyExpressionSerializer
+    tag = parsers.DutyExpressionDescriptionParser.tag.name
+
+
+class BaseMeasureTypeHandler(BaseHandler):
+    links = (
+        {
+            "model": models.MeasureTypeSeries,
+            "name": "measure_type_series",
+        },
+    )
+    serializer_class = serializers.MeasureTypeSerializer
+    tag = "BaseMeasureTypeHandler"
+
+
+class MeasureTypeHandler(BaseMeasureTypeHandler):
+    serializer_class = serializers.MeasureTypeSerializer
+    tag = parsers.MeasureTypeParser.tag.name
+
+
+@MeasureTypeHandler.register_dependant
+class MeasureTypeDescriptionHandler(BaseMeasureTypeHandler):
+    dependencies = [MeasureTypeHandler]
+    serializer_class = serializers.MeasureTypeSerializer
+    tag = parsers.MeasureTypeDescriptionParser.tag.name
+
+
+class AdditionalCodeTypeMeasureTypeHandler(BaseHandler):
+    identifying_fields = ("measure_type__sid", "additional_code_type__sid")
+    links = (
+        {
+            "model": models.MeasureType,
+            "name": "measure_type",
+        },
+        {
+            "model": AdditionalCodeType,
+            "name": "additional_code_type",
+        },
+    )
+    serializer_class = serializers.AdditionalCodeTypeMeasureTypeSerializer
+    tag = parsers.AdditionalCodeTypeMeasureTypeParser.tag.name
+
+
+class MeasureConditionCodeHandler(BaseHandler):
+    serializer_class = serializers.MeasureConditionCodeSerializer
+    tag = parsers.MeasureConditionCodeParser.tag.name
+
+
+@MeasureConditionCodeHandler.register_dependant
+class MeasureConditionCodeDescriptionHandler(BaseHandler):
+    dependencies = [MeasureConditionCodeHandler]
+    serializer_class = serializers.MeasureConditionCodeSerializer
+    tag = parsers.MeasureConditionCodeDescriptionParser.tag.name
+
+
+class MeasureActionHandler(BaseHandler):
+    serializer_class = serializers.MeasureActionSerializer
+    tag = parsers.MeasureActionParser.tag.name
+
+
+@MeasureActionHandler.register_dependant
+class MeasureActionDescriptionHandler(BaseHandler):
+    dependencies = [MeasureActionHandler]
+    serializer_class = serializers.MeasureActionSerializer
+    tag = parsers.MeasureActionDescriptionParser.tag.name
+
+
+class MeasureHandler(BaseHandler):
+    identifying_fields = (
+        "measure_type__sid",
+        "geographical_area__sid",
+        "goods_nomenclature__sid",
+        "additional_code__sid",
+        "order_number__order_number",
+        "reduction",
+    )
+    links = (
+        {
+            "model": models.MeasureType,
+            "name": "measure_type",
+        },
+        {
+            "model": GeographicalArea,
+            "name": "geographical_area",
+        },
+        {
+            "model": GoodsNomenclature,
+            "name": "goods_nomenclature",
+            "optional": True,
+        },
+        {
+            "model": AdditionalCode,
+            "name": "additional_code",
+            "optional": True,
+        },
+        {
+            "identifying_fields": (
+                "sid",
+                "order_number",
+            ),
+            "model": QuotaOrderNumber,
+            "name": "order_number",
+            "optional": True,
+        },
+        {
+            "model": Regulation,
+            "name": "generating_regulation",
+        },
+        {
+            "model": Regulation,
+            "name": "terminating_regulation",
+            "optional": True,
+        },
+    )
     serializer_class = serializers.MeasureSerializer
+    tag = parsers.MeasureParser.tag.name
 
-    tag = Tag("measure")
-    sid = TextElement(Tag("measure.sid"))
-    measure_type = TextElement(Tag("measure.type"))
-    geographical_area = TextElement(Tag("geographical.area"))
-    commodity_code = TextElement(Tag("goods.nomenclature.item.id"))
-    stopped = TextElement(Tag("stopped.flag"))
-    valid_between_lower = TextElement(Tag("validity.start.date"))
-    valid_between_upper = TextElement(Tag("validity.end.date"))
-
-    def clean(self):
-        super().clean()
-
-        commodity_code = self.data.pop("commodity_code", None)
-        if commodity_code:
-            self.data["commodity_code"] = {
-                "code": commodity_code,
-            }
-
-    def create(self, data, workbasket_id):
-        serializer = serializers.MeasureSerializer(data=data)
-        serializer.is_valid(raise_exception=True)
-        data = serializer.validated_data
-        data.update(workbasket_id=workbasket_id)
-        logging.debug(f"Creating Measure: {data}")
-        serializer.create(data)
+    def get_order_number_link(self, model, kwargs):
+        # XXX This seems like it might get the wrong object sometimes. Maybe we should
+        # just store the order number string on the measure, rather than link it to a
+        # QuotaOrderNumber instance?
+        return model.objects.get(
+            successor__isnull=True,
+            order_number=kwargs.pop("order_number"),
+        )
 
 
-class MeasureComponent(Writable, ElementParser):
-    tag = Tag("measure.component")
-    measure_sid = TextElement(Tag("measure.sid"))
-    duty_expression_sid = TextElement(Tag("duty.expression.sid"))
-    duty_amount = TextElement(Tag("duty.amount"))
-    monetary_unit_code = TextElement(Tag("monetary.unit.code"))
-    measurement_unit_code = TextElement(Tag("measurement.unit.code"))
+class MeasureComponentHandler(BaseHandler):
+    identifying_fields = (
+        "component_measure__sid",
+        "duty_expression__sid",
+    )
+    links = (
+        {
+            "identifying_fields": ("sid",),
+            "model": models.Measure,
+            "name": "component_measure",
+        },
+        {
+            "model": models.DutyExpression,
+            "name": "duty_expression",
+        },
+        {
+            "model": models.MonetaryUnit,
+            "name": "monetary_unit",
+            "optional": True,
+        },
+        {
+            "identifying_fields": (
+                "measurement_unit__code",
+                "measurement_unit_qualifier__code",
+            ),
+            "model": models.Measurement,
+            "name": "component_measurement",
+            "optional": True,
+        },
+    )
+    serializer_class = serializers.MeasureComponentSerializer
+    tag = parsers.MeasureComponentParser.tag.name
+
+    def get_component_measure_link(self, model, kwargs):
+        return model.objects.get(
+            sid=kwargs.pop("sid"),
+            successor__isnull=True,
+        )
+
+    def get_component_measurement_link(self, model, kwargs):
+        return model.objects.get_latest_version(
+            measurement_unit=models.MeasurementUnit.objects.get_latest_version(
+                code=kwargs.pop("measurement_unit__code")
+            ),
+            measurement_unit_qualifier=models.MeasurementUnitQualifier.objects.get_latest_version(
+                code=kwargs.pop("measurement_unit_qualifier__code")
+            ),
+            **kwargs,
+        )
 
 
-class MeasureCondition(Writable, ElementParser):
-    tag = Tag("measure.condition")
-    sid = TextElement(Tag("measure.condition.sid"))
-    measure_sid = TextElement(Tag("measure.sid"))
-    condition_code = TextElement(Tag("condition.code"))
-    component_sequence_number = TextElement(Tag("component.sequence.number"))
-    duty_amount = TextElement(Tag("condition.duty.amount"))
-    monetary_unit_code = TextElement(Tag("condition.monetary.unit.code"))
-    measurement_unit_code = TextElement(Tag("condition.measurement.unit.code"))
-    action_code = TextElement(Tag("action.code"))
+class MeasureConditionHandler(BaseHandler):
+    links = (
+        {
+            "identifying_fields": ("sid",),
+            "model": models.Measure,
+            "name": "dependent_measure",
+        },
+        {
+            "model": models.MeasureConditionCode,
+            "name": "condition_code",
+        },
+        {
+            "model": models.MonetaryUnit,
+            "name": "monetary_unit",
+            "optional": True,
+        },
+        {
+            "identifying_fields": (
+                "measurement_unit__code",
+                "measurement_unit_qualifier__code",
+            ),
+            "model": models.Measurement,
+            "name": "condition_measurement",
+            "optional": True,
+        },
+        {
+            "model": models.MeasureAction,
+            "name": "action",
+            "optional": True,
+        },
+        {
+            "model": Certificate,
+            "name": "required_certificate",
+            "optional": True,
+        },
+    )
+    serializer_class = serializers.MeasureConditionSerializer
+    tag = parsers.MeasureConditionParser.tag.name
+
+    def get_dependent_measure_link(self, model, kwargs):
+        return model.objects.get(
+            sid=kwargs.pop("sid"),
+            successor__isnull=True,
+        )
+
+    def get_condition_measurement_link(self, model, kwargs):
+        return model.objects.get_latest_version(
+            measurement_unit=models.MeasurementUnit.objects.get_latest_version(
+                code=kwargs.pop("measurement_unit__code")
+            ),
+            measurement_unit_qualifier=models.MeasurementUnitQualifier.objects.get_latest_version(
+                code=kwargs.pop("measurement_unit_qualifier__code")
+            ),
+            **kwargs,
+        )
 
 
-class MeasureConditionComponent(Writable, ElementParser):
-    tag = Tag("measure.condition.component")
-    measure_condition_sid = TextElement(Tag("measure.condition.sid"))
-    duty_expression_sid = TextElement(Tag("duty.expression.sid"))
-    duty_amount = TextElement(Tag("duty.amount"))
-    monetary_unit_code = TextElement(Tag("monetary.unit.code"))
-    measurement_unit_code = TextElement(Tag("measurement.unit.code"))
+class MeasureConditionComponentHandler(BaseHandler):
+    identifying_fields = ("condition__sid", "duty_expression__sid")
+    links = (
+        {
+            "model": models.MeasureCondition,
+            "name": "condition",
+        },
+        {
+            "model": models.DutyExpression,
+            "name": "duty_expression",
+        },
+        {
+            "model": models.MonetaryUnit,
+            "name": "monetary_unit",
+            "optional": True,
+        },
+        {
+            "identifying_fields": (
+                "measurement_unit__code",
+                "measurement_unit_qualifier__code",
+            ),
+            "model": models.Measurement,
+            "name": "condition_component_measurement",
+            "optional": True,
+        },
+    )
+    serializer_class = serializers.MeasureConditionComponentSerializer
+    tag = parsers.MeasureConditionComponentParser.tag.name
+
+    def get_condition_component_measurement_link(self, model, kwargs):
+        return model.objects.get_latest_version(
+            measurement_unit=models.MeasurementUnit.objects.get_latest_version(
+                code=kwargs.pop("measurement_unit__code")
+            ),
+            measurement_unit_qualifier=models.MeasurementUnitQualifier.objects.get_latest_version(
+                code=kwargs.pop("measurement_unit_qualifier__code")
+            ),
+            **kwargs,
+        )
 
 
-class MeasureExcludedGeographicalArea(Writable, ElementParser):
-    tag = Tag("measure.excluded.geographical.area")
-    measure_sid = TextElement(Tag("measure.sid"))
-    excluded_geographical_area_sid = TextElement(Tag("excluded.geographical.area"))
-    geographical_area_sid = TextElement(Tag("geograpical.area.sid"))
+class MeasureExcludedGeographicalAreaHandler(BaseHandler):
+    identifying_fields = (
+        "modified_measure__sid",
+        "excluded_geographical_area__sid",
+    )
+    links = (
+        {
+            "identifying_fields": ("sid",),
+            "model": models.Measure,
+            "name": "modified_measure",
+        },
+        {
+            "model": GeographicalArea,
+            "name": "excluded_geographical_area",
+        },
+    )
+    serializer_class = serializers.MeasureExcludedGeographicalAreaSerializer
+    tag = parsers.MeasureExcludedGeographicalAreaParser.tag.name
+
+    def get_modified_measure_link(self, model, kwargs):
+        return model.objects.get(
+            sid=kwargs.pop("sid"),
+            successor__isnull=True,
+        )
+
+
+class FootnoteAssociationMeasureHandler(BaseHandler):
+    identifying_fields = (
+        "footnoted_measure__sid",
+        "associated_footnote__footnote_type__footnote_type_id",
+        "associated_footnote__footnote_id",
+    )
+    links = (
+        {
+            "identifying_fields": ("sid",),
+            "model": models.Measure,
+            "name": "footnoted_measure",
+        },
+        {
+            "identifying_fields": (
+                "footnote_type__footnote_type_id",
+                "footnote_id",
+            ),
+            "model": Footnote,
+            "name": "associated_footnote",
+        },
+    )
+    serializer_class = serializers.FootnoteAssociationMeasureSerializer
+    tag = parsers.FootnoteAssociationMeasureParser.tag.name
+
+    def get_footnoted_measure_link(self, model, kwargs):
+        return model.objects.get(
+            sid=kwargs.pop("sid"),
+            successor__isnull=True,
+        )
+
+    def get_associated_footnote_link(self, model, kwargs):
+        return model.objects.get_latest_version(
+            footnote_type=FootnoteType.objects.get_latest_version(
+                footnote_type_id=kwargs.pop("footnote_type__footnote_type_id"),
+            ),
+            footnote_id=kwargs.pop("footnote_id"),
+            **kwargs,
+        )

--- a/measures/import_parsers.py
+++ b/measures/import_parsers.py
@@ -1,0 +1,596 @@
+from importer.namespaces import Tag
+from importer.parsers import ElementParser
+from importer.parsers import IntElement
+from importer.parsers import TextElement
+from importer.parsers import ValidityMixin
+from importer.parsers import Writable
+from importer.taric import Record
+
+
+@Record.register_child("measure_type_series")
+class MeasureTypeSeriesParser(ValidityMixin, Writable, ElementParser):
+    """
+    <xs:element name="measure.type.series" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="measure.type.series.id" type="MeasureTypeSeriesId"/>
+                <xs:element name="validity.start.date" type="Date"/>
+                <xs:element name="validity.end.date" type="Date" minOccurs="0"/>
+                <xs:element name="measure.type.combination" type="MeasureTypeCombination"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    """
+
+    tag = Tag("measure.type.series")
+
+    sid = TextElement(Tag("measure.type.series.id"))
+    measure_type_combination = IntElement(Tag("measure.type.combination"))
+
+
+@Record.register_child("measure.type.series.description")
+class MeasureTypeSeriesDescriptionParser(Writable, ElementParser):
+    """
+    <xs:element name="measure.type.series.description" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="measure.type.series.id" type="MeasureTypeSeriesId"/>
+                <xs:element name="language.id" type="LanguageId"/>
+                <xs:element name="description" type="ShortDescription" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    """
+
+    tag = Tag("measure.type.series.description")
+
+    sid = TextElement(Tag("measure.type.series.id"))
+    description = TextElement(Tag("description"))
+
+
+@Record.register_child("measurement_unit")
+class MeasurementUnitParser(ValidityMixin, Writable, ElementParser):
+    """
+    <xs:element name="measurement.unit" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="measurement.unit.code" type="MeasurementUnitCode"/>
+                <xs:element name="validity.start.date" type="Date"/>
+                <xs:element name="validity.end.date" type="Date" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    """
+
+    tag = Tag("measurement.unit")
+
+    code = TextElement(Tag("measurement.unit.code"))
+
+
+@Record.register_child("measurement_unit_description")
+class MeasurementUnitDescriptionParser(Writable, ElementParser):
+    """
+    <xs:element name="measurement.unit.description" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="measurement.unit.code" type="MeasurementUnitCode"/>
+                <xs:element name="language.id" type="LanguageId"/>
+                <xs:element name="description" type="ShortDescription" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    """
+
+    tag = Tag("measurement.unit.description")
+
+    code = TextElement(Tag("measurement.unit.code"))
+    description = TextElement(Tag("description"))
+
+
+@Record.register_child("measurement_unit_qualifier")
+class MeasurementUnitQualifierParser(ValidityMixin, Writable, ElementParser):
+    """
+    <xs:element name="measurement.unit.qualifier" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="measurement.unit.qualifier.code" type="MeasurementUnitQualifierCode"/>
+                <xs:element name="validity.start.date" type="Date"/>
+                <xs:element name="validity.end.date" type="Date" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    """
+
+    tag = Tag("measurement.unit.qualifier")
+
+    code = TextElement(Tag("measurement.unit.qualifier.code"))
+
+
+@Record.register_child("measurement_unit_qualifier_description")
+class MeasurementUnitQualifierDescriptionParser(Writable, ElementParser):
+    """
+    <xs:element name="measurement.unit.qualifier.description" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="measurement.unit.qualifier.code" type="MeasurementUnitQualifierCode"/>
+                <xs:element name="language.id" type="LanguageId"/>
+                <xs:element name="description" type="ShortDescription" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    """
+
+    tag = Tag("measurement.unit.qualifier.description")
+
+    code = TextElement(Tag("measurement.unit.qualifier.code"))
+    description = TextElement(Tag("description"))
+
+
+@Record.register_child("measurement")
+class MeasurementParser(ValidityMixin, Writable, ElementParser):
+    """
+    <xs:element name="measurement" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="measurement.unit.code" type="MeasurementUnitCode"/>
+                <xs:element name="measurement.unit.qualifier.code" type="MeasurementUnitQualifierCode"/>
+                <xs:element name="validity.start.date" type="Date"/>
+                <xs:element name="validity.end.date" type="Date" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    """
+
+    tag = Tag("measurement")
+
+    measurement_unit__code = TextElement(Tag("measurement.unit.code"))
+    measurement_unit_qualifier__code = TextElement(
+        Tag("measurement.unit.qualifier.code")
+    )
+
+
+@Record.register_child("monetary_unit")
+class MonetaryUnitParser(ValidityMixin, Writable, ElementParser):
+    """
+    <xs:element name="monetary.unit" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="monetary.unit.code" type="MonetaryUnitCode"/>
+                <xs:element name="validity.start.date" type="Date"/>
+                <xs:element name="validity.end.date" type="Date" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    """
+
+    tag = Tag("monetary.unit")
+
+    code = TextElement(Tag("monetary.unit.code"))
+
+
+@Record.register_child("monetary_unit_description")
+class MonetaryUnitDescriptionParser(Writable, ElementParser):
+    """
+    <xs:element name="monetary.unit.description" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="monetary.unit.code" type="MonetaryUnitCode"/>
+                <xs:element name="language.id" type="LanguageId"/>
+                <xs:element name="description" type="ShortDescription" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    """
+
+    tag = Tag("monetary.unit.description")
+
+    code = TextElement(Tag("monetary.unit.code"))
+    description = TextElement(Tag("description"))
+
+
+@Record.register_child("duty_expression")
+class DutyExpressionParser(ValidityMixin, Writable, ElementParser):
+    """
+    <xs:element name="duty.expression" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="duty.expression.id" type="DutyExpressionId"/>
+                <xs:element name="validity.start.date" type="Date"/>
+                <xs:element name="validity.end.date" type="Date" minOccurs="0"/>
+                <xs:element name="duty.amount.applicability.code" type="DutyAmountApplicabilityCode"/>
+                <xs:element name="measurement.unit.applicability.code" type="MeasurementUnitApplicabilityCode"/>
+                <xs:element name="monetary.unit.applicability.code" type="MonetaryUnitApplicabilityCode"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    """
+
+    tag = Tag("duty.expression")
+
+    sid = IntElement(Tag("duty.expression.id"))
+    duty_amount_applicability_code = IntElement(Tag("duty.amount.applicability.code"))
+    measurement_unit_applicability_code = IntElement(
+        Tag("measurement.unit.applicability.code")
+    )
+    monetary_unit_applicability_code = IntElement(
+        Tag("monetary.unit.applicability.code")
+    )
+
+
+@Record.register_child("duty_expression_description")
+class DutyExpressionDescriptionParser(Writable, ElementParser):
+    """
+    <xs:element name="duty.expression.description" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="duty.expression.id" type="DutyExpressionId"/>
+                <xs:element name="language.id" type="LanguageId"/>
+                <xs:element name="description" type="ShortDescription" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    """
+
+    tag = Tag("duty.expression.description")
+
+    sid = IntElement(Tag("duty.expression.id"))
+    description = TextElement(Tag("description"))
+
+
+@Record.register_child("measure_type")
+class MeasureTypeParser(ValidityMixin, Writable, ElementParser):
+    """
+    <xs:element name="measure.type" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="measure.type.id" type="MeasureTypeId"/>
+                <xs:element name="validity.start.date" type="Date"/>
+                <xs:element name="validity.end.date" type="Date" minOccurs="0"/>
+                <xs:element name="trade.movement.code" type="TradeMovementCode"/>
+                <xs:element name="priority.code" type="PriorityCode"/>
+                <xs:element name="measure.component.applicable.code" type="MeasurementUnitApplicabilityCode"/>
+                <xs:element name="origin.dest.code" type="OriginCode"/>
+                <xs:element name="order.number.capture.code" type="OrderNumberCaptureCode"/>
+                <xs:element name="measure.explosion.level" type="MeasureExplosionLevel"/>
+                <xs:element name="measure.type.series.id" type="MeasureTypeSeriesId"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    """
+
+    tag = Tag("measure.type")
+
+    sid = TextElement(Tag("measure.type.id"))
+    trade_movement_code = IntElement(Tag("trade.movement.code"))
+    priority_code = IntElement(Tag("priority.code"))
+    measure_component_applicability_code = IntElement(
+        Tag("measure.component.applicable.code")
+    )
+    origin_destination_code = IntElement(Tag("origin.dest.code"))
+    order_number_capture_code = IntElement(Tag("order.number.capture.code"))
+    measure_explosion_level = IntElement(Tag("measure.explosion.level"))
+    measure_type_series__sid = TextElement(Tag("measure.type.series.id"))
+
+
+@Record.register_child("measure_type_description")
+class MeasureTypeDescriptionParser(Writable, ElementParser):
+    """
+    <xs:element name="measure.type.description" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="measure.type.id" type="MeasureTypeId"/>
+                <xs:element name="language.id" type="LanguageId"/>
+                <xs:element name="description" type="ShortDescription" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    """
+
+    tag = Tag("measure.type.description")
+
+    sid = TextElement(Tag("measure.type.id"))
+    description = TextElement(Tag("description"))
+
+
+@Record.register_child("additional_code_type_measure_type")
+class AdditionalCodeTypeMeasureTypeParser(ValidityMixin, Writable, ElementParser):
+    """
+    <xs:element name="additional.code.type.measure.type" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="measure.type.id" type="MeasureTypeId"/>
+                <xs:element name="additional.code.type.id" type="AdditionalCodeTypeId"/>
+                <xs:element name="validity.start.date" type="Date"/>
+                <xs:element name="validity.end.date" type="Date" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    """
+
+    tag = Tag("additional.code.type.measure.type")
+
+    measure_type__sid = TextElement(Tag("measure.type.id"))
+    additional_code_type__sid = TextElement(Tag("additional.code.type.id"))
+
+
+@Record.register_child("measure_condition_code")
+class MeasureConditionCodeParser(ValidityMixin, Writable, ElementParser):
+    """
+    <xs:element name="measure.condition.code" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="condition.code" type="ConditionCode"/>
+                <xs:element name="validity.start.date" type="Date"/>
+                <xs:element name="validity.end.date" type="Date" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    """
+
+    tag = Tag("measure.condition.code")
+
+    code = TextElement(Tag("condition.code"))
+
+
+@Record.register_child("measure_condition_code_description")
+class MeasureConditionCodeDescriptionParser(Writable, ElementParser):
+    """
+    <xs:element name="measure.condition.code.description" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="condition.code" type="ConditionCode"/>
+                <xs:element name="language.id" type="LanguageId"/>
+                <xs:element name="description" type="ShortDescription" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    """
+
+    tag = Tag("measure.condition.code.description")
+
+    code = TextElement(Tag("condition.code"))
+    description = TextElement(Tag("description"))
+
+
+@Record.register_child("measure_action")
+class MeasureActionParser(ValidityMixin, Writable, ElementParser):
+    """
+    <xs:element name="measure.action" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="action.code" type="ActionCode"/>
+                <xs:element name="validity.start.date" type="Date"/>
+                <xs:element name="validity.end.date" type="Date" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    """
+
+    tag = Tag("measure.action")
+
+    code = TextElement(Tag("action.code"))
+
+
+@Record.register_child("measure_action_description")
+class MeasureActionDescriptionParser(Writable, ElementParser):
+    """
+    <xs:element name="measure.action.description" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="action.code" type="ActionCode"/>
+                <xs:element name="language.id" type="LanguageId"/>
+                <xs:element name="description" type="ShortDescription" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    """
+
+    tag = Tag("measure.action.description")
+
+    code = TextElement(Tag("action.code"))
+    description = TextElement(Tag("description"))
+
+
+@Record.register_child("measure")
+class MeasureParser(ValidityMixin, Writable, ElementParser):
+    """
+    <xs:element name="measure" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="measure.sid" type="SID"/>
+                <xs:element name="measure.type" type="MeasureTypeId"/>
+                <xs:element name="geographical.area" type="GeographicalAreaId"/>
+                <xs:element name="goods.nomenclature.item.id" type="GoodsNomenclatureItemId" minOccurs="0"/>
+                <xs:element name="additional.code.type" type="AdditionalCodeTypeId" minOccurs="0"/>
+                <xs:element name="additional.code" type="AdditionalCode" minOccurs="0"/>
+                <xs:element name="ordernumber" type="OrderNumber" minOccurs="0"/>
+                <xs:element name="reduction.indicator" type="ReductionIndicator" minOccurs="0"/>
+                <xs:element name="validity.start.date" type="Date"/>
+                <xs:element name="measure.generating.regulation.role" type="RegulationRoleTypeId"/>
+                <xs:element name="measure.generating.regulation.id" type="RegulationId"/>
+                <xs:element name="validity.end.date" type="Date" minOccurs="0"/>
+                <xs:element name="justification.regulation.role" type="RegulationRoleTypeId" minOccurs="0"/>
+                <xs:element name="justification.regulation.id" type="RegulationId" minOccurs="0"/>
+                <xs:element name="stopped.flag" type="StoppedFlag"/>
+                <xs:element name="geographical.area.sid" type="SID" minOccurs="0"/>
+                <xs:element name="goods.nomenclature.sid" type="SID" minOccurs="0"/>
+                <xs:element name="additional.code.sid" type="SID" minOccurs="0"/>
+                <xs:element name="export.refund.nomenclature.sid" type="SID" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    """
+
+    tag = Tag("measure")
+
+    sid = TextElement(Tag("measure.sid"))
+    measure_type__sid = TextElement(Tag("measure.type"))
+    geographical_area__area_id = TextElement(Tag("geographical.area"))
+    goods_nomenclature__item_id = TextElement(Tag("goods.nomenclature.item.id"))
+    additional_code__type__sid = TextElement(Tag("additional.code.type.id"))
+    additional_code__code = TextElement(Tag("additional.code"))
+    order_number__order_number = TextElement(Tag("ordernumber"))
+    reduction = IntElement(Tag("reduction.indicator"))
+    generating_regulation__role_type = IntElement(
+        Tag("measure.generating.regulation.role")
+    )
+    generating_regulation__regulation_id = TextElement(
+        Tag("measure.generating.regulation.id")
+    )
+    terminating_regulation__role_type = IntElement(Tag("justification.regulation.role"))
+    terminating_regulation__regulation_id = TextElement(
+        Tag("justification.regulation.id")
+    )
+    stopped = TextElement(Tag("stopped.flag"))
+    geographical_area__sid = TextElement(Tag("geographical.area.sid"))
+    goods_nomenclature__sid = TextElement(Tag("goods.nomenclature.sid"))
+    additional_code__sid = TextElement(Tag("additional.code.sid"))
+
+
+@Record.register_child("measure_component")
+class MeasureComponentParser(Writable, ElementParser):
+    """
+    <xs:element name="measure.component" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="measure.sid" type="SID"/>
+                <xs:element name="duty.expression.id" type="DutyExpressionId"/>
+                <xs:element name="duty.amount" type="DutyAmount" minOccurs="0"/>
+                <xs:element name="monetary.unit.code" type="MonetaryUnitCode" minOccurs="0"/>
+                <xs:element name="measurement.unit.code" type="MeasurementUnitCode" minOccurs="0"/>
+                <xs:element name="measurement.unit.qualifier.code" type="MeasurementUnitQualifierCode" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    """
+
+    tag = Tag("measure.component")
+
+    component_measure__sid = TextElement(Tag("measure.sid"))
+    duty_expression__sid = IntElement(Tag("duty.expression.id"))
+    duty_amount = TextElement(Tag("duty.amount"))
+    monetary_unit__code = TextElement(Tag("monetary.unit.code"))
+    component_measurement__measurement_unit__code = TextElement(
+        Tag("measurement.unit.code")
+    )
+    component_measurement__measurement_unit_qualifier__code = TextElement(
+        Tag("measurement.unit.qualifier.code")
+    )
+
+
+@Record.register_child("measure_condition")
+class MeasureConditionParser(Writable, ElementParser):
+    """
+    <xs:element name="measure.condition" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="measure.condition.sid" type="SID"/>
+                <xs:element name="measure.sid" type="SID"/>
+                <xs:element name="condition.code" type="ConditionCode"/>
+                <xs:element name="component.sequence.number" type="ComponentSequenceNumber"/>
+                <xs:element name="condition.duty.amount" type="DutyAmount" minOccurs="0"/>
+                <xs:element name="condition.monetary.unit.code" type="MonetaryUnitCode" minOccurs="0"/>
+                <xs:element name="condition.measurement.unit.code" type="MeasurementUnitCode" minOccurs="0"/>
+                <xs:element name="condition.measurement.unit.qualifier.code" type="MeasurementUnitQualifierCode" minOccurs="0"/>
+                <xs:element name="action.code" type="ActionCode" minOccurs="0"/>
+                <xs:element name="certificate.type.code" type="CertificateTypeCode" minOccurs="0"/>
+                <xs:element name="certificate.code" type="CertificateCode" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    """
+
+    tag = Tag("measure.condition")
+
+    sid = TextElement(Tag("measure.condition.sid"))
+    dependent_measure__sid = TextElement(Tag("measure.sid"))
+    condition_code__code = TextElement(Tag("condition.code"))
+    component_sequence_number = IntElement(Tag("component.sequence.number"))
+    duty_amount = TextElement(Tag("condition.duty.amount"))
+    monetary_unit__code = TextElement(Tag("condition.monetary.unit.code"))
+    condition_measurement__measurement_unit__code = TextElement(
+        Tag("condition.measurement.unit.code")
+    )
+    condition_measurement__measurement_unit_qualifier__code = TextElement(
+        Tag("condition.measurement.unit.qualifier.code")
+    )
+    action__code = TextElement(Tag("action.code"))
+    required_certificate__certificate_type__sid = TextElement(
+        Tag("certificate.type.code")
+    )
+    required_certificate__sid = TextElement(Tag("certificate.code"))
+
+
+@Record.register_child("measure_condition_component")
+class MeasureConditionComponentParser(Writable, ElementParser):
+    """
+    <xs:element name="measure.condition.component" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="measure.condition.sid" type="SID"/>
+                <xs:element name="duty.expression.id" type="DutyExpressionId"/>
+                <xs:element name="duty.amount" type="DutyAmount" minOccurs="0"/>
+                <xs:element name="monetary.unit.code" type="MonetaryUnitCode" minOccurs="0"/>
+                <xs:element name="measurement.unit.code" type="MeasurementUnitCode" minOccurs="0"/>
+                <xs:element name="measurement.unit.qualifier.code" type="MeasurementUnitQualifierCode" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    """
+
+    tag = Tag("measure.condition.component")
+
+    condition__sid = TextElement(Tag("measure.condition.sid"))
+    duty_expression__sid = IntElement(Tag("duty.expression.id"))
+    duty_amount = TextElement(Tag("duty.amount"))
+    monetary_unit__code = TextElement(Tag("monetary.unit.code"))
+    condition_component_measurement__measurement_unit__code = TextElement(
+        Tag("measurement.unit.code")
+    )
+    condition_component_measurement__measurement_unit_qualifier__code = TextElement(
+        Tag("measurement.unit.qualifier.code")
+    )
+
+
+@Record.register_child("measure_excluded_geographical_area")
+class MeasureExcludedGeographicalAreaParser(Writable, ElementParser):
+    """
+    <xs:element name="measure.excluded.geographical.area" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="measure.sid" type="SID"/>
+                <xs:element name="excluded.geographical.area" type="GeographicalAreaId"/>
+                <xs:element name="geographical.area.sid" type="SID"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    """
+
+    tag = Tag("measure.excluded.geographical.area")
+
+    modified_measure__sid = TextElement(Tag("measure.sid"))
+    excluded_geographical_area__area_id = TextElement(Tag("excluded.geographical.area"))
+    excluded_geographical_area__sid = TextElement(Tag("geographical.area.sid"))
+
+
+@Record.register_child("footnote_association_measure")
+class FootnoteAssociationMeasureParser(Writable, ElementParser):
+    """
+    <xs:element name="footnote.association.measure" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="measure.sid" type="SID"/>
+                <xs:element name="footnote.type.id" type="FootnoteTypeId"/>
+                <xs:element name="footnote.id" type="FootnoteId"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    """
+
+    tag = Tag("footnote.association.measure")
+
+    footnoted_measure__sid = TextElement(Tag("measure.sid"))
+    associated_footnote__footnote_type__footnote_type_id = TextElement(
+        Tag("footnote.type.id")
+    )
+    associated_footnote__footnote_id = TextElement(Tag("footnote.id"))

--- a/measures/jinja2/taric/measure_condition_component.xml
+++ b/measures/jinja2/taric/measure_condition_component.xml
@@ -7,7 +7,7 @@
       {%- if record.duty_amount -%}
       <oub:duty.amount>{{ record.duty_amount }}</oub:duty.amount>
       {%- endif %}
-      {%- if record.monetary_unit_code -%}
+      {%- if record.monetary_unit -%}
       <oub:monetary.unit.code>{{ record.monetary_unit.code }}</oub:monetary.unit.code>
       {%- endif %}
       {%- if record.condition_component_measurement -%}

--- a/measures/models.py
+++ b/measures/models.py
@@ -30,7 +30,7 @@ class MeasureTypeSeries(TrackedModel, ValidityMixin):
     description = ShortDescription()
 
     def __str__(self):
-        return f"{self.measure_type_series_id} - {self.description}"
+        return f"{self.sid} - {self.description}"
 
     def clean(self):
         validators.validate_unique_measure_type_series(self)
@@ -577,7 +577,7 @@ class MeasureExcludedGeographicalArea(TrackedModel):
     record_code = "430"
     subrecord_code = "15"
 
-    identifying_fields = ("measure", "excluded_geographical_area")
+    identifying_fields = ("modified_measure", "excluded_geographical_area")
 
     modified_measure = models.ForeignKey(Measure, on_delete=models.PROTECT)
     excluded_geographical_area = models.ForeignKey(

--- a/measures/serializers.py
+++ b/measures/serializers.py
@@ -10,12 +10,20 @@ from common.serializers import ValiditySerializerMixin
 from footnotes.serializers import FootnoteSerializer
 from geo_areas.serializers import GeographicalAreaSerializer
 from measures import models
+from measures import validators
 from quotas.serializers import QuotaOrderNumberSerializer
 from regulations.serializers import RegulationSerializer
 
 
 @TrackedModelSerializer.register_polymorphic_model
 class MeasureTypeSeriesSerializer(TrackedModelSerializerMixin, ValiditySerializerMixin):
+    sid = serializers.CharField(
+        validators=[validators.measure_type_series_id_validator]
+    )
+    measure_type_combination = serializers.ChoiceField(
+        choices=validators.MeasureTypeCombination.choices
+    )
+
     class Meta:
         model = models.MeasureTypeSeries
         fields = [
@@ -36,6 +44,10 @@ class MeasureTypeSeriesSerializer(TrackedModelSerializerMixin, ValiditySerialize
 
 @TrackedModelSerializer.register_polymorphic_model
 class MeasurementUnitSerializer(TrackedModelSerializerMixin, ValiditySerializerMixin):
+    code = serializers.CharField(
+        validators=[validators.measurement_unit_code_validator]
+    )
+
     class Meta:
         model = models.MeasurementUnit
         fields = [
@@ -57,6 +69,10 @@ class MeasurementUnitSerializer(TrackedModelSerializerMixin, ValiditySerializerM
 class MeasurementUnitQualifierSerializer(
     TrackedModelSerializerMixin, ValiditySerializerMixin
 ):
+    code = serializers.CharField(
+        validators=[validators.measurement_unit_qualifier_code_validator]
+    )
+
     class Meta:
         model = models.MeasurementUnitQualifier
         fields = [
@@ -96,6 +112,8 @@ class MeasurementSerializer(TrackedModelSerializerMixin, ValiditySerializerMixin
 
 @TrackedModelSerializer.register_polymorphic_model
 class MonetaryUnitSerializer(TrackedModelSerializerMixin, ValiditySerializerMixin):
+    code = serializers.CharField(validators=[validators.monetary_unit_code_validator])
+
     class Meta:
         model = models.MonetaryUnit
         fields = [
@@ -115,6 +133,17 @@ class MonetaryUnitSerializer(TrackedModelSerializerMixin, ValiditySerializerMixi
 
 @TrackedModelSerializer.register_polymorphic_model
 class DutyExpressionSerializer(TrackedModelSerializerMixin, ValiditySerializerMixin):
+    sid = serializers.ChoiceField(choices=validators.DutyExpressionId.choices)
+    duty_amount_applicability_code = serializers.ChoiceField(
+        choices=validators.ApplicabilityCode.choices
+    )
+    measurement_unit_applicability_code = serializers.ChoiceField(
+        choices=validators.ApplicabilityCode.choices
+    )
+    monetary_unit_applicability_code = serializers.ChoiceField(
+        choices=validators.ApplicabilityCode.choices
+    )
+
     class Meta:
         model = models.DutyExpression
         fields = [
@@ -138,6 +167,22 @@ class DutyExpressionSerializer(TrackedModelSerializerMixin, ValiditySerializerMi
 @TrackedModelSerializer.register_polymorphic_model
 class MeasureTypeSerializer(TrackedModelSerializerMixin, ValiditySerializerMixin):
     measure_type_series = MeasureTypeSeriesSerializer(read_only=True)
+    sid = serializers.CharField(validators=[validators.measure_type_id_validator])
+    trade_movement_code = serializers.ChoiceField(
+        choices=validators.ImportExportCode.choices
+    )
+    priority_code = serializers.IntegerField(
+        validators=[validators.validate_priority_code]
+    )
+    measure_component_applicability_code = serializers.ChoiceField(
+        choices=validators.ApplicabilityCode.choices
+    )
+    order_number_capture_code = serializers.ChoiceField(
+        choices=validators.OrderNumberCaptureCode.choices
+    )
+    measure_explosion_level = serializers.IntegerField(
+        validators=[validators.validate_measure_explosion_level]
+    )
 
     class Meta:
         model = models.MeasureType
@@ -190,6 +235,10 @@ class AdditionalCodeTypeMeasureTypeSerializer(
 class MeasureConditionCodeSerializer(
     TrackedModelSerializerMixin, ValiditySerializerMixin
 ):
+    code = serializers.CharField(
+        validators=[validators.measure_condition_code_validator]
+    )
+
     class Meta:
         model = models.MeasureConditionCode
         fields = [
@@ -209,6 +258,8 @@ class MeasureConditionCodeSerializer(
 
 @TrackedModelSerializer.register_polymorphic_model
 class MeasureActionSerializer(TrackedModelSerializerMixin, ValiditySerializerMixin):
+    code = serializers.CharField(validators=[validators.validate_action_code])
+
     class Meta:
         model = models.MeasureAction
         fields = [
@@ -236,8 +287,11 @@ class MeasureSerializer(TrackedModelSerializerMixin, ValiditySerializerMixin):
     order_number = QuotaOrderNumberSerializer(read_only=True)
     generating_regulation = RegulationSerializer(read_only=True)
     terminating_regulation = RegulationSerializer(read_only=True)
+    reduction = serializers.IntegerField(
+        validators=[validators.validate_reduction_indicator]
+    )
     export_refund_nomenclature_sid = serializers.IntegerField(
-        min_value=1, max_value=99999999
+        min_value=1, max_value=99999999, required=False
     )
 
     class Meta:
@@ -295,6 +349,9 @@ class MeasureConditionSerializer(TrackedModelSerializerMixin):
     condition_measurement = MeasurementSerializer(read_only=True)
     action = MeasureActionSerializer(read_only=True)
     required_certificate = CertificateSerializer(read_only=True)
+    component_sequence_number = serializers.IntegerField(
+        validators=[validators.validate_component_sequence_number]
+    )
 
     class Meta:
         model = models.MeasureCondition

--- a/measures/tests/conftest.py
+++ b/measures/tests/conftest.py
@@ -1,8 +1,21 @@
+from typing import Iterable
+from typing import Optional
+from typing import Type
+from typing import Union
+
 import pytest
 from django.core.exceptions import ValidationError
+from factory.django import DjangoModelFactory
 
+from common.models import TrackedModel
+from common.serializers import TrackedModelSerializer
 from common.tests import factories
+from common.tests.util import generate_test_import_xml as taric_xml
 from common.validators import ApplicabilityCode
+from common.validators import UpdateType
+from importer.management.commands.import_taric import import_taric
+from measures import serializers
+from workbaskets.validators import WorkflowStatus
 
 
 @pytest.fixture
@@ -29,6 +42,64 @@ def component_applicability():
                     field_name: value,
                 }
             )
+
+        return True
+
+    return check
+
+
+@pytest.fixture
+def imported_fields_match(valid_user):
+    """Provides a function for checking a model can be imported correctly.
+
+    The function takes the following parameters:
+        model: A model instance, or a factory class used to build the model.
+            This model should not already exist in the database.
+        serializer: An optional serializer class to convert the model to its TARIC XML
+            representation. If not provided, the function attempts to use a serializer
+            class named after the model, eg measures.serializers.<model-class-name>Serializer
+
+    The function serializes the model to TARIC XML, inputs this to the importer, then
+    fetches the newly created model from the database and compares the fields.
+
+    It returns True if there are no discrepancies, allowing it to be used with `assert`.
+    """
+
+    def check(
+        model: Union[TrackedModel, Type[DjangoModelFactory]],
+        serializer: Optional[Type[TrackedModelSerializer]] = None,
+    ) -> bool:
+        if isinstance(model, type) and issubclass(model, DjangoModelFactory):
+            model = model.build(update_type=UpdateType.CREATE)
+
+        assert isinstance(
+            model, TrackedModel
+        ), "Either a factory or an object instance needs to be provided"
+
+        if serializer is None:
+            serializer = getattr(serializers, f"{model.__class__.__name__}Serializer")
+
+        xml = taric_xml(serializer(model, context={"format": "xml"}).data)
+
+        import_taric(
+            xml,
+            valid_user.username,
+            WorkflowStatus.PUBLISHED,
+        )
+        imported = model.get_latest_version()
+
+        checked_fields = (
+            set(field.name for field in imported._meta.fields)
+            - set(field.name for field in TrackedModel._meta.fields)
+            - {"trackedmodel_ptr"}
+        )
+
+        for field in checked_fields:
+            imported_value = getattr(imported, field)
+            source_value = getattr(model, field)
+            assert (
+                imported_value == source_value
+            ), f"imported '{field}' ({imported_value} - {type(imported_value)}) does not match source '{field}' ({source_value} - {type(source_value)})"
 
         return True
 

--- a/measures/tests/test_importer.py
+++ b/measures/tests/test_importer.py
@@ -1,0 +1,157 @@
+import pytest
+
+from common.tests import factories
+from common.validators import UpdateType
+from measures.validators import OrderNumberCaptureCode
+from quotas.validators import AdministrationMechanism
+from workbaskets.validators import WorkflowStatus
+
+
+pytestmark = pytest.mark.django_db
+
+
+def test_measure_type_series_importer_create(imported_fields_match):
+    assert imported_fields_match(factories.MeasureTypeSeriesFactory)
+
+
+def test_measurement_unit_importer_create(imported_fields_match):
+    assert imported_fields_match(factories.MeasurementUnitFactory)
+
+
+def test_measurement_unit_qualifier_importer_create(imported_fields_match):
+    assert imported_fields_match(factories.MeasurementUnitQualifierFactory)
+
+
+def test_measurement_importer_create(imported_fields_match):
+    assert imported_fields_match(
+        factories.MeasurementFactory.build(
+            measurement_unit=factories.MeasurementUnitFactory(),
+            measurement_unit_qualifier=factories.MeasurementUnitQualifierFactory(),
+            update_type=UpdateType.CREATE,
+        ),
+    )
+
+
+def test_monetary_unit_importer_create(imported_fields_match):
+    assert imported_fields_match(factories.MonetaryUnitFactory)
+
+
+def test_duty_expression_importer_create(imported_fields_match):
+    assert imported_fields_match(factories.DutyExpressionFactory)
+
+
+def test_measure_type_importer_create(imported_fields_match):
+    assert imported_fields_match(
+        factories.MeasureTypeFactory.build(
+            measure_type_series=factories.MeasureTypeSeriesFactory(),
+            update_type=UpdateType.CREATE,
+        )
+    )
+
+
+def test_additional_code_type_measure_type_importer_create(imported_fields_match):
+    assert imported_fields_match(
+        factories.AdditionalCodeTypeMeasureTypeFactory.build(
+            measure_type=factories.MeasureTypeFactory(),
+            additional_code_type=factories.AdditionalCodeTypeFactory(),
+            update_type=UpdateType.CREATE,
+        )
+    )
+
+
+def test_measure_condition_code_importer_create(imported_fields_match):
+    assert imported_fields_match(factories.MeasureConditionCodeFactory)
+
+
+def test_measure_action_importer_create(imported_fields_match):
+    assert imported_fields_match(factories.MeasureActionFactory)
+
+
+def test_measure_importer_create(imported_fields_match):
+    rel = factories.AdditionalCodeTypeMeasureTypeFactory(
+        measure_type__order_number_capture_code=OrderNumberCaptureCode.MANDATORY,
+    )
+    origin = factories.QuotaOrderNumberOriginFactory(
+        order_number__mechanism=AdministrationMechanism.FCFS,
+        workbasket=factories.WorkBasketFactory(
+            pk=999,
+            status=WorkflowStatus.READY_FOR_EXPORT,
+            approver=factories.UserFactory(),
+        ),
+    )
+
+    assert imported_fields_match(
+        factories.MeasureFactory.build(
+            measure_type=rel.measure_type,
+            geographical_area=origin.geographical_area,
+            goods_nomenclature=factories.GoodsNomenclatureFactory(),
+            additional_code=factories.AdditionalCodeFactory(
+                type=rel.additional_code_type
+            ),
+            order_number=origin.order_number,
+            generating_regulation=factories.RegulationFactory(),
+            update_type=UpdateType.CREATE,
+        )
+    )
+
+
+def test_measure_component_importer_create(imported_fields_match):
+    assert imported_fields_match(
+        factories.MeasureComponentFactory.build(
+            component_measure=factories.MeasureFactory(),
+            duty_expression=factories.DutyExpressionFactory(),
+            monetary_unit=factories.MonetaryUnitFactory(),
+            component_measurement=factories.MeasurementFactory(),
+            update_type=UpdateType.CREATE,
+        )
+    )
+
+
+def test_measure_condition_importer_create(imported_fields_match):
+    assert imported_fields_match(
+        factories.MeasureConditionFactory.build(
+            dependent_measure=factories.MeasureFactory(),
+            condition_code=factories.MeasureConditionCodeFactory(),
+            monetary_unit=factories.MonetaryUnitFactory(),
+            condition_measurement=factories.MeasurementFactory(),
+            action=factories.MeasureActionFactory(),
+            required_certificate=factories.CertificateFactory(),
+            update_type=UpdateType.CREATE,
+        )
+    )
+
+
+def test_measure_condition_component_importer_create(imported_fields_match):
+    assert imported_fields_match(
+        factories.MeasureConditionComponentFactory.build(
+            condition=factories.MeasureConditionFactory(),
+            duty_expression=factories.DutyExpressionFactory(),
+            monetary_unit=factories.MonetaryUnitFactory(),
+            condition_component_measurement=factories.MeasurementFactory(),
+            update_type=UpdateType.CREATE,
+        )
+    )
+
+
+def test_measure_excluded_geographical_area_importer_create(imported_fields_match):
+    membership = factories.GeographicalMembershipFactory()
+
+    assert imported_fields_match(
+        factories.MeasureExcludedGeographicalAreaFactory.build(
+            modified_measure=factories.MeasureFactory(
+                geographical_area=membership.geo_group
+            ),
+            excluded_geographical_area=membership.member,
+            update_type=UpdateType.CREATE,
+        )
+    )
+
+
+def test_footnote_association_measure_importer_create(imported_fields_match):
+    assert imported_fields_match(
+        factories.FootnoteAssociationMeasureFactory.build(
+            footnoted_measure=factories.MeasureFactory(),
+            associated_footnote=factories.FootnoteFactory(),
+            update_type=UpdateType.CREATE,
+        )
+    )

--- a/measures/validators.py
+++ b/measures/validators.py
@@ -341,14 +341,19 @@ def validate_additional_code_associated_with_measure_type(measure):
 def validate_measure_unique_except_additional_code(measure):
     """ME16"""
 
-    query = {
-        field: getattr(measure, field)
-        for field in measure.identifying_fields
-        if field != "additional_code"
-    }
     if (
         type(measure)
-        .objects.filter(**query)
+        .objects.filter(
+            measure_type__sid=measure.measure_type.sid,
+            geographical_area__sid=measure.geographical_area.sid,
+            goods_nomenclature__sid=measure.goods_nomenclature.sid
+            if measure.goods_nomenclature
+            else None,
+            order_number__order_number=measure.order_number.order_number
+            if measure.order_number
+            else None,
+            reduction=measure.reduction,
+        )
         .exclude(pk=measure.pk if measure.pk else None)
         .exists()
     ):


### PR DESCRIPTION
It is a requirement for the project to be able to import Measures,
Measure Types, Components, Conditions, Duty Expressions, Measurements, Monetary Units,
etc from legacy TARIC3 XML data.

This commit introduces the import parsers and handlers for these models.