### PR TITLE
TP-542: Update frontend views to be inline with current relations.

### DIFF
--- a/additional_codes/models.py
+++ b/additional_codes/models.py
@@ -64,6 +64,12 @@ class AdditionalCode(TrackedModel, ValidityMixin):
     )
 
     def get_description(self):
+        if (
+            hasattr(self, "_prefetched_objects_cache")
+            and "descriptions" in self._prefetched_objects_cache
+        ):
+            descriptions = list(self.descriptions.all())
+            return descriptions[-1] if descriptions else None
         return self.descriptions.last()
 
     def get_descriptions(self, workbasket=None):

--- a/additional_codes/views.py
+++ b/additional_codes/views.py
@@ -14,7 +14,11 @@ class AdditionalCodeViewSet(viewsets.ReadOnlyModelViewSet):
     API endpoint that allows additional codes to be viewed.
     """
 
-    queryset = AdditionalCode.objects.all().prefetch_related("descriptions")
+    queryset = (
+        AdditionalCode.objects.current()
+        .select_related("type")
+        .prefetch_related("descriptions")
+    )
     serializer_class = AdditionalCodeSerializer
     permission_classes = [permissions.IsAuthenticated]
     filter_backends = [AdditionalCodeFilterBackend]

--- a/footnotes/models.py
+++ b/footnotes/models.py
@@ -99,6 +99,12 @@ class Footnote(TrackedModel, ValidityMixin):
         )
 
     def get_description(self):
+        if (
+            hasattr(self, "_prefetched_objects_cache")
+            and "descriptions" in self._prefetched_objects_cache
+        ):
+            descriptions = list(self.descriptions.all())
+            return descriptions[-1] if descriptions else None
         return self.get_descriptions().last()
 
     def _used_in(self, dependent_type: Type[TrackedModel]):

--- a/footnotes/views.py
+++ b/footnotes/views.py
@@ -19,7 +19,11 @@ class FootnoteViewSet(viewsets.ModelViewSet):
     API endpoint that allows footnotes to be viewed and edited.
     """
 
-    queryset = models.Footnote.objects.all().prefetch_related("descriptions")
+    queryset = (
+        models.Footnote.objects.current()
+        .select_related("footnote_type")
+        .prefetch_related("descriptions")
+    )
     serializer_class = FootnoteSerializer
     permission_classes = [permissions.IsAuthenticated]
     filter_backends = [FootnoteFilterBackend]
@@ -32,7 +36,11 @@ class FootnoteViewSet(viewsets.ModelViewSet):
 
 
 class FootnoteList(WithCurrentWorkBasket, ListView):
-    queryset = models.Footnote.objects.current()
+    queryset = (
+        models.Footnote.objects.current()
+        .select_related("footnote_type")
+        .prefetch_related("descriptions")
+    )
     template_name = "footnotes/list.jinja"
 
 
@@ -63,12 +71,20 @@ class FootnoteMixin:
 
 class FootnoteDetail(WithCurrentWorkBasket, FootnoteMixin, DetailView):
     template_name = "footnotes/detail.jinja"
-    queryset = models.Footnote.objects.current()
+    queryset = (
+        models.Footnote.objects.current()
+        .select_related("footnote_type")
+        .prefetch_related("descriptions")
+    )
 
 
 class FootnoteUpdate(FootnoteMixin, DraftUpdateView):
     form_class = forms.FootnoteForm
-    queryset = models.Footnote.objects.current()
+    queryset = (
+        models.Footnote.objects.current()
+        .select_related("footnote_type")
+        .prefetch_related("descriptions")
+    )
     template_name = "footnotes/edit.jinja"
 
     def get_form(self, form_class=None):
@@ -131,8 +147,6 @@ class FootnoteTypeViewSet(viewsets.ReadOnlyModelViewSet):
     API endpoint that allows footnote types to be viewed or edited.
     """
 
-    queryset = models.FootnoteType.objects.all().prefetch_related(
-        "footnotetypedescription_set"
-    )
+    queryset = models.FootnoteType.objects.current()
     serializer_class = FootnoteTypeSerializer
     permission_classes = [permissions.IsAuthenticated]

--- a/geo_areas/models.py
+++ b/geo_areas/models.py
@@ -56,7 +56,13 @@ class GeographicalArea(TrackedModel, ValidityMixin):
     )
 
     def get_description(self):
-        return self.geographicalareadescription_set.last()
+        if (
+            hasattr(self, "_prefetched_objects_cache")
+            and "descriptions" in self._prefetched_objects_cache
+        ):
+            descriptions = list(self.descriptions.all())
+            return descriptions[-1] if descriptions else None
+        return self.descriptions.last()
 
     def get_descriptions(self, workbasket=None):
         return (

--- a/geo_areas/views.py
+++ b/geo_areas/views.py
@@ -13,9 +13,7 @@ class GeoAreaViewSet(viewsets.ReadOnlyModelViewSet):
     API endpoint that allows geographical areas to be viewed.
     """
 
-    queryset = GeographicalArea.objects.all().prefetch_related(
-        "geographicalareadescription_set"
-    )
+    queryset = GeographicalArea.objects.current().prefetch_related("descriptions")
     serializer_class = GeographicalAreaSerializer
     permission_classes = [permissions.IsAuthenticated]
     filterset_class = GeographicalAreaFilter

--- a/regulations/views.py
+++ b/regulations/views.py
@@ -2,7 +2,6 @@ from django.shortcuts import render
 from rest_framework import filters
 from rest_framework import permissions
 from rest_framework import renderers
-from rest_framework import response
 from rest_framework import viewsets
 
 from regulations.models import Regulation
@@ -14,7 +13,7 @@ class RegulationViewSet(viewsets.ReadOnlyModelViewSet):
     API endpoint that allows regulations to be viewed.
     """
 
-    queryset = Regulation.objects.all()
+    queryset = Regulation.objects.current().select_related("regulation_group")
     serializer_class = RegulationSerializer
     permission_classes = [permissions.IsAuthenticated]
     filter_backends = [filters.SearchFilter]


### PR DESCRIPTION
Historically descriptions didn't have a named `related_name`. This has
changed recently and so the frontend queries were prefetching the
wrong related name and erroring as a result.

This commit updates the queries to use the correct related_name for
descriptions - it also improves the caching setup for fetching the
latest descriptions. This may need to be made more generic and more
flexible in the near future.