### PR TITLE
Remove description prefetch for Geo Areas

### DIFF
--- a/geo_areas/views.py
+++ b/geo_areas/views.py
@@ -19,7 +19,7 @@ class GeoAreaViewSet(viewsets.ReadOnlyModelViewSet):
 
 
 class GeographicalAreaList(TamatoListView):
-    queryset = GeographicalArea.objects.current().prefetch_related("descriptions")
+    queryset = GeographicalArea.objects.current()
     template_name = "geo_areas/list.jinja"
     filterset_class = GeographicalAreaFilter
     search_fields = ["sid", "descriptions__description"]
@@ -28,4 +28,4 @@ class GeographicalAreaList(TamatoListView):
 class GeographicalAreaDetail(TrackedModelDetailView):
     model = GeographicalArea
     template_name = "geo_areas/detail.jinja"
-    queryset = GeographicalArea.objects.current().prefetch_related("descriptions")
+    queryset = GeographicalArea.objects.current()


### PR DESCRIPTION
Prefetching helps save queries, however in some cases
it provides an incorrect description for Geographical
Areas. To remedy this prefetching has been removed from
Geographical Area views.