### PR TITLE
Fixes from the field

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,10 @@ help: Makefile
 	@sed -n 's/^##//p' $< | column -t -s ':' | sed -e 's/^/ /'
 	@echo
 
+ifndef PYTHON
+PYTHON=python
+endif
+
 clean-static:
 	@echo
 	@echo "> Removing collected static files..."
@@ -40,7 +44,7 @@ dependencies: requirements.txt
 collectstatic: compilescss
 	@echo
 	@echo "> Collecting static assets..."
-	@${BIN}python manage.py collectstatic --noinput
+	@${BIN}${PYTHON} manage.py collectstatic --noinput
 
 compilescss:
 	@echo
@@ -55,14 +59,14 @@ node_modules:
 migrate:
 	@echo
 	@echo "> Running database migrations..."
-	@python manage.py migrate --noinput
+	@${PYTHON} manage.py migrate --noinput
 
 ## run: Run webapp
 run: export DJANGO_SETTINGS_MODULE=settings.dev
 run: collectstatic migrate
 	@echo
 	@echo "> Running webapp..."
-	@python manage.py runserver_plus 0.0.0.0:8000
+	@${PYTHON} manage.py runserver_plus 0.0.0.0:8000
 
 run-cf: export DJANGO_SETTINGS_MODULE=settings
 run-cf: collectstatic migrate
@@ -75,7 +79,7 @@ test: export DJANGO_SETTINGS_MODULE=settings.test
 test:
 	@echo
 	@echo "> Running tests..."
-	python manage.py test
+	${PYTHON} manage.py test --failfast
 
 ## docker-image: Build docker image
 docker-image:
@@ -95,7 +99,7 @@ docker-test:
 	@echo "> Running tests in Docker..."
 	@docker-compose run \
 		-e DJANGO_SETTINGS_MODULE=settings.test \
-		${PROJECT} sh -c "docker/wait_for_db && python manage.py test -- --cov"
+		${PROJECT} sh -c "docker/wait_for_db && ${PYTHON} manage.py test -- --cov"
 
 ## build-docs: Build the project documentation
 build-docs html:

--- a/common/assets/envelope.xsd
+++ b/common/assets/envelope.xsd
@@ -41,7 +41,7 @@
             <xs:attribute name="id" use="required">
                 <xs:simpleType>
                     <xs:restriction base="xs:string">
-                        <xs:minLength value="1"/>
+                        <xs:pattern value="[0-9]{6}"/>
                     </xs:restriction>
                 </xs:simpleType>
             </xs:attribute>

--- a/common/tests/factories.py
+++ b/common/tests/factories.py
@@ -353,6 +353,38 @@ class FootnoteAssociationGoodsNomenclatureFactory(
     associated_footnote = factory.SubFactory(FootnoteFactory)
 
 
+class MeasurementUnitFactory(TrackedModelMixin, ValidityFactoryMixin):
+    class Meta:
+        model = "measures.MeasurementUnit"
+
+    code = string_sequence(3, characters=string.ascii_uppercase)
+    description = short_description()
+
+
+class MeasurementUnitQualifierFactory(TrackedModelMixin, ValidityFactoryMixin):
+    class Meta:
+        model = "measures.MeasurementUnitQualifier"
+
+    code = string_sequence(1, characters=string.ascii_uppercase)
+    description = short_description()
+
+
+class MeasurementFactory(TrackedModelMixin, ValidityFactoryMixin):
+    class Meta:
+        model = "measures.Measurement"
+
+    measurement_unit = factory.SubFactory(MeasurementUnitFactory)
+    measurement_unit_qualifier = factory.SubFactory(MeasurementUnitQualifierFactory)
+
+
+class MonetaryUnitFactory(TrackedModelMixin, ValidityFactoryMixin):
+    class Meta:
+        model = "measures.MonetaryUnit"
+
+    code = string_sequence(3, characters=string.ascii_uppercase)
+    description = short_description()
+
+
 class QuotaOrderNumberFactory(TrackedModelMixin, ValidityFactoryMixin):
     class Meta:
         model = "quotas.QuotaOrderNumber"
@@ -398,10 +430,16 @@ class QuotaDefinitionFactory(TrackedModelMixin, ValidityFactoryMixin):
     order_number = factory.SubFactory(QuotaOrderNumberFactory)
     volume = 0
     initial_volume = 0
+    monetary_unit = factory.SubFactory(MonetaryUnitFactory)
+    measurement_unit = factory.SubFactory(MeasurementUnitFactory)
     maximum_precision = 0
     quota_critical = False
     quota_critical_threshold = 80
     description = short_description()
+
+
+class QuotaDefinitionWithQualifierFactory(QuotaDefinitionFactory):
+    measurement_unit_qualifier = factory.SubFactory(MeasurementUnitQualifierFactory)
 
 
 class QuotaAssociationFactory(TrackedModelMixin):
@@ -488,38 +526,6 @@ class MeasureTypeSeriesFactory(TrackedModelMixin, ValidityFactoryMixin):
 
     sid = string_sequence(2, characters=string.ascii_uppercase)
     measure_type_combination = factory.fuzzy.FuzzyChoice(MeasureTypeCombination.values)
-    description = short_description()
-
-
-class MeasurementUnitFactory(TrackedModelMixin, ValidityFactoryMixin):
-    class Meta:
-        model = "measures.MeasurementUnit"
-
-    code = string_sequence(3, characters=string.ascii_uppercase)
-    description = short_description()
-
-
-class MeasurementUnitQualifierFactory(TrackedModelMixin, ValidityFactoryMixin):
-    class Meta:
-        model = "measures.MeasurementUnitQualifier"
-
-    code = string_sequence(1, characters=string.ascii_uppercase)
-    description = short_description()
-
-
-class MeasurementFactory(TrackedModelMixin, ValidityFactoryMixin):
-    class Meta:
-        model = "measures.Measurement"
-
-    measurement_unit = factory.SubFactory(MeasurementUnitFactory)
-    measurement_unit_qualifier = factory.SubFactory(MeasurementUnitQualifierFactory)
-
-
-class MonetaryUnitFactory(TrackedModelMixin, ValidityFactoryMixin):
-    class Meta:
-        model = "measures.MonetaryUnit"
-
-    code = string_sequence(3, characters=string.ascii_uppercase)
     description = short_description()
 
 

--- a/common/tests/factories.py
+++ b/common/tests/factories.py
@@ -600,6 +600,19 @@ class MeasureFactory(TrackedModelMixin, ValidityFactoryMixin):
         return self.generating_regulation
 
 
+class MeasureWithQuotaFactory(MeasureFactory):
+    measure_type = factory.SubFactory(
+        MeasureTypeFactory,
+        order_number_capture_code=OrderNumberCaptureCode.MANDATORY,
+    )
+    order_number = factory.SubFactory(
+        QuotaOrderNumberFactory,
+        origin__geographical_area=factory.SelfAttribute("...geographical_area"),
+        valid_between=factory.SelfAttribute("..valid_between"),
+        workbasket=factory.SelfAttribute("..workbasket"),
+    )
+
+
 class MeasureComponentFactory(TrackedModelMixin):
     class Meta:
         model = "measures.MeasureComponent"

--- a/measures/import_handlers.py
+++ b/measures/import_handlers.py
@@ -9,6 +9,7 @@ from importer.handlers import BaseHandler
 from measures import import_parsers as parsers
 from measures import models
 from measures import serializers
+from measures import unit_serializers
 from quotas.models import QuotaOrderNumber
 from regulations.models import Regulation
 
@@ -26,26 +27,26 @@ class MeasureTypeSeriesDescriptionHandler(BaseHandler):
 
 
 class MeasurementUnitHandler(BaseHandler):
-    serializer_class = serializers.MeasurementUnitSerializer
+    serializer_class = unit_serializers.MeasurementUnitSerializer
     tag = parsers.MeasurementUnitParser.tag.name
 
 
 @MeasurementUnitHandler.register_dependant
 class MeasurementUnitDescriptionHandler(BaseHandler):
     dependencies = [MeasurementUnitHandler]
-    serializer_class = serializers.MeasurementUnitSerializer
+    serializer_class = unit_serializers.MeasurementUnitSerializer
     tag = parsers.MeasurementUnitDescriptionParser.tag.name
 
 
 class MeasurementUnitQualifierHandler(BaseHandler):
-    serializer_class = serializers.MeasurementUnitQualifierSerializer
+    serializer_class = unit_serializers.MeasurementUnitQualifierSerializer
     tag = parsers.MeasurementUnitQualifierParser.tag.name
 
 
 @MeasurementUnitQualifierHandler.register_dependant
 class MeasurementUnitQualifierDescriptionHandler(BaseHandler):
     dependencies = [MeasurementUnitQualifierHandler]
-    serializer_class = serializers.MeasurementUnitQualifierSerializer
+    serializer_class = unit_serializers.MeasurementUnitQualifierSerializer
     tag = parsers.MeasurementUnitQualifierDescriptionParser.tag.name
 
 
@@ -61,19 +62,19 @@ class MeasurementHandler(BaseHandler):
             "name": "measurement_unit_qualifier",
         },
     )
-    serializer_class = serializers.MeasurementSerializer
+    serializer_class = unit_serializers.MeasurementSerializer
     tag = parsers.MeasurementParser.tag.name
 
 
 class MonetaryUnitHandler(BaseHandler):
-    serializer_class = serializers.MonetaryUnitSerializer
+    serializer_class = unit_serializers.MonetaryUnitSerializer
     tag = parsers.MonetaryUnitParser.tag.name
 
 
 @MonetaryUnitHandler.register_dependant
 class MonetaryUnitDescriptionHandler(BaseHandler):
     dependencies = [MonetaryUnitHandler]
-    serializer_class = serializers.MonetaryUnitSerializer
+    serializer_class = unit_serializers.MonetaryUnitSerializer
     tag = parsers.MonetaryUnitDescriptionParser.tag.name
 
 

--- a/measures/jinja2/taric/measure.xml
+++ b/measures/jinja2/taric/measure.xml
@@ -11,7 +11,7 @@
       <oub:additional.code>{{ record.additional_code.code }}</oub:additional.code>
       {%- endif -%}
       {%- if record.order_number %}
-      <oub:ordernumber>{{ record.order_number }}</oub:ordernumber>
+      <oub:ordernumber>{{ record.order_number.order_number }}</oub:ordernumber>
       {%- endif -%}
       {%- if record.reduction %}
       <oub:reduction.indicator>{{ record.reduction }}</oub:reduction.indicator>

--- a/measures/jinja2/taric/measure.xml
+++ b/measures/jinja2/taric/measure.xml
@@ -11,7 +11,7 @@
       <oub:additional.code>{{ record.additional_code.code }}</oub:additional.code>
       {%- endif -%}
       {%- if record.order_number %}
-      <oub:ordernumber>{{ record.order_number.order_number }}</oub:ordernumber>
+      <oub:ordernumber>{{ record.order_number }}</oub:ordernumber>
       {%- endif -%}
       {%- if record.reduction %}
       <oub:reduction.indicator>{{ record.reduction }}</oub:reduction.indicator>

--- a/measures/serializers.py
+++ b/measures/serializers.py
@@ -11,6 +11,9 @@ from footnotes.serializers import FootnoteSerializer
 from geo_areas.serializers import GeographicalAreaSerializer
 from measures import models
 from measures import validators
+from measures.unit_serializers import MeasurementSerializer
+from measures.unit_serializers import MonetaryUnitSerializer
+from quotas.serializers import QuotaOrderNumberSerializer
 from regulations.serializers import RegulationSerializer
 
 
@@ -28,95 +31,6 @@ class MeasureTypeSeriesSerializer(TrackedModelSerializerMixin, ValiditySerialize
         fields = [
             "sid",
             "measure_type_combination",
-            "description",
-            "valid_between",
-            "update_type",
-            "record_code",
-            "subrecord_code",
-            "description_record_code",
-            "description_subrecord_code",
-            "taric_template",
-            "start_date",
-            "end_date",
-        ]
-
-
-@TrackedModelSerializer.register_polymorphic_model
-class MeasurementUnitSerializer(TrackedModelSerializerMixin, ValiditySerializerMixin):
-    code = serializers.CharField(
-        validators=[validators.measurement_unit_code_validator]
-    )
-
-    class Meta:
-        model = models.MeasurementUnit
-        fields = [
-            "code",
-            "description",
-            "valid_between",
-            "update_type",
-            "record_code",
-            "subrecord_code",
-            "description_record_code",
-            "description_subrecord_code",
-            "taric_template",
-            "start_date",
-            "end_date",
-        ]
-
-
-@TrackedModelSerializer.register_polymorphic_model
-class MeasurementUnitQualifierSerializer(
-    TrackedModelSerializerMixin, ValiditySerializerMixin
-):
-    code = serializers.CharField(
-        validators=[validators.measurement_unit_qualifier_code_validator]
-    )
-
-    class Meta:
-        model = models.MeasurementUnitQualifier
-        fields = [
-            "code",
-            "description",
-            "valid_between",
-            "update_type",
-            "record_code",
-            "subrecord_code",
-            "description_record_code",
-            "description_subrecord_code",
-            "taric_template",
-            "start_date",
-            "end_date",
-        ]
-
-
-@TrackedModelSerializer.register_polymorphic_model
-class MeasurementSerializer(TrackedModelSerializerMixin, ValiditySerializerMixin):
-    measurement_unit = MeasurementUnitSerializer(read_only=True)
-    measurement_unit_qualifier = MeasurementUnitQualifierSerializer(read_only=True)
-
-    class Meta:
-        model = models.Measurement
-        fields = [
-            "measurement_unit",
-            "measurement_unit_qualifier",
-            "valid_between",
-            "update_type",
-            "record_code",
-            "subrecord_code",
-            "taric_template",
-            "start_date",
-            "end_date",
-        ]
-
-
-@TrackedModelSerializer.register_polymorphic_model
-class MonetaryUnitSerializer(TrackedModelSerializerMixin, ValiditySerializerMixin):
-    code = serializers.CharField(validators=[validators.monetary_unit_code_validator])
-
-    class Meta:
-        model = models.MonetaryUnit
-        fields = [
-            "code",
             "description",
             "valid_between",
             "update_type",
@@ -283,7 +197,7 @@ class MeasureSerializer(TrackedModelSerializerMixin, ValiditySerializerMixin):
     geographical_area = GeographicalAreaSerializer(read_only=True)
     goods_nomenclature = GoodsNomenclatureSerializer(read_only=True)
     additional_code = AdditionalCodeSerializer(read_only=True)
-    order_number = serializers.SerializerMethodField(read_only=True)
+    order_number = QuotaOrderNumberSerializer(read_only=True)
     generating_regulation = RegulationSerializer(read_only=True)
     terminating_regulation = RegulationSerializer(read_only=True)
     reduction = serializers.IntegerField(
@@ -292,10 +206,6 @@ class MeasureSerializer(TrackedModelSerializerMixin, ValiditySerializerMixin):
     export_refund_nomenclature_sid = serializers.IntegerField(
         min_value=1, max_value=99999999, required=False
     )
-
-    def get_order_number(self, obj):
-        if obj.order_number:
-            return obj.order_number.order_number
 
     class Meta:
         model = models.Measure

--- a/measures/serializers.py
+++ b/measures/serializers.py
@@ -11,7 +11,6 @@ from footnotes.serializers import FootnoteSerializer
 from geo_areas.serializers import GeographicalAreaSerializer
 from measures import models
 from measures import validators
-from quotas.serializers import QuotaOrderNumberSerializer
 from regulations.serializers import RegulationSerializer
 
 
@@ -284,7 +283,7 @@ class MeasureSerializer(TrackedModelSerializerMixin, ValiditySerializerMixin):
     geographical_area = GeographicalAreaSerializer(read_only=True)
     goods_nomenclature = GoodsNomenclatureSerializer(read_only=True)
     additional_code = AdditionalCodeSerializer(read_only=True)
-    order_number = QuotaOrderNumberSerializer(read_only=True)
+    order_number = serializers.SerializerMethodField(read_only=True)
     generating_regulation = RegulationSerializer(read_only=True)
     terminating_regulation = RegulationSerializer(read_only=True)
     reduction = serializers.IntegerField(
@@ -293,6 +292,10 @@ class MeasureSerializer(TrackedModelSerializerMixin, ValiditySerializerMixin):
     export_refund_nomenclature_sid = serializers.IntegerField(
         min_value=1, max_value=99999999, required=False
     )
+
+    def get_order_number(self, obj):
+        if obj.order_number:
+            return obj.order_number.order_number
 
     class Meta:
         model = models.Measure

--- a/measures/tests/test_importer.py
+++ b/measures/tests/test_importer.py
@@ -2,6 +2,7 @@ import pytest
 
 from common.tests import factories
 from common.validators import UpdateType
+from measures import unit_serializers
 from measures.validators import OrderNumberCaptureCode
 from quotas.validators import AdministrationMechanism
 from workbaskets.validators import WorkflowStatus
@@ -15,11 +16,17 @@ def test_measure_type_series_importer_create(imported_fields_match):
 
 
 def test_measurement_unit_importer_create(imported_fields_match):
-    assert imported_fields_match(factories.MeasurementUnitFactory)
+    assert imported_fields_match(
+        factories.MeasurementUnitFactory,
+        serializer=unit_serializers.MeasurementUnitSerializer,
+    )
 
 
 def test_measurement_unit_qualifier_importer_create(imported_fields_match):
-    assert imported_fields_match(factories.MeasurementUnitQualifierFactory)
+    assert imported_fields_match(
+        factories.MeasurementUnitQualifierFactory,
+        serializer=unit_serializers.MeasurementUnitQualifierSerializer,
+    )
 
 
 def test_measurement_importer_create(imported_fields_match):
@@ -29,11 +36,15 @@ def test_measurement_importer_create(imported_fields_match):
             measurement_unit_qualifier=factories.MeasurementUnitQualifierFactory(),
             update_type=UpdateType.CREATE,
         ),
+        serializer=unit_serializers.MeasurementSerializer,
     )
 
 
 def test_monetary_unit_importer_create(imported_fields_match):
-    assert imported_fields_match(factories.MonetaryUnitFactory)
+    assert imported_fields_match(
+        factories.MonetaryUnitFactory,
+        serializer=unit_serializers.MonetaryUnitSerializer,
+    )
 
 
 def test_duty_expression_importer_create(imported_fields_match):

--- a/measures/tests/test_xml.py
+++ b/measures/tests/test_xml.py
@@ -26,7 +26,7 @@ def test_footnote_association_measure_xml(api, schema, basket, xml):
     assert xml.find(".//footnote.association.measure", xml.nsmap) is not None
 
 
-@validate_taric_xml(factories.MeasureFactory)
+@validate_taric_xml(factories.MeasureWithQuotaFactory, check_order=False)
 def test_measure_xml(api, schema, basket, xml):
     assert xml.find(".//measure", xml.nsmap) is not None
 

--- a/measures/unit_serializers.py
+++ b/measures/unit_serializers.py
@@ -1,0 +1,96 @@
+from rest_framework import serializers
+
+from common.serializers import TrackedModelSerializer
+from common.serializers import TrackedModelSerializerMixin
+from common.serializers import ValiditySerializerMixin
+from measures import models
+from measures import validators
+
+
+@TrackedModelSerializer.register_polymorphic_model
+class MeasurementUnitSerializer(TrackedModelSerializerMixin, ValiditySerializerMixin):
+    code = serializers.CharField(
+        validators=[validators.measurement_unit_code_validator]
+    )
+
+    class Meta:
+        model = models.MeasurementUnit
+        fields = [
+            "code",
+            "description",
+            "valid_between",
+            "update_type",
+            "record_code",
+            "subrecord_code",
+            "description_record_code",
+            "description_subrecord_code",
+            "taric_template",
+            "start_date",
+            "end_date",
+        ]
+
+
+@TrackedModelSerializer.register_polymorphic_model
+class MeasurementUnitQualifierSerializer(
+    TrackedModelSerializerMixin, ValiditySerializerMixin
+):
+    code = serializers.CharField(
+        validators=[validators.measurement_unit_qualifier_code_validator]
+    )
+
+    class Meta:
+        model = models.MeasurementUnitQualifier
+        fields = [
+            "code",
+            "description",
+            "valid_between",
+            "update_type",
+            "record_code",
+            "subrecord_code",
+            "description_record_code",
+            "description_subrecord_code",
+            "taric_template",
+            "start_date",
+            "end_date",
+        ]
+
+
+@TrackedModelSerializer.register_polymorphic_model
+class MeasurementSerializer(TrackedModelSerializerMixin, ValiditySerializerMixin):
+    measurement_unit = MeasurementUnitSerializer(read_only=True)
+    measurement_unit_qualifier = MeasurementUnitQualifierSerializer(read_only=True)
+
+    class Meta:
+        model = models.Measurement
+        fields = [
+            "measurement_unit",
+            "measurement_unit_qualifier",
+            "valid_between",
+            "update_type",
+            "record_code",
+            "subrecord_code",
+            "taric_template",
+            "start_date",
+            "end_date",
+        ]
+
+
+@TrackedModelSerializer.register_polymorphic_model
+class MonetaryUnitSerializer(TrackedModelSerializerMixin, ValiditySerializerMixin):
+    code = serializers.CharField(validators=[validators.monetary_unit_code_validator])
+
+    class Meta:
+        model = models.MonetaryUnit
+        fields = [
+            "code",
+            "description",
+            "valid_between",
+            "update_type",
+            "record_code",
+            "subrecord_code",
+            "description_record_code",
+            "description_subrecord_code",
+            "taric_template",
+            "start_date",
+            "end_date",
+        ]

--- a/quotas/jinja2/taric/quota_definition.xml
+++ b/quotas/jinja2/taric/quota_definition.xml
@@ -9,14 +9,14 @@
         <oub:quota.order.number.sid>{{ record.order_number.sid }}</oub:quota.order.number.sid>
         <oub:volume>{{ record.volume }}</oub:volume>
         <oub:initial.volume>{{ record.initial_volume }}</oub:initial.volume>
-        {% if record.monetary_unit_code -%}
-        <oub:monetary.unit.code>{{ record.monetary_unit_code }}</oub:monetary.unit.code>
+        {% if record.monetary_unit -%}
+        <oub:monetary.unit.code>{{ record.monetary_unit.code }}</oub:monetary.unit.code>
         {%- endif %}
-        {% if record.measurement_unit_code -%}
-        <oub:measurement.unit.code>{{ record.measurement_unit_code }}</oub:measurement.unit.code>
+        {% if record.measurement_unit -%}
+        <oub:measurement.unit.code>{{ record.measurement_unit.code }}</oub:measurement.unit.code>
         {%- endif %}
-        {% if record.measurement_unit_qualifier_code -%}
-        <oub:measurement.unit.qualifier.code>{{ record.measurement_unit_qualifier_code }}</oub:measurement.unit.qualifier.code>
+        {% if record.measurement_unit_qualifier -%}
+        <oub:measurement.unit.qualifier.code>{{ record.measurement_unit_qualifier.code }}</oub:measurement.unit.qualifier.code>
         {%- endif %}
         <oub:maximum.precision>{{ record.maximum_precision }}</oub:maximum.precision>
         <oub:critical.state>{% if record.quota_critical %}Y{% else %}N{% endif %}</oub:critical.state>

--- a/quotas/models.py
+++ b/quotas/models.py
@@ -155,7 +155,7 @@ class QuotaDefinition(TrackedModel, ValidityMixin):
     )
 
     def __str__(self):
-        return self.description
+        return str(self.sid)
 
     def clean(self):
         validators.validate_monetary_unit_validity_spans_definition_validity(self)

--- a/quotas/serializers.py
+++ b/quotas/serializers.py
@@ -6,9 +6,9 @@ from common.serializers import TrackedModelSerializer
 from common.serializers import TrackedModelSerializerMixin
 from common.serializers import ValiditySerializerMixin
 from geo_areas.serializers import GeographicalAreaSerializer
-from measures.serializers import MeasurementUnitQualifierSerializer
-from measures.serializers import MeasurementUnitSerializer
-from measures.serializers import MonetaryUnitSerializer
+from measures.unit_serializers import MeasurementUnitQualifierSerializer
+from measures.unit_serializers import MeasurementUnitSerializer
+from measures.unit_serializers import MonetaryUnitSerializer
 from quotas import models
 
 

--- a/quotas/serializers.py
+++ b/quotas/serializers.py
@@ -6,6 +6,9 @@ from common.serializers import TrackedModelSerializer
 from common.serializers import TrackedModelSerializerMixin
 from common.serializers import ValiditySerializerMixin
 from geo_areas.serializers import GeographicalAreaSerializer
+from measures.serializers import MeasurementUnitQualifierSerializer
+from measures.serializers import MeasurementUnitSerializer
+from measures.serializers import MonetaryUnitSerializer
 from quotas import models
 
 
@@ -113,6 +116,9 @@ class QuotaDefinitionImporterSerializer(
 class QuotaDefinitionSerializer(TrackedModelSerializerMixin, ValiditySerializerMixin):
     order_number = QuotaOrderNumberSerializer(read_only=True)
     sid = serializers.IntegerField()
+    measurement_unit = MeasurementUnitSerializer(read_only=True)
+    measurement_unit_qualifier = MeasurementUnitQualifierSerializer(read_only=True)
+    monetary_unit = MonetaryUnitSerializer(read_only=True)
     sub_quotas = SimpleQuotaDefinitionSerializer(
         many=True, read_only=True, required=False
     )
@@ -125,6 +131,9 @@ class QuotaDefinitionSerializer(TrackedModelSerializerMixin, ValiditySerializerM
             "volume",
             "initial_volume",
             "maximum_precision",
+            "measurement_unit",
+            "measurement_unit_qualifier",
+            "monetary_unit",
             "quota_critical",
             "quota_critical_threshold",
             "description",

--- a/quotas/tests/test_xml.py
+++ b/quotas/tests/test_xml.py
@@ -30,9 +30,15 @@ def test_quota_order_number_origin_exclusion_xml(
     assert element is not None
 
 
-@validate_taric_xml(factories.QuotaDefinitionFactory)
+@validate_taric_xml(factories.QuotaDefinitionWithQualifierFactory)
 def test_quota_definition_xml(api_client, taric_schema, approved_workbasket, xml):
     element = xml.find(".//quota.definition", xml.nsmap)
+    assert element is not None
+    element = xml.find(".//monetary.unit.code", xml.nsmap)
+    assert element is not None
+    element = xml.find(".//measurement.unit.code", xml.nsmap)
+    assert element is not None
+    element = xml.find(".//measurement.unit.qualifier.code", xml.nsmap)
     assert element is not None
 
 

--- a/workbaskets/serializers.py
+++ b/workbaskets/serializers.py
@@ -20,7 +20,7 @@ class WorkBasketSerializer(serializers.ModelSerializer):
         return None
 
     def get_envelope_id(self, object: models.WorkBasket):
-        return object.pk
+        return str(object.pk).zfill(6)
 
     class Meta:
         model = models.WorkBasket


### PR DESCRIPTION
Another mixed bag of fixes for core:

- XSD change to ensure envelopes are produced according to our ID standard.
- Fix quota definition XML to include units.
- Don't use the quota description as a string representation as it may be `None`.
- Allow Python from a envrionment variable in the Makefile.