### PR TITLE
Fix taric test pollution test fail

### DIFF
--- a/taric/tests/test_models.py
+++ b/taric/tests/test_models.py
@@ -7,6 +7,8 @@ pytestmark = pytest.mark.django_db
 
 
 def test_envelope_transactions(date_ranges):
+    factories.EnvelopeFactory.reset_sequence()
+
     envelope = factories.EnvelopeFactory()
 
     assert envelope.envelope_id == f"{date_ranges.now:%y}0001"


### PR DESCRIPTION
Reset the factory sequence so test can't fail if it's not the first test to run using EnvelopeFactory.