### PR TITLE
Add a test hitting the HMRC sandbox API

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,12 +1,13 @@
 from datetime import datetime
 from datetime import timezone
 from functools import lru_cache
-from unittest.mock import patch, PropertyMock
+from unittest.mock import patch
+from unittest.mock import PropertyMock
 
 import boto3
 import pytest
-from django.core.exceptions import ValidationError
 from django.conf import settings
+from django.core.exceptions import ValidationError
 from lxml import etree
 from moto import mock_s3
 from psycopg2.extras import DateTimeTZRange
@@ -17,6 +18,27 @@ from common.tests import factories
 from common.tests.factories import WorkBasketFactory
 from common.tests.util import Dates
 from exporter.storages import HMRCStorage
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--hmrc-live-api",
+        action="store_true",
+        help="Test will call the live HMRC Sandbox API and not mock the request.",
+    )
+
+
+def pytest_configure(config):
+    config.addinivalue_line(
+        "markers", "hmrc_live_api: mark test calling the live HMRC Sandbox API"
+    )
+
+
+def pytest_runtest_setup(item):
+    if "hmrc_live_api" in item.keywords and not item.config.getoption(
+        "--hmrc-live-api"
+    ):
+        pytest.skip("Not calling live HMRC Sandbox API. Use --hmrc-live-api to do so.")
 
 
 @pytest.fixture(scope="session")

--- a/hmrc_sdes/api_client.py
+++ b/hmrc_sdes/api_client.py
@@ -26,7 +26,7 @@ class HmrcSdesClient(APIClient):
             ],
         )
         params = dict(
-            token_url=settings.HMRC["token_url"],
+            token_url="{base_url}{token_url}".format(**settings.HMRC),
             client_id=settings.HMRC["client_id"],
             client_secret=settings.HMRC["client_secret"],
             include_client_id=True,
@@ -41,11 +41,22 @@ class HmrcSdesClient(APIClient):
         self.srn = settings.HMRC["service_reference_number"]
 
     def get_default_headers(self) -> dict:
+        # TODO The correct values for these headers are to be confirmed by HMRC
         return dict(
             **super().get_default_headers(),
             **{
                 "Content-Type": "application/vnd.hmrc.1.0+json; charset=UTF-8",
                 "Accept": "application/vnd.hmrc.1.0+json",
+                "Gov-Client-Connection-Method": "OTHER_DIRECT",
+                "Gov-Client-Device-ID": settings.HMRC["device_id"],
+                "Gov-Client-Local-IPs": "127.0.0.1",
+                "Gov-Client-MAC-Addresses": "00%3A00%3A00%3A00%3A00%3A00",
+                "Gov-Client-Multi-Factor": "",
+                "Gov-Client-Timezone": "UTC+00:00",
+                "Gov-Client-User-Agent": "Linux/Debian%20Buster%2010.6 (Docker/container)",
+                "Gov-Client-User-IDs": "os=test",
+                "Gov-Vendor-License-IDs": "",
+                "Gov-Vendor-Version": "tariff-management-tool=0.0.0",
             },
         )
 

--- a/hmrc_sdes/tests/test_client.py
+++ b/hmrc_sdes/tests/test_client.py
@@ -1,5 +1,7 @@
 import json
 import os
+import uuid
+from hashlib import md5
 from unittest.mock import Mock
 
 import dotenv
@@ -9,14 +11,10 @@ from common.tests import factories
 from hmrc_sdes.api_client import HmrcSdesClient
 
 
-def test_sdes_client(responses, settings):
-    settings.HMRC = {
-        "client_id": "test",
-        "client_secret": "test",
-        "service_reference_number": "test-srn",
-        "token_url": "https://test-api.service.hmrc.gov.uk/oauth/token",
-    }
+pytestmark = pytest.mark.django_db
 
+
+def test_sdes_client(responses):
     responses.add(
         responses.POST,
         url="https://test-api.service.hmrc.gov.uk/oauth/token",
@@ -61,3 +59,34 @@ def test_sdes_client(responses, settings):
             "checksumAlgorithm": "MD5",
         },
     }
+
+
+@pytest.mark.hmrc_live_api
+def test_api_call(responses, settings):
+    responses.add_passthru(settings.HMRC["base_url"])
+
+    # reload settings from env, overriding test settings
+    dotenv.read_dotenv(os.path.join(settings.BASE_DIR, ".env"))
+    settings.HMRC["client_id"] = os.environ.get("HMRC_API_CLIENT_ID")
+    settings.HMRC["client_secret"] = os.environ.get("HMRC_API_CLIENT_SECRET")
+    settings.HMRC["service_reference_number"] = os.environ.get(
+        "HMRC_API_SERVICE_REFERENCE_NUMBER"
+    )
+
+    # fetches OAuth2 access token on instantiation
+    client = HmrcSdesClient()
+    assert client.get_session().token is not None
+
+    # check fraud prevention headers
+    result = client.get(
+        f"{client.base_url}/test/fraud-prevention-headers/validate",
+    ).json()
+    assert result.get("errors") is None
+
+    # generate a dummy upload of an empty file with a valid checksum
+    upload = factories.UploadFactory()
+    upload.file = Mock(size=0)
+    upload.checksum = md5("".encode("utf-8")).hexdigest()
+
+    response = client.notify_transfer_ready(upload)
+    assert response.status_code == 204  # no data on success

--- a/settings/common.py
+++ b/settings/common.py
@@ -3,6 +3,7 @@ Django settings for tamato project.
 """
 import os
 import sys
+import uuid
 from os.path import abspath
 from os.path import dirname
 from os.path import join
@@ -295,12 +296,18 @@ TARIC_XSD = os.path.join(BASE_DIR, "common", "assets", "taric3.xsd")
 
 DATA_IMPORT_USERNAME = os.environ.get("TAMATO_IMPORT_USERNAME", "test")
 
-# HMRC external API
+
+# -- HMRC API client settings
+# See https://developer.service.hmrc.gov.uk/api-documentation/docs/authorisation/application-restricted-endpoints
+# And https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/secure-data-exchange-notifications/1.0
+# And https://developer.service.hmrc.gov.uk/guides/fraud-prevention/
 HMRC = {
+    "base_url": os.environ.get(
+        "HMRC_API_BASE_URL", "https://test-api.service.hmrc.gov.uk"
+    ),
     "client_id": os.environ.get("HMRC_API_CLIENT_ID"),
     "client_secret": os.environ.get("HMRC_API_CLIENT_SECRET"),
-    "token_url": os.environ.get(
-        "HMRC_API_TOKEN_URL", "https://test-api.service.hmrc.gov.uk/oauth/token"
-    ),
+    "token_url": os.environ.get("HMRC_API_TOKEN_URL", "/oauth/token"),
     "service_reference_number": os.environ.get("HMRC_API_SERVICE_REFERENCE_NUMBER"),
+    "device_id": str(uuid.uuid4()),
 }

--- a/settings/test.py
+++ b/settings/test.py
@@ -11,6 +11,12 @@ INSTALLED_APPS.append("common.tests")
 # Bucket settings are belt-and-braces to guard against running in a real bucket
 HMRC_BUCKET_STORAGE_NAME = os.environ.get("TEST_HMRC_BUCKET_STORAGE_NAME", "test-hmrc")
 
+# HMRC API client settings
+HMRC["base_url"] = "https://test-api.service.hmrc.gov.uk"
+HMRC["client_id"] = "test-client-id"
+HMRC["client_secret"] = "test-client-secret"
+HMRC["service_reference_number"] = "test-srn"
+
 AWS_ACCESS_KEY_ID = os.environ.get("TEST_AWS_ACCESS_KEY_ID", "")
 AWS_SECRET_ACCESS_KEY = os.environ.get("TEST_AWS_SECRET_ACCESS_KEY", "")
 AWS_STORAGE_BUCKET_NAME = os.environ.get("TEST_AWS_STORAGE_BUCKET_NAME", "")


### PR DESCRIPTION
Questionable things ahead:
* This commit adds a test which is skipped by default.
* This test makes real HTTP requests to https://test-api.service.hmrc.gov.uk
* This test relies on a `.env` file in the project root directory

Run the test with `pytest hmrc_sdes --hmrc-live-api`.
The test will be skipped if the command line argument is omitted.