### PR TITLE
Fix cache issues in importer tests.

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -31,6 +31,7 @@ from common.util import get_field_tuple
 from common.util import TaricDateTimeRange
 from common.validators import UpdateType
 from exporter.storages import HMRCStorage
+from importer.nursery import get_nursery
 from importer.taric import process_taric_xml_stream
 from workbaskets.validators import WorkflowStatus
 
@@ -266,6 +267,7 @@ def imported_fields_match(valid_user, settings):
         model: Union[TrackedModel, Type[DjangoModelFactory]],
         serializer: Type[TrackedModelSerializer],
     ) -> TrackedModel:
+        get_nursery().cache.clear()
         settings.SKIP_WORKBASKET_VALIDATION = True
         if isinstance(model, type) and issubclass(model, DjangoModelFactory):
             model = model.build(update_type=UpdateType.CREATE)

--- a/importer/cache/base.py
+++ b/importer/cache/base.py
@@ -13,3 +13,6 @@ class BaseEngine:
 
     def dump(self):
         raise NotImplementedError
+
+    def clear(self):
+        raise NotImplementedError

--- a/importer/cache/cache.py
+++ b/importer/cache/cache.py
@@ -41,3 +41,6 @@ class ObjectCacheFacade:
 
     def dump(self):
         self.engine.dump()
+
+    def clear(self):
+        self.engine.clear()

--- a/importer/cache/memory.py
+++ b/importer/cache/memory.py
@@ -18,3 +18,6 @@ class MemoryCacheEngine(BaseEngine):
 
     def dump(self):
         pass
+
+    def clear(self):
+        self.CACHE.clear()

--- a/importer/cache/pickle.py
+++ b/importer/cache/pickle.py
@@ -34,3 +34,6 @@ class PickleCacheEngine(BaseEngine):
     def dump(self):
         with open(self.CACHE_FILE, "wb") as dump_file:
             pickle.dump(self.CACHE, dump_file)
+
+    def clear(self):
+        self.CACHE.clear()

--- a/importer/cache/redis.py
+++ b/importer/cache/redis.py
@@ -42,3 +42,7 @@ class RedisCacheEngine(BaseEngine):
 
     def dump(self):
         pass
+
+    def clear(self):
+        prefix = getattr(settings, "IMPORTER_CACHE_PREFIX", "__IMPORTER_CACHE")
+        cache.delete(f"{prefix}*")


### PR DESCRIPTION
In some cases bits of data get stuck in the test cache when
running, this causes a cascade of all following importer tests
to fail as they try to resolve the cache.

This commit adds a clearing action to the cache and utilises it
within the tests to ensure this issue does not arise.