### PR TITLE
Bump nodejs

### DIFF
--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -38,7 +38,7 @@ jobs:
     - name: Set up Node
       uses: actions/setup-node@v1
       with:
-        node-version: "14.15.1"
+        node-version: "14.16.1"
 
     - name: Install Dependencies
       run: |

--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -38,7 +38,7 @@ jobs:
     - name: Set up Node
       uses: actions/setup-node@v1
       with:
-        node-version: "14.15.1"
+        node-version: "14.16.1"
 
     - name: Install Dependencies
       run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:13.12-buster-slim AS jsdeps
+FROM node:lts-buster-slim AS jsdeps
 
 RUN apt-get update -y
 RUN apt-get install -y g++ build-essential python3

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ The app requires an s3 bucket on AWS or a compatible implementation, such as Min
 
 ### Running locally
 
-This app requires Python 3.8.x and Node 14.15.x
+This app requires Python 3.8.x and Node 14.16.x
 
 Create a Python virtualenv and install the dependencies:
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "repository": "https://github.com/uktrade/tamato.git",
   "licence": "MIT",
   "engines": {
-    "node": "14.15.4",
+    "node": "14.16.1",
     "npm": "6.14.10"
   },
   "dependencies": {


### PR DESCRIPTION
Our CI pipeline is failing due to support for node.js 14.15.1 being dropped.

This change updates our version of node to 14.16.1 - the latest LTS release.