### PR TITLE
TP-543: Update descriptions queries and fix business rules context.

### DIFF
--- a/additional_codes/models.py
+++ b/additional_codes/models.py
@@ -83,22 +83,6 @@ class AdditionalCode(TrackedModel, ValidityMixin):
         business_rules.ACN17,
     )
 
-    def get_description(self):
-        if (
-            hasattr(self, "_prefetched_objects_cache")
-            and "descriptions" in self._prefetched_objects_cache
-        ):
-            descriptions = list(self.descriptions.all())
-            return descriptions[-1] if descriptions else None
-        return self.get_descriptions().last()
-
-    def get_descriptions(self, workbasket=None):
-        return (
-            AdditionalCodeDescription.objects.latest_approved()
-            .filter(described_additional_code__sid=self.sid)
-            .with_workbasket(workbasket)
-        )
-
     def in_use(self):
         return (
             self.measure_set.model.objects.filter(

--- a/certificates/models.py
+++ b/certificates/models.py
@@ -74,26 +74,6 @@ class Certificate(TrackedModel, ValidityMixin):
     def code(self):
         return self.certificate_type.sid + self.sid
 
-    def get_descriptions(self, workbasket=None):
-        return (
-            CertificateDescription.objects.latest_approved()
-            .filter(
-                described_certificate__sid=self.sid,
-                described_certificate__certificate_type=self.certificate_type,
-            )
-            .with_workbasket(workbasket)
-        )
-
-    def get_description(self):
-        if (
-            hasattr(self, "_prefetched_objects_cache")
-            and "descriptions" in self._prefetched_objects_cache
-        ):
-            descriptions = list(self.descriptions.all())
-            return descriptions[-1] if descriptions else None
-
-        return self.get_descriptions().last()
-
     def __str__(self):
         return self.code
 

--- a/certificates/views.py
+++ b/certificates/views.py
@@ -30,11 +30,7 @@ class CertificateTypeViewSet(viewsets.ReadOnlyModelViewSet):
 class CertificatesList(TamatoListView):
     """UI endpoint for viewing and filtering Certificates."""
 
-    queryset = (
-        Certificate.objects.latest_approved()
-        .select_related("certificate_type")
-        .prefetch_related("descriptions")
-    )
+    queryset = Certificate.objects.latest_approved().select_related("certificate_type")
     template_name = "certificates/list.jinja"
     filterset_class = CertificateFilter
     search_fields = [
@@ -48,8 +44,4 @@ class CertificatesList(TamatoListView):
 class CertificateDetail(TrackedModelDetailView):
     model = Certificate
     template_name = "certificates/detail.jinja"
-    queryset = (
-        Certificate.objects.latest_approved()
-        .select_related("certificate_type")
-        .prefetch_related("descriptions")
-    )
+    queryset = Certificate.objects.latest_approved().select_related("certificate_type")

--- a/commodities/models.py
+++ b/commodities/models.py
@@ -68,22 +68,6 @@ class GoodsNomenclature(TrackedModel, ValidityMixin):
         business_rules.NIG35,
     )
 
-    def get_description(self):
-        if (
-            hasattr(self, "_prefetched_objects_cache")
-            and "descriptions" in self._prefetched_objects_cache
-        ):
-            descriptions = list(self.descriptions.all())
-            return descriptions[-1] if descriptions else None
-        return self.get_descriptions().last()
-
-    def get_descriptions(self, workbasket=None):
-        return (
-            GoodsNomenclatureDescription.objects.latest_approved()
-            .filter(described_goods_nomenclature__sid=self.sid)
-            .with_workbasket(workbasket)
-        )
-
     def __str__(self):
         return self.item_id
 

--- a/common/exceptions.py
+++ b/common/exceptions.py
@@ -4,3 +4,11 @@ class NoIdentifyingValuesGivenError(Exception):
 
 class AlreadyHasSuccessorError(Exception):
     pass
+
+
+class IllegalSaveError(Exception):
+    pass
+
+
+class NoDescriptionError(Exception):
+    pass

--- a/common/models/transactions.py
+++ b/common/models/transactions.py
@@ -74,7 +74,7 @@ class Transaction(TimestampedMixin):
         self.errors = []
 
         try:
-            BusinessRuleChecker(self.tracked_models.all()).validate()
+            BusinessRuleChecker(self.tracked_models.all(), self).validate()
         except BusinessRuleViolation as violation:
             self.errors.append(violation)
 

--- a/common/tests/factories.py
+++ b/common/tests/factories.py
@@ -11,6 +11,7 @@ from common.models import TrackedModel
 from common.tests.models import TestModel1
 from common.tests.models import TestModel2
 from common.tests.models import TestModel3
+from common.tests.models import TestModelDescription1
 from common.tests.util import Dates
 from common.validators import ApplicabilityCode
 from common.validators import UpdateType
@@ -304,6 +305,14 @@ class TestModel1Factory(TrackedModelMixin, ValidityFactoryMixin):
 
     name = factory.Faker("text", max_nb_chars=24)
     sid = numeric_sid()
+
+
+class TestModelDescription1Factory(TrackedModelMixin, ValidityFactoryMixin):
+    class Meta:
+        model = TestModelDescription1
+
+    described_record = factory.SubFactory(TestModel1Factory)
+    description = factory.Faker("text", max_nb_chars=500)
 
 
 class TestModel2Factory(TrackedModelMixin, ValidityFactoryMixin):

--- a/common/tests/migrations/0001_initial.py
+++ b/common/tests/migrations/0001_initial.py
@@ -95,4 +95,35 @@ class Migration(migrations.Migration):
             },
             bases=("common.trackedmodel", models.Model),
         ),
+        migrations.CreateModel(
+            name="TestModelDescription1",
+            fields=[
+                (
+                    "trackedmodel_ptr",
+                    models.OneToOneField(
+                        auto_created=True,
+                        on_delete=django.db.models.deletion.CASCADE,
+                        parent_link=True,
+                        primary_key=True,
+                        serialize=False,
+                        to="common.trackedmodel",
+                    ),
+                ),
+                ("valid_between", common.fields.TaricDateRangeField(db_index=True)),
+                ("description", models.CharField(max_length=500)),
+                (
+                    "described_record",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.PROTECT,
+                        related_name="descriptions",
+                        to="tests.testmodel1",
+                    ),
+                ),
+            ],
+            options={
+                "abstract": False,
+                "base_manager_name": "objects",
+            },
+            bases=("common.trackedmodel", models.Model),
+        ),
     ]

--- a/common/tests/models.py
+++ b/common/tests/models.py
@@ -35,3 +35,16 @@ class TestModel3(TrackedModel, ValidityMixin):
 
     sid = models.PositiveIntegerField()
     linked_model = models.ForeignKey(TestModel1, null=True, on_delete=models.PROTECT)
+
+
+class TestModelDescription1(TrackedModel, ValidityMixin):
+    __test__ = False
+    record_code = "01"
+    subrecord_code = "02"
+
+    described_record = models.ForeignKey(
+        TestModel1,
+        on_delete=models.PROTECT,
+        related_name="descriptions",
+    )
+    description = models.CharField(max_length=500)

--- a/common/tests/test_business_rules.py
+++ b/common/tests/test_business_rules.py
@@ -1,4 +1,5 @@
 from contextlib import contextmanager
+from typing import Type
 from unittest.mock import MagicMock
 from unittest.mock import patch
 
@@ -21,24 +22,25 @@ class TestRule(BusinessRule):
 
 def test_business_rule_violation_message():
     model = MagicMock()
-    violation = TestRule().violation(model)
+    violation = TestRule(model.transaction).violation(model)
 
     assert isinstance(violation, TestRule.Violation)
     assert violation.args == (None, model)
     assert violation.model == model
 
     setattr(TestRule.Violation, "__doc__", "A test message")
-    violation = TestRule().violation(model)
+    violation = TestRule(model.transaction).violation(model)
 
     assert violation.args == ("A test message", model)
 
-    violation = TestRule().violation(model, "A different message")
+    violation = TestRule(model.transaction).violation(model, "A different message")
 
     assert violation.args == ("A different message", model)
 
 
 @contextmanager
-def add_business_rules(model, rules=[], indirect=False):
+def add_business_rules(model, rules=None, indirect=False):
+    rules = rules or []
     with patch.object(
         type(model),
         f"{'indirect_' if indirect else ''}business_rules",
@@ -48,23 +50,23 @@ def add_business_rules(model, rules=[], indirect=False):
 
 
 def test_business_rules_validation():
-    model = factories.TestModel1Factory()
+    model = factories.TestModel1Factory.create()
 
     with add_business_rules(model, [TestRule]):
-        BusinessRuleChecker([model]).validate()
+        BusinessRuleChecker([model], model.transaction).validate()
 
     assert TestRule.validate.called_with(model)
 
 
 def test_indirect_business_rule_validation():
-    model = factories.TestModel3Factory()
+    model = factories.TestModel3Factory.create()
 
     with add_business_rules(model, [TestRule]), add_business_rules(
         model.linked_model,
         [TestRule],
         indirect=True,
     ):
-        BusinessRuleChecker([model.linked_model]).validate()
+        BusinessRuleChecker([model.linked_model], model.transaction).validate()
 
     assert TestRule.validate.called_with(model)
 
@@ -75,42 +77,42 @@ def test_indirect_business_rule_validation():
         NoOverlapping,
     ],
 )
-def rule(request):
+def rule(request) -> Type[BusinessRule]:
     return request.param
 
 
 def test_rule_with_no_other_models(rule):
-    model = factories.TestModel1Factory()
-    rule().validate(model)
+    model = factories.TestModel1Factory.create()
+    rule(model.transaction).validate(model)
 
 
 def test_rule_with_no_overlaps(rule):
-    model = factories.TestModel1Factory()
-    other = factories.TestModel1Factory()
-    rule().validate(model)
-    rule().validate(other)
+    model = factories.TestModel1Factory.create()
+    other = factories.TestModel1Factory.create()
+    rule(model.transaction).validate(model)
+    rule(other.transaction).validate(other)
 
 
 def test_rule_with_versions(rule, workbasket):
-    version1 = factories.TestModel1Factory()
+    version1 = factories.TestModel1Factory.create()
     version2 = version1.new_draft(workbasket)
-    rule().validate(version1)
-    rule().validate(version2)
+    rule(version1.transaction).validate(version1)
+    rule(version2.transaction).validate(version2)
 
 
 def test_unique_identifying_fields_with_overlaps():
-    model = factories.TestModel1Factory()
-    other = factories.TestModel1Factory(sid=model.sid)
+    model = factories.TestModel1Factory.create()
+    other = factories.TestModel1Factory.create(sid=model.sid)
     with pytest.raises(BusinessRuleViolation):
-        UniqueIdentifyingFields().validate(model)
+        UniqueIdentifyingFields(other.transaction).validate(model)
     with pytest.raises(BusinessRuleViolation):
-        UniqueIdentifyingFields().validate(other)
+        UniqueIdentifyingFields(other.transaction).validate(other)
 
 
 def test_unique_identifying_fields_with_custom_fields():
-    model = factories.TestModel2Factory()
-    UniqueIdentifyingFields().validate(model)
+    model = factories.TestModel2Factory.create()
+    UniqueIdentifyingFields(model.transaction).validate(model)
 
-    other = factories.TestModel2Factory(custom_sid=model.custom_sid)
+    other = factories.TestModel2Factory.create(custom_sid=model.custom_sid)
     with pytest.raises(BusinessRuleViolation):
-        UniqueIdentifyingFields().validate(other)
+        UniqueIdentifyingFields(other.transaction).validate(other)

--- a/footnotes/models.py
+++ b/footnotes/models.py
@@ -101,25 +101,6 @@ class Footnote(TrackedModel, ValidityMixin):
             },
         )
 
-    def get_descriptions(self, workbasket=None):
-        return (
-            FootnoteDescription.objects.latest_approved()
-            .filter(
-                described_footnote__footnote_id=self.footnote_id,
-                described_footnote__footnote_type=self.footnote_type,
-            )
-            .with_workbasket(workbasket)
-        )
-
-    def get_description(self):
-        if (
-            hasattr(self, "_prefetched_objects_cache")
-            and "descriptions" in self._prefetched_objects_cache
-        ):
-            descriptions = list(self.descriptions.all())
-            return descriptions[-1] if descriptions else None
-        return self.get_descriptions().last()
-
     def _used_in(self, dependent_type: Type[TrackedModel]):
         # TODO this should respect deletes
         return dependent_type.objects.filter(

--- a/geo_areas/business_rules.py
+++ b/geo_areas/business_rules.py
@@ -70,7 +70,7 @@ class GA5(BusinessRule):
                 parent__isnull=False,
                 sid=geo_area.sid,
             )
-            .approved_up_to_transaction(geo_area.transaction)
+            .approved_up_to_transaction(self.transaction)
             .exclude(
                 parent__valid_between__contains=F("valid_between"),
             )

--- a/geo_areas/models.py
+++ b/geo_areas/models.py
@@ -69,22 +69,6 @@ class GeographicalArea(TrackedModel, ValidityMixin):
         business_rules.GA22,
     )
 
-    def get_description(self):
-        if (
-            hasattr(self, "_prefetched_objects_cache")
-            and "descriptions" in self._prefetched_objects_cache
-        ):
-            descriptions = list(self.descriptions.all())
-            return descriptions[-1] if descriptions else None
-        return self.get_descriptions().last()
-
-    def get_descriptions(self, workbasket=None):
-        return (
-            GeographicalAreaDescription.objects.latest_approved()
-            .filter(area__sid=self.sid)
-            .with_workbasket(workbasket)
-        )
-
     def get_current_memberships(self):
         return (
             GeographicalMembership.objects.filter(

--- a/regulations/models.py
+++ b/regulations/models.py
@@ -227,6 +227,7 @@ class Regulation(TrackedModel):
                 generating_regulation__regulation_id=self.regulation_id,
                 generating_regulation__role_type=self.role_type,
             )
+            .approved_up_to_transaction(transaction=self.transaction)
             .exists()
         )
 


### PR DESCRIPTION
Currently described models don't have an obvious single mechanism for
fetching related descriptions. `.descriptions` would be the logical
method, however this only provides descriptions directly attached to
the given version, which is innacurate.

This commit introduces a generic `.get_descriptions` method on the
`TrackedModel` class so all described `TrackedModels` can automatically
fetch all related descriptions. This method optionally takes a
`Transaction` which triggers the query to use `approved_up_to_transaction`
by default it will use `latest_approved`.

In this process it was discovered that business rules currently don't pay
attention to the current transaction - only the given models transaction.
As business rules now often cross multiple transactions, including
transactions which were made after the given model, it is important
that the correct transaction is provided to the business rules.

This commit therefore also introduces a transaction argument when
initialising a business rule so it can make the correct query.