### PR TITLE
TAMATO-19: Fix validity check for geo memberships

### DIFF
--- a/geo_areas/business_rules.py
+++ b/geo_areas/business_rules.py
@@ -185,7 +185,7 @@ class GA16(BusinessRule):
             )
             .approved_up_to_transaction(membership.transaction)
             .exclude(
-                member__valid_between__contained_by=membership.geo_group.valid_between,
+                valid_between__contained_by=membership.geo_group.valid_between,
             )
             .exists()
         ):


### PR DESCRIPTION
The rule as written specifies that the group must
span the *membership* period of all of its members,
but our code checked that the group spanned the
*validity* period of its members.

This commit fixes that and introduces more tests.