### PR TITLE
Remove unnecessary migration dependency

### DIFF
--- a/measures/migrations/0001_initial.py
+++ b/measures/migrations/0001_initial.py
@@ -11,7 +11,6 @@ class Migration(migrations.Migration):
 
     dependencies = [
         ("commodities", "0001_initial"),
-        ("common", "0001_initial"),
     ]
 
     operations = [


### PR DESCRIPTION
Commodities migration 0001 already depends on Common migration 0001, so no need to list both in the Measure migration 0001