### PR TITLE
TP-655: Added more tests for the importer system.

### DIFF
--- a/common/tests/factories.py
+++ b/common/tests/factories.py
@@ -15,6 +15,7 @@ from common.tests.models import TestModelDescription1
 from common.tests.util import Dates
 from common.validators import ApplicabilityCode
 from common.validators import UpdateType
+from importer.models import ImporterChunkStatus
 from measures.validators import DutyExpressionId
 from measures.validators import ImportExportCode
 from measures.validators import MeasureTypeCombination
@@ -933,8 +934,22 @@ class ImportBatchFactory(factory.django.DjangoModelFactory):
     name = factory.sequence(str)
 
 
-class ImporterXMLChunk(factory.django.DjangoModelFactory):
+class ImporterXMLChunkFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = "importer.ImporterXMLChunk"
 
     batch = factory.SubFactory(ImportBatchFactory)
+    chunk_number = 1
+    status = ImporterChunkStatus.WAITING
+    chunk_text = """\
+<?xml version="1.0" encoding="UTF-8"?>
+<env:envelope xmlns="urn:publicid:-:DGTAXUD:TARIC:MESSAGE:1.0" xmlns:env="urn:publicid:-:DGTAXUD:GENERAL:ENVELOPE:1.0" id="1">
+</env:envelope>"""
+
+
+class BatchDependenciesFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = "importer.BatchDependencies"
+
+    dependent_batch = factory.SubFactory(ImportBatchFactory)
+    depends_on = factory.SubFactory(ImportBatchFactory)

--- a/importer/tasks.py
+++ b/importer/tasks.py
@@ -130,6 +130,7 @@ def find_and_run_next_batch_chunks(
         setup_chunk_task(batch, status, username)
         return
 
+    # If the job is a split job (should only be used for seed files) the following logic applies.
     dependency_tree = build_dependency_tree()
 
     record_codes = set(

--- a/importer/tests/conftest.py
+++ b/importer/tests/conftest.py
@@ -5,9 +5,10 @@ from rest_framework.serializers import ModelSerializer
 
 from common.tests import factories
 from common.tests.models import TestModel1
+from importer import models
 from importer.handlers import BaseHandler
-from importer.nursery import get_nursery
 from importer.nursery import TariffObjectNursery
+from importer.nursery import get_nursery
 from importer.utils import DispatchedObjectType
 
 
@@ -57,7 +58,7 @@ def handler_class_with_links(mock_serializer) -> Type[BaseHandler]:
             {
                 "model": TestModel1,
                 "name": "test_model_1",
-            }
+            },
         ]
         serializer_class = mock_serializer
         tag = "test_handler"
@@ -90,7 +91,9 @@ def prepped_handler(object_nursery, handler_class, handler_test_data) -> BaseHan
 
 @pytest.fixture
 def prepped_handler_with_dependencies1(
-    object_nursery, handler_class_with_dependencies, handler_test_data
+    object_nursery,
+    handler_class_with_dependencies,
+    handler_test_data,
 ) -> BaseHandler:
     return handler_class_with_dependencies(handler_test_data, object_nursery)
 
@@ -107,8 +110,28 @@ def prepped_handler_with_dependencies2(
 
 @pytest.fixture
 def prepped_handler_with_link(
-    handler_class_with_links, object_nursery, handler_test_data
+    handler_class_with_links,
+    object_nursery,
+    handler_test_data,
 ) -> BaseHandler:
     handler_test_data["data"]["test_model_1__sid"] = factories.TestModel1Factory().sid
 
     return handler_class_with_links(handler_test_data, object_nursery)
+
+
+@pytest.fixture
+def chunk() -> models.ImporterXMLChunk:
+    return factories.ImporterXMLChunkFactory.create()
+
+
+@pytest.fixture
+def batch() -> models.ImportBatch:
+    return factories.ImportBatchFactory.create()
+
+
+@pytest.fixture
+def batch_dependency() -> models.BatchDependencies:
+    dependencies = factories.BatchDependenciesFactory.create()
+    factories.ImporterXMLChunkFactory.create(batch=dependencies.depends_on)
+    factories.ImporterXMLChunkFactory.create(batch=dependencies.dependent_batch)
+    return dependencies

--- a/importer/tests/test_nursery.py
+++ b/importer/tests/test_nursery.py
@@ -1,5 +1,9 @@
 import pytest
 
+from common.tests import factories
+from common.tests.models import TestModel1
+from common.validators import UpdateType
+from footnotes.models import Footnote
 from importer import nursery
 
 
@@ -10,6 +14,42 @@ def test_nursery_gets_handler_with_tag(object_nursery, handler_class):
 def test_nursery_throws_error_on_no_handler(object_nursery):
     with pytest.raises(nursery.HandlerDoesNotExistError):
         object_nursery.get_handler("non-existent-tag")
+
+
+@pytest.mark.django_db
+def test_nursery_clears_cache(
+    handler_class,
+    object_nursery,
+    date_ranges,
+    unapproved_transaction,
+):
+    handler = handler_class(
+        {
+            "data": {
+                "sid": 1,
+                "name": "clears_cache",
+                "update_type": UpdateType.CREATE,
+                "valid_between": {
+                    "lower": date_ranges.normal.lower,
+                    "upper": date_ranges.normal.upper,
+                },
+            },
+            "tag": handler_class.tag,
+            "transaction_id": unapproved_transaction.pk,
+        },
+        object_nursery,
+    )
+    object_nursery._cache_handler(handler)
+
+    assert TestModel1.objects.count() == 0
+    assert object_nursery.cache.get(handler.key)
+
+    object_nursery.clear_cache()
+
+    assert object_nursery.cache.get(handler.key) is None
+    assert TestModel1.objects.count() == 1
+    assert TestModel1.objects.get().name == "clears_cache"
+    assert TestModel1.objects.get().sid == 1
 
 
 def test_nursery_caches_object(object_nursery, handler_class):
@@ -28,3 +68,18 @@ def test_nursery_caches_object(object_nursery, handler_class):
     assert handler.data == cached_handler.data
     assert handler.tag == cached_handler.tag
     assert handler.key == cached_handler.key
+
+
+@pytest.mark.django_db
+def test_nursery_gets_object_from_cache(object_nursery):
+    instance = factories.FootnoteFactory.create()
+    object_nursery.cache_object(instance)
+
+    identifying_fields = instance.get_identifying_fields()
+
+    cached_instance = object_nursery.get_obj_from_cache(
+        Footnote,
+        identifying_fields.keys(),
+        identifying_fields,
+    )
+    assert cached_instance == (instance.pk, instance.__class__.__name__)

--- a/importer/tests/test_tasks.py
+++ b/importer/tests/test_tasks.py
@@ -1,0 +1,128 @@
+from unittest import mock
+
+import pytest
+
+from common.tests import factories
+from importer import tasks
+from importer.models import ImporterChunkStatus
+
+pytestmark = pytest.mark.django_db
+
+
+@mock.patch("importer.tasks.find_and_run_next_batch_chunks")
+def test_import_chunk(mock_find_and_run: mock.MagicMock, valid_user, chunk):
+    tasks.import_chunk(chunk.pk, "PUBLISHED", valid_user.username)
+
+    chunk.refresh_from_db()
+    assert chunk.status == ImporterChunkStatus.DONE
+    mock_find_and_run.assert_called_once_with(
+        chunk.batch,
+        "PUBLISHED",
+        valid_user.username,
+    )
+
+
+@mock.patch("importer.tasks.process_taric_xml_stream", side_effect=KeyError("test"))
+def test_import_chunk_failed(valid_user, chunk):
+    try:
+        tasks.import_chunk(chunk.pk, "PUBLISHED", valid_user.username)
+    except KeyError:
+        pass
+
+    chunk.refresh_from_db()
+    assert chunk.status == ImporterChunkStatus.ERRORED
+
+
+@mock.patch("importer.tasks.import_chunk")
+def test_setup_chunk_task_already_running(mock_import_chunk, batch, valid_user):
+    """Assert that if a batch already has a running chunk, nothing happens."""
+    factories.ImporterXMLChunkFactory.create(
+        batch=batch,
+        status=ImporterChunkStatus.RUNNING,
+    )
+    tasks.setup_chunk_task(batch, "PUBLISHED", valid_user.username)
+
+    mock_import_chunk.delay.assert_not_called()
+
+
+@mock.patch("importer.tasks.import_chunk")
+def test_setup_chunk_task_no_chunks(mock_import_chunk, batch, valid_user):
+    """Assert that if a batch has no chunks, nothing happens."""
+    tasks.setup_chunk_task(batch, "PUBLISHED", valid_user.username)
+
+    mock_import_chunk.delay.assert_not_called()
+
+
+@mock.patch("importer.tasks.import_chunk")
+def test_setup_chunk_task(mock_import_chunk, chunk, valid_user):
+    """Assert that if a batch has no running chunks, a chunk is set to run."""
+    tasks.setup_chunk_task(chunk.batch, "PUBLISHED", valid_user.username)
+
+    chunk.refresh_from_db()
+
+    assert chunk.status == ImporterChunkStatus.RUNNING
+    mock_import_chunk.delay.assert_called_once_with(
+        chunk.pk,
+        "PUBLISHED",
+        valid_user.username,
+    )
+
+
+@mock.patch("importer.tasks.setup_chunk_task")
+def test_find_and_run_next_batch_chunks_already_running(
+    mock_setup_chunk_task,
+    batch_dependency,
+    valid_user,
+):
+    """Assert that if a batch already has running chunk, nothing happens."""
+    batch_dependency.depends_on.chunks.update(status=ImporterChunkStatus.RUNNING)
+    batch = batch_dependency.dependent_batch
+    tasks.find_and_run_next_batch_chunks(batch, "PUBLISHED", valid_user.username)
+
+    mock_setup_chunk_task.assert_not_called()
+    assert list(batch.chunks.values_list("status", flat=True)) == [
+        ImporterChunkStatus.WAITING,
+    ]
+
+
+@mock.patch("importer.tasks.import_chunk")
+def test_find_and_run_next_batch_chunks_finished_runs_dependencies(
+    mock_import_chunk,
+    batch_dependency,
+    valid_user,
+):
+    """Assert that if a batch has completely finished, it's dependencies start
+    running."""
+    batch_dependency.depends_on.chunks.update(status=ImporterChunkStatus.DONE)
+    tasks.find_and_run_next_batch_chunks(
+        batch_dependency.depends_on,
+        "PUBLISHED",
+        valid_user.username,
+    )
+    batch = batch_dependency.dependent_batch
+
+    assert list(batch.chunks.values_list("status", flat=True)) == [
+        ImporterChunkStatus.RUNNING,
+    ]
+    mock_import_chunk.delay.assert_called_once_with(
+        batch.chunks.first().pk,
+        "PUBLISHED",
+        valid_user.username,
+    )
+
+
+@mock.patch("importer.tasks.import_chunk")
+def test_find_and_run_next_batch_chunks(mock_import_chunk, batch, valid_user):
+    """Assert that if a batch is not running that this starts the next chunk."""
+    for chunk_number in range(1, 3):
+        factories.ImporterXMLChunkFactory.create(batch=batch, chunk_number=chunk_number)
+
+    tasks.find_and_run_next_batch_chunks(batch, "PUBLISHED", valid_user.username)
+
+    assert batch.chunks.first().status == ImporterChunkStatus.RUNNING
+    assert batch.chunks.last().status == ImporterChunkStatus.WAITING
+    mock_import_chunk.delay.assert_called_once_with(
+        batch.chunks.first().pk,
+        "PUBLISHED",
+        valid_user.username,
+    )


### PR DESCRIPTION
Added tests for the nursery caching interface as well as the tasks.

There's still elements of the importer untested, and lots of edge cases which could have done with testing. But no time to do it in!

I'll document some of the key bits that are missing on the ticket.