### PR TITLE
Add footnote applicability check to commodity codes

### DIFF
--- a/commodities/business_rules.py
+++ b/commodities/business_rules.py
@@ -6,6 +6,7 @@ from django.db.models import Count
 
 from common.business_rules import BusinessRule
 from common.business_rules import DescriptionsRules
+from common.business_rules import FootnoteApplicability
 from common.business_rules import NoOverlapping
 from common.business_rules import PreventDeleteIfInUse
 from common.business_rules import ValidityPeriodContained
@@ -207,6 +208,13 @@ class NIG12(DescriptionsRules):
     """
 
     model_name = "goods nomenclature"
+
+
+class NIG18(FootnoteApplicability):
+    """Footnotes with a footnote type for which the application type = "CN
+    footnotes" must be linked to CN lines (all codes up to 8 digits)."""
+
+    applicable_field = "goods_nomenclature"
 
 
 class NIG22(ValidityPeriodContained):

--- a/common/business_rules.py
+++ b/common/business_rules.py
@@ -388,3 +388,26 @@ class DescriptionsRules(BusinessRule):
             filter(lambda x: x > model.valid_between.upper, valid_froms),
         ):
             raise self.generate_violation(model, "start after end")
+
+
+class FootnoteApplicability(BusinessRule):
+    """Check that a footnote type can be applied to a certain model, based on
+    the set of :class:`~footnote.validators.ApplicationCode` that the model
+    reports is valid for itself."""
+
+    applicable_field: str
+    """The field containing a model to check applicability for. It must have a
+    property or attribute called :attr:`footnote_application_codes`."""
+
+    footnote_type_field: str = "associated_footnote__footnote_type"
+    """The field containing a footnote type to check for applicability."""
+
+    def validate(self, model):
+        applicable_model = get_field_tuple(model, self.applicable_field)[1]
+        footnote_type = get_field_tuple(model, self.footnote_type_field)[1]
+
+        if (
+            footnote_type.application_code
+            not in applicable_model.footnote_application_codes
+        ):
+            raise self.violation(model)

--- a/footnotes/validators.py
+++ b/footnotes/validators.py
@@ -21,7 +21,3 @@ footnote_type_id_validator = RegexValidator(fr"^{FOOTNOTE_TYPE_ID_PATTERN}$")
 
 FOOTNOTE_ID_PATTERN = r"([0-9]{3}|[0-9]{5})"
 footnote_id_validator = RegexValidator(fr"^{FOOTNOTE_ID_PATTERN}$")
-
-
-FootnoteIDValidator = None
-FootnoteTypeIDValidator = None

--- a/measures/business_rules.py
+++ b/measures/business_rules.py
@@ -7,6 +7,7 @@ from dateutil.relativedelta import relativedelta
 from django.db.models import Q
 
 from common.business_rules import BusinessRule
+from common.business_rules import FootnoteApplicability
 from common.business_rules import MustExist
 from common.business_rules import PreventDeleteIfInUse
 from common.business_rules import UniqueIdentifyingFields
@@ -17,7 +18,6 @@ from common.util import TaricDateRange
 from common.util import validity_range_contains_range
 from common.validators import ApplicabilityCode
 from common.validators import UpdateType
-from footnotes.validators import ApplicationCode
 from geo_areas.validators import AreaCode
 from quotas.validators import AdministrationMechanism
 
@@ -1145,25 +1145,12 @@ class ME70(BusinessRule):
             raise self.violation(association)
 
 
-class ME71(BusinessRule):
+class ME71(FootnoteApplicability):
     """Footnotes with a footnote type for which the application type = "CN footnotes"
     cannot be associated with TARIC codes (codes with pos. 9-10 different from 00).
     """
 
-    def validate(self, association):
-        measure = association.footnoted_measure
-        if measure.goods_nomenclature is None:
-            return
-
-        commodity_code = measure.goods_nomenclature.item_id
-
-        is_taric_code = len(commodity_code) <= 8 or commodity_code[8:] != "00"
-        application_code = (
-            association.associated_footnote.footnote_type.application_code
-        )
-
-        if is_taric_code and application_code == ApplicationCode.CN_MEASURES:
-            raise self.violation(measure)
+    applicable_field = "footnoted_measure"
 
 
 class ME73(MeasureValidityPeriodContained):

--- a/measures/models.py
+++ b/measures/models.py
@@ -1,4 +1,5 @@
 from datetime import date
+from typing import Set
 
 from django.db import models
 from polymorphic.managers import PolymorphicManager
@@ -10,6 +11,7 @@ from common.models import TrackedModel
 from common.models.mixins.validity import ValidityMixin
 from common.util import TaricDateRange
 from common.validators import UpdateType
+from footnotes import validators as footnote_validators
 from measures import business_rules
 from measures import validators
 from measures.querysets import MeasureConditionQuerySet
@@ -525,6 +527,15 @@ class Measure(TrackedModel, ValidityMixin):
     )
 
     objects = PolymorphicManager.from_queryset(MeasuresQuerySet)()
+
+    @property
+    def footnote_application_codes(self) -> Set[footnote_validators.ApplicationCode]:
+        codes = {footnote_validators.ApplicationCode.DYNAMIC_FOOTNOTE}
+        if self.goods_nomenclature:
+            codes.add(footnote_validators.ApplicationCode.OTHER_MEASURES)
+        if not self.goods_nomenclature.is_taric_code:
+            codes.add(footnote_validators.ApplicationCode.CN_MEASURES)
+        return codes
 
     validity_field_name = "db_effective_valid_between"
 


### PR DESCRIPTION
Only footnotes with a footnote type that have one of three possible application codes are allowed to be applied to commodity codes. This commit implements the business rule NIG18 that ensures only footnotes with the right type can be associated.

It also DRYs up some similar logic for measures, and makes what footnote codes should apply a property of the models themselves.