### PR TITLE
Regulation information text should contain URL and public ID

### DIFF
--- a/common/tests/factories.py
+++ b/common/tests/factories.py
@@ -148,6 +148,9 @@ class RegulationFactory(TrackedModelMixin):
         if o.role_type == 1
         else None
     )
+    information_text = string_sequence(length=50)
+    public_identifier = factory.sequence(lambda n: f"S.I. 2021/{n}")
+    url = factory.sequence(lambda n: f"https://legislation.gov.uk/uksi/2021/{n}")
 
 
 class GeographicalAreaFactory(TrackedModelMixin, ValidityFactoryMixin):

--- a/regulations/import_handlers.py
+++ b/regulations/import_handlers.py
@@ -29,11 +29,27 @@ class RegulationHandler(BaseHandler):
     serializer_class = serializers.RegulationImporterSerializer
     tag = parsers.BaseRegulationParser.tag.name
 
+    def clean(self, data: dict) -> dict:
+        if "information_text" in data and "|" in data["information_text"]:
+            text, pid, url = data["information_text"].split("|")
+            data["information_text"] = text
+            data["public_identifier"] = pid
+            data["url"] = url
+        return super().clean(data)
+
 
 class BaseRegulationThroughTableHandler(BaseHandler):
     links = ({"model": models.Regulation, "name": "target_regulation"},)
     serializer_class = serializers.RegulationImporterSerializer
     tag = "BaseRegulationThroughTableHandler"
+
+    def clean(self, data: dict) -> dict:
+        if "information_text" in data and "|" in data["information_text"]:
+            text, pid, url = data["information_text"].split("|")
+            data["information_text"] = text
+            data["public_identifier"] = pid
+            data["url"] = url
+        return super().clean(data)
 
 
 class AmendmentRegulationHandler(BaseRegulationThroughTableHandler):

--- a/regulations/jinja2/taric/regulation.xml
+++ b/regulations/jinja2/taric/regulation.xml
@@ -43,8 +43,8 @@
 {#            {% endif %}#}
         <oub:replacement.indicator>{{ record.replacement_indicator }}</oub:replacement.indicator>
         <oub:stopped.flag>{{ record.stopped | int }}</oub:stopped.flag>
-        {% if record.information_text %}
-        <oub:information.text>{{ record.information_text }}</oub:information.text>
+        {% if record.compound_information_text %}
+        <oub:information.text>{{ record.compound_information_text }}</oub:information.text>
         {% endif %}
         <oub:approved.flag>{{ record.approved | int }}</oub:approved.flag>
     </oub:base.regulation>

--- a/regulations/serializers.py
+++ b/regulations/serializers.py
@@ -173,11 +173,17 @@ class RegulationImporterSerializer(
         validators=[validators.regulation_id_validator],
     )
 
+    compound_information_text = serializers.SerializerMethodField()
     official_journal_number = serializers.CharField(read_only=False, required=False)
     official_journal_page = serializers.IntegerField(read_only=False, required=False)
     published_at = serializers.DateTimeField(read_only=False, required=False)
     replacement_indicator = serializers.IntegerField(read_only=False)
     valid_between = TARIC3DateTimeRangeField(required=False)
+
+    def get_compound_information_text(self, obj):
+        parts = [obj.information_text, obj.public_identifier, obj.url]
+        if any(parts):
+            return "|".join([p or "" for p in parts])
 
     class Meta:
         model = models.Regulation
@@ -189,7 +195,10 @@ class RegulationImporterSerializer(
             "official_journal_number",
             "official_journal_page",
             "published_at",
+            "compound_information_text",
             "information_text",
+            "public_identifier",
+            "url",
             "approved",
             "replacement_indicator",
             "stopped",
@@ -219,6 +228,7 @@ class RegulationSerializer(
     terminations = NestedTerminationSerializer(many=True)
     replaces = NestedRegulationSerializer(many=True)
     replacements = NestedReplacementSerializer(many=True)
+    compound_information_text = serializers.SerializerMethodField()
 
     published_date = serializers.SerializerMethodField()
     effective_end_date = serializers.SerializerMethodField()
@@ -231,6 +241,11 @@ class RegulationSerializer(
         if obj.effective_end_date:
             return self.date_format_string.format(obj.effective_end_date)
 
+    def get_compound_information_text(self, obj):
+        parts = [obj.information_text, obj.public_identifier, obj.url]
+        if any(parts):
+            return "|".join([p or "" for p in parts])
+
     class Meta:
         model = models.Regulation
         fields = [
@@ -240,6 +255,7 @@ class RegulationSerializer(
             "official_journal_number",
             "official_journal_page",
             "published_date",
+            "compound_information_text",
             "information_text",
             "approved",
             "replacement_indicator",

--- a/regulations/tests/test_importer.py
+++ b/regulations/tests/test_importer.py
@@ -36,7 +36,13 @@ def create_and_test_m2m_regulation(
             "replacement_indicator": test_regulation.replacement_indicator,
             "community_code": test_regulation.community_code,
             "stopped": test_regulation.stopped,
-            "information_text": test_regulation.information_text,
+            "information_text": "|".join(
+                [
+                    test_regulation.information_text,
+                    test_regulation.public_identifier,
+                    test_regulation.url,
+                ]
+            ),
             "approved": test_regulation.approved,
         },
         "target_regulation": {

--- a/regulations/tests/test_xml.py
+++ b/regulations/tests/test_xml.py
@@ -10,3 +10,11 @@ pytestmark = pytest.mark.django_db
 def test_regulation_xml(api_client, taric_schema, approved_workbasket, xml):
     element = xml.find(".//base.regulation", xml.nsmap)
     assert element is not None
+
+
+@validate_taric_xml(factories.RegulationFactory)
+def test_information_text_contains_url_and_public_id(api, schema, workbasket, xml):
+    text = xml.findtext(".//information.text", namespaces=xml.nsmap)
+    assert "|" in text
+    assert "https://" in text
+    assert "S.I." in text


### PR DESCRIPTION
This is the format tentatively agreed with the Trade Tariff Service for adding extra information about UK legislation. We now output the pipe format in the order:

    information_text "|" public_identifier "|" url

And we also detect this in XML so that we can load any TAP-produced regulations in this format.

CC @matthewford – does this still match the format expected by the Trade Tariff Service?