### PR TITLE
Fixes to some business rules

### DIFF
--- a/measures/business_rules.py
+++ b/measures/business_rules.py
@@ -1,12 +1,10 @@
 """Business rules for measures."""
 from datetime import datetime
-from datetime import timedelta
 from datetime import timezone
 from typing import Mapping
 from typing import Optional
 
 from dateutil.relativedelta import relativedelta
-from django.db.models import Count
 from django.db.models import Q
 
 from common.business_rules import BusinessRule
@@ -345,7 +343,8 @@ class ME32(BusinessRule):
                 if matching_measures.filter(
                     goods_nomenclature__indents__nodes__in=tree.values_list(
                         "pk", flat=True
-                    )
+                    ),
+                    valid_between__overlap=measure.effective_valid_between,
                 ).exists():
                     raise self.violation(measure)
 

--- a/measures/business_rules.py
+++ b/measures/business_rules.py
@@ -287,7 +287,9 @@ class ME25(BusinessRule):
     date of the measure must be less than or equal to the end date.
     """
 
-    # TODO handle implicit end date?
+    def validate(self, measure):
+        if measure.valid_between.lower > measure.effective_end_date:
+            raise self.violation(measure)
 
 
 class ME32(BusinessRule):

--- a/measures/models.py
+++ b/measures/models.py
@@ -508,7 +508,6 @@ class MeasureComponent(TrackedModel):
         business_rules.ME50,
         business_rules.ME51,
         business_rules.ME52,
-        business_rules.ME108,
     )
 
 
@@ -557,7 +556,6 @@ class MeasureCondition(TrackedModel):
         business_rules.ME60,
         business_rules.ME61,
         business_rules.ME62,
-        business_rules.ME62,
         business_rules.ME63,
         business_rules.ME64,
     )
@@ -591,6 +589,7 @@ class MeasureConditionComponent(TrackedModel):
         business_rules.ME53,
         business_rules.ME105,
         business_rules.ME106,
+        business_rules.ME108,
     )
 
 

--- a/measures/tests/test_business_rules.py
+++ b/measures/tests/test_business_rules.py
@@ -400,11 +400,24 @@ def test_ME25(date_ranges):
     """If the measure’s end date is specified (implicitly or explicitly) then the start
     date of the measure must be less than or equal to the end date.
 
-    End date will in almost all circumstances be null for measures.
+    End date will in almost all circumstances be explicit for measures.
     """
+
+    business_rules.ME25().validate(
+        factories.MeasureFactory.create(valid_between=date_ranges.normal)
+    )
 
     with pytest.raises(DataError):
         factories.MeasureFactory.create(valid_between=date_ranges.backwards)
+
+    with pytest.raises(BusinessRuleViolation):
+        business_rules.ME25().validate(
+            factories.MeasureFactory.create(
+                valid_between=date_ranges.no_end,
+                generating_regulation__valid_between=date_ranges.earlier,
+                generating_regulation__effective_end_date=date_ranges.earlier.upper,
+            )
+        )
 
 
 def test_ME32(date_ranges):


### PR DESCRIPTION
- Remove some business rule application mistakes
    - Don't need to check ME62 twice
    - ME108 is for condition components, not ordinary
      components
- Implement ME25
    - ME25 had no implementation which caused violations
    when cleaning a transaction. This commit adds an
    implemetation of ME25 and tests.
- Fix ME32 false positive on non-overlapping measures
    - The current implementation of ME32 accidentally
    fires even when measures do not overlap in time.
    This commit adds the time constraint and a test to
    check that ME32 passess successfully when the
    measures are not overlapping in time.