### PR TITLE
Add missing validations for geographical areas

### DIFF
--- a/geo_areas/models.py
+++ b/geo_areas/models.py
@@ -46,6 +46,9 @@ class GeographicalArea(TrackedModel, ValidityMixin):
     def get_description(self):
         return self.geographicalareadescription_set.last()
 
+    def validate_workbasket(self):
+        validators.validate_at_least_one_description(self)
+
     def __str__(self):
         return f'"{self.get_area_code_display()}" SID:{self.sid}'
 
@@ -136,6 +139,13 @@ class GeographicalAreaDescription(TrackedModel, ValidityMixin):
 
     def clean(self):
         validators.validate_description_is_not_null(self)
+        validators.validate_geographical_area_description_have_unique_start_date(self)
+        validators.validate_geographical_area_description_start_date_before_geographical_area_end_date(
+            self
+        )
+        validators.validate_first_geographical_area_description_has_geographical_area_start_date(
+            self
+        )
 
     def __str__(self):
         return f'description ({self.sid}) - "{self.description}" for {self.area}'

--- a/geo_areas/validators.py
+++ b/geo_areas/validators.py
@@ -29,6 +29,69 @@ def validate_description_is_not_null(area_description):
         raise ValidationError({"description": "A description cannot be blank"})
 
 
+def validate_first_geographical_area_description_has_geographical_area_start_date(
+    geographical_area_description,
+):
+    """GA3"""
+
+    geographical_area = geographical_area_description.area
+
+    if (
+        geographical_area.geographicalareadescription_set.count() == 0
+        and geographical_area.valid_between.lower
+        != geographical_area_description.valid_between.lower
+    ):
+        raise ValidationError(
+            {
+                "valid_between": f"The first description for geographical area {geographical_area} "
+                f"must have the same start date as the geographical area"
+            }
+        )
+
+
+def validate_geographical_area_description_have_unique_start_date(
+    geographical_area_description,
+):
+    """GA3"""
+    geographical_area = geographical_area_description.area
+
+    if geographical_area.geographicalareadescription_set.filter(
+        valid_between__startswith=geographical_area_description.valid_between.lower
+    ).exists():
+        raise ValidationError(
+            {
+                "valid_between": f"Geographical area {geographical_area} cannot have two descriptions with the same start date"
+            }
+        )
+
+
+def validate_geographical_area_description_start_date_before_geographical_area_end_date(
+    geographical_area_description,
+):
+    """GA3"""
+    geographical_area = geographical_area_description.area
+
+    if (
+        geographical_area.valid_between.upper is not None
+        and geographical_area_description.valid_between.lower
+        >= geographical_area.valid_between.upper
+    ):
+        raise ValidationError(
+            {
+                "valid_between": "The start date must be less than or equal to the end "
+                "date of the geographical area."
+            }
+        )
+
+
+def validate_at_least_one_description(area):
+    """
+    GA3
+    """
+    if area.geographicalareadescription_set.count() < 1:
+        raise ValidationError("At least one description record is mandatory.")
+
+
 def validate_member_is_country_or_region(area_membership):
     """
     GA13


### PR DESCRIPTION
There are a number of ways to break GA3 that we
haven't accounted for in our current business
rules (although it seems our downstream systems
are only able to catch some of these).

Most of this code is lifted directly from the
additional codes application... which makes me
wonder if it would be worth abstracting out a
common pattern here for description-period-based
business rules.