### PR TITLE
Check validation rules on import and log them as errors.

### DIFF
--- a/additional_codes/business_rules.py
+++ b/additional_codes/business_rules.py
@@ -8,6 +8,7 @@ from common.business_rules import NoOverlapping
 from common.business_rules import PreventDeleteIfInUse
 from common.business_rules import UniqueIdentifyingFields
 from common.business_rules import ValidityPeriodContained
+from common.business_rules import ValidityPeriodContains
 
 
 class CT1(UniqueIdentifyingFields):
@@ -59,25 +60,12 @@ class ACN4(NoOverlapping):
     )
 
 
-class ACN13(BusinessRule):
+class ACN13(ValidityPeriodContains):
     """When an additional code is used in an additional code nomenclature
     measure then the validity period of the additional code must span the
     validity period of the measure."""
 
-    def validate(self, additional_code):
-        Measure = additional_code.measure_set.model
-        if (
-            Measure.objects.filter(
-                additional_code__sid=additional_code.sid,
-            )
-            .with_effective_valid_between()
-            .approved_up_to_transaction(additional_code.transaction)
-            .exclude(
-                db_effective_valid_between__contained_by=additional_code.valid_between,
-            )
-            .exists()
-        ):
-            raise self.violation(additional_code)
+    contained_field_name = "measure"
 
 
 class ACN17(ValidityPeriodContained):

--- a/commodities/import_handlers.py
+++ b/commodities/import_handlers.py
@@ -2,8 +2,6 @@ import logging
 import random
 import time
 from datetime import timedelta
-from typing import Any
-from typing import Optional
 
 from dateutil.relativedelta import relativedelta
 from django.db import transaction
@@ -14,19 +12,12 @@ from commodities import models
 from commodities import serializers
 from commodities.exceptions import InvalidIndentError
 from common.util import TaricDateRange
+from common.util import maybe_min
 from common.validators import UpdateType
 from footnotes.models import Footnote
 from importer.handlers import BaseHandler
 
 logger = logging.getLogger(__name__)
-
-
-def maybe_min(*objs: Optional[Any]) -> Optional[Any]:
-    present = [d for d in objs if d is not None]
-    if any(present):
-        return min(present)
-    else:
-        return None
 
 
 class GoodsNomenclatureHandler(BaseHandler):

--- a/common/business_rules.py
+++ b/common/business_rules.py
@@ -243,7 +243,7 @@ class ValidityPeriodContained(BusinessRule):
 
         if not container:
             # TODO should this raise an exception?
-            log.warning(
+            log.debug(
                 "Skipping %s: Container field %s not found.",
                 self.__class__.__name__,
                 self.container_field_name,

--- a/common/models/mixins.py
+++ b/common/models/mixins.py
@@ -32,5 +32,22 @@ class ValidityMixin(models.Model):
 
     valid_between = TaricDateRangeField(db_index=True)
 
+    validity_field_name: str = "valid_between"
+    """The name of the field that should be used for validity date checking."""
+
+    @classmethod
+    def objects_with_validity_field(cls):
+        """
+        Returns a QuerySet which will have this model's validity date field (as
+        specified by :attr:`validity_field_name`) present on the returned
+        models.
+
+        The need for this is that some models (e.g.
+        :class:`~measures.models.Measure`) use a validity date that is computed
+        on demand as part of a database query and hence is not present on the
+        default queryset.
+        """
+        return cls.objects
+
     class Meta:
         abstract = True

--- a/common/models/records.py
+++ b/common/models/records.py
@@ -570,8 +570,6 @@ class TrackedModel(PolymorphicModel):
         identifying_fields = identifying_fields or self.identifying_fields
         fields = {}
 
-        identifying_fields = identifying_fields or self.identifying_fields
-
         for field in identifying_fields:
             value = self
             for layer in field.split("__"):

--- a/common/tests/test_serializers.py
+++ b/common/tests/test_serializers.py
@@ -79,7 +79,10 @@ def test_envelope_serializer_outputs_expected_items(approved_workbasket):
 
     output = io.BytesIO()
     with EnvelopeSerializer(output, random.randint(2, 9999)) as env:
-        env.render_transaction(approved_workbasket.tracked_models.all())
+        env.render_transaction(
+            models=approved_workbasket.tracked_models.all(),
+            transaction_id=tx.order,
+        )
 
     output_xml = etree.XML(output.getvalue())
     output_record_codes = {*taric_xml_record_codes(output_xml)}

--- a/exporter/serializers.py
+++ b/exporter/serializers.py
@@ -74,7 +74,7 @@ class MultiFileEnvelopeTransactionSerializer(EnvelopeSerializer):
                 #
                 continue
 
-            envelope_body = self.render_envelope_body(tracked_models)
+            envelope_body = self.render_envelope_body(tracked_models, transaction.order)
             envelope_body_size = len(envelope_body.encode())
             if self.is_envelope_full(envelope_body_size):
                 oversize = not self.can_fit_one_envelope(

--- a/geo_areas/business_rules.py
+++ b/geo_areas/business_rules.py
@@ -252,11 +252,13 @@ class GA20(BusinessRule):
     area group."""
 
     def validate(self, membership):
+        if not membership.geo_group.parent:
+            return
+
         parent = membership.geo_group.parent_current
 
         if (
-            parent
-            and parent.members.filter(
+            parent.members.filter(
                 member__sid=membership.member.sid,
             )
             .approved_up_to_transaction(membership.transaction)

--- a/geo_areas/business_rules.py
+++ b/geo_areas/business_rules.py
@@ -8,6 +8,7 @@ from common.business_rules import MustExist
 from common.business_rules import NoOverlapping
 from common.business_rules import PreventDeleteIfInUse
 from common.business_rules import UniqueIdentifyingFields
+from common.business_rules import ValidityPeriodContains
 from common.business_rules import only_applicable_after
 from geo_areas.validators import AreaCode
 
@@ -125,24 +126,12 @@ class GA7(NoOverlapping):
     identifying_fields = ("area_id",)
 
 
-class GA10(BusinessRule):
+class GA10(ValidityPeriodContains):
     """When a geographical area is referenced in a measure then the validity
     period of the geographical area must span the validity period of the
     measure."""
 
-    def validate(self, geo_area):
-        if (
-            geo_area.measures.model.objects.filter(
-                geographical_area__sid=geo_area.sid,
-            )
-            .approved_up_to_transaction(geo_area.transaction)
-            .with_effective_valid_between()
-            .exclude(
-                db_effective_valid_between__contained_by=geo_area.valid_between,
-            )
-            .exists()
-        ):
-            raise self.violation(geo_area)
+    contained_field_name = "measures"
 
 
 class GA11(BusinessRule):

--- a/geo_areas/models.py
+++ b/geo_areas/models.py
@@ -66,7 +66,6 @@ class GeographicalArea(TrackedModel, ValidityMixin):
         business_rules.GA7,
         business_rules.GA10,
         business_rules.GA11,
-        business_rules.GA12,
         business_rules.GA21,
         business_rules.GA22,
     )
@@ -132,6 +131,7 @@ class GeographicalMembership(TrackedModel, ValidityMixin):
     identifying_fields = ("geo_group__sid", "member__sid")
 
     business_rules = (
+        business_rules.GA12,
         business_rules.GA13,
         business_rules.GA16,
         business_rules.GA17,

--- a/importer/management/commands/import_taric.py
+++ b/importer/management/commands/import_taric.py
@@ -7,15 +7,22 @@ from workbaskets.validators import WorkflowStatus
 
 
 def import_taric(
-    taric3_file, username, status, name, split_codes: bool = False, dependencies=None
+    taric3_file,
+    username,
+    status,
+    name,
+    split_codes: bool = False,
+    dependencies=None,
 ):
     batch = setup_batch(
-        batch_name=name, dependencies=dependencies, split_on_code=split_codes
+        batch_name=name,
+        dependencies=dependencies,
+        split_on_code=split_codes,
     )
     with open(taric3_file, "rb") as seed_file:
         batch = chunk_taric(seed_file, batch)
 
-    run_batch(batch.name, username, status)
+    run_batch(batch.name, status, username)
 
 
 class Command(BaseCommand):

--- a/importer/taric.py
+++ b/importer/taric.py
@@ -28,6 +28,9 @@ from taric.models import EnvelopeTransaction
 from workbaskets.models import WorkBasket
 from workbaskets.validators import WorkflowStatus
 
+if settings.SENTRY_ENABLED:
+    from sentry_sdk import capture_exception
+
 logger = logging.getLogger(__name__)
 
 now = time.time()
@@ -131,6 +134,8 @@ class TransactionParser(ElementParser):
         except ValidationError as e:
             for message in e.messages:
                 logger.error(message)
+            if settings.SENTRY_ENABLED:
+                capture_exception(e)
 
     def end(self, element: etree.Element):
         super().end(element)

--- a/measures/business_rules.py
+++ b/measures/business_rules.py
@@ -11,6 +11,7 @@ from common.business_rules import MustExist
 from common.business_rules import PreventDeleteIfInUse
 from common.business_rules import UniqueIdentifyingFields
 from common.business_rules import ValidityPeriodContained
+from common.business_rules import ValidityPeriodContains
 from common.business_rules import only_applicable_after
 from common.util import TaricDateRange
 from common.util import validity_range_contains_range
@@ -61,11 +62,11 @@ class MT1(UniqueIdentifyingFields):
     """The measure type code must be unique."""
 
 
-class MT3(MeasureValidityPeriodContained):
+class MT3(ValidityPeriodContains):
     """When a measure type is used in a measure then the validity period of the
     measure type must span the validity period of the measure."""
 
-    container_field_name = "measure_type"
+    contained_field_name = "measure"
 
 
 class MT4(MustExist):

--- a/measures/models.py
+++ b/measures/models.py
@@ -78,13 +78,6 @@ class MeasurementUnit(TrackedModel, ValidityMixin):
         business_rules.ME51,
         business_rules.ME63,
     )
-    business_rules = (
-        business_rules.MT1,
-        business_rules.MT3,
-        business_rules.MT4,
-        business_rules.MT7,
-        business_rules.MT10,
-    )
 
 
 class MeasurementUnitQualifier(TrackedModel, ValidityMixin):
@@ -263,6 +256,13 @@ class MeasureType(TrackedModel, ValidityMixin):
         business_rules.ME1,
         business_rules.ME10,
         business_rules.ME88,
+    )
+    business_rules = (
+        business_rules.MT1,
+        business_rules.MT3,
+        business_rules.MT4,
+        business_rules.MT7,
+        business_rules.MT10,
     )
 
     def in_use(self):
@@ -515,6 +515,8 @@ class Measure(TrackedModel, ValidityMixin):
 
     objects = PolymorphicManager.from_queryset(MeasuresQuerySet)()
 
+    validity_field_name = "db_effective_valid_between"
+
     @property
     def effective_end_date(self):
         """Measure end dates may be overridden by regulations."""
@@ -550,6 +552,10 @@ class Measure(TrackedModel, ValidityMixin):
     @property
     def effective_valid_between(self):
         return TaricDateRange(self.valid_between.lower, self.effective_end_date)
+
+    @classmethod
+    def objects_with_validity_field(cls):
+        return super().objects_with_validity_field().with_effective_valid_between()
 
     def has_components(self):
         return (

--- a/measures/tests/test_business_rules.py
+++ b/measures/tests/test_business_rules.py
@@ -78,7 +78,7 @@ def test_MT3(date_ranges):
     )
 
     with pytest.raises(BusinessRuleViolation):
-        business_rules.MT3(measure.transaction).validate(measure)
+        business_rules.MT3(measure.transaction).validate(measure.measure_type)
 
 
 def test_MT4(reference_nonexistent_record):

--- a/quotas/business_rules.py
+++ b/quotas/business_rules.py
@@ -6,6 +6,7 @@ from common.business_rules import BusinessRule
 from common.business_rules import PreventDeleteIfInUse
 from common.business_rules import UniqueIdentifyingFields
 from common.business_rules import ValidityPeriodContained
+from common.business_rules import ValidityPeriodContains
 from common.business_rules import only_applicable_after
 from common.validators import UpdateType
 from geo_areas.validators import AreaCode
@@ -105,44 +106,20 @@ class ON8(ON7):
 
 
 @only_applicable_after("2007-12-31")
-class ON9(BusinessRule):
+class ON9(ValidityPeriodContains):
     """When a quota order number is used in a measure then the validity period
     of the quota order number must span the validity period of the measure."""
 
-    def validate(self, order_number):
-        if (
-            order_number.measure_set.model.objects.filter(
-                order_number__sid=order_number.sid,
-            )
-            .with_effective_valid_between()
-            .exclude(
-                db_effective_valid_between__contained_by=order_number.valid_between,
-            )
-            .exists()
-        ):
-            raise self.violation(order_number)
+    contained_field_name = "measure"
 
 
 @only_applicable_after("2007-12-31")
-class ON10(BusinessRule):
+class ON10(ValidityPeriodContains):
     """When a quota order number is used in a measure then the validity period
     of the quota order number origin must span the validity period of the
     measure."""
 
-    def validate(self, origin):
-        # XXX should this take a QuotaOrderNumber and check all related
-        # QuotaOrderNumberOrigins?
-        if (
-            origin.order_number.measure_set.model.objects.filter(
-                order_number__sid=origin.order_number.sid,
-            )
-            .with_effective_valid_between()
-            .exclude(
-                db_effective_valid_between__contained_by=origin.valid_between,
-            )
-            .exists()
-        ):
-            raise self.violation(origin)
+    contained_field_name = "order_number__measure"
 
 
 @only_applicable_after("2007-12-31")

--- a/quotas/business_rules.py
+++ b/quotas/business_rules.py
@@ -271,9 +271,27 @@ class QA2(ValidityPeriodContained):
 
 
 class QA3(BusinessRule):
-    """When converted to the measurement unit of the main quota, the volume of a
+    """
+    When converted to the measurement unit of the main quota, the volume of a
     sub-quota must always be lower than or equal to the volume of the main
-    quota."""
+    quota.
+
+    (The wording of this rule implies that quotas with different units can be
+    linked together and there is no business rule that prevents this from
+    happening. However, historically there have been no quotas where the units
+    have been different and we should maintain this going forward as the system
+    has no conversion ratios or other way of relating units to each other.)
+    """
+
+    def validate(self, association):
+        main = association.main_quota
+        sub = association.sub_quota
+        if not (
+            sub.measurement_unit == main.measurement_unit
+            and sub.volume <= main.volume
+            and sub.initial_volume <= main.initial_volume
+        ):
+            raise self.violation(association)
 
 
 class QA4(BusinessRule):

--- a/settings/common.py
+++ b/settings/common.py
@@ -345,7 +345,9 @@ LOGGING = {
 
 # -- Sentry error tracking
 
-if os.environ.get("SENTRY_DSN"):
+SENTRY_ENABLED = is_truthy(os.environ.get("SENTRY_DSN", "False"))
+
+if SENTRY_ENABLED:
     import sentry_sdk
     from sentry_sdk.integrations.django import DjangoIntegration
     from sentry_sdk.integrations.redis import RedisIntegration


### PR DESCRIPTION
Previously the clean method on workbaskets was not implemented, so there was no validation performed on import.

But also, running against the entire workbasket is not what we want – as per ADR 12, validations need to be performed after every transaction.

This commit changes our import validation to run business rules after every transaction, but also implements a clean method for a workbasket as well (it will be useful later).

Notably we also no longer halt an import run when an error is found and instead just print an error. The reason for this is that when importing we are normally importing well-formed XML and business rule violations are (at the moment) normally an indication that our implementations are wrong. Plus, it's much easier to debug data when it is in the database rather than in the XML files. So this gives us the option to do that more easily.

When we come around to implementing receipt parsing and marking individual transactions as errored in TP-452, we can change this behaviour and as well as logging an error we can mark the individual transaction as being in an error state.