### PR TITLE
Only show current members for Geo Areas

### DIFF
--- a/geo_areas/jinja2/includes/geo_areas/tabs/memberships.jinja
+++ b/geo_areas/jinja2/includes/geo_areas/tabs/memberships.jinja
@@ -1,6 +1,6 @@
 <h2 class="govuk-heading-l">Memberships</h2>
 {% set table_rows = [] %}
-{% for membership in object.memberships.all() %}
+{% for membership in object.memberships.current() %}
   {{ table_rows.append([
     {"text": "{:%d %b %Y}".format(membership.valid_between.lower)},
     {"text": "{:%d %b %Y}".format(membership.valid_between.upper) if membership.valid_between.upper else "-"},


### PR DESCRIPTION
Currently Geo Areas shows all members with all their versions in one. It should instead
only show the most current versions of each member.

This commit changes the query to only get current members.