### PR TITLE
Fix `dump_transactions` and accept an envelope ID.

### DIFF
--- a/exporter/management/commands/dump_transactions.py
+++ b/exporter/management/commands/dump_transactions.py
@@ -1,5 +1,3 @@
-import sys
-
 from exporter.management.commands.util import get_envelope_of_active_workbaskets
 from exporter.management.commands.util import WorkBasketBaseCommand
 from workbaskets.models import WorkBasket
@@ -15,6 +13,11 @@ class Command(WorkBasketBaseCommand):
     help = "Output workbaskets ready for export to a file or stdout"
 
     def add_arguments(self, parser):
+        parser.add_argument(
+            "envelope_id",
+            help="The 6-digit envelope ID to use on the generated envelope.",
+            type=int,
+        )
         parser.add_argument(
             "-o",
             "--output",
@@ -32,7 +35,9 @@ class Command(WorkBasketBaseCommand):
     def handle(self, *args, **options):
         workbaskets = WorkBasket.objects.filter(status=WorkflowStatus.READY_FOR_EXPORT)
 
-        envelope = get_envelope_of_active_workbaskets(workbaskets)
+        envelope = get_envelope_of_active_workbaskets(
+            options["envelope_id"], workbaskets
+        )
 
         f = self.get_output_file(options["filename"])
         f.write(envelope.decode("utf-8"))

--- a/exporter/management/commands/util.py
+++ b/exporter/management/commands/util.py
@@ -13,16 +13,18 @@ from workbaskets.validators import WorkflowStatus
 from workbaskets.views import WorkBasketViewSet
 
 
-def get_envelope_of_active_workbaskets(workbaskets: Sequence[WorkBasket]) -> bytes:
+def get_envelope_of_active_workbaskets(
+    envelope_id: int, workbaskets: Sequence[WorkBasket]
+) -> bytes:
     """Return bytes object; Envelope XML of workbaskets ready for export."""
     # Re-use the DRF infrastructure, so data is exactly the same
     # as can be output via views for testing.
     view = WorkBasketViewSet.as_view({"get": "list"})
     request = RequestFactory().get(
-        "/api/workbaskets.xml", status=WorkflowStatus.READY_FOR_EXPORT
+        "/api/workbaskets.xml", data={"status": WorkflowStatus.READY_FOR_EXPORT}
     )
 
-    response = view(request, workbaskets, format="xml", envelope_id=1)
+    response = view(request, workbaskets, format="xml", envelope_id=envelope_id)
     envelope = response.render().content
     return envelope
 


### PR DESCRIPTION
Looks like this got broken at some point in the past. This now successfully outputs any workbasket currently in ready to export status, and accepts an envelope ID.

We'll be using this command for as long as we have a manual interface with HMRC.