### PR TITLE
Allow disabling SSO

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ When running tests the settings module defaults to settings.test
 
 | Name | Description |
 | ---- | ----------- | 
+| SSO_ENABLED              | Use DIT staff SSO for authentication. You may want to set this to `"false"` for local development. If `"false"`, Django's ModelBackend authentication is used instead. (default `"true"`) |
 | AUTHBROKER_URL           | Base URL of the OAuth2 authentication broker (default https://sso.trade.gov.uk) |
 | AUTHBROKER_CLIENT_ID     | Client ID used to connect to the OAuth2 authentication broker |
 | AUTHBROKER_CLIENT_SECRET | Client secret used to connect to the OAuth2 authentication broker |

--- a/common/jinja2.py
+++ b/common/jinja2.py
@@ -1,6 +1,7 @@
 import os
 import re
 
+from django.conf import settings
 from django.contrib import messages
 from django.template.defaultfilters import pluralize
 from django.templatetags.static import static
@@ -70,6 +71,7 @@ def environment(**kwargs):
             "get_current_workbasket": WorkBasket.current,
             "pluralize": pluralize,
             "render_bundle": render_bundle,
+            "settings": settings,
             "static": static,
             "url": reverse,
             "webpack_static": webpack_static,

--- a/common/jinja2/layouts/layout.jinja
+++ b/common/jinja2/layouts/layout.jinja
@@ -15,7 +15,7 @@
     "serviceUrl": "#",
     "navigation": [
       {
-        "href": url("logout") if request.user.is_authenticated else url("authbroker_client:login"),
+        "href": url("logout") if request.user.is_authenticated else settings.LOGIN_URL,
         "text": "Sign out" if request.user.is_authenticated else "Sign In"
       }
     ]

--- a/sample.env
+++ b/sample.env
@@ -14,3 +14,8 @@ AWS_S3_ENDPOINT_URL=http://s3:9003
 # Minio - local s3 server
 MINIO_ACCESS_KEY=minio_access_key
 MINIO_SECRET_KEY=minio_secret_key
+
+# SSO OAuth2 settings
+SSO_ENABLED=true
+AUTHBROKER_CLIENT_ID=client_id
+AUTHBROKER_CLIENT_SECRET=client_secret

--- a/urls.py
+++ b/urls.py
@@ -19,12 +19,6 @@ from django.urls import include
 from django.urls import path
 
 urlpatterns = [
-    path(
-        "auth/",
-        include(
-            "authbroker_client.urls",
-        ),
-    ),
     path("", include("common.urls")),
     path("", include("additional_codes.urls")),
     path("", include("certificates.urls")),
@@ -37,6 +31,17 @@ urlpatterns = [
     path("", include("workbaskets.urls")),
     path("admin/", admin.site.urls),
 ]
+
+if settings.SSO_ENABLED:
+    urlpatterns = [
+        path(
+            "auth/",
+            include(
+                "authbroker_client.urls",
+            ),
+        ),
+        *urlpatterns,
+    ]
 
 if "debug_toolbar" in settings.INSTALLED_APPS:
     import debug_toolbar


### PR DESCRIPTION
When running locally, during development, it may be useful to disable
SSO and avoid requiring an internet connection.

This change adds an environment variable `SSO_ENABLED` which switches
on the SSO authentication flow if truthy (eg "on", or "true"), and
disables it if falsy - falling back to Django's auth ModelBackend, which
authenticates users in the database.