### PR TITLE
Add some checks to pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,8 +1,23 @@
 repos:
-  - repo: https://github.com/timothycrosley/isort
-    rev: 4.3.21
+  - repo: https://github.com/asottile/add-trailing-comma
+    rev: v2.1.0
+    hooks:
+      - id: add-trailing-comma
+  - repo: git@github.com:myint/autoflake.git
+    rev: v1.4
+    hooks:
+      - id: autoflake
+        args: ['--in-place', '--remove-all-unused-imports', '--remove-unused-variable']
+  - repo: https://github.com/pycqa/isort
+    rev: 5.7.0
     hooks:
     -   id: isort
+        args: [--force-single-line-imports]
+  - repo: git@github.com:myint/docformatter.git
+    rev: v1.4
+    hooks:
+      - id: docformatter
+        args: ['--in-place', '--wrap-summaries=80', '--wrap-descriptions=80', '--pre-summary-newline']
   - repo: https://github.com/psf/black
     rev: 20.8b1
     hooks:


### PR DESCRIPTION
Adds the following pre-commit plugins:
- add-trailing-comma
- autoflake (removes unused imports and variables)
- isort (fix configuration)
- docformatter (standardise doc-comment format)