### PR TITLE
Prevent ME32 on measures with implicit end dates

### DIFF
--- a/measures/business_rules.py
+++ b/measures/business_rules.py
@@ -356,11 +356,11 @@ class ME32(BusinessRule):
 
                 # check for any measures associated to commodity codes in the tree which
                 # clash with the specified measure
-                clashing_measures = matching_measures.filter(
+                clashing_measures = matching_measures.with_effective_valid_between().filter(
                     goods_nomenclature__indents__nodes__in=tree.values_list(
                         "pk", flat=True
                     ),
-                    valid_between__overlap=measure.effective_valid_between,
+                    db_effective_valid_between__overlap=measure.effective_valid_between,
                 )
                 if clashing_measures.exists():
                     raise self.violation(measure)


### PR DESCRIPTION
Previously ME32 only considered the explicit validity period of any matching measures. 

It now also considers the implicit validity period through the user of `effective_valid_between`.

Tests have also been refactored to make it easier to check all the permutations of dates and comm codes, all in their own transaction (otherwise the transactions have to be controlled manually).