### PR TITLE
TP-575: Add an Activity Stream endpoint for Data Workspace.

### DIFF
--- a/exporter/tests/test_views.py
+++ b/exporter/tests/test_views.py
@@ -1,0 +1,39 @@
+import pytest
+from django.test import Client
+from django.urls import reverse
+
+from common.tests import factories
+from exporter import views
+
+
+@pytest.mark.django_db
+def test_activity_stream(admin_client: Client):
+    certificate_type = factories.CertificateTypeFactory.create()
+    factories.CertificateFactory.create_batch(50, certificate_type=certificate_type)
+    response = admin_client.get(reverse("activity-stream"))
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["@context"] == [
+        "https://www.w3.org/ns/activitystreams",
+        {"dit": "https://www.trade.gov.uk/ns/activitystreams/v1"},
+    ]
+    assert data["type"] == "Collection"
+    certificate_data = data["orderedItems"]
+    assert len(certificate_data) == 50
+    object_data = certificate_data[0]["object"]
+    assert "dit:TaMaTo:Certificate:sid" in object_data
+    # Make sure we replace relations with activity stream IDs
+    assert object_data[
+        "dit:TaMaTo:Certificate:certificate_type"
+    ] == views.get_activity_stream_item_id(certificate_type)
+
+    # Test the next page as well
+    next = data["next"]
+    next_response = admin_client.get(next)
+    assert next_response.status_code == 200
+    next_data = next_response.json()
+    assert (
+        len(next_data["orderedItems"]) == 1
+    )  # Should just be the CertificateType as that is the 51st item.
+    assert "next" not in next_data

--- a/exporter/urls.py
+++ b/exporter/urls.py
@@ -1,0 +1,11 @@
+from django.urls import path
+
+from exporter import views
+
+urlpatterns = [
+    path(
+        "api/activity-stream/",
+        views.activity_stream,
+        name="activity-stream",
+    ),
+]

--- a/exporter/views.py
+++ b/exporter/views.py
@@ -1,0 +1,164 @@
+from collections import defaultdict
+from typing import Dict
+from typing import List
+from typing import Type
+
+from django.http import HttpRequest
+from django.http import JsonResponse
+from django.urls import reverse
+from django.views.decorators.http import require_GET
+
+from common.models import TrackedModel
+from common.serializers import TrackedModelSerializer
+
+
+def get_latest_tracked_models(request, per_page: int = 20) -> List[TrackedModel]:
+    """
+    Get the latest current objects in PK order. Paginate via the PK.
+
+    Django Polymorphic struggles to use select_related across the inherited models.
+    To get around this this function fetches the raw data from the TrackedModel table
+    with the polymorphic_ctype (so the actual class we want) - 1 query.
+
+    It then collects all these into a dictionary mapped against the actual class we
+    want. Another query is then made against each class to get their data and related
+    objects in one - 1 query per class.
+
+    Query total = 1 + n (n = number of actual tracked classes involved).
+    """
+    starting_pk = request.GET.get("start")
+
+    tracked_models = (
+        TrackedModel.objects.current()
+        .select_related("polymorphic_ctype")
+        .order_by("-pk")
+        .non_polymorphic()
+    )
+
+    if starting_pk:
+        tracked_models = tracked_models.filter(pk__lt=starting_pk)
+
+    obj_map: Dict[Type[TrackedModel], List[int]] = defaultdict(list)
+
+    for obj in tracked_models[:per_page]:
+        obj_map[obj.polymorphic_ctype.model_class()].append(obj.pk)
+
+    full_tracked_models = []
+
+    for tracked_class, pk_list in obj_map.items():
+        full_tracked_models.extend(
+            tracked_class.objects.filter(pk__in=pk_list).select_related()
+        )
+
+    full_tracked_models.sort(key=lambda x: -x.pk)
+    return full_tracked_models
+
+
+def get_activity_stream_item_type(obj: TrackedModel) -> str:
+    return f"dit:TaMaTo:{obj.__class__.__name__}"
+
+
+def get_activity_stream_item_id(obj: TrackedModel) -> str:
+    item_type = get_activity_stream_item_type(obj)
+    return f"{item_type}:{''.join(str(value) for value in obj.get_identifying_fields().values())}"
+
+
+def tracked_model_to_activity_stream_item(obj: TrackedModel):
+    """
+    Convert a TrackedModel into a data object suitable for consumption
+    by Activity Stream as outlined in https://www.w3.org/TR/activitystreams-core/
+
+    Instead of providing the full nested data for every related object the
+    relations are removed and provided as their equivalent ActivityStream
+    IDs.
+    """
+
+    item_type = get_activity_stream_item_type(obj)
+    item_id = get_activity_stream_item_id(obj)
+    published = obj.transaction.updated_at.isoformat()
+
+    # Find all the relations to remove and replace with activity stream IDs.
+    exclusions = []
+    extra_data = {}
+    for relation, _ in obj.get_relations():
+        exclusions.append(relation.name)
+        if hasattr(obj, relation.name):
+            extra_data[f"{item_type}:{relation.name}"] = get_activity_stream_item_id(
+                getattr(obj, relation.name)
+            )
+
+    obj_data = {
+        f"{item_type}:{key}": value
+        for key, value in TrackedModelSerializer(
+            obj,
+            read_only=True,
+            context={"format": "json"},
+            child_kwargs={"omit": exclusions},
+        ).data.items()
+    }
+
+    if f"{item_type}:valid_between" in obj_data:
+        # DITs Elastic system has these as keywords:
+        # https://github.com/uktrade/activity-stream/blob/e6fc63f/core/app/app_outgoing_elasticsearch.py#L335
+        extra_data["startTime"] = obj_data[f"{item_type}:valid_between"].get("lower")
+        extra_data["endTime"] = obj_data[f"{item_type}:valid_between"].get("upper")
+
+    obj_data.update(**extra_data)
+
+    data = {
+        "id": item_id,
+        "published": published,
+        "object": {
+            "id": item_id,
+            "type": item_type,
+            "name": str(obj),
+            **obj_data,
+        },
+    }
+
+    return data
+
+
+def next_url(tracked_model: TrackedModel, request: HttpRequest) -> str:
+    return request.build_absolute_uri(
+        reverse("activity-stream") + f"?start={tracked_model.pk}"
+    )
+
+
+@require_GET
+def activity_stream(request):
+    """
+    Build an activity stream response of the latest and current TrackedModels.
+
+    TrackedModels are provided in reverse PK order. If a starting PK is provided
+    in the request then only TrackedModels with PK less than the provided one
+    are given.
+
+    The response conforms to the ActivityStream format defined at
+    https://www.w3.org/TR/activitystreams-core/
+    """
+    per_page = 50
+
+    tracked_models = get_latest_tracked_models(request, per_page)
+
+    page = {
+        "@context": [
+            "https://www.w3.org/ns/activitystreams",
+            {"dit": "https://www.trade.gov.uk/ns/activitystreams/v1"},
+        ],
+        "type": "Collection",
+        "orderedItems": [
+            tracked_model_to_activity_stream_item(tracked_object)
+            for tracked_object in tracked_models
+        ],
+        **(
+            {"next": next_url(tracked_models[-1], request)}
+            if len(tracked_models) == per_page
+            else {}
+        ),
+    }
+
+    return JsonResponse(
+        data=page,
+        status=200,
+    )

--- a/footnotes/tests/bdd/test_edit_footnote.py
+++ b/footnotes/tests/bdd/test_edit_footnote.py
@@ -4,11 +4,9 @@ import re
 import pytest
 from dateutil.relativedelta import relativedelta
 from pytest_bdd import given
-from pytest_bdd import parsers
 from pytest_bdd import scenarios
 from pytest_bdd import then
 from pytest_bdd import when
-from rest_framework.reverse import reverse
 
 from common.tests import factories
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,6 +21,7 @@ django-treebeard
 django-webpack-loader
 django_extensions
 djangorestframework
+drf-flex-fields==0.8.8
 factory-boy
 freezegun
 git+https://github.com/alphagov/govuk-frontend-jinja.git

--- a/urls.py
+++ b/urls.py
@@ -23,6 +23,7 @@ urlpatterns = [
     path("", include("additional_codes.urls")),
     path("", include("certificates.urls")),
     path("", include("commodities.urls")),
+    path("", include("exporter.urls")),
     path("", include("footnotes.urls")),
     path("", include("geo_areas.urls")),
     path("", include("importer.urls")),


### PR DESCRIPTION
It is a requirement that the tariff data be open and as accessible as possible.
Part of this is to make the data available on Data Workspace, and the advised
route to do so is to expose an endpoint that provides all the current tariff
data in an ActivityStream format.

This commit adds an endpoint in the exporter package which formats all the
latest TrackedModels (paginated by 20) in the ActivityStream format ready
for consumption by DataWorkspace.