### PR TITLE
TP-610 Fix measures filter issues

### DIFF
--- a/measures/filters.py
+++ b/measures/filters.py
@@ -8,6 +8,7 @@ from django_filters import CharFilter
 from django_filters import ChoiceFilter
 from django_filters import DateFilter
 
+from additional_codes.filters import COMBINED_ADDITIONAL_CODE_AND_TYPE_ID
 from common.filters import TamatoFilter
 from common.forms import DateInputFieldFixed
 from footnotes.filters import COMBINED_FOOTNOTE_AND_TYPE_ID
@@ -47,7 +48,7 @@ class MeasureFilter(TamatoFilter):
 
     additional_code = CharFilter(
         label="Additional code",
-        field_name="additional_code__sid",
+        method="filter_additional_code",
     )
 
     geographical_area = CharFilter(
@@ -57,7 +58,7 @@ class MeasureFilter(TamatoFilter):
 
     order_number = CharFilter(
         label="Quota order number",
-        field_name="order_number__sid",
+        field_name="order_number__order_number",
     )
 
     regulation = CharFilter(
@@ -96,6 +97,17 @@ class MeasureFilter(TamatoFilter):
     clear_url = reverse_lazy("measure-ui-list")
 
     def date_modifier(self, queryset, name, value):
+        return queryset
+
+    def filter_additional_code(self, queryset, name, value):
+        if value:
+            match = COMBINED_ADDITIONAL_CODE_AND_TYPE_ID.match(value)
+            if match:
+                return queryset.filter(
+                    additional_code__code=match.group("code"),
+                    additional_code__type__sid=match.group("type__sid"),
+                )
+            return queryset.none()
         return queryset
 
     def filter_footnotes(self, queryset, name, value):

--- a/measures/jinja2/includes/measures/list.jinja
+++ b/measures/jinja2/includes/measures/list.jinja
@@ -16,9 +16,9 @@
     {"text": measure.measure_type.sid ~ " - " ~ measure.measure_type.description},
     {"text": measure.goods_nomenclature.item_id|wordwrap(2)|replace("\n", " ") if measure.goods_nomenclature else '-', "classes": "govuk-!-width-one-eighth"},
     {"text": measure.duty_sentence if measure.duty_sentence else '-'},
-    {"html": create_link(url("additional_code-ui-detail", kwargs={"sid": measure.additional_code.sid}),measure.additional_code.sid) if measure.additional_code else '-'},
+    {"html": create_link(url("additional_code-ui-detail", kwargs={"sid": measure.additional_code.sid}), measure.additional_code.type.sid ~ measure.additional_code.code) if measure.additional_code else '-'},
     {"html": create_link(url("geoarea-ui-detail", kwargs={"sid": measure.geographical_area.sid}), measure.geographical_area.area_id ~ " - " ~ measure.geographical_area.get_description().description) if measure.geographical_area else '-'},
-    {"text": measure.order_number.sid if measure.order_number else '-'},
+    {"text": create_link(measure.order_number.get_url(), measure.order_number.order_number) if measure.order_number else '-'},
     {"text": footnotes if measure.footnotes.all() else '-'},
     {"text": conditions_list(measure) if measure.conditions.latest_approved() else "-", "classes": "govuk-!-width-one-quarter"},
   ]) or "" }}

--- a/measures/jinja2/includes/measures/tabs/core_data.jinja
+++ b/measures/jinja2/includes/measures/tabs/core_data.jinja
@@ -53,7 +53,7 @@
     },
     {
         "key": {"text": "End date"},
-        "value": {"text":  "{:%d %b %Y}".format(measure.valid_between.upper) if measure.valid_between.upper else "-"},
+        "value": {"text":  "{:%d %b %Y}".format(measure.effective_end_date) if measure.effective_end_date else "-"},
         "actions": {"items": []}
     },
     {

--- a/measures/views.py
+++ b/measures/views.py
@@ -7,7 +7,7 @@ from measures.filters import MeasureFilter
 class MeasureList(TamatoListView):
     """UI endpoint for viewing and filtering Measures."""
 
-    queryset = models.Measure.objects.with_duty_sentence()
+    queryset = models.Measure.objects.with_duty_sentence().latest_approved()
     template_name = "measures/list.jinja"
     filterset_class = MeasureFilter
 


### PR DESCRIPTION
- Change additional code filter to work on the type / code setup we currently display, also changed the list view to show that. 
- Changed the end date on the measure detail page to be the effective end date  
- Changed the quota filter to work on the order number, and the list view also to show it (also links off to the quota detail page now)
- Made list view only search for latest approved measures