### PR TITLE
Update Geo Memberships to use the membership validity dates

### DIFF
--- a/geo_areas/jinja2/includes/geo_areas/tabs/memberships.jinja
+++ b/geo_areas/jinja2/includes/geo_areas/tabs/memberships.jinja
@@ -1,11 +1,11 @@
 <h2 class="govuk-heading-l">Memberships</h2>
 {% set table_rows = [] %}
-{% for membership in object.get_current_members() %}
+{% for membership in object.get_current_memberships() %}
   {{ table_rows.append([
     {"text": "{:%d %b %Y}".format(membership.valid_between.lower)},
     {"text": "{:%d %b %Y}".format(membership.valid_between.upper) if membership.valid_between.upper else "-"},
-    {"text": membership.area_id},
-    {"text": membership.get_description().description},
+    {"text": membership.member.area_id},
+    {"text": membership.member.get_description().description},
   ]) or "" }}
 {% endfor %}
 {% if table_rows == [] %}

--- a/geo_areas/models.py
+++ b/geo_areas/models.py
@@ -71,16 +71,14 @@ class GeographicalArea(TrackedModel, ValidityMixin):
             .with_workbasket(workbasket)
         )
 
-    def get_current_members(self):
-        return [
-            membership.member
-            for membership in GeographicalMembership.objects.filter(
+    def get_current_memberships(self):
+        return (
+            GeographicalMembership.objects.filter(
                 geo_group__sid=self.sid,
             )
             .current()
             .select_related("member")
-            .prefetch_related("member__descriptions")
-        ]
+        )
 
     def in_use(self):
         # TODO handle deletes


### PR DESCRIPTION
Currently the memberships tab uses the dates of the country's
existence, not of the membership's existence.

This commit updates the template to use the correct date range.
It also optimises the query a bit (by creating more queries,
but faster executing ones).