### PR TITLE
TP-640: Replace inappropriate parent nodes.

### DIFF
--- a/common/tests/factories.py
+++ b/common/tests/factories.py
@@ -438,7 +438,7 @@ indent_path_generator = string_generator(4)
 
 def build_indent_path(good_indent_node):
     parent = good_indent_node.parent
-    if parent:
+    if parent is not None:
         parent.numchild += 1
         parent.save()
         return parent.path + indent_path_generator()
@@ -638,7 +638,7 @@ class QuotaEventFactory(TrackedModelMixin):
 
     @factory.lazy_attribute
     def data(self):
-        now = "{:%Y-%m-%d}".format(Dates().now)
+        now = f"{Dates().now:%Y-%m-%d}"
         if self.subrecord_code == "00":
             return {
                 "old.balance": "0.0",
@@ -731,7 +731,7 @@ class MeasureActionFactory(TrackedModelMixin, ValidityFactoryMixin):
     class Meta:
         model = "measures.MeasureAction"
 
-    code = factory.Sequence(lambda x: "{0:02d}".format(x + 1))
+    code = factory.Sequence(lambda x: f"{x + 1:02d}")
     description = short_description()
 
 

--- a/common/tests/util.py
+++ b/common/tests/util.py
@@ -27,7 +27,7 @@ from importer.management.commands.import_taric import import_taric
 from workbaskets.validators import WorkflowStatus
 
 INTERDEPENDENT_IMPORT_IMPLEMENTED = True
-UPDATE_IMPORTER_IMPLEMENTED = False
+UPDATE_IMPORTER_IMPLEMENTED = True
 EXPORT_REFUND_NOMENCLATURE_IMPLEMENTED = False
 COMMODITIES_IMPLEMENTED = True
 MEURSING_TABLES_IMPLEMENTED = False
@@ -123,7 +123,7 @@ def validate_taric_xml_record_order(xml):
             full_code = record_code + subrecord_code
             if full_code < last_code:
                 raise TaricDataAssertionError(
-                    f"Elements out of order in XML: {last_code}, {full_code}"
+                    f"Elements out of order in XML: {last_code}, {full_code}",
                 )
             last_code = full_code
 

--- a/common/util.py
+++ b/common/util.py
@@ -1,4 +1,6 @@
 """Miscellaneous utility functions."""
+from __future__ import annotations
+
 from typing import Optional
 from typing import TypeVar
 from typing import Union
@@ -48,6 +50,15 @@ class TaricDateRange(DateRange):
         if not upper:
             bounds = "[)"
         super().__init__(lower, upper, bounds, empty)
+
+    def upper_is_greater(self, compared_date_range: TaricDateRange) -> bool:
+        if self.upper_inf and not compared_date_range.upper_inf:
+            return True
+        if (
+            None not in {self.upper, compared_date_range.upper}
+        ) and self.upper > compared_date_range.upper:
+            return True
+        return False
 
 
 # XXX keep for migrations


### PR DESCRIPTION
In some cases new Goods Nomenclature Indents are inserted in between
old indents and their children. When this happens it is important to
update the tree by migrating these children under the new indent.

This commit introduces an addition to the GoodsNomenclatureIndentHandler
post_save method, finding inappropriate parents of possible child nodes
and replacing them with the new indent.