### PR TITLE
Updates to FTA importer

### DIFF
--- a/common/tests/util.py
+++ b/common/tests/util.py
@@ -383,6 +383,20 @@ class Dates:
         )
 
     @classmethod
+    def short_after(cls, dt):
+        return DateTimeTZRange(
+            dt + relativedelta(days=+14),
+            dt + relativedelta(months=+1),
+        )
+
+    @classmethod
+    def short_overlap(cls, dt):
+        return DateTimeTZRange(
+            dt + relativedelta(months=-1),
+            dt + relativedelta(months=+1),
+        )
+
+    @classmethod
     def medium_before(cls, dt):
         return DateTimeTZRange(
             dt + relativedelta(months=-1),

--- a/importer/management/commands/import_fta.py
+++ b/importer/management/commands/import_fta.py
@@ -146,11 +146,13 @@ class FTAQuotaImporter(RowsImporter):
             update_type=UpdateType.CREATE,
         )
         quota_origin.save()
-
-        yield [
+        to_output = [
             quota,
             quota_origin,
-        ]  # TODO: don't output licensed quotas
+        ]
+
+        if quota.mechanism != AdministrationMechanism.LICENSED:
+            yield to_output
 
         # If this is a seasonal quota that would normally have already started,
         # start is on 1 Jan and use the interim volume to set up the quota
@@ -183,7 +185,8 @@ class FTAQuotaImporter(RowsImporter):
             update_type=UpdateType.CREATE,
         )
         normal_qd.save()
-        yield [normal_qd]
+        if quota.mechanism != AdministrationMechanism.LICENSED:
+            yield [normal_qd]
 
         # 4. Create a defn for 2021 from interim volume and Jan 01 to start date
         if row.type == QuotaType.NON_CALENDAR and start_date > BREXIT:
@@ -207,7 +210,8 @@ class FTAQuotaImporter(RowsImporter):
                 update_type=UpdateType.CREATE,
             )
             interim_qd.save()
-            yield [interim_qd]
+            if quota.mechanism != AdministrationMechanism.LICENSED:
+                yield [interim_qd]
 
 
 class TransitionCategory(Enum):

--- a/importer/management/commands/import_fta.py
+++ b/importer/management/commands/import_fta.py
@@ -47,6 +47,7 @@ from quotas.models import QuotaAssociation
 from quotas.models import QuotaDefinition
 from quotas.models import QuotaOrderNumber
 from quotas.models import QuotaOrderNumberOrigin
+from quotas.models import QuotaOrderNumberOriginExclusion
 from quotas.validators import AdministrationMechanism
 from quotas.validators import QuotaCategory
 from quotas.validators import SubQuotaType
@@ -149,6 +150,19 @@ class FTAQuotaImporter(RowsImporter):
             quota,
             quota_origin,
         ]
+
+        for excluded_id in row.excluded_origins:
+            excluded_area = GeographicalArea.objects.as_at(BREXIT).get(
+                area_id=excluded_id
+            )
+            exclusion = QuotaOrderNumberOriginExclusion(
+                origin=quota_origin,
+                excluded_geographical_area=excluded_area,
+                workbasket=self.workbasket,
+                update_type=UpdateType.CREATE,
+            )
+            exclusion.save()
+            to_output.append(exclusion)
 
         if quota.mechanism != AdministrationMechanism.LICENSED:
             yield to_output

--- a/importer/management/commands/patterns.py
+++ b/importer/management/commands/patterns.py
@@ -76,6 +76,7 @@ def parse_list(value: str) -> List[str]:
 class OldMeasureRow:
     def __init__(self, old_row: List[Cell]) -> None:
         assert old_row is not None
+        self.origin_id = str(old_row[14].value)
         self.goods_nomenclature_sid = int(old_row[0].value)
         self.item_id = clean_item_id(old_row[1])
         self.inherited_measure = bool(old_row[6].value)
@@ -84,9 +85,7 @@ class OldMeasureRow:
         self.measure_type = str(int(old_row[8].value))
         self.geo_sid = int(old_row[13].value)
         self.measure_start_date = parse_date(old_row[16])
-        self.measure_end_date = blank(
-            old_row[17].value, lambda _: parse_date(old_row[17])
-        )
+        self.measure_end_date = blank(old_row[17], parse_date)
         self.regulation_role = int(old_row[18].value)
         self.regulation_id = str(old_row[19].value)
         self.order_number = blank(old_row[15].value, str)
@@ -97,9 +96,10 @@ class OldMeasureRow:
         self.export_refund_sid = blank(old_row[25].value, int)
         self.reduction = blank(old_row[26].value, int)
         self.footnotes = parse_list(old_row[27].value)
-        self.goods_nomenclature = GoodsNomenclature.objects.get(
-            sid=self.goods_nomenclature_sid
-        )
+
+    @cached_property
+    def goods_nomenclature(self) -> GoodsNomenclature:
+        return GoodsNomenclature.objects.get(sid=self.goods_nomenclature_sid)
 
     @cached_property
     def additional_code(self) -> Optional[AdditionalCode]:

--- a/importer/management/commands/utils.py
+++ b/importer/management/commands/utils.py
@@ -103,8 +103,11 @@ def maybe_max(*objs: Optional[TypeVar("T")]) -> Optional[TypeVar("T")]:
         return None
 
 
-def blank(value: Any, convert: Callable[[Any], TypeVar("T")]) -> Optional[TypeVar("T")]:
-    return None if value == "" else convert(value)
+def blank(
+    obj: Union[Cell, Any], convert: Callable[[Any], TypeVar("T")]
+) -> Optional[TypeVar("T")]:
+    value = obj.value if type(obj) is Cell else obj
+    return None if value == "" else convert(obj)
 
 
 def col(label: str) -> int:


### PR DESCRIPTION
Updates the FTA spreadsheet importer to handle more exotic quotas and also to correctly understand dates across the Brexit boundary.

- Handle origin certificates in origin quotas.
- Actually output multiple countries into one envelope.
- Fix date handling in the FTA importer
- Handle quota suspensions in the FTA importer.
- Handle excluded quota origins in the FTA importer.
- Handle quota associations in the FTA importer.
- Import universal style quotas into the FTA importer.
- Don't output licensed quotas from the FTA importer.
- Untie date boundary handling from parsing of rates