### PR TITLE
TP-333: Allow fetching of "latest" versions of a relation in a single…

### DIFF
--- a/additional_codes/validators.py
+++ b/additional_codes/validators.py
@@ -1,3 +1,4 @@
+from django.core.exceptions import ObjectDoesNotExist
 from django.core.exceptions import ValidationError
 from django.core.validators import RegexValidator
 from django.db.models import IntegerChoices
@@ -37,6 +38,11 @@ def validate_additional_code_type(obj):
     The referenced additional code type must exist and have as application code
     "non-Meursing" or "Export refund for processed agricultural good".
     """
+    try:
+        if obj.type is None:
+            return
+    except ObjectDoesNotExist as e:
+        raise ValidationError("The referenced additional code type must exist.") from e
 
     permitted_codes = [
         ApplicationCode.ADDITIONAL_CODES,

--- a/common/tests/factories.py
+++ b/common/tests/factories.py
@@ -9,6 +9,7 @@ from factory.fuzzy import FuzzyChoice
 
 from common.tests.models import TestModel1
 from common.tests.models import TestModel2
+from common.tests.models import TestModel3
 from common.tests.util import Dates
 from common.validators import ApplicabilityCode
 from common.validators import UpdateType
@@ -309,6 +310,14 @@ class TestModel2Factory(TrackedModelMixin, ValidityFactoryMixin):
 
     description = factory.Faker("text", max_nb_chars=24)
     custom_sid = numeric_sid()
+
+
+class TestModel3Factory(TrackedModelMixin, ValidityFactoryMixin):
+    class Meta:
+        model = TestModel3
+
+    linked_model = factory.SubFactory(TestModel1Factory)
+    sid = numeric_sid()
 
 
 class AdditionalCodeTypeFactory(TrackedModelMixin, ValidityFactoryMixin):

--- a/common/tests/migrations/0001_initial.py
+++ b/common/tests/migrations/0001_initial.py
@@ -68,4 +68,37 @@ class Migration(migrations.Migration):
             },
             bases=("common.trackedmodel", models.Model),
         ),
+        migrations.CreateModel(
+            name="TestModel3",
+            fields=[
+                (
+                    "trackedmodel_ptr",
+                    models.OneToOneField(
+                        auto_created=True,
+                        on_delete=django.db.models.deletion.CASCADE,
+                        parent_link=True,
+                        primary_key=True,
+                        serialize=False,
+                        to="common.trackedmodel",
+                    ),
+                ),
+                (
+                    "valid_between",
+                    django.contrib.postgres.fields.ranges.DateTimeRangeField(),
+                ),
+                ("sid", models.PositiveIntegerField()),
+                (
+                    "linked_model",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.PROTECT,
+                        to="tests.testmodel1",
+                    ),
+                ),
+            ],
+            options={
+                "abstract": False,
+                "base_manager_name": "objects",
+            },
+            bases=("common.trackedmodel", models.Model),
+        ),
     ]

--- a/common/tests/models.py
+++ b/common/tests/models.py
@@ -26,3 +26,12 @@ class TestModel2(TrackedModel, ValidityMixin):
     description = models.CharField(max_length=24, null=True)
 
     identifying_fields = ("custom_sid",)
+
+
+class TestModel3(TrackedModel, ValidityMixin):
+    __test__ = False
+    record_code = "03"
+    subrecord_code = "01"
+
+    sid = models.PositiveIntegerField()
+    linked_model = models.ForeignKey(TestModel1, on_delete=models.PROTECT)


### PR DESCRIPTION
… query.

The data model within TaMaTo is intended to be versioned. That is to say
that any row within a table derived from TrackedModel holds some identifying
columns which are non-unique. If multiple rows have the same data within these
identifying columns they are seen as multiple versions of the same object.

However foreign keys must be made on the primary key field of a table. With
this being the case it is possible to create a row on one table (e.g. Table1)
and link it to a row in another table (e.g. Table2). This row in Table2 can
then be "updated" - adding a new row to the table and a new version of the
object. In this case the foreign key on Table1 may be considered stale, but
only within the date range of the new row that has been added on Table2.

To solve this problem a mechanism has been added to allow fetching of the
"latest" row representing the latest version of an object for all
relations pertaining to derivatives of TrackedModels.

In python this allows us to define a model like so:

```python3
class ExampleModel(TrackedModel):
    # must be a TrackedModel
    other_model = models.ForeignKey(OtherModel, on_delete=models.PROTECT)
```

And then access the latest version of the relation by simply adding _current
to the attribute name like so:

```python3
example_model = ExampleModel.objects.first()
example_model.other_model_current  # Gets the most recent version
```

If done like in the above example, a query is generated specifically to fetch
this latest version of the row. However another mechanism has been added at
the queryset level which enable this to be done in a single query. This is
the `with_latest_links` QuerySet method.

This method utilises the `VersionGroup` instance the `TrackedModel` is attached
to and its `current_version` key back to `TrackedModel`. In this case there
is a direct linear path of Foreign Key relationships leading to the most
recent row for each relationship an object has.

An advantage of this over other proposed solutions is that it can be analysed
recursively (technically it can follow the relationships over the entire database
if need be) whilst still following direct FK relationships. All of which is done
within a simple Django `select_related` clause.