### PR TITLE
More ME32 fixes

### DIFF
--- a/common/tests/factories.py
+++ b/common/tests/factories.py
@@ -178,7 +178,7 @@ class RegulationFactory(TrackedModelMixin):
     approved = True
     role_type = 1
     valid_between = factory.LazyAttribute(
-        lambda o: Dates().no_end if o.role_type == 1 else None
+        lambda o: Dates().no_end if o.role_type == 1 else None,
     )
     community_code = 1
     regulation_group = factory.LazyAttribute(
@@ -187,7 +187,7 @@ class RegulationFactory(TrackedModelMixin):
             transaction=o.transaction,
         )
         if o.role_type == 1
-        else None
+        else None,
     )
     information_text = string_sequence(length=50)
     public_identifier = factory.sequence(lambda n: f"S.I. 2021/{n}")
@@ -475,7 +475,8 @@ class GoodsNomenclatureOriginFactory(TrackedModelMixin):
 
     new_goods_nomenclature = factory.SubFactory(SimpleGoodsNomenclatureFactory)
     derived_from_goods_nomenclature = factory.SubFactory(
-        SimpleGoodsNomenclatureFactory, valid_between=date_ranges("big")
+        SimpleGoodsNomenclatureFactory,
+        valid_between=date_ranges("big"),
     )
 
 
@@ -484,15 +485,17 @@ class GoodsNomenclatureSuccessorFactory(TrackedModelMixin):
         model = "commodities.GoodsNomenclatureSuccessor"
 
     replaced_goods_nomenclature = factory.SubFactory(
-        SimpleGoodsNomenclatureFactory, valid_between=date_ranges("adjacent_earlier")
+        SimpleGoodsNomenclatureFactory,
+        valid_between=date_ranges("adjacent_earlier"),
     )
     absorbed_into_goods_nomenclature = factory.SubFactory(
-        SimpleGoodsNomenclatureFactory
+        SimpleGoodsNomenclatureFactory,
     )
 
 
 class FootnoteAssociationGoodsNomenclatureFactory(
-    TrackedModelMixin, ValidityFactoryMixin
+    TrackedModelMixin,
+    ValidityFactoryMixin,
 ):
     class Meta:
         model = "commodities.FootnoteAssociationGoodsNomenclature"
@@ -742,7 +745,7 @@ class MeasureFactory(TrackedModelMixin, ValidityFactoryMixin):
     measure_type = factory.SubFactory(MeasureTypeFactory)
     additional_code = None
     order_number = None
-    reduction = factory.Faker("random_int", min=1, max=3)
+    reduction = factory.Sequence(lambda x: (x + 1) % 4)
     generating_regulation = factory.SubFactory(RegulationFactory)
     stopped = False
     export_refund_nomenclature_sid = None
@@ -758,7 +761,8 @@ class MeasureFactory(TrackedModelMixin, ValidityFactoryMixin):
         leave_measure = kwargs.pop("leave_measure", False)
         if "measure_type" in kwargs and not leave_measure:
             kwargs["measure_type"] = cls.measure_type_explosion(
-                kwargs["measure_type"], kwargs.get("goods_nomenclature")
+                kwargs["measure_type"],
+                kwargs.get("goods_nomenclature"),
             )
         obj = model_class(*args, **kwargs)
         obj.save()
@@ -785,7 +789,8 @@ class MeasureWithAdditionalCodeFactory(MeasureFactory):
 
 class MeasureWithQuotaFactory(MeasureFactory):
     measure_type = factory.SubFactory(
-        MeasureTypeFactory, order_number_capture_code=OrderNumberCaptureCode.MANDATORY
+        MeasureTypeFactory,
+        order_number_capture_code=OrderNumberCaptureCode.MANDATORY,
     )
     order_number = factory.SubFactory(
         QuotaOrderNumberFactory,
@@ -867,7 +872,7 @@ class MeasureExcludedGeographicalAreaFactory(TrackedModelMixin):
 
 
 class MeasureExcludedGeographicalMembershipFactory(
-    MeasureExcludedGeographicalAreaFactory
+    MeasureExcludedGeographicalAreaFactory,
 ):
     class Meta:
         exclude = ["membership"]

--- a/measures/business_rules.py
+++ b/measures/business_rules.py
@@ -15,6 +15,7 @@ from common.business_rules import only_applicable_after
 from common.util import TaricDateRange
 from common.util import validity_range_contains_range
 from common.validators import ApplicabilityCode
+from common.validators import UpdateType
 from footnotes.validators import ApplicationCode
 from geo_areas.validators import AreaCode
 from quotas.validators import AdministrationMechanism
@@ -307,7 +308,10 @@ class ME32(BusinessRule):
     """
 
     def validate(self, measure):
-        if measure.goods_nomenclature is None:
+        if (
+            measure.goods_nomenclature is None
+            or measure.update_type == UpdateType.DELETE
+        ):
             return
 
         # build the query for measures matching the given measure

--- a/measures/business_rules.py
+++ b/measures/business_rules.py
@@ -186,8 +186,11 @@ class ME6(MustExist):
 
 
 class ME7(BusinessRule):
-    """The goods nomenclature code must be a product code. It may not be an
-    intermediate line."""
+    """
+    The goods nomenclature code must be a product code.
+
+    It may not be an intermediate line.
+    """
 
     def validate(self, measure):
         if measure.goods_nomenclature and measure.goods_nomenclature.suffix != "80":
@@ -318,13 +321,22 @@ class ME32(BusinessRule):
         query = Q(
             measure_type__sid=measure.measure_type.sid,
             geographical_area__sid=measure.geographical_area.sid,
+            reduction=measure.reduction,
         )
         if measure.order_number is not None:
             query &= Q(order_number__sid=measure.order_number.sid)
+        elif measure.dead_order_number is not None:
+            query &= Q(dead_order_number=measure.dead_order_number)
+        else:
+            query &= Q(order_number__isnull=True, dead_order_number__isnull=True)
+
         if measure.additional_code is not None:
             query &= Q(additional_code__sid=measure.additional_code.sid)
-        if measure.reduction is not None:
-            query &= Q(reduction=measure.reduction)
+        elif measure.dead_additional_code is not None:
+            query &= Q(dead_additional_code=measure.dead_additional_code)
+        else:
+            query &= Q(additional_code__isnull=True, dead_additional_code__isnull=True)
+
         matching_measures = (
             type(measure)
             .objects.filter(query)

--- a/measures/business_rules.py
+++ b/measures/business_rules.py
@@ -185,12 +185,8 @@ class ME6(MustExist):
 
 
 class ME7(BusinessRule):
-    """
-    The goods nomenclature code must be a product code. It may not be an
-    intermediate line.
-
-    test
-    """
+    """The goods nomenclature code must be a product code. It may not be an
+    intermediate line."""
 
     def validate(self, measure):
         if measure.goods_nomenclature and measure.goods_nomenclature.suffix != "80":
@@ -650,9 +646,8 @@ class ME40(BusinessRule):
     specified.  If the flag is set "not permitted" then no measure component or
     measure condition component must exist.  Measure components and measure
     condition components are mutually exclusive. A measure can have either
-    components or condition components (if the ‘duty expression’ flag is.
-
-    ‘mandatory’ or ‘optional’) but not both.
+    components or condition components (if the "duty expression" flag is
+    "mandatory" or "optional") but not both.
 
     This describes the fact that measures of certain types MUST have components
     (duties) assigned to them, whereas others must not. Note the sub-clause also

--- a/measures/tests/test_business_rules.py
+++ b/measures/tests/test_business_rules.py
@@ -1010,8 +1010,7 @@ def test_ME40(applicability_code, component, condition_component):
     specified.  If the flag is set "not permitted" then no measure component or
     measure condition component must exist.  Measure components and measure
     condition components are mutually exclusive. A measure can have either
-    components or condition components (if the ‘duty expression’ flag is.
-
+    components or condition components (if the ‘duty expression’ flag is
     ‘mandatory’ or ‘optional’) but not both.
 
     This describes the fact that measures of certain types MUST have components

--- a/measures/tests/test_business_rules.py
+++ b/measures/tests/test_business_rules.py
@@ -530,11 +530,19 @@ def existing_measure_data(request, date_ranges, existing_goods_nomenclature):
             },
             False,
         ),
+        (
+            lambda d: {
+                "valid_between": d.overlap_normal_earlier,
+                "update_type": UpdateType.DELETE,
+            },
+            False
+        )
     ),
     ids=[
         "explicit:overlapping",
         "implicit:not-overlapping",
         "explicit:not-overlapping",
+        "deleted",
     ],
 )
 def related_measure_data(request, date_ranges, related_goods_nomenclature):

--- a/measures/tests/test_business_rules.py
+++ b/measures/tests/test_business_rules.py
@@ -521,6 +521,41 @@ def existing_measure(request, date_ranges, existing_goods_nomenclature):
         ),
         (
             lambda d: {
+                "valid_between": d.overlap_normal_earlier,
+                "measure_type": factories.MeasureTypeFactory(),
+            },
+            False,
+        ),
+        (
+            lambda d: {
+                "valid_between": d.overlap_normal_earlier,
+                "geographical_area": factories.GeographicalAreaFactory(),
+            },
+            False,
+        ),
+        (
+            lambda d: {
+                "valid_between": d.overlap_normal_earlier,
+                "order_number": factories.QuotaOrderNumberFactory(),
+            },
+            False,
+        ),
+        (
+            lambda d: {
+                "valid_between": d.overlap_normal_earlier,
+                "additional_code": factories.AdditionalCodeFactory(),
+            },
+            False,
+        ),
+        (
+            lambda d: {
+                "valid_between": d.overlap_normal_earlier,
+                "reduction": None,
+            },
+            False,
+        ),
+        (
+            lambda d: {
                 "valid_between": Dates.no_end_before(d.adjacent_earlier.lower),
                 "generating_regulation__valid_between": d.adjacent_earlier,
                 "generating_regulation__effective_end_date": d.adjacent_earlier.upper,
@@ -543,6 +578,11 @@ def existing_measure(request, date_ranges, existing_goods_nomenclature):
     ),
     ids=[
         "explicit:overlapping",
+        "explicit:overlapping:measure_type",
+        "explicit:overlapping:geographical_area",
+        "explicit:overlapping:order_number",
+        "explicit:overlapping:additional_code",
+        "explicit:overlapping:reduction",
         "implicit:not-overlapping",
         "explicit:not-overlapping",
         "deleted",
@@ -553,18 +593,8 @@ def related_measure_dates(request, date_ranges):
     return callable(date_ranges), date_overlap
 
 
-@pytest.fixture(
-    params=(
-        None,
-        "measure_type",
-        "geographical_area",
-        "order_number",
-        "additional_code",
-        "reduction",
-    ),
-)
+@pytest.fixture
 def related_measure_data(
-    request,
     related_measure_dates,
     related_goods_nomenclature,
     existing_measure,
@@ -580,9 +610,7 @@ def related_measure_data(
         "reduction": existing_measure.reduction,
         **validity_data,
     }
-    if request.param in full_data:
-        del full_data[request.param]
-    error_expected = date_overlap and nomenclature_overlap and (request.param is None)
+    error_expected = date_overlap and nomenclature_overlap
 
     return full_data, error_expected
 


### PR DESCRIPTION
- ME32: Cut down on the number of test cases
- ME32: Handle dead fields as well as null cases.
- ME32: Prevent trigger on measure deletion.
- Measure business rules formatting.
- ME32: Use current indents to ignore past history of codes
