### PR TITLE
Fix importer test shared state

### DIFF
--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -72,15 +72,6 @@ jobs:
     - name: Report code coverage
       uses: codecov/codecov-action@v1
 
-    - name: Generate test result report
-      uses: afiore/action-allure-report@v0.1.0
-
-    - name: Upload test result report
-      uses: actions/upload-artifact@v1
-      with:
-        name: test-results-report
-        path: allure-report
-
     - name: Build documentation
       uses: ammaraskar/sphinx-action@0.4
       with:

--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -65,15 +65,6 @@ jobs:
     - name: Report code coverage
       uses: codecov/codecov-action@v1
 
-    - name: Generate test result report
-      uses: afiore/action-allure-report@v0.1.0
-
-    - name: Upload test result report
-      uses: actions/upload-artifact@v1
-      with:
-        name: test-results-report
-        path: allure-report
-
     - name: Build documentation
       uses: ammaraskar/sphinx-action@0.4
       with:

--- a/importer/tests/conftest.py
+++ b/importer/tests/conftest.py
@@ -14,7 +14,9 @@ from importer.utils import DispatchedObjectType
 
 @pytest.fixture
 def object_nursery() -> TariffObjectNursery:
-    return get_nursery()
+    nursery = get_nursery()
+    yield nursery
+    nursery.cache.clear()
 
 
 @pytest.fixture

--- a/importer/tests/test_tasks.py
+++ b/importer/tests/test_tasks.py
@@ -10,7 +10,12 @@ pytestmark = pytest.mark.django_db
 
 
 @mock.patch("importer.tasks.find_and_run_next_batch_chunks")
-def test_import_chunk(mock_find_and_run: mock.MagicMock, valid_user, chunk):
+def test_import_chunk(
+    mock_find_and_run: mock.MagicMock,
+    valid_user,
+    chunk,
+    object_nursery,
+):
     tasks.import_chunk(chunk.pk, "PUBLISHED", valid_user.username)
 
     chunk.refresh_from_db()


### PR DESCRIPTION
The object_nursery fixture was maintaining state across tests, leading to failures.

This commit erases the nursery cache between each test.