### PR TITLE
TP-534: Integrate DIT staff SSO

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,9 @@ When running tests the settings module defaults to settings.test
 
 | Name | Description |
 | ---- | ----------- | 
+| AUTHBROKER_URL           | Base URL of the OAuth2 authentication broker (default https://sso.trade.gov.uk) |
+| AUTHBROKER_CLIENT_ID     | Client ID used to connect to the OAuth2 authentication broker |
+| AUTHBROKER_CLIENT_SECRET | Client secret used to connect to the OAuth2 authentication broker |
 | DATABASE_URL             | Connection details for the database, formatted per the [dj-database-url schema](https://github.com/jacobian/dj-database-url#url-schema) |
 | LOG_LEVEL                | The level of logging messages in the web app. One of CRITICAL, ERROR, WARNING, INFO, DEBUG, NOTSET.                                     |
 | CELERY_LOG_LEVEL         | The level of logging for the celery worker. One of CRITICAL, ERROR, WARNING, INFO, DEBUG, NOTSET.                                       |

--- a/common/jinja2/layouts/layout.jinja
+++ b/common/jinja2/layouts/layout.jinja
@@ -15,7 +15,7 @@
     "serviceUrl": "#",
     "navigation": [
       {
-        "href": url("logout") if request.user.is_authenticated else url("login"),
+        "href": url("logout") if request.user.is_authenticated else url("authbroker_client:login"),
         "text": "Sign out" if request.user.is_authenticated else "Sign In"
       }
     ]

--- a/common/tests/util.py
+++ b/common/tests/util.py
@@ -142,6 +142,7 @@ def validate_taric_xml(
             api_client,
             taric_schema,
             approved_transaction,
+            valid_user,
             *args,
             **kwargs,
         ):
@@ -158,6 +159,7 @@ def validate_taric_xml(
                 transaction=approved_transaction, **factory_kwargs or {}
             )
 
+            api_client.force_login(user=valid_user)
             response = api_client.get(
                 reverse(
                     "workbasket-detail",

--- a/quotas/tests/test_xml.py
+++ b/quotas/tests/test_xml.py
@@ -67,6 +67,7 @@ def test_quota_event_xml(
     api_client,
     taric_schema,
     approved_transaction,
+    valid_user,
     subrecord_code,
     event_type_name,
 ):
@@ -90,4 +91,4 @@ def test_quota_event_xml(
         element = xml.find(f".//{tag}", xml.nsmap)
         assert element is not None
 
-    test_event_type(api_client, taric_schema, approved_transaction)
+    test_event_type(api_client, taric_schema, approved_transaction, valid_user)

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,7 @@ django-polymorphic
 django-redis
 django-rest-polymorphic
 django-sequences
+django-staff-sso-client
 django-storages
 django-treebeard
 django-webpack-loader

--- a/settings/common.py
+++ b/settings/common.py
@@ -10,6 +10,7 @@ from os.path import dirname
 from os.path import join
 
 import dj_database_url
+from django.urls import reverse_lazy
 
 from common.util import is_truthy
 
@@ -62,6 +63,7 @@ INSTALLED_APPS = [
     # "health_check.db",
     # "health_check.cache",
     # "health_check.storage",
+    "authbroker_client",
     "polymorphic",
     "rest_framework",
     "webpack_loader",
@@ -91,6 +93,7 @@ MIDDLEWARE = [
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
+    "authbroker_client.middleware.ProtectAllViewsMiddleware",
 ]
 
 TEMPLATES = [
@@ -119,10 +122,17 @@ TEMPLATES = [
 
 
 # -- Auth
+LOGIN_URL = reverse_lazy("authbroker_client:login")
+LOGIN_REDIRECT_URL = reverse_lazy("home")
 
-# TODO - tie in to DIT SSO?
-LOGIN_REDIRECT_URL = "index"
+AUTHBROKER_URL = os.environ.get("AUTHBROKER_URL", "https://sso.trade.gov.uk")
+AUTHBROKER_CLIENT_ID = os.environ.get("AUTHBROKER_CLIENT_ID")
+AUTHBROKER_CLIENT_SECRET = os.environ.get("AUTHBROKER_CLIENT_SECRET")
 
+AUTHENTICATION_BACKENDS = (
+    "authbroker_client.backends.AuthbrokerBackend",
+    "django.contrib.auth.backends.ModelBackend",
+)
 
 # -- Security
 SECRET_KEY = os.environ.get("SECRET_KEY", "@@i$w*ct^hfihgh21@^8n+&ba@_l3x")

--- a/urls.py
+++ b/urls.py
@@ -19,6 +19,12 @@ from django.urls import include
 from django.urls import path
 
 urlpatterns = [
+    path(
+        "auth/",
+        include(
+            "authbroker_client.urls",
+        ),
+    ),
     path("", include("common.urls")),
     path("", include("additional_codes.urls")),
     path("", include("certificates.urls")),


### PR DESCRIPTION
It is a requirement that changes to the tariff can be attributed to the user who made
them, for auditing purposes. It may also be required later that different groups of
users have different permissions, for example only some users may be permitted to
approve workbaskets.

This commit integrates the tariff editor with the DIT single sign-on authentication
broker service (https://sso.trade.gov.uk). All pages in the tariff editor require an
authenticated user, so if not currently authenticated, the user is redirected on any
page request to the DIT SSO login screen. After successfully logging in, they are
redirected back to the tariff editor.

Credentials for the DIT SSO broker service are secret, so not included in this commit.
The credentials are passed into the tariff editor via environment variables. If you need
the credentials for running locally, let me know.