### PR TITLE
TP-739 Fix certificate search to find type and code together

### DIFF
--- a/certificates/filters.py
+++ b/certificates/filters.py
@@ -3,6 +3,7 @@ from django.contrib.postgres.aggregates import StringAgg
 from django.urls import reverse_lazy
 
 from certificates import models
+from certificates.validators import COMBINED_CERTIFICATE_AND_TYPE_ID
 from common.filters import ActiveStateMixin
 from common.filters import LazyMultipleChoiceFilter
 from common.filters import TamatoFilter
@@ -11,9 +12,12 @@ from common.filters import type_choices
 
 class CertificateFilter(TamatoFilter, ActiveStateMixin):
     search_fields = (
+        StringAgg("certificate_type__sid", delimiter=" "),
         "sid",
         StringAgg("descriptions__description", delimiter=" "),
-    )  # XXX order is important
+    )
+
+    search_regex = COMBINED_CERTIFICATE_AND_TYPE_ID
 
     certificate_type = LazyMultipleChoiceFilter(
         choices=type_choices(models.CertificateType.objects.latest_approved()),

--- a/certificates/validators.py
+++ b/certificates/validators.py
@@ -1,3 +1,5 @@
+import re
+
 from django.core.validators import RegexValidator
 
 CERTIFICATE_TYPE_SID_REGEX = r"[A-Z0-9]{1}"
@@ -5,3 +7,7 @@ certificate_type_sid_validator = RegexValidator(fr"^{CERTIFICATE_TYPE_SID_REGEX}
 
 CERTIFICATE_SID_REGEX = r"[A-Z0-9]{3}"
 certificate_sid_validator = RegexValidator(fr"^{CERTIFICATE_SID_REGEX}$")
+
+COMBINED_CERTIFICATE_AND_TYPE_ID = re.compile(
+    fr"(?P<certificate_type__sid>{CERTIFICATE_TYPE_SID_REGEX})(?P<sid>{CERTIFICATE_SID_REGEX})",
+)


### PR DESCRIPTION
## Summary
Before, if you searched on type and sid, it would fail. Now you can search on type, sid or both.
## Screenshots
![image](https://user-images.githubusercontent.com/76431740/116577818-bc5d5d80-a908-11eb-975e-f1275310adb8.png)
