### PR TITLE
Update views must inherit from generic.UpdateView

### DIFF
--- a/common/views.py
+++ b/common/views.py
@@ -47,7 +47,7 @@ class CreateView(generic.CreateView):
         return Transaction()
 
 
-class UpdateView(CreateView):
+class UpdateView(generic.UpdateView):
     """Create an updated version of a TrackedModel."""
 
     UPDATE_TYPE = UpdateType.UPDATE


### PR DESCRIPTION
Although updates are actually creating new versions of a record, the view class
must still be a subclass of generic.UpdateView so that the current object is
retrieved using the identifiers in the request and is added to the template
context.

This fixes a 500 error on attempting to edit a footnote.