### PR TITLE
Documentation upgrades

### DIFF
--- a/docs/adr/0010-convert-the-importer-to-a-pipeline.rst
+++ b/docs/adr/0010-convert-the-importer-to-a-pipeline.rst
@@ -53,8 +53,6 @@ records will even arrive in the same transaction.
 Consequentially there were two false assumptions made when designing the
 initial importer:
 
-::
-
 1) All records come complete and ready to insert into the database.
 2) All records come in the correct order.
 
@@ -69,8 +67,6 @@ Decision
 To be able to handle the incomplete data records being input the
 importer is being split into 3 components which work together as a
 pipeline. The three components are as follows:
-
-::
 
 1) XML Parser - parses XML data into a python dict.
 2) Object Nursery - Collects python dicts and stores them until a complete object can be made.
@@ -162,10 +158,8 @@ records and belated linked records is enabled (not handled, enabled).
 
 The Nursery has 4 core functions:
 
-::
-
 1) To receive a python dictionary with a workbasket ID and a unique identifier for the record type (in the case
-  of the XML parser the unique identifier is the tag name).
+   of the XML parser the unique identifier is the tag name).
 2) To match these python dictionaries against the handlers responsible for building them into database records.
 3) To store any records that cannot yet be processed by a handler.
 4) To fetch a record when it is ready to be processed by a handler.
@@ -297,8 +291,6 @@ This approach is similar to the one taken (store data until the
 dependencies are found). But everything is done within the parser. As a
 result there are 3 issues with this approach compared to the current
 solution:
-
-::
 
 1) There is no guarantee the dependent data is found within the same XML file being parsed.
 2) The system is tightly coupled, it would be far harder to adapt to varying model needs.

--- a/docs/adr/index.rst
+++ b/docs/adr/index.rst
@@ -4,13 +4,6 @@ Architectural Decision Records
 .. toctree::
    :maxdepth: 2
    :caption: Architectural Decision Records:
+   :glob:
 
-   0001-record-architecture-decisions
-   0002-use-pytest-bdd-for-bdd-testing
-   0003-use-django-rest-framework
-   0004-xml-export-and-import
-   0005-use-model-tracking-and-workbaskets
-   0006-use-django-polymorphic
-   0007-changes-go-through-a-stateful-workflow
-   0008-simplify-workflow-states
-   0010-convert-the-importer-to-a-pipeline
+   *

--- a/docs/business_rules/additional_codes.rst
+++ b/docs/business_rules/additional_codes.rst
@@ -1,0 +1,5 @@
+Additional Codes
+================
+
+.. automodule:: additional_codes.business_rules
+    :members:

--- a/docs/business_rules/certificates.rst
+++ b/docs/business_rules/certificates.rst
@@ -1,0 +1,5 @@
+Certificates
+============
+
+.. automodule:: certificates.business_rules
+    :members:

--- a/docs/business_rules/commodities.rst
+++ b/docs/business_rules/commodities.rst
@@ -1,0 +1,5 @@
+Goods Nomenclature
+==================
+
+.. automodule:: commodities.business_rules
+    :members:

--- a/docs/business_rules/common.rst
+++ b/docs/business_rules/common.rst
@@ -1,0 +1,5 @@
+Base classes
+============
+
+.. automodule:: common.business_rules
+    :members:

--- a/docs/business_rules/footnotes.rst
+++ b/docs/business_rules/footnotes.rst
@@ -1,0 +1,5 @@
+Footnotes
+=========
+
+.. automodule:: footnotes.business_rules
+    :members:

--- a/docs/business_rules/geo_areas.rst
+++ b/docs/business_rules/geo_areas.rst
@@ -1,0 +1,5 @@
+Geographical Areas
+==================
+
+.. automodule:: geo_areas.business_rules
+    :members:

--- a/docs/business_rules/index.rst
+++ b/docs/business_rules/index.rst
@@ -1,0 +1,11 @@
+Business Rules
+==============
+
+
+.. toctree::
+   :maxdepth: 5
+   :caption: Business rules:
+   :glob:
+
+   *
+

--- a/docs/business_rules/measures.rst
+++ b/docs/business_rules/measures.rst
@@ -1,0 +1,5 @@
+Measures
+========
+
+.. automodule:: measures.business_rules
+    :members:

--- a/docs/business_rules/quotas.rst
+++ b/docs/business_rules/quotas.rst
@@ -1,0 +1,5 @@
+Quotas
+======
+
+.. automodule:: quotas.business_rules
+    :members:

--- a/docs/business_rules/regulations.rst
+++ b/docs/business_rules/regulations.rst
@@ -1,0 +1,5 @@
+Regulations
+===========
+
+.. automodule:: regulations.business_rules
+    :members:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -34,6 +34,7 @@ django.setup()
 # ones.
 extensions = [
     "sphinx.ext.autodoc",
+    "sphinx.ext.viewcode",
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/importer/index.rst
+++ b/docs/importer/index.rst
@@ -5,9 +5,7 @@ The Importer
 .. toctree::
    :maxdepth: 5
    :caption: The importer docs:
+   :glob:
 
-   ./parsers_and_namespaces
-   ./nursery
-   ./handlers
-   ./taric
+   *
 

--- a/docs/project.rst
+++ b/docs/project.rst
@@ -21,3 +21,4 @@ Contents
    :maxdepth: 5
 
    adr/index
+   business_rules/index

--- a/importer/handlers.py
+++ b/importer/handlers.py
@@ -34,8 +34,8 @@ class BaseHandlerMeta(type):
 
     Firstly there are two required attributes:
 
-    1) "tag" - a string which is what matches the handler against the incoming data.
-    2) "serializer_class" - a ModelSerializer which is used to validate and create the database object.
+    1. "tag" - a string which is what matches the handler against the incoming data.
+    2. "serializer_class" - a ModelSerializer which is used to validate and create the database object.
 
     Without these attributes the class cannot function properly. To ensure these are defined the metaclass
     checks for their existence and type. If they aren't properly defined then an error is raised at compile
@@ -79,9 +79,11 @@ class BaseHandler(metaclass=BaseHandlerMeta):
     This effectively takes place in 8 stages:
 
     Init:
+
     1) The handler is initialised with the initial data.
 
     Build:
+
     2) The handler checks for dependencies and links. If there are none it goes to step 5.
     3) The handler searches for dependencies which may contain extra required data. If any can't be found it
        asks to be cached and resolved later, the process stops. If they are found it unifies the data.
@@ -89,6 +91,7 @@ class BaseHandler(metaclass=BaseHandlerMeta):
        cached and resolved later, the process stops. If they are found it stores them.
 
     Dispatch:
+
     5) The handler validates the complete data against the serializer.
     6) The handler runs any pre-save processing, including adding the foreign keys to the validated data.
     7) The handler saves the object to the database.

--- a/importer/taric.py
+++ b/importer/taric.py
@@ -95,9 +95,10 @@ class TransactionParser(ElementParser):
         """Save the transaction and the contained records to the database.
 
         :param data: A dict of the parsed element, containing at least an "id" and list
-        of "message" dicts
+            of "message" dicts
         :param envelope_id: The ID of the containing Envelope
         :param workbasket_id: The primary key of the workbasket to add transactions to
+
         """
         logging.debug(f"Saving transaction {self.data['id']}")
 

--- a/measures/business_rules.py
+++ b/measures/business_rules.py
@@ -466,6 +466,7 @@ class ME9(BusinessRule):
     """If no additional code is specified then the goods code is mandatory.
 
     A measure can be assigned to:
+
     - a commodity code only (most measures)
     - a commodity code plus an additional code (e.g. trade remedies, pharma duties,
       routes of ingress)
@@ -539,6 +540,7 @@ class ME87(BusinessRule):
     account extensions and abrogation.
 
     A regulation’s validity period is hugely complex in the EU’s world.
+
     - A regulation is initially assigned a start date. It may be assigned an end date as
       well at the point of creation but this is rare.
     - The EU then may choose to end date the regulation using its end date field – in
@@ -1103,9 +1105,11 @@ class ME73(MeasureValidityPeriodContained):
 
 class ME104(BusinessRule):
     """The justification regulation must be either:
+
         - the measure’s measure-generating regulation, or
         - a measure-generating regulation, valid on the day after the measure’s
           (explicit) end date.
+
     If the measure’s measure-generating regulation is ‘approved’, then so must be the
     justification regulation.
     """


### PR DESCRIPTION
- Add business rules to the documentation.
- Fix up documentation to not emit so many warnings
    - Updates to Pygments that are [about to land](https://github.com/pygments/pygments/pull/1657) will
      take care of the remaining issue with `dot`.