### PR TITLE
TP-526 Add validation for non-printable whitespace character in legislation text

### DIFF
--- a/regulations/tests/test_validators.py
+++ b/regulations/tests/test_validators.py
@@ -1,0 +1,17 @@
+import pytest
+
+from common.tests.util import check_validator
+from regulations import validators
+
+
+@pytest.mark.parametrize(
+    "value, expected_valid",
+    [
+        ("hello world", True),
+        ("hello|world", False),
+        ("hello\xA0world", False),
+        ("hello world\xA0", False),
+    ],
+)
+def test_valid_footnote_id(value, expected_valid):
+    check_validator(validators.no_information_text_delimiters, value, expected_valid)

--- a/regulations/validators.py
+++ b/regulations/validators.py
@@ -76,4 +76,6 @@ regulation_id_validator = RegexValidator(
 """
 )
 
-no_information_text_delimiters = RegexValidator(r"^[^|]*$", "Must not contain '|'")
+no_information_text_delimiters = RegexValidator(
+    r"^[^|\xA0]*$", "Must not contain '|' or 0xA0"
+)


### PR DESCRIPTION
We have previously extended the system to include
the public ID and URL in the `information_text`
field for the Trade Tariff Serivce in 97ea76a6.

It turns out that the HMRC system filters this out
and replaces it with some whitespace character:
`0xA0` in UTF-8.

We should continue to output pipes and add a
validation that this character isn't present
anywhere else in the final text string, so that
the Trade Tariff Service can split on that
character instead.