### PR TITLE
TP-567: Fix search on current frontend views.

### DIFF
--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -56,7 +56,7 @@ jobs:
         DATABASE_URL: postgres://postgres:postgres@localhost:5432/postgres
         DJANGO_SETTINGS_MODULE: settings.test
       run: |
-        python manage.py test -- --cov --cov-report=xml --alluredir=allure-results -m "not bdd"
+        python manage.py test -- --cov --cov-report=xml --alluredir=allure-results --nomigrations
 
     - name: Run Linter
       run: |

--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -56,7 +56,7 @@ jobs:
         DATABASE_URL: postgres://postgres:postgres@localhost:5432/postgres
         DJANGO_SETTINGS_MODULE: settings.test
       run: |
-        python manage.py test -- --cov --cov-report=xml --alluredir=allure-results -m "not bdd"
+        python manage.py test -- --cov --cov-report=xml --alluredir=allure-results --nomigrations
 
     - name: Run Linter
       run: |

--- a/additional_codes/tests/bdd/test_browse_additional_codes.py
+++ b/additional_codes/tests/bdd/test_browse_additional_codes.py
@@ -19,7 +19,7 @@ def additional_code_search(search_term, client):
 
 @then("the search result should contain the additional code searched for")
 def additional_code_list(additional_code_search):
-    results = additional_code_search.json()
+    results = additional_code_search.json()["results"]
     assert len(results) == 1
     result = results[0]
     assert result["code"] == "000"

--- a/additional_codes/views.py
+++ b/additional_codes/views.py
@@ -1,16 +1,14 @@
-from django.shortcuts import render
-from django.core.paginator import Paginator
 from django.conf import settings
+from django.core.paginator import Paginator
+from django.shortcuts import render
 from rest_framework import permissions
 from rest_framework import viewsets
-
 
 from additional_codes.filters import AdditionalCodeFilterBackend
 from additional_codes.models import AdditionalCode
 from additional_codes.models import AdditionalCodeType
 from additional_codes.serializers import AdditionalCodeSerializer
 from additional_codes.serializers import AdditionalCodeTypeSerializer
-
 from common.pagination import build_pagination_list
 
 
@@ -27,11 +25,10 @@ class AdditionalCodeViewSet(viewsets.ReadOnlyModelViewSet):
     serializer_class = AdditionalCodeSerializer
     filter_backends = [AdditionalCodeFilterBackend]
     search_fields = [
-        "sid",
-        "code",
-        "descriptions__description",
         "type__sid",
-        "type__description",
+        "code",
+        "sid",
+        "descriptions__description",
     ]
 
 
@@ -68,6 +65,6 @@ class AdditionalCodeTypeViewSet(viewsets.ReadOnlyModelViewSet):
     API endpoint that allows additional code types to be viewed.
     """
 
-    queryset = AdditionalCodeType.objects.all()
+    queryset = AdditionalCodeType.objects.current()
     serializer_class = AdditionalCodeTypeSerializer
     permission_classes = [permissions.IsAuthenticated]

--- a/common/filters.py
+++ b/common/filters.py
@@ -1,18 +1,62 @@
+import re
+from typing import Optional
+
 from django.contrib.postgres.search import SearchVector
+from django_filters import CharFilter
+from django_filters import FilterSet
 from rest_framework import filters
 from rest_framework.settings import api_settings
 
 
-class TamatoFilterBackend(filters.BaseFilterBackend):
+class TamatoFilterMixin:
+    """
+    Generic filter mixin to provide basic search fields and an overrideable
+    method for getting the search term.
+    """
+
     search_fields = ("sid",)
 
-    def get_search_term(self, request):
-        return request.query_params.get(api_settings.SEARCH_PARAM, "")
+    search_regex: Optional[re.Pattern] = None
+
+    def get_search_term(self, value):
+        if self.search_regex:
+            match = self.search_regex.match(value.strip())
+            if match:
+                return " ".join(match.groups())
+        return value
+
+    def search_queryset(self, queryset, search_term):
+        return queryset.annotate(search=SearchVector(*self.search_fields)).filter(
+            search=search_term
+        )
+
+
+class TamatoFilterBackend(filters.BaseFilterBackend, TamatoFilterMixin):
+    """
+    Basic Filter for API views.
+
+    This will grab the text from the `?search=` query param and do a full text search
+    over the given `search_fields` - defaulting to SID only.
+    """
 
     def filter_queryset(self, request, queryset, view):
-        search_term = self.get_search_term(request)
+        search_term = self.get_search_term(
+            request.query_params.get(api_settings.SEARCH_PARAM, "")
+        )
         if search_term:
-            return queryset.annotate(search=SearchVector(*self.search_fields)).filter(
-                search=search_term
-            )
+            return self.search_queryset(queryset, search_term)
         return filters.SearchFilter().filter_queryset(request, queryset, view)
+
+
+class TamatoFilter(FilterSet, TamatoFilterMixin):
+    """
+    Basic Filter for UI views.
+
+    This will grab the text from the `?search=` query param and do a full text search
+    over the given `search_fields` - defaulting to SID only.
+    """
+
+    search = CharFilter(method="filter_search")
+
+    def filter_search(self, queryset, name, value):
+        return self.search_queryset(queryset, value)

--- a/conftest.py
+++ b/conftest.py
@@ -56,6 +56,16 @@ def pytest_runtest_setup(item):
         pytest.skip("Not calling live HMRC Sandbox API. Use --hmrc-live-api to do so.")
 
 
+def pytest_bdd_apply_tag(tag, function):
+    if tag == "todo":
+        marker = pytest.mark.skip(reason="Not implemented yet")
+        marker(function)
+        return True
+    else:
+        # Fall back to pytest-bdd's default behavior
+        return None
+
+
 @pytest.fixture(scope="session")
 def celery_config():
     return {

--- a/footnotes/filters.py
+++ b/footnotes/filters.py
@@ -1,7 +1,11 @@
 import re
 
+from django.contrib.postgres.aggregates import StringAgg
+
+from common.filters import TamatoFilter
 from common.filters import TamatoFilterBackend
-from footnotes.models import Footnote
+from common.filters import TamatoFilterMixin
+from footnotes import models
 from footnotes.validators import FOOTNOTE_ID_PATTERN
 from footnotes.validators import FOOTNOTE_TYPE_ID_PATTERN
 
@@ -12,19 +16,29 @@ COMBINED_FOOTNOTE_AND_TYPE_ID = re.compile(
 )
 
 
-class FootnoteFilterBackend(TamatoFilterBackend):
+class FootnoteFilterMixin(TamatoFilterMixin):
     """
-    Filter that combines footnote type ID and footnote ID
+    Filter mixin to allow custom filtering on descriptions,
+    footnote type ID and footnote id.
+
+    Also provides a regex to split combined footnote type IDs and footnote IDs.
+    e.g. "CA001" -> "CA", "001"
     """
 
     search_fields = (
-        "footnote_type__footnote_type_id",
+        StringAgg("footnote_type__footnote_type_id", delimiter=" "),
         "footnote_id",
+        StringAgg("descriptions__description", delimiter=" "),
     )  # XXX order is important
 
-    def get_search_term(self, request):
-        search_term = super().get_search_term(request)
-        match = COMBINED_FOOTNOTE_AND_TYPE_ID.match(search_term.strip())
-        if match:
-            return " ".join(match.groups())
-        return search_term
+    search_regex = COMBINED_FOOTNOTE_AND_TYPE_ID
+
+
+class FootnoteFilterBackend(TamatoFilterBackend, FootnoteFilterMixin):
+    pass
+
+
+class FootnoteFilter(TamatoFilter, FootnoteFilterMixin):
+    class Meta:
+        model = models.Footnote
+        fields = ["footnote_id", "footnote_type__footnote_type_id"]

--- a/footnotes/tests/bdd/features/edit-footnote.feature
+++ b/footnotes/tests/bdd/features/edit-footnote.feature
@@ -1,4 +1,4 @@
-@bdd
+@bdd @todo
 Feature: Edit Footnote
 
 Background:

--- a/footnotes/tests/bdd/test_browse_footnotes.py
+++ b/footnotes/tests/bdd/test_browse_footnotes.py
@@ -19,7 +19,7 @@ def footnotes_search(client):
 
 @then("the search result should contain the footnote searched for")
 def footnotes_list(footnotes_search):
-    results = footnotes_search.json()
+    results = footnotes_search.json()["results"]
     assert len(results) == 1
     result = results[0]
     assert (

--- a/footnotes/views.py
+++ b/footnotes/views.py
@@ -1,12 +1,13 @@
 from django.http import Http404
 from django.views.generic import DetailView
-from django.views.generic import ListView
+from django_filters.views import FilterView
 from rest_framework import permissions
 from rest_framework import viewsets
 from rest_framework.reverse import reverse
 
 from footnotes import forms
 from footnotes import models
+from footnotes.filters import FootnoteFilter
 from footnotes.filters import FootnoteFilterBackend
 from footnotes.serializers import FootnoteSerializer
 from footnotes.serializers import FootnoteTypeSerializer
@@ -35,13 +36,20 @@ class FootnoteViewSet(viewsets.ModelViewSet):
     ]
 
 
-class FootnoteList(WithCurrentWorkBasket, ListView):
+class FootnoteList(WithCurrentWorkBasket, FilterView):
     queryset = (
         models.Footnote.objects.current()
         .select_related("footnote_type")
         .prefetch_related("descriptions")
     )
     template_name = "footnotes/list.jinja"
+    filterset_class = FootnoteFilter
+    search_fields = [
+        "footnote_id",
+        "footnote_type__footnote_type_id",
+        "descriptions__description",
+        "footnote_type__description",
+    ]
 
 
 class FootnoteMixin:

--- a/geo_areas/filters.py
+++ b/geo_areas/filters.py
@@ -1,27 +1,38 @@
 import logging
 
-from django.contrib.postgres.search import SearchVector
+from django.contrib.postgres.aggregates import StringAgg
 from django_filters import rest_framework as filters
 
+from common.filters import TamatoFilter
+from common.filters import TamatoFilterBackend
+from common.filters import TamatoFilterMixin
 from geo_areas.models import GeographicalArea
 from geo_areas.validators import AreaCode
 
 log = logging.getLogger(__name__)
 
 
-class GeographicalAreaFilter(filters.FilterSet):
+class GeographicalAreaFilterMixin(TamatoFilterMixin):
+    """
+    Filter mixin to allow custom filtering on descriptions,
+    SIDs and area_codes, area_id.
+    """
+
+    search_fields = (
+        "sid",
+        "area_code",
+        "area_id",
+        StringAgg("descriptions__description", delimiter=" "),
+    )
+
+
+class GeographicalAreaFilterBackend(TamatoFilterBackend, GeographicalAreaFilterMixin):
+    pass
+
+
+class GeographicalAreaFilter(TamatoFilter, GeographicalAreaFilterMixin):
     area_code = filters.TypedMultipleChoiceFilter(choices=AreaCode.choices, coerce=int)
 
     class Meta:
         model = GeographicalArea
         fields = ["area_id", "sid", "area_code"]
-
-    @property
-    def qs(self):
-        queryset = super().qs
-        search_term = self.request.query_params.get("search", "")
-        log.debug(f"Search term: {search_term}")
-        if search_term:
-            vector = SearchVector("id", "geographicalareadescription__description")
-            queryset = queryset.annotate(search=vector).filter(search=search_term)
-        return queryset

--- a/geo_areas/tests/bdd/test_browse_geo_areas.py
+++ b/geo_areas/tests/bdd/test_browse_geo_areas.py
@@ -19,7 +19,7 @@ def geo_area_search(search_term, client):
 
 @then("the search result should contain the geographical_area searched for")
 def geo_area_list(geo_area_search):
-    results = geo_area_search.json()
+    results = geo_area_search.json()["results"]
     assert len(results) == 1
     result = results[0]
     assert result["area_id"] == "1001"

--- a/regulations/filters.py
+++ b/regulations/filters.py
@@ -1,9 +1,28 @@
 from django_filters import rest_framework as filters
 
+from common.filters import TamatoFilter
+from common.filters import TamatoFilterBackend
+from common.filters import TamatoFilterMixin
 from regulations.models import Regulation
+from regulations.validators import RoleType
 
 
-class RegulationFilter(filters.FilterSet):
+class RegulationFilterMixin(TamatoFilterMixin):
+    """
+    Filter mixin to allow custom filtering on regulation_id,
+    role_type and information_text.
+    """
+
+    search_fields = ("regulation_id", "role_type", "information_text")
+
+
+class RegulationFilterBackend(TamatoFilterBackend, RegulationFilterMixin):
+    pass
+
+
+class RegulationFilter(TamatoFilter, RegulationFilterMixin):
+    role_type = filters.TypedMultipleChoiceFilter(choices=RoleType.choices, coerce=int)
+
     class Meta:
-        model = regulation
-        fields = ["regulation_id", "regulation_type__regulation_type_id"]
+        model = Regulation
+        fields = ["regulation_id", "role_type"]

--- a/regulations/tests/bdd/test_regulations.py
+++ b/regulations/tests/bdd/test_regulations.py
@@ -32,7 +32,7 @@ def regulations_search(client):
 
 @then("the search result should contain the regulation searched for")
 def regulations_list(regulations_search):
-    results = regulations_search.json()
+    results = regulations_search.json()["results"]
     assert len(results) == 1
     result = results[0]
     assert result["regulation_id"] == "C2000000"

--- a/regulations/views.py
+++ b/regulations/views.py
@@ -1,9 +1,9 @@
 from django.shortcuts import render
-from rest_framework import filters
 from rest_framework import permissions
 from rest_framework import renderers
 from rest_framework import viewsets
 
+from regulations.filters import RegulationFilterBackend
 from regulations.models import Regulation
 from regulations.serializers import RegulationSerializer
 
@@ -16,7 +16,7 @@ class RegulationViewSet(viewsets.ReadOnlyModelViewSet):
     queryset = Regulation.objects.current().select_related("regulation_group")
     serializer_class = RegulationSerializer
     permission_classes = [permissions.IsAuthenticated]
-    filter_backends = [filters.SearchFilter]
+    filter_backends = [RegulationFilterBackend]
     search_fields = ["regulation_id"]
 
 


### PR DESCRIPTION
The old views have used a mix of Rest Framework UI views and
standard Django Generic views. As a result the filtering setups
have become a bit confusing - they also simply don't work as
descriptions have been updated.

This commit fixes the reverse relations to descriptions and creates
a more generic filtering setup which serves both standard Django views
and Rest Framework UI views.