### PR TITLE
TP-568: Small patch to fix search functionality.

### DIFF
--- a/additional_codes/filters.py
+++ b/additional_codes/filters.py
@@ -22,7 +22,7 @@ from common.util import TaricDateTimeRange
 
 
 COMBINED_ADDITIONAL_CODE_AND_TYPE_ID = re.compile(
-    r"^(?P<type__sid>[A-Z0-9])(?P<code>[A-Z0-9]{3})$"
+    r"(?P<type__sid>[A-Z0-9])(?P<code>[A-Z0-9]{3})"
 )
 
 


### PR DESCRIPTION
Currently if an regexable piece of data exists within a search
query the rest of the search query will be removed in favour of it
which is not desired behaviour. It also expected anything regexable
to be at the front of the query.

This commit fixes this behaviour to prepend the query with the regexed
data and provide the rest of the search query as well. re.search has also
replaced re.match which enables the term to be found anywhere in the query.

In addition to this the Additional Codes regex expected the search term
to _only_ be the ID, which is wrong. This has been updated.