### PR TITLE
Default settings module to settings.test if running tests..

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,6 @@ run-cf: collectstatic migrate
 	@gunicorn -b 0.0.0.0:8080 wsgi:application
 
 ## test: Run tests
-test: export DJANGO_SETTINGS_MODULE=settings.test
 test:
 	@echo
 	@echo "> Running tests..."
@@ -98,7 +97,6 @@ docker-test:
 	@echo
 	@echo "> Running tests in Docker..."
 	@docker-compose run \
-		-e DJANGO_SETTINGS_MODULE=settings.test \
 		${PROJECT} sh -c "docker/wait_for_db && ${PYTHON} manage.py test -- --cov"
 
 ## build-docs: Build the project documentation

--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ To run with coverage use the following:
 
     ./manage.py test -- --cov
 
+When running tests the settings module defaults to settings.test
+
 ## Environment Variables
 
 | Name | Description |

--- a/manage.py
+++ b/manage.py
@@ -8,7 +8,9 @@ import dotenv
 
 def main():
     in_test = not {"pytest", "test"}.isdisjoint(sys.argv[1:])
-    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "settings.test" if in_test else "settings")
+    os.environ.setdefault(
+        "DJANGO_SETTINGS_MODULE", "settings.test" if in_test else "settings"
+    )
     try:
         from django.core.management import execute_from_command_line
     except ImportError as exc:

--- a/manage.py
+++ b/manage.py
@@ -7,7 +7,8 @@ import dotenv
 
 
 def main():
-    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "settings")
+    in_test = not {"pytest", "test"}.isdisjoint(sys.argv[1:])
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "settings.test" if in_test else "settings")
     try:
         from django.core.management import execute_from_command_line
     except ImportError as exc:


### PR DESCRIPTION
Change `manage.py` so that DJANGO_SETTINGS_MODULE defaults to `settings.test` if `test` or `pytest` is in the commandline.

Update README, and remove don't explicitly set this in `Makefile`.