### PR TITLE
TP-647: Check users have permission to edit

### DIFF
--- a/additional_codes/tests/bdd/features/browse-additional-codes.feature
+++ b/additional_codes/tests/bdd/features/browse-additional-codes.feature
@@ -2,7 +2,7 @@
 Feature: Additional Codes
 
 Background:
-    Given a valid user named "Alice"
+    Given a valid user named Alice
     And additional code X000
 
 Scenario: Searching by additional code

--- a/additional_codes/tests/bdd/features/detail_additional_codes.feature
+++ b/additional_codes/tests/bdd/features/detail_additional_codes.feature
@@ -2,7 +2,7 @@
 Feature: Additional Codes
 
 Background:
-    Given a valid user named "Alice"
+    Given a valid user named Alice
     And additional code X000
 
 Scenario: View additional code core data

--- a/additional_codes/tests/bdd/features/edit_additional_codes.feature
+++ b/additional_codes/tests/bdd/features/edit_additional_codes.feature
@@ -1,0 +1,19 @@
+@bdd
+Feature: Edit Additional Codes
+
+Background:
+    Given a valid user named Carol
+    And a valid user named David
+    And Carol is in the policy group
+    And additional code X000
+    And there is a current workbasket
+
+Scenario: Edit permission granted
+    Given I am logged in as Carol
+    When I edit additional code X000
+    Then I see an edit form
+
+Scenario: Edit permission denied
+    Given I am logged in as David
+    When I edit additional code X000
+    Then I am not permitted to edit

--- a/additional_codes/tests/bdd/test_edit_additional_codes.py
+++ b/additional_codes/tests/bdd/test_edit_additional_codes.py
@@ -1,0 +1,24 @@
+import pytest
+from pytest_bdd import scenarios
+from pytest_bdd import then
+from pytest_bdd import when
+
+pytestmark = pytest.mark.django_db
+
+scenarios("features/edit_additional_codes.feature")
+
+
+@pytest.fixture
+@when("I edit additional code X000")
+def model_edit_page(client, additional_code_X000):
+    return client.get(additional_code_X000.get_url("edit"))
+
+
+@then("I am not permitted to edit")
+def edit_permission_denied(model_edit_page):
+    assert model_edit_page.status_code == 403
+
+
+@then("I see an edit form")
+def edit_permission_granted(model_edit_page):
+    assert model_edit_page.status_code == 200

--- a/additional_codes/views.py
+++ b/additional_codes/views.py
@@ -1,7 +1,6 @@
 from typing import Optional
 from typing import Type
 
-from django.contrib.auth.mixins import PermissionRequiredMixin
 from django.db import models
 from rest_framework import permissions
 from rest_framework import viewsets
@@ -93,13 +92,11 @@ class AdditionalCodeDetail(AdditionalCodeMixin, TrackedModelDetailView):
 
 
 class AdditionalCodeUpdate(
-    PermissionRequiredMixin,
     AdditionalCodeMixin,
     TrackedModelDetailMixin,
     DraftUpdateView,
 ):
     form_class = AdditionalCodeForm
-    permission_required = "common.change_trackedmodel"
 
     def get_object(self, queryset: Optional[models.QuerySet] = None) -> models.Model:
         obj = super().get_object(queryset)
@@ -114,13 +111,11 @@ class AdditionalCodeUpdate(
 
 
 class AdditionalCodeUpdateDescription(
-    PermissionRequiredMixin,
     AdditionalCodeDescriptionMixin,
     TrackedModelDetailMixin,
     DraftUpdateView,
 ):
     form_class = AdditionalCodeDescriptionForm
-    permission_required = "common.change_trackedmodel"
     template_name = "common/edit_description.jinja"
 
     def get_object(self, queryset: Optional[models.QuerySet] = None) -> models.Model:

--- a/certificates/tests/bdd/conftest.py
+++ b/certificates/tests/bdd/conftest.py
@@ -1,0 +1,20 @@
+import pytest
+from pytest_bdd import given
+
+from common.tests import factories
+
+pytestmark = pytest.mark.django_db
+
+
+@given("certificate X000", target_fixture="certificate_X000")
+def certificate_X000(date_ranges):
+    desc = factories.CertificateDescriptionFactory.create(
+        described_certificate=factories.CertificateFactory.create(
+            certificate_type=factories.CertificateTypeFactory.create(
+                sid="X",
+            ),
+            sid="000",
+        ),
+        description="This is X000",
+    )
+    return desc.described_certificate

--- a/certificates/tests/bdd/features/edit.feature
+++ b/certificates/tests/bdd/features/edit.feature
@@ -1,0 +1,19 @@
+@bdd
+Feature: Edit Certificates
+
+Background:
+    Given a valid user named Carol
+    And a valid user named David
+    And Carol is in the policy group
+    And certificate X000
+    And there is a current workbasket
+
+Scenario: Edit permission granted
+    Given I am logged in as Carol
+    When I edit certificate X000
+    Then I see an edit form
+
+Scenario: Edit permission denied
+    Given I am logged in as David
+    When I edit certificate X000
+    Then I am not permitted to edit

--- a/certificates/tests/bdd/test_edit_certificates.py
+++ b/certificates/tests/bdd/test_edit_certificates.py
@@ -1,0 +1,24 @@
+import pytest
+from pytest_bdd import scenarios
+from pytest_bdd import then
+from pytest_bdd import when
+
+pytestmark = pytest.mark.django_db
+
+scenarios("features/edit.feature")
+
+
+@pytest.fixture
+@when("I edit certificate X000")
+def model_edit_page(client, certificate_X000):
+    return client.get(certificate_X000.get_url("edit"))
+
+
+@then("I am not permitted to edit")
+def edit_permission_denied(model_edit_page):
+    assert model_edit_page.status_code == 403
+
+
+@then("I see an edit form")
+def edit_permission_granted(model_edit_page):
+    assert model_edit_page.status_code == 200

--- a/certificates/views.py
+++ b/certificates/views.py
@@ -1,7 +1,6 @@
 from typing import Optional
 from typing import Type
 
-from django.contrib.auth.mixins import PermissionRequiredMixin
 from django.db import models
 from rest_framework import permissions
 from rest_framework import viewsets
@@ -69,13 +68,11 @@ class CertificateDetail(CertificateMixin, TrackedModelDetailView):
 
 
 class CertificateUpdate(
-    PermissionRequiredMixin,
     CertificateMixin,
     TrackedModelDetailMixin,
     DraftUpdateView,
 ):
     form_class = CertificateForm
-    permission_required = "common.change_trackedmodel"
 
     def get_object(self, queryset: Optional[models.QuerySet] = None) -> models.Model:
         obj = super().get_object(queryset)

--- a/common/tests/bdd/features/edit.feature
+++ b/common/tests/bdd/features/edit.feature
@@ -1,0 +1,18 @@
+Feature: Edit Permissions
+
+Background:
+    Given a valid user named Carol
+    And a valid user named David
+    And Carol is in the policy group
+    And a model exists
+    And there is a current workbasket
+
+Scenario: Edit permission granted
+    Given I am logged in as Carol
+    When I edit a model
+    Then I see an edit form
+
+Scenario: Edit permission denied
+    Given I am logged in as David
+    When I edit a model
+    Then I am not permitted to edit

--- a/common/tests/bdd/test_edit_view.py
+++ b/common/tests/bdd/test_edit_view.py
@@ -1,0 +1,35 @@
+import pytest
+from pytest_bdd import given
+from pytest_bdd import scenarios
+from pytest_bdd import then
+from pytest_bdd import when
+
+from common.tests import factories
+
+pytestmark = pytest.mark.django_db
+
+scenarios("features")
+
+
+@pytest.fixture
+@given("a model exists")
+def tracked_model(approved_transaction):
+    return factories.FootnoteFactory.create(
+        transaction=approved_transaction,
+    )
+
+
+@pytest.fixture
+@when("I edit a model")
+def model_edit_page(client, tracked_model):
+    return client.get(tracked_model.get_url("edit"))
+
+
+@then("I am not permitted to edit")
+def edit_permission_denied(model_edit_page):
+    assert model_edit_page.status_code == 403
+
+
+@then("I see an edit form")
+def edit_permission_granted(model_edit_page):
+    assert model_edit_page.status_code == 200

--- a/common/tests/factories.py
+++ b/common/tests/factories.py
@@ -58,6 +58,15 @@ class UserFactory(factory.django.DjangoModelFactory):
     username = factory.sequence(lambda n: f"{factory.Faker('name')}{n}")
 
 
+class UserGroupFactory(factory.django.DjangoModelFactory):
+    """User Group factory."""
+
+    class Meta:
+        model = "auth.Group"
+
+    name = factory.Faker("bs")
+
+
 class WorkBasketFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = "workbaskets.WorkBasket"

--- a/common/tests/test_views.py
+++ b/common/tests/test_views.py
@@ -3,8 +3,9 @@ from django.urls import reverse
 
 from workbaskets.models import WorkBasket
 
+pytestmark = pytest.mark.django_db
 
-@pytest.mark.django_db
+
 def test_index_creates_workbasket_if_needed(valid_user_client, approved_workbasket):
     assert WorkBasket.objects.is_not_approved().count() == 0
     response = valid_user_client.get(reverse("index"))
@@ -12,7 +13,6 @@ def test_index_creates_workbasket_if_needed(valid_user_client, approved_workbask
     assert WorkBasket.objects.is_not_approved().count() == 1
 
 
-@pytest.mark.django_db
 def test_index_doesnt_creates_workbasket_if_not_needed(
     valid_user_client,
     new_workbasket,

--- a/common/views.py
+++ b/common/views.py
@@ -3,6 +3,7 @@ from typing import Type
 
 import django.contrib.auth.views
 from django.conf import settings
+from django.contrib.auth.mixins import PermissionRequiredMixin
 from django.contrib.auth.mixins import UserPassesTestMixin
 from django.core.cache import cache
 from django.core.paginator import Paginator
@@ -95,9 +96,10 @@ class LogoutView(django.contrib.auth.views.LogoutView):
     template_name = "common/logged_out.jinja"
 
 
-class CreateView(generic.CreateView):
+class CreateView(PermissionRequiredMixin, generic.CreateView):
     """Create a new tracked model."""
 
+    permission_required = "common.add_trackedmodel"
     UPDATE_TYPE = UpdateType.CREATE
 
     def form_valid(self, form):
@@ -113,10 +115,11 @@ class CreateView(generic.CreateView):
         return Transaction()
 
 
-class UpdateView(generic.UpdateView):
+class UpdateView(PermissionRequiredMixin, generic.UpdateView):
     """Create an updated version of a TrackedModel."""
 
     UPDATE_TYPE = UpdateType.UPDATE
+    permission_required = "common.change_trackedmodel"
     template_name = "common/edit.jinja"
 
     def get_success_url(self):

--- a/footnotes/tests/bdd/conftest.py
+++ b/footnotes/tests/bdd/conftest.py
@@ -1,4 +1,3 @@
-from django.contrib.auth.models import Permission
 from pytest_bdd import given
 
 from common.tests import factories
@@ -24,29 +23,3 @@ def footnote_NC000(date_ranges, approved_transaction):
         transaction=approved_transaction,
     )
     return footnote
-
-
-@given(
-    'a valid user named "Bob" with permission to edit footnotes',
-    target_fixture="user_bob",
-)
-def user_bob():
-    bob = factories.UserFactory(username="Bob")
-    bob.user_permissions.add(
-        *list(
-            Permission.objects.filter(
-                content_type__app_label="footnotes",
-                codename__in=[
-                    "change_footnote",
-                    "add_footnotedescription",
-                    "change_footnotedescription",
-                ],
-            )
-        )
-    )
-    return bob
-
-
-@given("I am logged in as Bob", target_fixture="user_bob_login")
-def user_bob_login(client, user_bob):
-    client.force_login(user_bob)

--- a/footnotes/tests/bdd/features/browse-footnotes.feature
+++ b/footnotes/tests/bdd/features/browse-footnotes.feature
@@ -4,7 +4,7 @@ Feature: Footnotes
 
 
 Background:
-    Given a valid user named "Alice"
+    Given a valid user named Alice
     And footnote NC000
 
 

--- a/footnotes/tests/bdd/features/detail-footnotes.feature
+++ b/footnotes/tests/bdd/features/detail-footnotes.feature
@@ -4,7 +4,7 @@ Feature: Footnotes
 
 
 Background:
-    Given a valid user named "Alice"
+    Given a valid user named Alice
     And footnote NC000
 
 

--- a/footnotes/tests/bdd/features/edit-footnote.feature
+++ b/footnotes/tests/bdd/features/edit-footnote.feature
@@ -2,9 +2,10 @@
 Feature: Edit Footnote
 
 Background:
-    Given a valid user named "Bob" with permission to edit footnotes
+    Given a valid user named Bob
+    And Bob is in the policy group
     And footnote NC000
-    And a current workbasket
+    And there is a current workbasket
 
 
 Scenario: View Footnote edit screen

--- a/footnotes/tests/bdd/test_edit_footnote.py
+++ b/footnotes/tests/bdd/test_edit_footnote.py
@@ -3,27 +3,14 @@ import re
 
 import pytest
 from dateutil.relativedelta import relativedelta
-from pytest_bdd import given
 from pytest_bdd import scenarios
 from pytest_bdd import then
 from pytest_bdd import when
-
-from common.tests import factories
-
 
 pytestmark = pytest.mark.django_db
 
 
 scenarios("features/edit-footnote.feature")
-
-
-@given("a current workbasket")
-def current_workbasket(client):
-    workbasket = factories.WorkBasketFactory()
-    session = client.session
-    session["workbasket"] = workbasket.to_json()
-    session.save()
-    return workbasket
 
 
 @pytest.fixture
@@ -56,7 +43,8 @@ def submit_footnote_NC000(client, footnote_NC000, change):
     change_payload = {
         "start date": make_payload(existing.lower + relativedelta(days=+1)),
         "end date": make_payload(
-            existing.lower, existing.upper + relativedelta(months=+1)
+            existing.lower,
+            existing.upper + relativedelta(months=+1),
         ),
     }
     return client.post(footnote_NC000.get_url("edit"), change_payload[change])
@@ -64,7 +52,8 @@ def submit_footnote_NC000(client, footnote_NC000, change):
 
 @then("I should be presented with a footnote update screen")
 def i_should_be_presented_with_a_footnote_update_screen(
-    submit_footnote_NC000, footnote_NC000
+    submit_footnote_NC000,
+    footnote_NC000,
 ):
     """I should be presented with a footnote update screen."""
     assert submit_footnote_NC000.status_code == 302

--- a/footnotes/views.py
+++ b/footnotes/views.py
@@ -1,7 +1,6 @@
 from typing import Optional
 from typing import Type
 
-from django.contrib.auth.mixins import PermissionRequiredMixin
 from django.db.models import Model
 from django.db.models import QuerySet
 from rest_framework import permissions
@@ -92,13 +91,11 @@ class FootnoteDetail(FootnoteMixin, TrackedModelDetailView):
 
 
 class FootnoteUpdate(
-    PermissionRequiredMixin,
     FootnoteMixin,
     TrackedModelDetailMixin,
     DraftUpdateView,
 ):
     form_class = forms.FootnoteForm
-    permission_required = "common.change_trackedmodel"
 
     def get_object(self, queryset: Optional[QuerySet] = None) -> Model:
         obj = super().get_object(queryset)
@@ -117,13 +114,11 @@ class FootnoteConfirmUpdate(FootnoteMixin, TrackedModelDetailView):
 
 
 class FootnoteUpdateDescription(
-    PermissionRequiredMixin,
     FootnoteDescriptionMixin,
     TrackedModelDetailMixin,
     DraftUpdateView,
 ):
     form_class = forms.FootnoteDescriptionForm
-    permission_required = "common.change_trackedmodel"
     template_name = "common/edit_description.jinja"
 
     def get_object(self, queryset: Optional[QuerySet] = None) -> Model:

--- a/geo_areas/tests/bdd/features/browse_geo_areas.feature
+++ b/geo_areas/tests/bdd/features/browse_geo_areas.feature
@@ -3,7 +3,7 @@ Feature: Geographical areas
 
 
 Background:
-    Given a valid user named "Alice"
+    Given a valid user named Alice
     And geographical_area 1001 with a description and area_code 0
 
 Scenario Outline: Searching for a geographical_area

--- a/geo_areas/tests/bdd/features/detail_geo_areas.feature
+++ b/geo_areas/tests/bdd/features/detail_geo_areas.feature
@@ -3,7 +3,7 @@ Feature: Geographical areas
 
 
 Background:
-    Given a valid user named "Alice"
+    Given a valid user named Alice
     And geographical_area 1001 with a description and area_code 0
     And geographical_area 1002 with a description and area_code 1
 

--- a/regulations/tests/bdd/features/regulations.feature
+++ b/regulations/tests/bdd/features/regulations.feature
@@ -3,7 +3,7 @@ Feature: Regulations
     Legal Acts which generate measures or affect applicability of existing regulations
 
 Background:
-    Given a valid user named "Alice"
+    Given a valid user named Alice
     And some regulations
     And regulation C2000000
 


### PR DESCRIPTION
This commit modifies our generic Create and Update class-based views to inherit from PermissionRequiredMixin to ensure only users with permission to edit the tariff are allowed to do so. This saves having to use the mixin with every component create and update view class.

Also, I've added a first pass at a generic BDD test for edit views - this currently only tests that a 403 response is returned if the user does not have permission to edit. It would be nice to reduce the copy-pasta by making a generic "I edit \<model> <unique-id>" step, but it's a little out of scope for this PR.

As a bonus, I've added some BDD tests for additional codes and certificates edit views. I haven't touched the footnotes BDD tests for now.