### PR TITLE
Make workbaskets.xml great again.

### DIFF
--- a/common/renderers.py
+++ b/common/renderers.py
@@ -20,7 +20,8 @@ class TaricXMLRenderer(TemplateHTMLRenderer):
         context = super().get_template_context(*args, **kwargs)
 
         if isinstance(context, list):
-            context = {"items": context, "envelope_id": f"{counter_generator()():06}"}
+            context = {"results": context, "envelope_id": f"{counter_generator()():06}"}
+
         context["message_counter"] = counter_generator()
         context["counter_generator"] = counter_generator
         return context

--- a/common/renderers.py
+++ b/common/renderers.py
@@ -19,9 +19,7 @@ class TaricXMLRenderer(TemplateHTMLRenderer):
     def get_template_context(self, *args, **kwargs):
         context = super().get_template_context(*args, **kwargs)
 
-        if isinstance(context, list):
-            context = {"results": context, "envelope_id": f"{counter_generator()():06}"}
-
+        context["envelope_id"] = f"{counter_generator()():06}"
         context["message_counter"] = counter_generator()
         context["counter_generator"] = counter_generator
         return context

--- a/importer/management/commands/utils.py
+++ b/importer/management/commands/utils.py
@@ -696,9 +696,9 @@ class EnvelopeSerializer:
                 render_to_string(
                     template_name="workbaskets/taric/transaction.xml",
                     context={
-                        "tracked_models": map(
-                            self.serializer.to_representation, models
-                        ),
+                        "tracked_models": TrackedModelSerializer(
+                            models, many=True, read_only=True
+                        ).data,
                         "transaction_id": self.transaction_counter(),
                         "counter_generator": counter_generator,
                         "message_counter": self.message_counter,

--- a/workbaskets/jinja2/workbaskets/taric/workbasket_list.xml
+++ b/workbaskets/jinja2/workbaskets/taric/workbasket_list.xml
@@ -1,6 +1,6 @@
 {%- extends "common/taric/base.xml"  -%}
 {%- block transactions -%}
-{%- for workbasket in items -%}
+{%- for workbasket in results -%}
 <!-- workbasket {{workbasket.id}} -->
 {%- set transactions = workbasket.transactions -%}
 {%- include "workbaskets/taric/workbasket.xml" -%}


### PR DESCRIPTION
This is a small PR to make /api/workbaskets.xml output data again.

It changes the key for the list of results to be `results` - which is where Pagination outputs them.

This changes EnvelopeSerializer to use `TrackedModelSerializer(models, many=True, read_only=True).data` instead of it's custom map iterator.

`envelope_id` is wrong here, and there aren't any tests - but how this work will probably need changing in TP-396.

This is more to return some kind of base, so that when the new envelope serialization is added it's easy to see that it doesn't break anything.