### PR TITLE
Handle partially-loaded elements in XML parsing

### DIFF
--- a/importer/tests/test_parsers.py
+++ b/importer/tests/test_parsers.py
@@ -77,6 +77,102 @@ def test_element_parser_with_repeated_children():
     }
 
 
+def test_element_parser_with_grandchildren():
+    class Grandchild(ElementParser):
+        tag = Tag("grandchild")
+
+    class Child(ElementParser):
+        tag = Tag("child")
+        grandchild = Grandchild(many=True)
+
+    class TestElement(ElementParser):
+        tag = Tag("test")
+        child = Child(many=True)
+
+    parser = TestElement()
+
+    el = etree.Element(str(Tag("test")))
+    child = etree.Element(str(Tag("child")))
+    grandchild = etree.Element(str(Tag("grandchild")), {"id": "2"})
+
+    child.extend([grandchild])
+    el.extend([child])
+
+    parser.start(el)
+    parser.start(child)
+    parser.start(grandchild)
+    parser.end(grandchild)
+    parser.end(child)
+    parser.end(el)
+
+    assert parser.data == {"child": [{"grandchild": [{"id": "2"}]}]}
+
+
+def test_element_parser_with_two_levels_of_same_tag():
+    class Grandchild(ElementParser):
+        tag = Tag("child")
+
+    class Child(ElementParser):
+        tag = Tag("child")
+        grandchild = Grandchild(many=True)
+
+    class TestElement(ElementParser):
+        tag = Tag("test")
+        child = Child(many=True)
+
+    parser = TestElement()
+
+    el = etree.Element(str(Tag("test")))
+    child = etree.Element(str(Tag("child")))
+    grandchild = etree.Element(str(Tag("child")), {"id": "2"})
+
+    child.extend([grandchild])
+    el.extend([child])
+
+    parser.start(el)
+    parser.start(child)
+    parser.start(grandchild)
+    parser.end(grandchild)
+    parser.end(child)
+    parser.end(el)
+
+    assert parser.data == {"child": [{"grandchild": [{"id": "2"}]}]}
+
+
+def test_element_parser_with_partially_loaded_element():
+    """If we use a streaming XML parser, the API will return start events for
+    XML events before all/any of their children have been loaded. For this
+    reason, we can't use any algorithm which looks at children as part of start
+    events."""
+
+    class Foo(ElementParser):
+        tag = Tag("foo")
+
+    class TestElement(ElementParser):
+        tag = Tag("test")
+        foo = Foo(many=True)
+
+    parser = TestElement()
+
+    el = etree.Element(str(Tag("test")))
+    children = [etree.Element(str(Tag("foo")), {"id": str(i)}) for i in range(3)]
+
+    parser.start(el)  # with no children
+    for child in children:
+        el.extend([child])
+        parser.start(child)
+        parser.end(child)
+    parser.end(el)
+
+    assert parser.data == {
+        "foo": [
+            {"id": "0"},
+            {"id": "1"},
+            {"id": "2"},
+        ],
+    }
+
+
 def test_validity_mixin():
     class TestElement(ValidityMixin, ElementParser):
         tag = Tag("test")


### PR DESCRIPTION
The `etree` streaming API will sometimes emit start
events for elements without their children if
passed a IO object or the Pull mecahnism is used.
This is because the API will consume input in
blocks and return as many events as it can, rather
than waiting for elements to be complete.

So we are not able to check what elements an
element has when handling a start event. To get
around this, this commit removes the need for
looking at if an element is a leaf node and
instead introduces extra state fields to keep
track of if the parser is currently parsing an
element or not, which is sufficient for selecting
the right parser. (This should also remove the
limitation on only having a single level of
nesting.)