### PR TITLE
Fix HMRC SDES notification payload JSON

### DIFF
--- a/hmrc_sdes/models.py
+++ b/hmrc_sdes/models.py
@@ -24,7 +24,7 @@ class Upload(models.Model):
     checksum = models.CharField(max_length=32, editable=False)
     notification_sent = models.DateTimeField(editable=False, null=True)
 
-    def notify_hmrc(self, now: Optional[datetime]):
+    def notify_hmrc(self, now: Optional[datetime] = None):
         client = HmrcSdesClient()
         client.notify_transfer_ready(self)
 
@@ -41,7 +41,7 @@ class Upload(models.Model):
     def notification_payload(self):
         return {
             "informationType": "EDM",
-            "correlationID": self.correlation_id,
+            "correlationID": str(self.correlation_id),
             "file": {
                 "fileName": self.filename,
                 "fileSize": self.file.size,


### PR DESCRIPTION
The Upload model generates a JSON payload ready to be sent to the HMRC
SDES API, but had an error where it passed a UUID object instead of a
string.

This commit fixes that error and also sets a default value for the `now`
argument to `Upload.notify_hmrc()` for convenience.