### PR TITLE
Calculate code coverage correctly

### DIFF
--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -63,7 +63,7 @@ jobs:
         DATABASE_URL: postgres://postgres:postgres@localhost:5432/postgres
         DJANGO_SETTINGS_MODULE: settings.test
       run: |
-        python manage.py test -- --cov --cov-report=xml --alluredir=allure-results --nomigrations
+        make test
 
     - name: Run Linter
       run: |

--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -56,7 +56,7 @@ jobs:
         DATABASE_URL: postgres://postgres:postgres@localhost:5432/postgres
         DJANGO_SETTINGS_MODULE: settings.test
       run: |
-        python manage.py test -- --cov --cov-report=xml --alluredir=allure-results --nomigrations
+        make test
 
     - name: Run Linter
       run: |

--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ coverage.xml
 *.py,cover
 .hypothesis/
 .pytest_cache/
+allure-results/
 
 # Translations
 *.mo
@@ -95,7 +96,7 @@ ipython_config.py
 __pypackages__/
 
 # Celery stuff
-celerybeat-schedule
+celerybeat-schedule*
 celerybeat.pid
 
 # SageMath parsed files
@@ -138,5 +139,8 @@ webpack-stats.json
 
 # PyCharm
 .idea/
+
+# VS Code
+.vscode/
 
 *.gz

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ export
 
 SPHINXOPTS    ?=
 
-.PHONY: help clean clean-bytecode clean-static collectstatic compilescss dependencies docker-image docker-test node_modules run test build-docs
+.PHONY: help clean clean-bytecode clean-static collectstatic compilescss dependencies docker-image docker-test node_modules run test test-fast build-docs
 
 
 
@@ -69,10 +69,16 @@ run: collectstatic migrate
 	@${PYTHON} manage.py runserver_plus 0.0.0.0:8000
 
 ## test: Run tests
-test:
+test-fast:
 	@echo
 	@echo "> Running tests..."
 	${PYTHON} manage.py test --failfast
+
+test:
+	@echo
+	@echo "> Running tests..."
+	@coverage run --source='.' manage.py test -- --alluredir=allure-results --nomigrations
+	@coverage xml
 
 ## docker-image: Build docker image
 docker-image:

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,7 +36,6 @@ psycopg2-binary==2.8.6
 pygments>=2.8
 pytest==6.2.2
 pytest-bdd==4.0.2
-pytest-cov==2.11.1
 pytest-django==4.1.0
 pytest-responses==0.4.0
 requests-oauthlib==1.3.0


### PR DESCRIPTION
At the moment our code coverage is not reported correctly. For some reason `pytest-cov` seems to initialise after Django has already loaded all of the code, meaning that our imports and definitions are reported as not hit. This is unhelpful because it clouds the real areas in the code that do not have adequate coverage.

This commit changes to calling `coverage` directly which correctly captures all of the statements.