### PR TITLE
TP-541: Prevent deletion of linked quotas.

### DIFF
--- a/quotas/models.py
+++ b/quotas/models.py
@@ -175,6 +175,9 @@ class QuotaDefinition(TrackedModel, ValidityMixin):
         business_rules.QD10,
         business_rules.QD11,
         business_rules.PreventQuotaDefinitionDeletion,
+        business_rules.QuotaAssociationMustReferToANonDeletedSubQuota,
+        business_rules.QuotaSuspensionMustReferToANonDeletedQuotaDefinition,
+        business_rules.QuotaBlockingPeriodMustReferToANonDeletedQuotaDefinition,
     )
 
     def __str__(self):


### PR DESCRIPTION
Quota Associations, Quota Suspensions and Quota Blocking
Periods all demand that their linked quotas be live. I.e.
the linked Quota Definitions can not be deleted until the
relevant associations, suspensions and blocking periods
either refer to a different quota or are deleted themselves.

This commit introduces a business rule to check that any
quota being deleted cannot be referred to by an association,
suspension or blocking period.