### PR TITLE
Spring clean

### DIFF
--- a/additional_codes/filters.py
+++ b/additional_codes/filters.py
@@ -4,14 +4,14 @@ from django.contrib.postgres.aggregates import StringAgg
 from django.forms import CheckboxSelectMultiple
 from django.urls import reverse_lazy
 
-from additional_codes.models import AdditionalCode
-from additional_codes.validators import TypeChoices
+from additional_codes import models
 from common.filters import ActiveStateMixin
 from common.filters import LazyMultipleChoiceFilter
 from common.filters import StartYearMixin
 from common.filters import TamatoFilter
 from common.filters import TamatoFilterBackend
 from common.filters import TamatoFilterMixin
+from common.filters import type_choices
 
 COMBINED_ADDITIONAL_CODE_AND_TYPE_ID = re.compile(
     r"(?P<type__sid>[A-Z0-9])(?P<code>[A-Z0-9]{3})",
@@ -55,7 +55,7 @@ class AdditionalCodeFilter(
     """
 
     additional_code_type = LazyMultipleChoiceFilter(
-        choices=TypeChoices.choices,
+        choices=type_choices(models.AdditionalCodeType.objects.latest_approved()),
         widget=CheckboxSelectMultiple,
         field_name="type__sid",
         label="Additional Code Type",
@@ -66,6 +66,6 @@ class AdditionalCodeFilter(
     clear_url = reverse_lazy("additional_code-ui-list")
 
     class Meta:
-        model = AdditionalCode
+        model = models.AdditionalCode
         # Defines the order shown in the form.
         fields = ["search", "additional_code_type", "start_year", "active_state"]

--- a/additional_codes/tests/test_business_rules.py
+++ b/additional_codes/tests/test_business_rules.py
@@ -6,6 +6,7 @@ from additional_codes import models
 from additional_codes.validators import ApplicationCode
 from common.business_rules import BusinessRuleViolation
 from common.tests import factories
+from common.tests.util import raises_if
 from common.tests.util import requires_meursing_tables
 
 pytestmark = pytest.mark.django_db
@@ -88,14 +89,8 @@ def test_ACN2_allowed_application_codes(app_code, expect_error):
     additional_code = factories.AdditionalCodeFactory.create(
         type__application_code=app_code,
     )
-    try:
+    with raises_if(BusinessRuleViolation, expect_error):
         business_rules.ACN2(additional_code.transaction).validate(additional_code)
-    except BusinessRuleViolation:
-        if not expect_error:
-            raise
-    else:
-        if expect_error:
-            pytest.fail("DID NOT RAISE BusinessRuleViolation")
 
 
 def test_ACN3(date_ranges):

--- a/additional_codes/validators.py
+++ b/additional_codes/validators.py
@@ -1,7 +1,5 @@
-from django.core.exceptions import ValidationError
 from django.core.validators import RegexValidator
 from django.db.models import IntegerChoices
-from django.db.models import Subquery
 from django.db.models import TextChoices
 
 additional_code_type_sid_validator = RegexValidator(r"^[A-Z0-9]$")
@@ -40,19 +38,3 @@ class TypeChoices(TextChoices):
 
 
 additional_code_validator = RegexValidator(r"^[A-Z0-9][A-Z0-9][A-Z0-9]$")
-
-
-def validate_at_least_one_description(
-    additional_code_class,
-    description_class,
-    workbasket,
-):
-    if not description_class.objects.filter(
-        described_additional_code__sid__in=Subquery(
-            additional_code_class.objects.filter(workbasket=workbasket).values_list(
-                "sid",
-                flat=True,
-            ),
-        ),
-    ).exists():
-        raise ValidationError("At least one description record is mandatory.")

--- a/additional_codes/validators.py
+++ b/additional_codes/validators.py
@@ -1,6 +1,5 @@
 from django.core.validators import RegexValidator
 from django.db.models import IntegerChoices
-from django.db.models import TextChoices
 
 additional_code_type_sid_validator = RegexValidator(r"^[A-Z0-9]$")
 
@@ -13,28 +12,6 @@ class ApplicationCode(IntegerChoices):
     ADDITIONAL_CODES = 1, "Additional codes"
     MEURSING_ADDITIONAL_CODES = 3, "Meursing additional codes"
     EXPORT_REFUND_AGRI = 4, "Export refund for processed agricultural goods"
-
-
-class TypeChoices(TextChoices):
-    """SID choices for Additional Code Types."""
-
-    TARIFF_PREFERENCE = "2", "2 - Tariff preference"
-    PROHIBITION = "3", "3 - Prohibition / Restriction / Surveillance"
-    RESTRICTIONS = "4", "4 - Restrictions"
-    AGRICULTURAL_TABLES = "6", "6 - Agricultural Tables (non-Meursing)"
-    ANTI_DUMPING_8 = "8", "8 - Anti-dumping / countervailing"
-    EXPORT_REFUNDS = "9", "9 - Export Refunds"
-    ANTI_DUMPING_A = "A", "A - Anti-dumping / countervailing"
-    ANTI_DUMPING_B = "B", "B - Anti-dumping / countervailing"
-    ANTI_DUMPING_C = "C", "C - Anti-dumping / countervailing"
-    DUAL_USE = "D", "D - Dual Use"
-    REFUND = "P", "P - Refund for basic products"
-    TRADE_REMEDIES = (
-        "T",
-        "T - This is the additional code type for UK trade remedies from 2021",
-    )
-    VAT = "V", "V - VAT"
-    EXCISE = "X", "X - EXCISE"
 
 
 additional_code_validator = RegexValidator(r"^[A-Z0-9][A-Z0-9][A-Z0-9]$")

--- a/certificates/filters.py
+++ b/certificates/filters.py
@@ -1,30 +1,12 @@
-from crispy_forms_gds.choices import Choice
 from django import forms
 from django.contrib.postgres.aggregates import StringAgg
 from django.urls import reverse_lazy
-from django.utils.safestring import mark_safe
 
 from certificates import models
 from common.filters import ActiveStateMixin
 from common.filters import LazyMultipleChoiceFilter
 from common.filters import TamatoFilter
-from common.jinja2 import break_words
-
-
-def certificate_type_choices():
-    certificate_types = models.CertificateType.objects.latest_approved()
-    return [
-        Choice(
-            certificate_type.sid,
-            mark_safe(
-                "{0} - {1}".format(
-                    certificate_type.sid,
-                    break_words(certificate_type.description),
-                ),
-            ),
-        )
-        for certificate_type in certificate_types
-    ]
+from common.filters import type_choices
 
 
 class CertificateFilter(TamatoFilter, ActiveStateMixin):
@@ -34,7 +16,7 @@ class CertificateFilter(TamatoFilter, ActiveStateMixin):
     )  # XXX order is important
 
     certificate_type = LazyMultipleChoiceFilter(
-        choices=certificate_type_choices,
+        choices=type_choices(models.CertificateType.objects.latest_approved()),
         widget=forms.CheckboxSelectMultiple,
         field_name="certificate_type__sid",
         label="Certificate Type",

--- a/certificates/validators.py
+++ b/certificates/validators.py
@@ -1,14 +1,7 @@
-from django.core.exceptions import ValidationError
 from django.core.validators import RegexValidator
-
 
 CERTIFICATE_TYPE_SID_REGEX = r"^[A-Z0-9]{1}$"
 certificate_type_sid_validator = RegexValidator(CERTIFICATE_TYPE_SID_REGEX)
 
 CERTIFICATE_SID_REGEX = r"^[A-Z0-9]{3}$"
 certificate_sid_validator = RegexValidator(CERTIFICATE_SID_REGEX)
-
-
-def validate_description_is_not_null(certificate_description):
-    if not certificate_description.description:
-        raise ValidationError({"description": "A description cannot be blank"})

--- a/commodities/tests/test_business_rules.py
+++ b/commodities/tests/test_business_rules.py
@@ -4,6 +4,7 @@ from django.db import DataError
 from commodities import business_rules
 from common.business_rules import BusinessRuleViolation
 from common.tests import factories
+from common.tests.util import raises_if
 from common.validators import UpdateType
 
 pytestmark = pytest.mark.django_db
@@ -137,14 +138,8 @@ def test_NIG10(date_ranges, valid_between, expect_error):
             valid_between,
         ),
     )
-    try:
+    with raises_if(BusinessRuleViolation, expect_error):
         business_rules.NIG10(successor.transaction).validate(successor)
-    except BusinessRuleViolation:
-        if not expect_error:
-            raise
-    else:
-        if expect_error:
-            pytest.fail("DID NOT RAISE BusinessRuleViolation")
 
 
 def test_NIG11_one_indent_mandatory():

--- a/commodities/validators.py
+++ b/commodities/validators.py
@@ -1,4 +1,3 @@
-from django.core.exceptions import ValidationError
 from django.core.validators import RegexValidator
 
 ITEM_ID_REGEX = r"\d{10}"
@@ -6,8 +5,3 @@ item_id_validator = RegexValidator(ITEM_ID_REGEX)
 
 SUFFIX_REGEX = r"\d{2}"
 suffix_validator = RegexValidator(SUFFIX_REGEX)
-
-
-def validate_description_is_not_null(goods_description):
-    if not goods_description.description:
-        raise ValidationError({"description": "A description cannot be blank"})

--- a/common/serializers.py
+++ b/common/serializers.py
@@ -315,21 +315,6 @@ class TaricDataAssertionError(AssertionError):
     pass
 
 
-def validate_taric_xml_record_order(xml):
-    """Raise AssertionError if any record codes are not in order."""
-    for transaction in xml.findall(".//transaction"):
-        last_code = "00000"
-        for record in transaction.findall(".//record", namespaces=xml.nsmap):
-            record_code = record.findtext(".//record.code", namespaces=xml.nsmap)
-            subrecord_code = record.findtext(".//subrecord.code", namespaces=xml.nsmap)
-            full_code = record_code + subrecord_code
-            if full_code < last_code:
-                raise TaricDataAssertionError(
-                    f"Elements out of order in XML: {last_code}, {full_code}",
-                )
-            last_code = full_code
-
-
 def validate_envelope(envelope_file, skip_declaration=False):
     """
     Validate envelope content for XML issues and data order issues.

--- a/common/tests/test_filters.py
+++ b/common/tests/test_filters.py
@@ -1,0 +1,21 @@
+import pytest
+
+from common.filters import type_choices
+from common.tests.factories import TestModel2Factory
+from common.tests.models import TestModel2
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture(params=(0, 1, 10))
+def choice_inputs(request):
+    return [TestModel2Factory() for _ in range(request.param)]
+
+
+def test_type_choices(choice_inputs):
+    get_choices = type_choices(TestModel2.objects.all())
+    choices = get_choices()
+
+    assert len(choices) == len(choice_inputs)
+    for input, output in zip(choice_inputs, choices):
+        assert output.value == input.custom_sid

--- a/common/tests/util.py
+++ b/common/tests/util.py
@@ -4,9 +4,6 @@ from datetime import timezone
 from functools import wraps
 from io import BytesIO
 from itertools import count
-from typing import Any
-from typing import Dict
-from typing import Type
 
 import pytest
 from dateutil.parser import parse as parse_date
@@ -14,18 +11,11 @@ from dateutil.relativedelta import relativedelta
 from django.core.exceptions import ValidationError
 from django.template.loader import render_to_string
 from django.urls import reverse
-from factory.django import DjangoModelFactory
 from freezegun import freeze_time
 from lxml import etree
 
-from common.models import TrackedModel
 from common.renderers import counter_generator
-from common.serializers import TrackedModelSerializer
-from common.serializers import validate_taric_xml_record_order
 from common.util import TaricDateRange
-from common.validators import UpdateType
-from importer.management.commands.import_taric import import_taric
-from workbaskets.validators import WorkflowStatus
 
 INTERDEPENDENT_IMPORT_IMPLEMENTED = True
 UPDATE_IMPORTER_IMPLEMENTED = True
@@ -200,67 +190,6 @@ def validate_taric_xml(
 
             func(
                 *args,
-                **kwargs,
-            )
-
-        return wraps
-
-    return decorator
-
-
-def validate_taric_import(
-    serializer: Type[TrackedModelSerializer],
-    factory: DjangoModelFactory = None,
-    instance: TrackedModel = None,
-    update_type: int = UpdateType.CREATE.value,
-    factory_kwargs: Dict[str, Any] = None,
-    dependencies: Dict[str, Type[DjangoModelFactory]] = None,
-):
-    def decorator(func):
-        def wraps(valid_user, *args, **kwargs):
-            if not factory and not instance:
-                raise AssertionError(
-                    "Either a factory or an object instance need to be provided",
-                )
-            if factory and instance:
-                raise AssertionError(
-                    "Either a factory or an object instance need to be provided - not both.",
-                )
-
-            _factory_kwargs = factory_kwargs or {}
-            _factory_kwargs.update(
-                **{
-                    name: dependency_factory.create()
-                    for name, dependency_factory in (
-                        dependencies.items() if dependencies else {}.items()
-                    )
-                }
-            )
-
-            test_object = (
-                instance
-                if instance
-                else factory.build(update_type=update_type, **(_factory_kwargs or {}))
-            )
-
-            xml = generate_test_import_xml(
-                serializer(test_object, context={"format": "xml"}).data,
-            )
-
-            import_taric(xml, valid_user.username, WorkflowStatus.PUBLISHED.value)
-
-            model = instance.__class__ if instance else factory._meta.model
-
-            db_kwargs = {
-                field: getattr(test_object, field) for field in model.identifying_fields
-            }
-            db_object = model.objects.get_latest_version(**db_kwargs)
-
-            func(
-                valid_user,
-                *args,
-                test_object=test_object,
-                db_object=db_object,
                 **kwargs,
             )
 

--- a/common/util.py
+++ b/common/util.py
@@ -5,7 +5,6 @@ from typing import Optional
 from typing import TypeVar
 from typing import Union
 
-from django.db import connection
 from psycopg2.extras import DateRange
 from psycopg2.extras import DateTimeRange
 
@@ -111,39 +110,6 @@ def validity_range_contains_range(
             return False
 
     return True
-
-
-def create_sequence(
-    name: str,
-    start: Optional[int] = None,
-    increment_by: int = 1,
-    max_value: Optional[int] = None,
-    min_value: Optional[int] = None,
-    cache: int = 1,
-    cycle: bool = False,
-) -> str:
-    """Generate SQL to create a PostgreSQL sequence."""
-
-    parts = [
-        f"CREATE SEQUENCE IF NOT EXISTS {name}",
-        f"INCREMENT BY {increment_by}",
-        f"MINVALUE {min_value}" if min_value is not None else "NO MINVALUE",
-        f"MAXVALUE {max_value}" if max_value is not None else "NO MAXVALUE",
-        f"START {start}" if start is not None else "",
-        f"CACHE {cache}",
-        "CYCLE" if cycle else "NO CYCLE",
-    ]
-    return " ".join(parts) + ";"
-
-
-def get_next_sequence_value(sequence_name: str) -> int:
-    """Fetch next value in named sequence."""
-
-    with connection.cursor() as cursor:
-        cursor.execute("SELECT nextval(%s)", [sequence_name])
-        row = cursor.fetchone()
-
-    return row[0]
 
 
 def get_field_tuple(model, field):

--- a/exporter/tests/test_exporter_commands.py
+++ b/exporter/tests/test_exporter_commands.py
@@ -4,10 +4,10 @@ import pytest
 from django.core.management import call_command
 from lxml import etree
 
-from common.serializers import validate_taric_xml_record_order
 from common.tests.factories import FootnoteTypeFactory
 from common.tests.factories import RegulationFactory
 from common.tests.util import taric_xml_record_codes
+from common.tests.util import validate_taric_xml_record_order
 
 pytestmark = pytest.mark.django_db
 

--- a/exporter/tests/test_exporter_tasks.py
+++ b/exporter/tests/test_exporter_tasks.py
@@ -3,10 +3,10 @@ from unittest import mock
 import pytest
 from lxml import etree
 
-from common.serializers import validate_taric_xml_record_order
 from common.tests.factories import FootnoteTypeFactory
 from common.tests.factories import RegulationFactory
 from common.tests.util import taric_xml_record_codes
+from common.tests.util import validate_taric_xml_record_order
 from exporter.tasks import upload_workbaskets
 
 pytestmark = pytest.mark.django_db

--- a/footnotes/filters.py
+++ b/footnotes/filters.py
@@ -1,6 +1,5 @@
 import re
 
-from crispy_forms_gds.choices import Choice
 from django.contrib.postgres.aggregates import StringAgg
 from django.forms import CheckboxSelectMultiple
 from django.urls import reverse_lazy
@@ -11,6 +10,7 @@ from common.filters import StartYearMixin
 from common.filters import TamatoFilter
 from common.filters import TamatoFilterBackend
 from common.filters import TamatoFilterMixin
+from common.filters import type_choices
 from footnotes import models
 from footnotes.validators import FOOTNOTE_ID_PATTERN
 from footnotes.validators import FOOTNOTE_TYPE_ID_PATTERN
@@ -43,20 +43,6 @@ class FootnoteFilterBackend(TamatoFilterBackend, FootnoteFilterMixin):
     pass
 
 
-def footnote_type_choices():
-    footnote_types = models.FootnoteType.objects.latest_approved()
-    return [
-        Choice(
-            footnote_type.footnote_type_id,
-            "{0} - {1}".format(
-                footnote_type.footnote_type_id,
-                footnote_type.description,
-            ),
-        )
-        for footnote_type in footnote_types
-    ]
-
-
 class FootnoteFilter(
     TamatoFilter,
     FootnoteFilterMixin,
@@ -65,7 +51,7 @@ class FootnoteFilter(
 ):
 
     footnote_type = LazyMultipleChoiceFilter(
-        choices=footnote_type_choices,
+        choices=type_choices(models.FootnoteType.objects.latest_approved()),
         widget=CheckboxSelectMultiple,
         field_name="footnote_type__footnote_type_id",
         label="Footnote Type",

--- a/hmrc_sdes/models.py
+++ b/hmrc_sdes/models.py
@@ -1,5 +1,0 @@
-# XXX need to keep this for migrations to work, can delete later
-def to_hmrc(instance):
-    """Generate the filepath to upload to HMRC."""
-
-    return f"tohmrc/staging/DIT{instance.envelope.envelope_id}.xml"

--- a/hmrc_sdes/validators.py
+++ b/hmrc_sdes/validators.py
@@ -1,4 +1,0 @@
-from django.core.validators import RegexValidator
-
-
-EnvelopeIdValidator = RegexValidator(r"^(?P<year>\d\d)(?P<counter>\d{4})$")


### PR DESCRIPTION
Fixing up the coverage has revealed a few areas where we have unused or untested code. This commit addresses the lowest of the low-hanging fruit from these.

- Clean-up of dead or duplicated code ed6d329
  * Remove dead or unused code
  * Remove instances of raises_if duplication
  * Improve type hints in some places
- Remove use of hard-coded additional code type list 90926fb
  * Also add a generic helper for generating a list of type choices.

