### PR TITLE
Fix regulation attributes and measure tag

### DIFF
--- a/measures/import_parsers.py
+++ b/measures/import_parsers.py
@@ -427,7 +427,7 @@ class MeasureParser(ValidityMixin, Writable, ElementParser):
     measure_type__sid = TextElement(Tag("measure.type"))
     geographical_area__area_id = TextElement(Tag("geographical.area"))
     goods_nomenclature__item_id = TextElement(Tag("goods.nomenclature.item.id"))
-    additional_code__type__sid = TextElement(Tag("additional.code.type.id"))
+    additional_code__type__sid = TextElement(Tag("additional.code.type"))
     additional_code__code = TextElement(Tag("additional.code"))
     order_number__order_number = TextElement(Tag("ordernumber"))
     reduction = IntElement(Tag("reduction.indicator"))

--- a/measures/jinja2/taric/measure.xml
+++ b/measures/jinja2/taric/measure.xml
@@ -7,7 +7,7 @@
       <oub:geographical.area>{{ record.geographical_area.area_id }}</oub:geographical.area>
       <oub:goods.nomenclature.item.id>{{ record.goods_nomenclature.item_id }}</oub:goods.nomenclature.item.id>
       {%- if record.additional_code %}
-      <oub:additional.code.type.id>{{ record.additional_code.type.sid }}</oub:additional.code.type.id>
+      <oub:additional.code.type>{{ record.additional_code.type.sid }}</oub:additional.code.type>
       <oub:additional.code>{{ record.additional_code.code }}</oub:additional.code>
       {%- endif -%}
       {%- if record.order_number %}

--- a/regulations/serializers.py
+++ b/regulations/serializers.py
@@ -54,7 +54,7 @@ class AmendmentSerializer(
 
 
 class NestedAmendmentSerializer(serializers.HyperlinkedModelSerializer):
-    regulation = NestedRegulationSerializer()
+    enacting_regulation = NestedRegulationSerializer()
 
     class Meta:
         model = models.Amendment
@@ -81,7 +81,7 @@ class ReplacementSerializer(
 
 
 class NestedReplacementSerializer(serializers.HyperlinkedModelSerializer):
-    regulation = NestedRegulationSerializer()
+    enacting_regulation = NestedRegulationSerializer()
 
     class Meta:
         model = models.Replacement
@@ -106,7 +106,7 @@ class ExtensionSerializer(
 
 
 class NestedExtensionSerializer(serializers.HyperlinkedModelSerializer):
-    regulation = NestedRegulationSerializer()
+    enacting_regulation = NestedRegulationSerializer()
 
     class Meta:
         model = models.Extension
@@ -131,7 +131,7 @@ class SuspensionSerializer(
 
 
 class NestedSuspensionSerializer(serializers.HyperlinkedModelSerializer):
-    regulation = NestedRegulationSerializer()
+    enacting_regulation = NestedRegulationSerializer()
 
     class Meta:
         model = models.Suspension
@@ -156,7 +156,7 @@ class TerminationSerializer(
 
 
 class NestedTerminationSerializer(serializers.HyperlinkedModelSerializer):
-    regulation = NestedRegulationSerializer()
+    enacting_regulation = NestedRegulationSerializer()
 
     class Meta:
         model = models.Termination


### PR DESCRIPTION
- Wrong xml tag used for additional code in measure xml. Unfortunately it seems the TARIC import didn't import any additional codes on measures due to this bug.
- Fix some attributes in the regulation serialiser