### PR TITLE
Remove deprecated get_url methods

### DIFF
--- a/measures/models.py
+++ b/measures/models.py
@@ -1,7 +1,6 @@
 from datetime import date
 
 from django.db import models
-from django.urls import reverse
 from polymorphic.managers import PolymorphicManager
 
 from common.fields import ApplicabilityCode
@@ -573,14 +572,6 @@ class Measure(TrackedModel, ValidityMixin):
             )
             .filter(condition__dependent_measure__sid=self.sid)
             .exists()
-        )
-
-    def get_url(self, action="detail"):
-        return reverse(
-            f"measure-ui-{action}",
-            kwargs={
-                "sid": self.sid,
-            },
         )
 
     def get_conditions(self):

--- a/quotas/models.py
+++ b/quotas/models.py
@@ -2,7 +2,6 @@ from decimal import Decimal
 
 from django.core.serializers.json import DjangoJSONEncoder
 from django.db import models
-from django.urls import reverse
 
 from common.fields import ShortDescription
 from common.fields import SignedIntSID
@@ -66,14 +65,6 @@ class QuotaOrderNumber(TrackedModel, ValidityMixin):
         return self.measure_set.model.objects.filter(
             order_number__sid=self.sid,
         ).exists()
-
-    def get_url(self, action="detail"):
-        return reverse(
-            f"quota-ui-{action}",
-            kwargs={
-                "sid": self.sid,
-            },
-        )
 
     class Meta:
         verbose_name = "quota"

--- a/regulations/models.py
+++ b/regulations/models.py
@@ -1,7 +1,6 @@
 from django.core.validators import MaxValueValidator
 from django.core.validators import RegexValidator
 from django.db import models
-from django.urls import reverse
 
 from common.fields import ShortDescription
 from common.fields import TaricDateRangeField
@@ -230,15 +229,6 @@ class Regulation(TrackedModel):
             )
             .approved_up_to_transaction(transaction=self.transaction)
             .exists()
-        )
-
-    def get_url(self, action="detail"):
-        return reverse(
-            f"regulation-ui-{action}",
-            kwargs={
-                "role_type": self.role_type,
-                "regulation_id": self.regulation_id,
-            },
         )
 
 


### PR DESCRIPTION
These implementations broke when called in the measures, quotas and regulations detail templates.

A working and generic implementation is provided in TrackedModel, so these methods are
no longer needed.