### PR TITLE
TP-172 Fix non-unique certificate SID scenario

### DIFF
--- a/certificates/jinja2/certificates/detail.jinja
+++ b/certificates/jinja2/certificates/detail.jinja
@@ -2,7 +2,7 @@
 {% from "components/summary-list/macro.njk" import govukSummaryList %}
 {% from "components/table/macro.njk" import govukTable %}
 
-{% set page_title = "Certificate: " ~ object.sid %}
+{% set page_title = "Certificate: " ~ object.code %}
 {% set find_edit_url = url("certificate-ui-list") %}
 
 {% set core_data_tab_html %}{% include "includes/certificates/tabs/core_data.jinja" %}{% endset %}

--- a/certificates/jinja2/includes/certificates/list.jinja
+++ b/certificates/jinja2/includes/certificates/list.jinja
@@ -1,7 +1,7 @@
 {% set table_rows = [] %}
 {% for certificate in object_list %}
   {% set object_link -%}
-    <a class="govuk-link govuk-!-font-weight-bold" href="{{ certificate.get_url() }}">{{ certificate.sid}}</a>
+    <a class="govuk-link govuk-!-font-weight-bold" href="{{ certificate.get_url() }}">{{ certificate.code}}</a>
   {%- endset %}
   {{ table_rows.append([
     {"html": object_link},

--- a/certificates/jinja2/includes/certificates/tabs/core_data.jinja
+++ b/certificates/jinja2/includes/certificates/tabs/core_data.jinja
@@ -5,7 +5,7 @@
             "rows": [
             {
                 "key": {"text": "Certificate ID"},
-                "value": {"text": object.sid},
+                "value": {"text": object.code},
                 "actions": {"items": []}
             },
             {

--- a/certificates/models.py
+++ b/certificates/models.py
@@ -95,6 +95,7 @@ class Certificate(TrackedModel, ValidityMixin):
         return reverse(
             f"certificate-ui-{action}",
             kwargs={
+                "certificate_type__sid": self.certificate_type.sid,
                 "sid": self.sid,
             },
         )

--- a/certificates/urls.py
+++ b/certificates/urls.py
@@ -5,6 +5,8 @@ from rest_framework import routers
 
 from certificates import views
 from certificates.validators import CERTIFICATE_SID_REGEX
+from certificates.validators import CERTIFICATE_TYPE_SID_REGEX
+
 
 api_router = routers.DefaultRouter()
 api_router.register(r"certificates", views.CertificatesViewSet)
@@ -17,7 +19,7 @@ ui_patterns = [
         name="certificate-ui-list",
     ),
     re_path(
-        fr"^(?P<sid>{CERTIFICATE_SID_REGEX[1:-1]})$",
+        fr"^(?P<certificate_type__sid>{CERTIFICATE_TYPE_SID_REGEX[1:-1]})(?P<sid>{CERTIFICATE_SID_REGEX[1:-1]})$",
         views.CertificateDetail.as_view(),
         name="certificate-ui-detail",
     ),


### PR DESCRIPTION
## Summary 
A certificate sid alone is not unique, it's the combination of the type id and the sid that is. Changed so that we now use both.