### PR TITLE
TP-580 Refactor footnote list page

### DIFF
--- a/common/static/common/js/application.js
+++ b/common/static/common/js/application.js
@@ -2,5 +2,7 @@ const images = require.context('../../../../node_modules/govuk-frontend/govuk/as
 const imagePath = (name) => images(name, true)
 
 require.context('govuk-frontend/govuk/assets');
+import showHideCheckboxes from './showHideCheckboxes';
 import { initAll } from 'govuk-frontend';
+showHideCheckboxes();
 initAll();

--- a/common/static/common/js/showHideCheckboxes.js
+++ b/common/static/common/js/showHideCheckboxes.js
@@ -1,0 +1,74 @@
+let showMoreClicked = {};
+
+const nodeListForEach = (nodes, callback) => {
+    if (window.NodeList.prototype.forEach) {
+      return nodes.forEach(callback)
+    }
+    for (let i = 0; i < nodes.length; i++) {
+      callback.call(window, nodes[i], i, nodes)
+    }
+}
+
+class FilterShowMore {
+    constructor(module) {
+        this.module = module;
+        this.button = this.module.getElementsByClassName('js-filter-show-more')[0];
+    }
+    init() {
+        if (!this.module || !this.button) {
+            return
+        }
+    
+        if (this.hasBeenRevealed()) {
+            this.revealChoices();
+        } else {
+            this.button.classList.remove('js-hidden');
+            this.button.addEventListener('click', () => this.revealChoices());
+        }
+    }
+    hasBeenRevealed() {
+        return showMoreClicked[this.module.getAttribute('data-show-more-id')] !== undefined;
+    }
+    revealChoices() {
+        this.button.classList.add('js-hidden');
+
+        let choices = Array.from(this.module.getElementsByClassName('js-hidden'));
+        choices.forEach((choice) => {
+            choice.style.display = 'block';
+        });
+        showMoreClicked[this.module.getAttribute('data-show-more-id')] = true;
+    }
+}
+
+const createShowButton = () => {
+    const button = document.createElement('button');
+    button.classList.add('govuk-button', 'govuk-button--secondary', 'js-filter-show-more');
+    button.innerText = 'Show more';
+    button.type = 'button'
+    return button;
+}
+
+const setupCheckBoxes = () => {
+    const checkboxSets = Array.from(document.getElementsByClassName('govuk-checkboxes'));
+    checkboxSets.forEach((checkboxSet) => {
+        if (checkboxSet.children.length > 10) {
+            Array.from(checkboxSet.children).forEach((checkbox, index) => {
+                if (index > 9) {
+                    checkbox.classList.add('js-hidden')
+                }
+            })
+            checkboxSet.dataset.module="filter-show-more";
+            checkboxSet.append(createShowButton());
+        }
+    })
+}
+
+const installFilterShowMore = () => {
+    setupCheckBoxes();
+    let modules = document.querySelectorAll('[data-module="filter-show-more"]');
+    nodeListForEach(modules, (module) => {
+        new FilterShowMore(module).init()
+    });
+}
+
+export default installFilterShowMore;

--- a/common/static/common/scss/_layout.scss
+++ b/common/static/common/scss/_layout.scss
@@ -27,3 +27,11 @@
     width: 12.5% !important;
   }
 }
+
+.js-hidden {
+  display: none;
+}
+
+.js-filter-show-more {
+  margin-bottom: 0;
+}

--- a/footnotes/filters.py
+++ b/footnotes/filters.py
@@ -1,10 +1,23 @@
 import re
+from datetime import datetime
 
+from crispy_forms_gds.choices import Choice
+from django import forms
 from django.contrib.postgres.aggregates import StringAgg
+from django.db.models import DateTimeField
+from django.db.models import Q
+from django.db.models.functions import Extract
+from django.db.models.functions import Lower
+from django.urls import reverse_lazy
+from django_filters import MultipleChoiceFilter
 
+from common.filters import ACTIVE_STATE_CHOICES
+from common.filters import last_10_years
+from common.filters import LazyMultipleChoiceFilter
 from common.filters import TamatoFilter
 from common.filters import TamatoFilterBackend
 from common.filters import TamatoFilterMixin
+from common.util import TaricDateTimeRange
 from footnotes import models
 from footnotes.validators import FOOTNOTE_ID_PATTERN
 from footnotes.validators import FOOTNOTE_TYPE_ID_PATTERN
@@ -38,7 +51,72 @@ class FootnoteFilterBackend(TamatoFilterBackend, FootnoteFilterMixin):
     pass
 
 
+def footnote_type_choices():
+    footnote_types = models.FootnoteType.objects.current()
+    return [
+        Choice(
+            footnote_type.footnote_type_id,
+            "{0} - {1}".format(
+                footnote_type.footnote_type_id, footnote_type.description
+            ),
+        )
+        for footnote_type in footnote_types
+    ]
+
+
 class FootnoteFilter(TamatoFilter, FootnoteFilterMixin):
+
+    footnote_type = LazyMultipleChoiceFilter(
+        choices=footnote_type_choices,
+        widget=forms.CheckboxSelectMultiple,
+        field_name="footnote_type__footnote_type_id",
+        label="Footnote Type",
+        help_text="Select all that apply",
+        required=False,
+    )
+
+    start_year = LazyMultipleChoiceFilter(
+        choices=last_10_years,
+        widget=forms.CheckboxSelectMultiple,
+        method="filter_start_year",
+        label="Start Year",
+        help_text="Select all that apply",
+        required=False,
+    )
+
+    active_state = MultipleChoiceFilter(
+        choices=ACTIVE_STATE_CHOICES,
+        widget=forms.CheckboxSelectMultiple,
+        method="filter_active_state",
+        label="Active state",
+        help_text="Select all that apply",
+        required=False,
+    )
+
+    def filter_start_year(self, queryset, name, value):
+        if value:
+            queryset = queryset.annotate(
+                start_year=Extract(
+                    Lower("valid_between", output_field=DateTimeField()), "year"
+                )
+            ).filter(start_year__in=value)
+        return queryset
+
+    def filter_active_state(self, queryset, name, value):
+
+        active_status_filter = Q()
+        current_date = TaricDateTimeRange(datetime.now(), datetime.now())
+        if value == ["active"]:
+            active_status_filter = Q(valid_between__upper_inf=True) | Q(
+                valid_between__contains=current_date
+            )
+        if value == ["terminated"]:
+            active_status_filter = Q(valid_between__fully_lt=current_date)
+
+        return queryset.filter(active_status_filter)
+
+    clear_url = reverse_lazy("additional_code-ui-list")
+
     class Meta:
         model = models.Footnote
-        fields = ["footnote_id", "footnote_type__footnote_type_id"]
+        fields = ["search"]

--- a/footnotes/jinja2/footnotes/list.jinja
+++ b/footnotes/jinja2/footnotes/list.jinja
@@ -1,45 +1,6 @@
-{% extends "layouts/layout.jinja" %}
+{% set object_type = "footnote" %}
+{% set form_url = "footnote-ui-list" %}
+{% set list_include = "includes/footnotes_list.jinja" %}
 
-{% from "components/button/macro.njk" import govukButton %}
-{% from "components/input/macro.njk" import govukInput %}
-{% from "components/table/macro.njk" import govukTable %}
 
-{% set page_title = "Find and edit footnotes" %}
-
-{% block beforeContent %}
-  {{ govukBreadcrumbs({
-    "items": [
-      {"text": "Home", "href": url("index")},
-      {"text": page_title}
-    ]
-  }) }}
-{% endblock %}
-
-{% block content %}
-  <h1 class="govuk-heading-xl">{{ page_title }}</h1>
-  <p class="govuk-body">
-    Enter criteria to help find a footnote.
-    Alternatively, <a href="">create a new footnote</a>.
-  </p>
-
-  <div class="filter-layout">
-    <form class="filter-layout__filters" method="get" action="{{ url("footnote-ui-list") }}">
-      {{ govukInput({
-        "id": "search",
-        "name": "search",
-        "label": {
-          "text": "Search",
-          "classes": "govuk-label--m",
-          "attributes": {}
-        },
-        "formGroup": {}
-      }) }}
-
-      {{ govukButton({"text": "Filter"}) }}
-    </form>
-
-    <div class="filter-layout__content">
-      {% include "includes/footnotes_list.jinja" %}
-    </div>
-  </div>
-{% endblock %}
+{%- include "layouts/list.jinja" -%}

--- a/footnotes/jinja2/includes/footnotes/tabs/descriptions.jinja
+++ b/footnotes/jinja2/includes/footnotes/tabs/descriptions.jinja
@@ -14,14 +14,8 @@
         {{ govukTable({
             "firstCellIsHeader": false,
             "head": [
-            {
-                "text": "Start Date",
-                "classes": "govuk-!-width-one-quarter"
-            },
-            {
-                "text": "Description",
-                "classes": "govuk-!-width-two-thirds"
-            }
+                {"text": "Start Date", "classes":  "govuk-!-width-one-eighth"},
+                {"text": "Description"}
             ],
             "rows": description_rows
         }) }}

--- a/footnotes/jinja2/includes/footnotes/tabs/version_control.jinja
+++ b/footnotes/jinja2/includes/footnotes/tabs/version_control.jinja
@@ -17,7 +17,7 @@
         {"text": "Status"},
         {"text": "Start date"},
         {"text": "End date"},
-        {"text": "Description"}
+        {"text": "Description", "classes": "govuk-!-width-one-half"}
     ],
     "rows": version_rows
 }) }}

--- a/footnotes/jinja2/includes/footnotes_list.jinja
+++ b/footnotes/jinja2/includes/footnotes_list.jinja
@@ -2,23 +2,23 @@
       {% set table_rows = [] %}
       {% for footnote in object_list %}
         {% set footnote_link -%}
-        <a href="{{ footnote.get_url() }}">{{ footnote|string }}</a>
+        <a class="govuk-link govuk-!-font-weight-bold" href="{{ footnote.get_url() }}">{{ footnote|string }}</a>
         {%- endset %}
         {{ table_rows.append([
           {"html": footnote_link},
           {"text": footnote.get_description().description|default("")},
-          {"text": footnote.footnote_type.description},
-          {"text": ""},
+          {"text": footnote.footnote_type.footnote_type_id ~ " - " ~ break_words(footnote.footnote_type.description)},
+          {"text": footnote.footnote_type.get_application_code_display()},
           {"text": "{:%d %b %Y}".format(footnote.valid_between.lower)},
           {"text": "{:%d %b %Y}".format(footnote.valid_between.upper) if footnote.valid_between.upper else "-"},
-          {"text": ""},
+          {"text": footnote.transaction.workbasket.get_status_display()},
         ]) or "" }}
       {% endfor %}
       {{ govukTable({
         "head": [
           {"text": "ID"},
           {"text": "Description"},
-          {"text": "Type"},
+          {"text": "Type", "classes":  "govuk-!-width-one-eighth"},
           {"text": "Usage"},
           {"text": "Start date"},
           {"text": "End date"},

--- a/footnotes/validators.py
+++ b/footnotes/validators.py
@@ -5,7 +5,6 @@ from django.core.exceptions import ValidationError
 from django.core.validators import RegexValidator
 from django.db import models
 
-
 # Footnote type application codes
 class ApplicationCode(models.IntegerChoices):
     CN_NOMENCLATURE = 1, "CN nomenclature"


### PR DESCRIPTION
## Summary 
Refactored the list page to look more like the designs, also moved a few common search fields into common, rather than have repetitive code. 
## Changes
- General styling tweaks
- Moved start year and active year into the common filters
- Added JS button for showing more than 10 checkboxes, similar to the implementation at https://data.trade.gov.uk/
## Screenshots
**_(The grey bit of box at the bottom left is the screen capture extension not working properly, not an actual bug)_**

![image](https://user-images.githubusercontent.com/76431740/106177541-8d601000-6190-11eb-850f-705161aa8d3a.png)
