### PR TITLE
TP-690: Model in use rules should respect deletes

### DIFF
--- a/additional_codes/models.py
+++ b/additional_codes/models.py
@@ -92,7 +92,7 @@ class AdditionalCode(TrackedModel, ValidityMixin):
             self.measure_set.model.objects.filter(
                 additional_code__sid=self.sid,
             )
-            .latest_approved()
+            .approved_up_to_transaction(self.transaction)
             .exists()
         )
 

--- a/additional_codes/tests/test_models.py
+++ b/additional_codes/tests/test_models.py
@@ -1,0 +1,14 @@
+import pytest
+
+from common.tests import factories
+
+pytestmark = pytest.mark.django_db
+
+
+def test_additional_code_in_use(in_use_check_respects_deletes):
+    assert in_use_check_respects_deletes(
+        factories.AdditionalCodeFactory,
+        "in_use",
+        factories.MeasureFactory,
+        "additional_code",
+    )

--- a/certificates/models.py
+++ b/certificates/models.py
@@ -31,8 +31,11 @@ class CertificateType(TrackedModel, ValidityMixin):
     )
 
     def in_use(self):
-        # TODO handle deletes
-        return Certificate.objects.filter(certificate_type__sid=self.sid).exists()
+        return (
+            Certificate.objects.filter(certificate_type__sid=self.sid)
+            .approved_up_to_transaction(self.transaction)
+            .exists()
+        )
 
     def __str__(self):
         return self.sid
@@ -78,11 +81,14 @@ class Certificate(TrackedModel, ValidityMixin):
         return self.code
 
     def in_use(self):
-        # TODO handle deletes
-        return self.measurecondition_set.model.objects.filter(
-            required_certificate__sid=self.sid,
-            required_certificate__certificate_type=self.certificate_type,
-        ).exists()
+        return (
+            self.measurecondition_set.model.objects.filter(
+                required_certificate__sid=self.sid,
+                required_certificate__certificate_type=self.certificate_type,
+            )
+            .approved_up_to_transaction(self.transaction)
+            .exists()
+        )
 
 
 class CertificateDescription(DescriptionMixin, ValidityMixin, TrackedModel):

--- a/certificates/tests/test_models.py
+++ b/certificates/tests/test_models.py
@@ -1,0 +1,23 @@
+import pytest
+
+from common.tests import factories
+
+pytestmark = pytest.mark.django_db
+
+
+def test_certificate_type_in_use(in_use_check_respects_deletes):
+    assert in_use_check_respects_deletes(
+        factories.CertificateTypeFactory,
+        "in_use",
+        factories.CertificateFactory,
+        "certificate_type",
+    )
+
+
+def test_certificate_in_user(in_use_check_respects_deletes):
+    assert in_use_check_respects_deletes(
+        factories.CertificateFactory,
+        "in_use",
+        factories.MeasureConditionFactory,
+        "required_certificate",
+    )

--- a/commodities/models.py
+++ b/commodities/models.py
@@ -79,7 +79,7 @@ class GoodsNomenclature(TrackedModel, ValidityMixin):
             self.measures.model.objects.filter(
                 goods_nomenclature__sid=self.sid,
             )
-            .latest_approved()
+            .approved_up_to_transaction(self.transaction)
             .exists()
         )
 

--- a/commodities/tests/test_models.py
+++ b/commodities/tests/test_models.py
@@ -1,0 +1,14 @@
+import pytest
+
+from common.tests import factories
+
+pytestmark = pytest.mark.django_db
+
+
+def test_goods_nomenclature_in_use(in_use_check_respects_deletes):
+    assert in_use_check_respects_deletes(
+        factories.GoodsNomenclatureFactory,
+        "in_use",
+        factories.MeasureFactory,
+        "goods_nomenclature",
+    )

--- a/common/tests/factories.py
+++ b/common/tests/factories.py
@@ -764,7 +764,7 @@ class MeasureFactory(TrackedModelMixin, ValidityFactoryMixin):
     measure_type = factory.SubFactory(MeasureTypeFactory)
     additional_code = None
     order_number = None
-    reduction = factory.Sequence(lambda x: (x + 1) % 4)
+    reduction = factory.Sequence(lambda x: x % 4 + 1)
     generating_regulation = factory.SubFactory(RegulationFactory)
     stopped = False
     export_refund_nomenclature_sid = None

--- a/footnotes/tests/test_models.py
+++ b/footnotes/tests/test_models.py
@@ -1,0 +1,41 @@
+import pytest
+
+from common.tests import factories
+
+pytestmark = pytest.mark.django_db
+
+
+def test_footnote_type_in_use(in_use_check_respects_deletes):
+    assert in_use_check_respects_deletes(
+        factories.FootnoteTypeFactory,
+        "in_use",
+        factories.FootnoteFactory,
+        "footnote_type",
+    )
+
+
+def test_footnote_used_in_additional_code(in_use_check_respects_deletes):
+    assert in_use_check_respects_deletes(
+        factories.FootnoteFactory,
+        "used_in_additional_code",
+        factories.FootnoteAssociationAdditionalCodeFactory,
+        "associated_footnote",
+    )
+
+
+def test_footnote_used_in_goods_nomenclature(in_use_check_respects_deletes):
+    assert in_use_check_respects_deletes(
+        factories.FootnoteFactory,
+        "used_in_goods_nomenclature",
+        factories.FootnoteAssociationGoodsNomenclatureFactory,
+        "associated_footnote",
+    )
+
+
+def test_footnote_used_in_measure(in_use_check_respects_deletes):
+    assert in_use_check_respects_deletes(
+        factories.FootnoteFactory,
+        "used_in_measure",
+        factories.FootnoteAssociationMeasureFactory,
+        "associated_footnote",
+    )

--- a/geo_areas/models.py
+++ b/geo_areas/models.py
@@ -80,16 +80,22 @@ class GeographicalArea(TrackedModel, ValidityMixin):
         )
 
     def in_use(self):
-        # TODO handle deletes
-        return self.measures.model.objects.filter(
-            geographical_area__sid=self.sid,
-        ).exists()
+        return (
+            self.measures.model.objects.filter(
+                geographical_area__sid=self.sid,
+            )
+            .approved_up_to_transaction(self.transaction)
+            .exists()
+        )
 
     def is_a_parent(self):
-        # TODO handle deletes
-        return GeographicalArea.objects.filter(
-            parent__sid=self.sid,
-        ).exists()
+        return (
+            GeographicalArea.objects.filter(
+                parent__sid=self.sid,
+            )
+            .approved_up_to_transaction(self.transaction)
+            .exists()
+        )
 
     def __str__(self):
         return f"{self.get_area_code_display()} {self.area_id}"
@@ -157,10 +163,13 @@ class GeographicalMembership(TrackedModel, ValidityMixin):
             raise ValueError(f"{area} is not part of membership {self}")
 
     def member_used_in_measure_exclusion(self):
-        # TODO handle deletes
-        return self.member.measureexcludedgeographicalarea_set.model.objects.filter(
-            excluded_geographical_area__sid=self.member.sid,
-        ).exists()
+        return (
+            self.member.measureexcludedgeographicalarea_set.model.objects.filter(
+                excluded_geographical_area__sid=self.member.sid,
+            )
+            .approved_up_to_transaction(self.transaction)
+            .exists()
+        )
 
 
 class GeographicalAreaDescription(TrackedModel, ValidityMixin):

--- a/geo_areas/tests/test_models.py
+++ b/geo_areas/tests/test_models.py
@@ -59,3 +59,12 @@ def test_other_on_membership():
         membership.other(factories.GeoGroupFactory())
     with pytest.raises(ValueError):
         membership.other(factories.CountryFactory())
+
+
+def test_geo_area_in_use(in_use_check_respects_deletes):
+    assert in_use_check_respects_deletes(
+        factories.GeographicalAreaFactory,
+        "in_use",
+        factories.MeasureFactory,
+        "geographical_area",
+    )

--- a/measures/models.py
+++ b/measures/models.py
@@ -49,10 +49,13 @@ class MeasureTypeSeries(TrackedModel, ValidityMixin):
     )
 
     def in_use(self):
-        # TODO handle deletes
-        return MeasureType.objects.filter(
-            measure_type_series__sid=self.sid,
-        ).exists()
+        return (
+            MeasureType.objects.filter(
+                measure_type_series__sid=self.sid,
+            )
+            .approved_up_to_transaction(self.transaction)
+            .exists()
+        )
 
 
 class MeasurementUnit(TrackedModel, ValidityMixin):
@@ -266,8 +269,11 @@ class MeasureType(TrackedModel, ValidityMixin):
     )
 
     def in_use(self):
-        # TODO handle deletes
-        return Measure.objects.filter(measure_type__sid=self.sid).exists()
+        return (
+            Measure.objects.filter(measure_type__sid=self.sid)
+            .approved_up_to_transaction(self.transaction)
+            .exists()
+        )
 
     @property
     def components_mandatory(self):
@@ -336,11 +342,13 @@ class MeasureConditionCode(TrackedModel, ValidityMixin):
     )
 
     def used_in_component(self):
-        # TODO handle deletes
-        # TODO handle MeasureConditionCode versions
-        return MeasureConditionComponent.objects.filter(
-            condition__condition_code__code=self.code,
-        ).exists()
+        return (
+            MeasureConditionComponent.objects.filter(
+                condition__condition_code__code=self.code,
+            )
+            .approved_up_to_transaction(self.transaction)
+            .exists()
+        )
 
 
 class MeasureAction(TrackedModel, ValidityMixin):
@@ -376,10 +384,13 @@ class MeasureAction(TrackedModel, ValidityMixin):
     )
 
     def in_use(self):
-        # TODO handle deletes
-        return MeasureConditionComponent.objects.filter(
-            condition__action__code=self.code,
-        ).exists()
+        return (
+            MeasureConditionComponent.objects.filter(
+                condition__action__code=self.code,
+            )
+            .approved_up_to_transaction(self.transaction)
+            .exists()
+        )
 
 
 class Measure(TrackedModel, ValidityMixin):

--- a/measures/tests/test_models.py
+++ b/measures/tests/test_models.py
@@ -132,3 +132,31 @@ def test_measure_termination(workbasket, measure_to_terminate, termination_date)
         assert terminated_measure.valid_between.upper_inf is False
         assert terminated_measure.valid_between.upper <= termination_date
     terminated_measure.clean()
+
+
+def test_measure_type_series_in_use(in_use_check_respects_deletes):
+    assert in_use_check_respects_deletes(
+        factories.MeasureTypeSeriesFactory,
+        "in_use",
+        factories.MeasureTypeFactory,
+        "measure_type_series",
+    )
+
+
+def test_measure_type_in_use(in_use_check_respects_deletes):
+    assert in_use_check_respects_deletes(
+        factories.MeasureTypeFactory,
+        "in_use",
+        factories.MeasureFactory,
+        "measure_type",
+        leave_measure=True,
+    )
+
+
+def test_measure_action_in_use(in_use_check_respects_deletes):
+    assert in_use_check_respects_deletes(
+        factories.MeasureActionFactory,
+        "in_use",
+        factories.MeasureConditionComponentFactory,
+        "condition__action",
+    )

--- a/quotas/models.py
+++ b/quotas/models.py
@@ -61,10 +61,13 @@ class QuotaOrderNumber(TrackedModel, ValidityMixin):
         return self.order_number
 
     def in_use(self):
-        # TODO this should respect deletes
-        return self.measure_set.model.objects.filter(
-            order_number__sid=self.sid,
-        ).exists()
+        return (
+            self.measure_set.model.objects.filter(
+                order_number__sid=self.sid,
+            )
+            .approved_up_to_transaction(self.transaction)
+            .exists()
+        )
 
     class Meta:
         verbose_name = "quota"
@@ -103,10 +106,13 @@ class QuotaOrderNumberOrigin(TrackedModel, ValidityMixin):
     )
 
     def in_use(self):
-        # TODO this should respect deletes
-        return self.order_number.measure_set.model.objects.filter(
-            order_number__sid=self.order_number.sid,
-        ).exists()
+        return (
+            self.order_number.measure_set.model.objects.filter(
+                order_number__sid=self.order_number.sid,
+            )
+            .approved_up_to_transaction(self.transaction)
+            .exists()
+        )
 
 
 class QuotaOrderNumberOriginExclusion(TrackedModel):

--- a/quotas/tests/test_models.py
+++ b/quotas/tests/test_models.py
@@ -1,0 +1,24 @@
+import pytest
+
+from common.tests import factories
+
+pytestmark = pytest.mark.django_db
+
+
+def test_quota_order_number_in_use(in_use_check_respects_deletes):
+    assert in_use_check_respects_deletes(
+        factories.QuotaOrderNumberFactory,
+        "in_use",
+        factories.MeasureFactory,
+        "order_number",
+    )
+
+
+def test_quota_order_number_origin_in_use(in_use_check_respects_deletes):
+    assert in_use_check_respects_deletes(
+        factories.QuotaOrderNumberOriginFactory,
+        "in_use",
+        factories.MeasureFactory,
+        "order_number",
+        through="order_number",
+    )

--- a/regulations/models.py
+++ b/regulations/models.py
@@ -216,7 +216,6 @@ class Regulation(TrackedModel):
         if self.role_type != validators.RoleType.BASE:
             return
 
-        # TODO handle deletes
         return (
             self.measure_set.model.objects.filter(
                 terminating_regulation__regulation_id=self.regulation_id,

--- a/workbaskets/models.py
+++ b/workbaskets/models.py
@@ -243,5 +243,5 @@ class WorkBasket(TimestampedMixin):
 
         if "composite_key" not in kwargs:
             kwargs["composite_key"] = f"{self.pk}-{kwargs['order']}"
-        transaction = self.transactions.model.objects.create(workbasket=self, **kwargs)
-        return transaction
+
+        return self.transactions.model.objects.create(workbasket=self, **kwargs)


### PR DESCRIPTION
Some business rules (particularly ones which prevent deleting a record) apply if a
record is currently "in use".

For example, if a `FootnoteType` is associated with at least one `Footnote` record, then
that `FootnoteType` is considered "in use".

But if all `Footnote`s that had been associated with the type were then deleted, the 
`FootnoteType` would still consider itself "in use".

Similarly, if a `Footnote` was subsequently associated with the type, but the transaction
containing that association was not yet approved, the `FootnoteType` would still consider
itself "in use".

This change corrects this class of business rules to correctly exclude deleted records
and those in "future" transactions from consideration of whether a record is "in use".