### PR TITLE
Patch 2 for showing only current members in geo members tab

### DIFF
--- a/geo_areas/jinja2/includes/geo_areas/tabs/memberships.jinja
+++ b/geo_areas/jinja2/includes/geo_areas/tabs/memberships.jinja
@@ -1,6 +1,6 @@
 <h2 class="govuk-heading-l">Memberships</h2>
 {% set table_rows = [] %}
-{% for membership in object.memberships.current() %}
+{% for membership in object.get_current_members() %}
   {{ table_rows.append([
     {"text": "{:%d %b %Y}".format(membership.valid_between.lower)},
     {"text": "{:%d %b %Y}".format(membership.valid_between.upper) if membership.valid_between.upper else "-"},

--- a/geo_areas/models.py
+++ b/geo_areas/models.py
@@ -71,6 +71,17 @@ class GeographicalArea(TrackedModel, ValidityMixin):
             .with_workbasket(workbasket)
         )
 
+    def get_current_members(self):
+        return [
+            membership.member
+            for membership in GeographicalMembership.objects.filter(
+                geo_group__sid=self.sid,
+            )
+            .current()
+            .select_related("member")
+            .prefetch_related("member__descriptions")
+        ]
+
     def in_use(self):
         # TODO handle deletes
         return self.measures.model.objects.filter(
@@ -110,10 +121,14 @@ class GeographicalMembership(TrackedModel, ValidityMixin):
     subrecord_code = "15"
 
     geo_group = models.ForeignKey(
-        GeographicalArea, related_name="members", on_delete=models.PROTECT
+        GeographicalArea,
+        related_name="members",
+        on_delete=models.PROTECT,
     )
     member = models.ForeignKey(
-        GeographicalArea, related_name="groups", on_delete=models.PROTECT
+        GeographicalArea,
+        related_name="groups",
+        on_delete=models.PROTECT,
     )
 
     identifying_fields = ("geo_group__sid", "member__sid")
@@ -142,7 +157,9 @@ class GeographicalAreaDescription(TrackedModel, ValidityMixin):
     period_subrecord_code = "05"
 
     area = models.ForeignKey(
-        GeographicalArea, on_delete=models.CASCADE, related_name="descriptions"
+        GeographicalArea,
+        on_delete=models.CASCADE,
+        related_name="descriptions",
     )
     description = ShortDescription()
     sid = SignedIntSID(db_index=True)


### PR DESCRIPTION
The previous patch would find only the current members (via the
geographical area table), however as the query was proxied through
memberships (a separate table) it still resulted in duplicate
members being shown.

This commit introduces a new method which builds a list of members
based on the memberships being current - removing duplicates.