### PR TITLE
TP-669: Remove references to the workbasket on a change.

### DIFF
--- a/common/jinja2/common/confirm_update.jinja
+++ b/common/jinja2/common/confirm_update.jinja
@@ -24,7 +24,7 @@
       
       {{ govukPanel({
         "titleText": object._meta.verbose_name|capitalize ~ " " ~ object|string ~ " has been updated.",
-        "text": "This change has been added to " ~ request.session.workbasket.title,
+        "text": "This change has been added to your tariff changes",
         "classes": "govuk-!-margin-bottom-7"
       }) }}
 

--- a/footnotes/jinja2/footnotes/confirm_update.jinja
+++ b/footnotes/jinja2/footnotes/confirm_update.jinja
@@ -18,7 +18,7 @@
 {% block content %}
   {{ govukPanel({
     "titleText": "Footnote " ~ object|string ~ " has been updated.",
-    "html": "This change has been added to your workbasket<br>" ~ request.session.workbasket.title
+    "text": "This change has been added to your tariff changes"
   }) }}
 
   <h2 class="govuk-heading-m">Next steps</h2>

--- a/footnotes/jinja2/footnotes/confirm_update_description.jinja
+++ b/footnotes/jinja2/footnotes/confirm_update_description.jinja
@@ -18,7 +18,7 @@
 {% block content %}
   {{ govukPanel({
     "titleText": "The description for footnote " ~ object.described_footnote|string ~ " has been updated.",
-    "html": "This change has been added to your workbasket<br>" ~ request.session.workbasket.title
+    "text": "This change has been added to your tariff changes"
   }) }}
 
   <h2 class="govuk-heading-m">Next steps</h2>


### PR DESCRIPTION
Currently when succesfully changing a model the workbasket is referenced.
This is unnecessary. Therefore this commit removes the reference to the
workbasket.