### PR TITLE
Clean up XML and importer tests

### DIFF
--- a/additional_codes/tests/test_importer.py
+++ b/additional_codes/tests/test_importer.py
@@ -6,48 +6,23 @@ from common.tests import factories
 pytestmark = pytest.mark.django_db
 
 
-def test_additional_code_type_importer_create(imported_fields_match):
+def test_additional_code_type_importer(imported_fields_match):
     assert imported_fields_match(
         factories.AdditionalCodeTypeFactory,
         serializers.AdditionalCodeTypeSerializer,
     )
 
 
-def test_additional_code_type_importer_update(update_imported_fields_match):
-    assert update_imported_fields_match(
-        factories.AdditionalCodeTypeFactory,
-        serializers.AdditionalCodeTypeSerializer,
-    )
-
-
-def test_additional_code_importer_create(imported_fields_match):
+def test_additional_code_importer(imported_fields_match):
     assert imported_fields_match(
-        factories.AdditionalCodeFactory.build(
-            type=factories.AdditionalCodeTypeFactory.create(),
-        ),
-        serializers.AdditionalCodeSerializer,
-    )
-
-
-def test_additional_code_importer_update(update_imported_fields_match):
-    assert update_imported_fields_match(
         factories.AdditionalCodeFactory,
         serializers.AdditionalCodeSerializer,
         dependencies={"type": factories.AdditionalCodeTypeFactory},
     )
 
 
-def test_additional_code_description_importer_create(imported_fields_match):
+def test_additional_code_description_importer(imported_fields_match):
     assert imported_fields_match(
-        factories.AdditionalCodeDescriptionFactory.build(
-            described_additionalcode=factories.AdditionalCodeFactory.create(),
-        ),
-        serializers.AdditionalCodeDescriptionSerializer,
-    )
-
-
-def test_additional_code_description_importer_update(update_imported_fields_match):
-    assert update_imported_fields_match(
         factories.AdditionalCodeDescriptionFactory,
         serializers.AdditionalCodeDescriptionSerializer,
         dependencies={"described_additionalcode": factories.AdditionalCodeFactory},

--- a/additional_codes/tests/test_xml.py
+++ b/additional_codes/tests/test_xml.py
@@ -2,29 +2,28 @@ import pytest
 
 from common.tests import factories
 from common.tests.util import validate_taric_xml
+from common.xml.namespaces import nsmap
 
 pytestmark = pytest.mark.django_db
 
 
 @validate_taric_xml(factories.AdditionalCodeTypeFactory)
-def test_additional_code_type_xml(api_client, taric_schema, approved_transaction, xml):
-    element = xml.find(".//additional.code.type", xml.nsmap)
+def test_additional_code_type_xml(xml):
+    element = xml.find(".//oub:additional.code.type", nsmap)
     assert element is not None
-    element = xml.find(".//additional.code.type.description", xml.nsmap)
+    element = xml.find(".//oub:additional.code.type.description", nsmap)
     assert element is not None
 
 
 @validate_taric_xml(factories.AdditionalCodeDescriptionFactory)
-def test_additional_code_description_xml(
-    api_client, taric_schema, approved_transaction, xml
-):
-    element = xml.find(".//additional.code.description", xml.nsmap)
+def test_additional_code_description_xml(xml):
+    element = xml.find(".//oub:additional.code.description", nsmap)
     assert element is not None
-    element = xml.find(".//additional.code.description.period", xml.nsmap)
+    element = xml.find(".//oub:additional.code.description.period", nsmap)
     assert element is not None
 
 
 @validate_taric_xml(factories.AdditionalCodeFactory)
-def test_additional_code_xml(api_client, taric_schema, approved_transaction, xml):
-    element = xml.find(".//additional.code", xml.nsmap)
+def test_additional_code_xml(xml):
+    element = xml.find(".//oub:additional.code", nsmap)
     assert element is not None

--- a/certificates/tests/test_importer.py
+++ b/certificates/tests/test_importer.py
@@ -6,46 +6,23 @@ from common.tests import factories
 pytestmark = pytest.mark.django_db
 
 
-def test_certificate_type_importer_create(imported_fields_match):
+def test_certificate_type_importer(imported_fields_match):
     assert imported_fields_match(
-        factories.CertificateTypeFactory, serializers.CertificateTypeSerializer
+        factories.CertificateTypeFactory,
+        serializers.CertificateTypeSerializer,
     )
 
 
-def test_certificate_type_importer_update(update_imported_fields_match):
-    assert update_imported_fields_match(
-        factories.CertificateTypeFactory, serializers.CertificateTypeSerializer
-    )
-
-
-def test_certificate_importer_create(imported_fields_match):
+def test_certificate_importer(imported_fields_match):
     assert imported_fields_match(
-        factories.CertificateFactory.build(
-            certificate_type=factories.CertificateTypeFactory.create()
-        ),
-        serializers.CertificateSerializer,
-    )
-
-
-def test_certificate_importer_update(update_imported_fields_match):
-    assert update_imported_fields_match(
         factories.CertificateFactory,
         serializers.CertificateSerializer,
         dependencies={"certificate_type": factories.CertificateTypeFactory},
     )
 
 
-def test_certificate_description_importer_create(imported_fields_match):
+def test_certificate_description_importer(imported_fields_match):
     assert imported_fields_match(
-        factories.CertificateDescriptionFactory.build(
-            described_certificate=factories.CertificateFactory.create()
-        ),
-        serializers.CertificateDescriptionSerializer,
-    )
-
-
-def test_certificate_description_importer_update(update_imported_fields_match):
-    assert update_imported_fields_match(
         factories.CertificateDescriptionFactory,
         serializers.CertificateDescriptionSerializer,
         dependencies={"described_certificate": factories.CertificateFactory},

--- a/certificates/tests/test_xml.py
+++ b/certificates/tests/test_xml.py
@@ -2,29 +2,28 @@ import pytest
 
 from common.tests import factories
 from common.tests.util import validate_taric_xml
+from common.xml.namespaces import nsmap
 
 pytestmark = pytest.mark.django_db
 
 
 @validate_taric_xml(factories.CertificateTypeFactory)
-def test_certificate_type_xml(api_client, taric_schema, approved_transaction, xml):
-    element = xml.find(".//certificate.type", xml.nsmap)
+def test_certificate_type_xml(xml):
+    element = xml.find(".//oub:certificate.type", nsmap)
     assert element is not None
-    element = xml.find(".//certificate.type.description", xml.nsmap)
+    element = xml.find(".//oub:certificate.type.description", nsmap)
     assert element is not None
 
 
 @validate_taric_xml(factories.CertificateDescriptionFactory)
-def test_certificate_description_xml(
-    api_client, taric_schema, approved_transaction, xml
-):
-    element = xml.find(".//certificate.description", xml.nsmap)
+def test_certificate_description_xml(xml):
+    element = xml.find(".//oub:certificate.description", nsmap)
     assert element is not None
-    element = xml.find(".//certificate.description.period", xml.nsmap)
+    element = xml.find(".//oub:certificate.description.period", nsmap)
     assert element is not None
 
 
 @validate_taric_xml(factories.CertificateFactory)
-def test_certificate_xml(api_client, taric_schema, approved_transaction, xml):
-    element = xml.find(".//certificate", xml.nsmap)
+def test_certificate_xml(xml):
+    element = xml.find(".//oub:certificate", nsmap)
     assert element is not None

--- a/commodities/tests/test_xml.py
+++ b/commodities/tests/test_xml.py
@@ -2,53 +2,44 @@ import pytest
 
 from common.tests import factories
 from common.tests.util import validate_taric_xml
+from common.xml.namespaces import nsmap
 
 pytestmark = pytest.mark.django_db
 
 
 @validate_taric_xml(factories.GoodsNomenclatureFactory)
-def test_goods_nomenclature_xml(api_client, taric_schema, approved_transaction, xml):
-    element = xml.find(".//goods.nomenclature", xml.nsmap)
+def test_goods_nomenclature_xml(xml):
+    element = xml.find(".//oub:goods.nomenclature", nsmap)
     assert element is not None
 
 
 @validate_taric_xml(factories.GoodsNomenclatureIndentFactory)
-def test_goods_nomenclature_indent_xml(
-    api_client, taric_schema, approved_transaction, xml
-):
-    element = xml.find(".//goods.nomenclature.indents", xml.nsmap)
+def test_goods_nomenclature_indent_xml(xml):
+    element = xml.find(".//oub:goods.nomenclature.indents", nsmap)
     assert element is not None
 
 
 @validate_taric_xml(factories.GoodsNomenclatureOriginFactory)
-def test_goods_nomenclature_origin_xml(
-    api_client, taric_schema, approved_transaction, xml
-):
-    element = xml.find(".//goods.nomenclature.origin", xml.nsmap)
+def test_goods_nomenclature_origin_xml(xml):
+    element = xml.find(".//oub:goods.nomenclature.origin", nsmap)
     assert element is not None
 
 
 @validate_taric_xml(factories.GoodsNomenclatureSuccessorFactory)
-def test_goods_nomenclature_successor_xml(
-    api_client, taric_schema, approved_transaction, xml
-):
-    element = xml.find(".//goods.nomenclature.successor", xml.nsmap)
+def test_goods_nomenclature_successor_xml(xml):
+    element = xml.find(".//oub:goods.nomenclature.successor", nsmap)
     assert element is not None
 
 
 @validate_taric_xml(factories.GoodsNomenclatureDescriptionFactory)
-def test_goods_nomenclature_description_xml(
-    api_client, taric_schema, approved_transaction, xml
-):
-    element = xml.find(".//goods.nomenclature.description", xml.nsmap)
+def test_goods_nomenclature_description_xml(xml):
+    element = xml.find(".//oub:goods.nomenclature.description", nsmap)
     assert element is not None
-    element = xml.find(".//goods.nomenclature.description.period", xml.nsmap)
+    element = xml.find(".//oub:goods.nomenclature.description.period", nsmap)
     assert element is not None
 
 
 @validate_taric_xml(factories.FootnoteAssociationGoodsNomenclatureFactory)
-def test_footnote_association_goods_nomenclature_xml(
-    api_client, taric_schema, approved_transaction, xml
-):
-    element = xml.find(".//footnote.association.goods.nomenclature", xml.nsmap)
+def test_footnote_association_goods_nomenclature_xml(xml):
+    element = xml.find(".//oub:footnote.association.goods.nomenclature", nsmap)
     assert element is not None

--- a/common/xml/namespaces.py
+++ b/common/xml/namespaces.py
@@ -1,0 +1,11 @@
+"""TARIC3 XML namespaces."""
+
+ENVELOPE = "env"
+SEED_MESSAGE = "ns2"  # this is the prefix used in the seed file
+TARIC_MESSAGE = "oub"  # this is the prefix used in EU TARIC3 xml files
+
+nsmap = {
+    ENVELOPE: "urn:publicid:-:DGTAXUD:GENERAL:ENVELOPE:1.0",
+    SEED_MESSAGE: "urn:publicid:-:DGTAXUD:TARIC:MESSAGE:1.0",
+    TARIC_MESSAGE: "urn:publicid:-:DGTAXUD:TARIC:MESSAGE:1.0",
+}

--- a/conftest.py
+++ b/conftest.py
@@ -404,7 +404,6 @@ def imported_fields_match(
         factory: Type[DjangoModelFactory],
         serializer: Type[TrackedModelSerializer],
         dependencies: Optional[Dict[str, Any]] = None,
-        validity=(date_ranges.normal, date_ranges.adjacent_no_end),
     ):
         Model: Type[TrackedModel] = factory._meta.model
         previous_version: TrackedModel = None
@@ -423,26 +422,8 @@ def imported_fields_match(
                 kwargs[name] = dependency_model
 
         if update_type in (UpdateType.UPDATE, UpdateType.DELETE):
-            if validity:
-                if issubclass(factory, factories.ValidityFactoryMixin):
-                    kwargs["valid_between"] = validity[0]
-                elif issubclass(
-                    factory,
-                    factories.ValidityStartFactoryMixin,
-                ):
-                    kwargs["validity_start"] = validity[0].lower
-
             previous_version = factory.create(**kwargs)
             kwargs.update(previous_version.get_identifying_fields())
-
-        if validity:
-            if issubclass(factory, factories.ValidityFactoryMixin):
-                kwargs["valid_between"] = validity[1]
-            elif issubclass(
-                factory,
-                factories.ValidityStartFactoryMixin,
-            ):
-                kwargs["validity_start"] = validity[1].lower
 
         try:
             updated_model = run_xml_import(

--- a/footnotes/tests/test_importer.py
+++ b/footnotes/tests/test_importer.py
@@ -6,46 +6,23 @@ from footnotes import serializers
 pytestmark = pytest.mark.django_db
 
 
-def test_footnote_type_importer_create(imported_fields_match):
+def test_footnote_type_importer(imported_fields_match):
     assert imported_fields_match(
-        factories.FootnoteTypeFactory, serializers.FootnoteTypeSerializer
+        factories.FootnoteTypeFactory,
+        serializers.FootnoteTypeSerializer,
     )
 
 
-def test_footnote_type_importer_update(update_imported_fields_match):
-    assert update_imported_fields_match(
-        factories.FootnoteTypeFactory, serializers.FootnoteTypeSerializer
-    )
-
-
-def test_footnote_importer_create(imported_fields_match):
+def test_footnote_importer(imported_fields_match):
     assert imported_fields_match(
-        factories.FootnoteFactory.build(
-            footnote_type=factories.FootnoteTypeFactory.create()
-        ),
-        serializers.FootnoteSerializer,
-    )
-
-
-def test_footnote_importer_update(update_imported_fields_match):
-    assert update_imported_fields_match(
         factories.FootnoteFactory,
         serializers.FootnoteSerializer,
         dependencies={"footnote_type": factories.FootnoteTypeFactory},
     )
 
 
-def test_footnote_description_importer_create(imported_fields_match):
+def test_footnote_description_importer(imported_fields_match):
     assert imported_fields_match(
-        factories.FootnoteDescriptionFactory.build(
-            described_footnote=factories.FootnoteFactory.create()
-        ),
-        serializers.FootnoteDescriptionSerializer,
-    )
-
-
-def test_footnote_description_importer_update(update_imported_fields_match):
-    assert update_imported_fields_match(
         factories.FootnoteDescriptionFactory,
         serializers.FootnoteDescriptionSerializer,
         dependencies={"described_footnote": factories.FootnoteFactory},

--- a/footnotes/tests/test_xml.py
+++ b/footnotes/tests/test_xml.py
@@ -2,27 +2,28 @@ import pytest
 
 from common.tests import factories
 from common.tests.util import validate_taric_xml
+from common.xml.namespaces import nsmap
 
 pytestmark = pytest.mark.django_db
 
 
 @validate_taric_xml(factories.FootnoteTypeFactory)
-def test_footnote_type_xml(api_client, taric_schema, approved_transaction, xml):
-    element = xml.find(".//footnote.type", xml.nsmap)
+def test_footnote_type_xml(xml):
+    element = xml.find(".//oub:footnote.type", nsmap)
     assert element is not None
-    element = xml.find(".//footnote.type.description", xml.nsmap)
+    element = xml.find(".//oub:footnote.type.description", nsmap)
     assert element is not None
 
 
 @validate_taric_xml(factories.FootnoteFactory)
-def test_footnote_xml(api_client, taric_schema, approved_transaction, xml):
-    element = xml.find(".//footnote", xml.nsmap)
+def test_footnote_xml(xml):
+    element = xml.find(".//oub:footnote", nsmap)
     assert element is not None
 
 
 @validate_taric_xml(factories.FootnoteDescriptionFactory)
-def test_footnote_description_xml(api_client, taric_schema, approved_transaction, xml):
-    element = xml.find(".//footnote.description.period", xml.nsmap)
+def test_footnote_description_xml(xml):
+    element = xml.find(".//oub:footnote.description.period", nsmap)
     assert element is not None
-    element = xml.find(".//footnote.description", xml.nsmap)
+    element = xml.find(".//oub:footnote.description", nsmap)
     assert element is not None

--- a/geo_areas/tests/test_importer.py
+++ b/geo_areas/tests/test_importer.py
@@ -6,68 +6,33 @@ from geo_areas import serializers
 pytestmark = pytest.mark.django_db
 
 
-def test_geo_area_importer_create(imported_fields_match):
+def test_geo_area_importer(imported_fields_match):
     assert imported_fields_match(
         factories.GeographicalAreaFactory,
         serializers.GeographicalAreaSerializer,
     )
 
 
-def test_geo_area_importer_update(update_imported_fields_match):
-    assert update_imported_fields_match(
-        factories.GeographicalAreaFactory, serializers.GeographicalAreaSerializer
-    )
-
-
-def test_geo_area_with_parent_importer_create(imported_fields_match):
+def test_geo_area_with_parent_importer(imported_fields_match):
     assert imported_fields_match(
-        factories.GeographicalAreaFactory.build(
-            parent=factories.GeographicalAreaFactory.create(), area_code=1
-        ),
-        serializers.GeographicalAreaSerializer,
-    )
-
-
-def test_geo_area_with_parent_importer_update(update_imported_fields_match):
-    assert update_imported_fields_match(
-        factories.GeographicalAreaFactory,
+        factories.GeoGroupFactory,
         serializers.GeographicalAreaSerializer,
         dependencies={"parent": factories.GeographicalAreaFactory},
-        kwargs={"area_code": 1},
     )
 
 
-def test_geo_area_description_importer_create(imported_fields_match):
+def test_geo_area_description_importer(imported_fields_match):
     assert imported_fields_match(
-        factories.GeographicalAreaDescriptionFactory.build(
-            area=factories.GeographicalAreaFactory.create()
-        ),
-        serializers.GeographicalAreaDescriptionImporterSerializer,
-    )
-
-
-def test_geo_area_description_importer_update(update_imported_fields_match):
-    assert update_imported_fields_match(
         factories.GeographicalAreaDescriptionFactory,
         serializers.GeographicalAreaDescriptionImporterSerializer,
         dependencies={"area": factories.GeographicalAreaFactory},
     )
 
 
-def test_geo_area_membership_importer_create(imported_fields_match):
-    assert imported_fields_match(
-        factories.GeographicalMembershipFactory.build(
-            geo_group=factories.GeographicalAreaFactory.create(area_code=1),
-            member=factories.GeographicalAreaFactory.create(area_code=0),
-        ),
-        serializers.GeographicalMembershipSerializer,
-    )
-
-
-def test_geo_area_membership_importer_update(update_imported_fields_match):
+def test_geo_area_membership_importer(imported_fields_match):
     group = factories.GeographicalAreaFactory.create(area_code=1)
     member = factories.GeographicalAreaFactory.create(area_code=0)
-    assert update_imported_fields_match(
+    assert imported_fields_match(
         factories.GeographicalMembershipFactory,
         serializers.GeographicalMembershipSerializer,
         dependencies={"geo_group": group, "member": member},

--- a/geo_areas/tests/test_xml.py
+++ b/geo_areas/tests/test_xml.py
@@ -2,27 +2,26 @@ import pytest
 
 from common.tests import factories
 from common.tests.util import validate_taric_xml
+from common.xml.namespaces import nsmap
 
 pytestmark = pytest.mark.django_db
 
 
 @validate_taric_xml(factories.GeographicalAreaFactory)
-def test_geographical_area_xml(api_client, taric_schema, approved_transaction, xml):
-    element = xml.find(".//geographical.area", xml.nsmap)
+def test_geographical_area_xml(xml):
+    element = xml.find(".//oub:geographical.area", nsmap)
     assert element is not None
 
 
 @validate_taric_xml(factories.GeographicalAreaDescriptionFactory)
-def test_geographical_area_description_xml(
-    api_client, taric_schema, approved_transaction, xml
-):
-    element = xml.find(".//geographical.area.description", xml.nsmap)
+def test_geographical_area_description_xml(xml):
+    element = xml.find(".//oub:geographical.area.description", nsmap)
     assert element is not None
-    element = xml.find(".//geographical.area.description.period", xml.nsmap)
+    element = xml.find(".//oub:geographical.area.description.period", nsmap)
     assert element is not None
 
 
 @validate_taric_xml(factories.GeographicalMembershipFactory)
-def test_geo_membership_xml(api_client, taric_schema, approved_transaction, xml):
-    element = xml.find(".//geographical.area.membership", xml.nsmap)
+def test_geo_membership_xml(xml):
+    element = xml.find(".//oub:geographical.area.membership", nsmap)
     assert element is not None

--- a/importer/namespaces.py
+++ b/importer/namespaces.py
@@ -3,22 +3,9 @@ from typing import Tuple
 from typing import TypeVar
 from typing import Union
 
-
-Namespace = Tuple[str, str]
-
-ENVELOPE = "env"
-NS0 = "ns0"
-NS1 = "ns1"
-SEED_MESSAGE = "ns2"  # this is the prefix used in the seed file
-TARIC_MESSAGE = "oub"  # this is the prefix used in EU TARIC3 xml files
-
-nsmap = {
-    ENVELOPE: "urn:publicid:-:DGTAXUD:GENERAL:ENVELOPE:1.0",
-    NS0: "urn:publicid:-:DGTAXUD:GENERAL:ENVELOPE:1.0",
-    NS1: "urn:publicid:-:DGTAX UD:TARIC:MESSAGE:1.0",
-    SEED_MESSAGE: "urn:publicid:-:DGTAXUD:TARIC:MESSAGE:1.0",
-    TARIC_MESSAGE: "urn:publicid:-:DGTAXUD:TARIC:MESSAGE:1.0",
-}
+from common.xml.namespaces import TARIC_MESSAGE
+from common.xml.namespaces import SEED_MESSAGE
+from common.xml.namespaces import nsmap
 
 T = TypeVar("T", bound="Tag")
 

--- a/importer/taric.py
+++ b/importer/taric.py
@@ -16,9 +16,9 @@ from lxml import etree
 
 from common import models
 from common.validators import UpdateType
-from importer.namespaces import ENVELOPE
+from common.xml.namespaces import ENVELOPE
+from common.xml.namespaces import nsmap
 from importer.namespaces import Tag
-from importer.namespaces import nsmap
 from importer.nursery import get_nursery
 from importer.parsers import ElementParser
 from importer.parsers import ParserError

--- a/measures/tests/test_importer.py
+++ b/measures/tests/test_importer.py
@@ -1,68 +1,37 @@
 import pytest
 
 from common.tests import factories
-from common.validators import UpdateType
 from measures import serializers
 from measures import unit_serializers
 from measures.validators import OrderNumberCaptureCode
 from quotas.validators import AdministrationMechanism
 
-
 pytestmark = pytest.mark.django_db
 
 
-def test_measure_type_series_importer_create(imported_fields_match):
+def test_measure_type_series_importer(imported_fields_match):
     assert imported_fields_match(
-        factories.MeasureTypeSeriesFactory, serializers.MeasureTypeSeriesSerializer
+        factories.MeasureTypeSeriesFactory,
+        serializers.MeasureTypeSeriesSerializer,
     )
 
 
-def test_measure_type_series_importer_update(update_imported_fields_match):
-    assert update_imported_fields_match(
-        factories.MeasureTypeSeriesFactory, serializers.MeasureTypeSeriesSerializer
-    )
-
-
-def test_measurement_unit_importer_create(imported_fields_match):
+def test_measurement_unit_importer(imported_fields_match):
     assert imported_fields_match(
         factories.MeasurementUnitFactory,
         serializer=unit_serializers.MeasurementUnitSerializer,
     )
 
 
-def test_measurement_unit_importer_update(update_imported_fields_match):
-    assert update_imported_fields_match(
-        factories.MeasurementUnitFactory, unit_serializers.MeasurementUnitSerializer
-    )
-
-
-def test_measurement_unit_qualifier_importer_create(imported_fields_match):
+def test_measurement_unit_qualifier_importer(imported_fields_match):
     assert imported_fields_match(
         factories.MeasurementUnitQualifierFactory,
         serializer=unit_serializers.MeasurementUnitQualifierSerializer,
     )
 
 
-def test_measurement_unit_qualifier_importer_update(update_imported_fields_match):
-    assert update_imported_fields_match(
-        factories.MeasurementUnitQualifierFactory,
-        unit_serializers.MeasurementUnitQualifierSerializer,
-    )
-
-
-def test_measurement_importer_create(imported_fields_match):
+def test_measurement_importer(imported_fields_match):
     assert imported_fields_match(
-        factories.MeasurementFactory.build(
-            measurement_unit=factories.MeasurementUnitFactory.create(),
-            measurement_unit_qualifier=factories.MeasurementUnitQualifierFactory.create(),
-            update_type=UpdateType.CREATE,
-        ),
-        serializer=unit_serializers.MeasurementSerializer,
-    )
-
-
-def test_measurement_importer_update(update_imported_fields_match):
-    assert update_imported_fields_match(
         factories.MeasurementFactory,
         serializers.MeasurementSerializer,
         dependencies={
@@ -72,80 +41,58 @@ def test_measurement_importer_update(update_imported_fields_match):
     )
 
 
-def test_monetary_unit_importer_create(imported_fields_match):
+def test_monetary_unit_importer(imported_fields_match):
     assert imported_fields_match(
         factories.MonetaryUnitFactory,
         serializer=unit_serializers.MonetaryUnitSerializer,
     )
 
 
-def test_monetary_unit_importer_update(update_imported_fields_match):
-    assert update_imported_fields_match(
-        factories.MonetaryUnitFactory, unit_serializers.MeasurementUnitSerializer
-    )
-
-
-def test_duty_expression_importer_create(imported_fields_match):
+def test_duty_expression_importer(imported_fields_match):
     assert imported_fields_match(
-        factories.DutyExpressionFactory, serializers.DutyExpressionSerializer
+        factories.DutyExpressionFactory,
+        serializers.DutyExpressionSerializer,
     )
 
 
-def test_duty_expression_importer_update(update_imported_fields_match):
-    assert update_imported_fields_match(
-        factories.DutyExpressionFactory, serializers.DutyExpressionSerializer
-    )
-
-
-def test_measure_type_importer_create(imported_fields_match):
+def test_measure_type_importer(imported_fields_match):
     assert imported_fields_match(
-        factories.MeasureTypeFactory.build(
-            measure_type_series=factories.MeasureTypeSeriesFactory.create(),
-            update_type=UpdateType.CREATE,
-        ),
+        factories.MeasureTypeFactory,
         serializers.MeasureTypeSerializer,
+        dependencies={
+            "measure_type_series": factories.MeasureTypeSeriesFactory,
+        },
     )
 
 
-def test_additional_code_type_measure_type_importer_create(imported_fields_match):
+def test_additional_code_type_measure_type_importer(imported_fields_match):
     assert imported_fields_match(
-        factories.AdditionalCodeTypeMeasureTypeFactory.build(
-            measure_type=factories.MeasureTypeFactory.create(),
-            additional_code_type=factories.AdditionalCodeTypeFactory.create(),
-            update_type=UpdateType.CREATE,
-        ),
+        factories.AdditionalCodeTypeMeasureTypeFactory,
         serializers.AdditionalCodeTypeMeasureTypeSerializer,
+        dependencies={
+            "measure_type": factories.MeasureTypeFactory,
+            "additional_code_type": factories.AdditionalCodeTypeFactory,
+        },
     )
 
 
-def test_measure_condition_code_importer_create(imported_fields_match):
+def test_measure_condition_code_importer(imported_fields_match):
     assert imported_fields_match(
         factories.MeasureConditionCodeFactory,
         serializers.MeasureConditionCodeSerializer,
     )
 
 
-def test_measure_condition_code_importer_update(update_imported_fields_match):
-    assert update_imported_fields_match(
-        factories.MeasureConditionCodeFactory,
-        serializers.MeasureConditionCodeSerializer,
-    )
-
-
-def test_measure_action_importer_create(imported_fields_match):
+def test_measure_action_importer(imported_fields_match):
     assert imported_fields_match(
-        factories.MeasureActionFactory, serializers.MeasureActionSerializer
+        factories.MeasureActionFactory,
+        serializers.MeasureActionSerializer,
     )
 
 
-def test_measure_action_importer_update(update_imported_fields_match):
-    assert update_imported_fields_match(
-        factories.MeasureActionFactory, serializers.MeasureActionSerializer
-    )
-
-
-def test_measure_importer_create(
-    imported_fields_match, approved_transaction, unapproved_transaction
+def test_measure_importer(
+    imported_fields_match,
+    approved_transaction,
 ):
     rel = factories.AdditionalCodeTypeMeasureTypeFactory.create(
         measure_type__order_number_capture_code=OrderNumberCaptureCode.MANDATORY,
@@ -157,126 +104,81 @@ def test_measure_importer_create(
     ac = factories.AdditionalCodeFactory.create(type=rel.additional_code_type)
 
     assert imported_fields_match(
-        factories.MeasureFactory.build(
-            measure_type=rel.measure_type,
-            geographical_area=origin.geographical_area,
-            goods_nomenclature=factories.GoodsNomenclatureFactory.create(
-                item_id="7600000000"
-            ),
-            additional_code=ac,
-            order_number=origin.order_number,
-            generating_regulation=factories.RegulationFactory.create(),
-            update_type=UpdateType.CREATE,
-        ),
-        serializers.MeasureSerializer,
-    )
-
-
-def test_measure_importer_update(
-    update_imported_fields_match, approved_transaction, unapproved_transaction
-):
-    rel = factories.AdditionalCodeTypeMeasureTypeFactory.create(
-        measure_type__order_number_capture_code=OrderNumberCaptureCode.MANDATORY,
-    )
-    origin = factories.QuotaOrderNumberOriginFactory.create(
-        order_number__mechanism=AdministrationMechanism.FCFS,
-        transaction=unapproved_transaction,
-    )
-    assert update_imported_fields_match(
         factories.MeasureFactory,
         serializers.MeasureSerializer,
         dependencies={
             "measure_type": rel.measure_type,
             "geographical_area": origin.geographical_area,
             "goods_nomenclature": factories.GoodsNomenclatureFactory,
-            "additional_code": factories.AdditionalCodeFactory.create(
-                type=rel.additional_code_type
-            ),
+            "additional_code": ac,
             "order_number": origin.order_number,
             "generating_regulation": factories.RegulationFactory,
         },
     )
 
 
-def test_measure_component_importer_create(imported_fields_match):
+def test_measure_component_importer(imported_fields_match):
     assert imported_fields_match(
-        factories.MeasureComponentFactory.build(
-            component_measure=factories.MeasureFactory.create(),
-            duty_expression=factories.DutyExpressionFactory.create(),
-            monetary_unit=factories.MonetaryUnitFactory.create(),
-            component_measurement=factories.MeasurementFactory.create(),
-            update_type=UpdateType.CREATE,
-        ),
+        factories.MeasureComponentFactory,
         serializers.MeasureComponentSerializer,
+        dependencies={
+            "component_measure": factories.MeasureFactory,
+            "duty_expression": factories.DutyExpressionFactory,
+            "monetary_unit": factories.MonetaryUnitFactory,
+            "component_measurement": factories.MeasurementFactory,
+        },
     )
 
 
-def test_measure_condition_importer_create(imported_fields_match):
+def test_measure_condition_importer(imported_fields_match):
     assert imported_fields_match(
-        factories.MeasureConditionFactory.build(
-            dependent_measure=factories.MeasureFactory.create(),
-            condition_code=factories.MeasureConditionCodeFactory.create(),
-            monetary_unit=factories.MonetaryUnitFactory.create(),
-            condition_measurement=factories.MeasurementFactory.create(),
-            action=factories.MeasureActionFactory.create(),
-            required_certificate=factories.CertificateFactory.create(),
-            update_type=UpdateType.CREATE,
-        ),
+        factories.MeasureConditionFactory,
         serializers.MeasureConditionSerializer,
+        dependencies={
+            "dependent_measure": factories.MeasureFactory,
+            "condition_code": factories.MeasureConditionCodeFactory,
+            "monetary_unit": factories.MonetaryUnitFactory,
+            "condition_measurement": factories.MeasurementFactory,
+            "action": factories.MeasureActionFactory,
+            "required_certificate": factories.CertificateFactory,
+        },
     )
 
 
-def test_measure_condition_component_importer_create(imported_fields_match):
+def test_measure_condition_component_importer(imported_fields_match):
     assert imported_fields_match(
-        factories.MeasureConditionComponentFactory.build(
-            condition=factories.MeasureConditionFactory.create(),
-            duty_expression=factories.DutyExpressionFactory.create(),
-            monetary_unit=factories.MonetaryUnitFactory.create(),
-            component_measurement=factories.MeasurementFactory.create(),
-            update_type=UpdateType.CREATE,
-        ),
+        factories.MeasureConditionComponentFactory,
         serializers.MeasureConditionComponentSerializer,
+        dependencies={
+            "condition": factories.MeasureConditionFactory,
+            "duty_expression": factories.DutyExpressionFactory,
+            "monetary_unit": factories.MonetaryUnitFactory,
+            "component_measurement": factories.MeasurementFactory,
+        },
     )
 
 
-def test_measure_excluded_geographical_area_importer_create(imported_fields_match):
+def test_measure_excluded_geographical_area_importer(imported_fields_match):
     membership = factories.GeographicalMembershipFactory.create()
 
     assert imported_fields_match(
-        factories.MeasureExcludedGeographicalAreaFactory.build(
-            modified_measure=factories.MeasureFactory.create(
-                geographical_area=membership.geo_group
-            ),
-            excluded_geographical_area=membership.member,
-        ),
-        serializers.MeasureExcludedGeographicalAreaSerializer,
-    )
-
-
-def test_measure_excluded_geographical_area_importer_update(
-    update_imported_fields_match,
-):
-    membership = factories.GeographicalMembershipFactory.create()
-
-    assert update_imported_fields_match(
         factories.MeasureExcludedGeographicalAreaFactory,
         serializers.MeasureExcludedGeographicalAreaSerializer,
         dependencies={
             "modified_measure": factories.MeasureFactory.create(
-                geographical_area=membership.geo_group
+                geographical_area=membership.geo_group,
             ),
             "excluded_geographical_area": membership.member,
         },
-        validity=False,
     )
 
 
-def test_footnote_association_measure_importer_create(imported_fields_match):
+def test_footnote_association_measure_importer(imported_fields_match):
     assert imported_fields_match(
-        factories.FootnoteAssociationMeasureFactory.build(
-            footnoted_measure=factories.MeasureFactory.create(),
-            associated_footnote=factories.FootnoteFactory.create(),
-            update_type=UpdateType.CREATE,
-        ),
+        factories.FootnoteAssociationMeasureFactory,
         serializers.FootnoteAssociationMeasureSerializer,
+        dependencies={
+            "footnoted_measure": factories.MeasureFactory,
+            "associated_footnote": factories.FootnoteFactory,
+        },
     )

--- a/measures/tests/test_xml.py
+++ b/measures/tests/test_xml.py
@@ -2,146 +2,144 @@ import pytest
 
 from common.tests import factories
 from common.tests.util import validate_taric_xml
+from common.xml.namespaces import nsmap
 
 pytestmark = pytest.mark.django_db
 
 
 @validate_taric_xml(factories.AdditionalCodeTypeMeasureTypeFactory)
-def test_additional_code_type_measure_type_xml(
-    api_client, taric_schema, approved_transaction, xml
-):
-    assert xml.find(".//additional.code.type.measure.type", xml.nsmap) is not None
+def test_additional_code_type_measure_type_xml(xml):
+    assert xml.find(".//oub:additional.code.type.measure.type", nsmap) is not None
 
 
 @validate_taric_xml(factories.DutyExpressionFactory)
-def test_duty_expression_xml(api_client, taric_schema, approved_transaction, xml):
-    assert xml.find(".//duty.expression", xml.nsmap) is not None
-    assert xml.find(".//duty.expression.description", xml.nsmap) is not None
+def test_duty_expression_xml(xml):
+    assert xml.find(".//oub:duty.expression", nsmap) is not None
+    assert xml.find(".//oub:duty.expression.description", nsmap) is not None
     assert (
-        xml.findtext(".//duty.expression.description/language.id", namespaces=xml.nsmap)
+        xml.findtext(
+            ".//oub:duty.expression.description/oub:language.id", namespaces=nsmap
+        )
         == "EN"
     )
 
 
 @validate_taric_xml(factories.FootnoteAssociationMeasureFactory)
-def test_footnote_association_measure_xml(
-    api_client, taric_schema, approved_transaction, xml
-):
-    assert xml.find(".//footnote.association.measure", xml.nsmap) is not None
+def test_footnote_association_measure_xml(xml):
+    assert xml.find(".//oub:footnote.association.measure", nsmap) is not None
 
 
 @validate_taric_xml(factories.MeasureWithQuotaFactory, check_order=False)
-def test_measure_xml(api_client, taric_schema, approved_transaction, xml):
-    assert xml.find(".//measure", xml.nsmap) is not None
+def test_measure_xml(xml):
+    assert xml.find(".//oub:measure", nsmap) is not None
 
 
 @validate_taric_xml(factories.MeasureActionFactory)
-def test_measure_action_xml(api_client, taric_schema, approved_transaction, xml):
-    assert xml.find(".//measure.action", xml.nsmap) is not None
-    assert xml.find(".//measure.action.description", xml.nsmap) is not None
+def test_measure_action_xml(xml):
+    assert xml.find(".//oub:measure.action", nsmap) is not None
+    assert xml.find(".//oub:measure.action.description", nsmap) is not None
     assert (
-        xml.findtext(".//measure.action.description/language.id", namespaces=xml.nsmap)
+        xml.findtext(
+            ".//oub:measure.action.description/oub:language.id", namespaces=nsmap
+        )
         == "EN"
     )
 
 
 @validate_taric_xml(factories.MeasureComponentFactory)
-def test_measure_component_xml(api_client, taric_schema, approved_transaction, xml):
-    assert xml.find(".//measure.component", xml.nsmap) is not None
+def test_measure_component_xml(xml):
+    assert xml.find(".//oub:measure.component", nsmap) is not None
 
 
 @validate_taric_xml(factories.MeasureConditionFactory)
-def test_measure_condition_xml(api_client, taric_schema, approved_transaction, xml):
-    assert xml.find(".//measure.condition", xml.nsmap) is not None
+def test_measure_condition_xml(xml):
+    assert xml.find(".//oub:measure.condition", nsmap) is not None
 
 
 @validate_taric_xml(factories.MeasureConditionCodeFactory)
-def test_measure_condition_code_xml(
-    api_client, taric_schema, approved_transaction, xml
-):
-    assert xml.find(".//measure.condition.code", xml.nsmap) is not None
-    assert xml.find(".//measure.condition.code.description", xml.nsmap) is not None
+def test_measure_condition_code_xml(xml):
+    assert xml.find(".//oub:measure.condition.code", nsmap) is not None
+    assert xml.find(".//oub:measure.condition.code.description", nsmap) is not None
     assert (
         xml.findtext(
-            ".//measure.condition.code.description/language.id", namespaces=xml.nsmap
+            ".//oub:measure.condition.code.description/oub:language.id",
+            namespaces=nsmap,
         )
         == "EN"
     )
 
 
 @validate_taric_xml(factories.MeasureConditionComponentFactory)
-def test_measure_condition_component_xml(
-    api_client, taric_schema, approved_transaction, xml
-):
-    assert xml.find(".//measure.condition.component", xml.nsmap) is not None
+def test_measure_condition_component_xml(xml):
+    assert xml.find(".//oub:measure.condition.component", nsmap) is not None
 
 
 @validate_taric_xml(factories.MeasureExcludedGeographicalMembershipFactory)
-def test_measure_excluded_geographical_area_xml(
-    api_client, taric_schema, approved_transaction, xml
-):
-    assert xml.find(".//measure.excluded.geographical.area", xml.nsmap) is not None
+def test_measure_excluded_geographical_area_xml(xml):
+    assert xml.find(".//oub:measure.excluded.geographical.area", nsmap) is not None
 
 
 @validate_taric_xml(factories.MeasureTypeFactory)
-def test_measure_type_xml(api_client, taric_schema, approved_transaction, xml):
-    assert xml.find(".//measure.type", xml.nsmap) is not None
-    assert xml.find(".//measure.type.description", xml.nsmap) is not None
+def test_measure_type_xml(xml):
+    assert xml.find(".//oub:measure.type", nsmap) is not None
+    assert xml.find(".//oub:measure.type.description", nsmap) is not None
     assert (
-        xml.findtext(".//measure.type.description/language.id", namespaces=xml.nsmap)
+        xml.findtext(
+            ".//oub:measure.type.description/oub:language.id", namespaces=nsmap
+        )
         == "EN"
     )
 
 
 @validate_taric_xml(factories.MeasureTypeSeriesFactory)
-def test_measure_type_series_xml(api_client, taric_schema, approved_transaction, xml):
-    assert xml.find(".//measure.type.series", xml.nsmap) is not None
-    assert xml.find(".//measure.type.series.description", xml.nsmap) is not None
+def test_measure_type_series_xml(xml):
+    assert xml.find(".//oub:measure.type.series", nsmap) is not None
+    assert xml.find(".//oub:measure.type.series.description", nsmap) is not None
     assert (
         xml.findtext(
-            ".//measure.type.series.description/language.id", namespaces=xml.nsmap
+            ".//oub:measure.type.series.description/oub:language.id", namespaces=nsmap
         )
         == "EN"
     )
 
 
 @validate_taric_xml(factories.MeasurementFactory)
-def test_measurement_xml(api_client, taric_schema, approved_transaction, xml):
-    assert xml.find(".//measurement", xml.nsmap) is not None
+def test_measurement_xml(xml):
+    assert xml.find(".//oub:measurement", nsmap) is not None
 
 
 @validate_taric_xml(factories.MeasurementUnitFactory)
-def test_measurement_unit_xml(api_client, taric_schema, approved_transaction, xml):
-    assert xml.find(".//measurement.unit", xml.nsmap) is not None
-    assert xml.find(".//measurement.unit.description", xml.nsmap) is not None
+def test_measurement_unit_xml(xml):
+    assert xml.find(".//oub:measurement.unit", nsmap) is not None
+    assert xml.find(".//oub:measurement.unit.description", nsmap) is not None
     assert (
         xml.findtext(
-            ".//measurement.unit.description/language.id", namespaces=xml.nsmap
+            ".//oub:measurement.unit.description/oub:language.id", namespaces=nsmap
         )
         == "EN"
     )
 
 
 @validate_taric_xml(factories.MeasurementUnitQualifierFactory)
-def test_measurement_unit_qualifier_xml(
-    api_client, taric_schema, approved_transaction, xml
-):
-    assert xml.find(".//measurement.unit.qualifier", xml.nsmap) is not None
-    assert xml.find(".//measurement.unit.qualifier.description", xml.nsmap) is not None
+def test_measurement_unit_qualifier_xml(xml):
+    assert xml.find(".//oub:measurement.unit.qualifier", nsmap) is not None
+    assert xml.find(".//oub:measurement.unit.qualifier.description", nsmap) is not None
     assert (
         xml.findtext(
-            ".//measurement.unit.qualifier.description/language.id",
-            namespaces=xml.nsmap,
+            ".//oub:measurement.unit.qualifier.description/oub:language.id",
+            namespaces=nsmap,
         )
         == "EN"
     )
 
 
 @validate_taric_xml(factories.MonetaryUnitFactory)
-def test_monetary_unit_xml(api_client, taric_schema, approved_transaction, xml):
-    assert xml.find(".//monetary.unit", xml.nsmap) is not None
-    assert xml.find(".//monetary.unit.description", xml.nsmap) is not None
+def test_monetary_unit_xml(xml):
+    assert xml.find(".//oub:monetary.unit", nsmap) is not None
+    assert xml.find(".//oub:monetary.unit.description", nsmap) is not None
     assert (
-        xml.findtext(".//monetary.unit.description/language.id", namespaces=xml.nsmap)
+        xml.findtext(
+            ".//oub:monetary.unit.description/oub:language.id", namespaces=nsmap
+        )
         == "EN"
     )

--- a/quotas/tests/test_importer.py
+++ b/quotas/tests/test_importer.py
@@ -6,32 +6,15 @@ from quotas import serializers
 pytestmark = pytest.mark.django_db
 
 
-def test_quota_order_number_importer_create(imported_fields_match):
+def test_quota_order_number_importer(imported_fields_match):
     assert imported_fields_match(
         factories.QuotaOrderNumberFactory,
         serializers.QuotaOrderNumberSerializer,
     )
 
 
-def test_quota_order_number_importer_update(update_imported_fields_match):
-    assert update_imported_fields_match(
-        factories.QuotaOrderNumberFactory,
-        serializers.QuotaOrderNumberSerializer,
-    )
-
-
-def test_quota_order_number_origin_importer_create(imported_fields_match):
+def test_quota_order_number_origin_importer(imported_fields_match):
     assert imported_fields_match(
-        factories.QuotaOrderNumberOriginFactory.build(
-            order_number=factories.QuotaOrderNumberFactory.create(),
-            geographical_area=factories.GeographicalAreaFactory.create(),
-        ),
-        serializers.QuotaOrderNumberOriginSerializer,
-    )
-
-
-def test_quota_order_number_origin_importer_update(update_imported_fields_match):
-    assert update_imported_fields_match(
         factories.QuotaOrderNumberOriginFactory,
         serializers.QuotaOrderNumberOriginSerializer,
         dependencies={
@@ -41,44 +24,21 @@ def test_quota_order_number_origin_importer_update(update_imported_fields_match)
     )
 
 
-def test_quota_order_number_origin_exclusion_importer_create(imported_fields_match):
-    assert imported_fields_match(
-        factories.QuotaOrderNumberOriginExclusionFactory.build(
-            origin=factories.QuotaOrderNumberOriginFactory.create(),
-            excluded_geographical_area=factories.GeographicalAreaFactory.create(),
-        ),
-        serializers.QuotaOrderNumberOriginExclusionSerializer,
-    )
-
-
-def test_quota_order_number_origin_exclusion_importer_update(
-    update_imported_fields_match,
+def test_quota_order_number_origin_exclusion_importer(
+    imported_fields_match,
 ):
-    assert update_imported_fields_match(
+    assert imported_fields_match(
         factories.QuotaOrderNumberOriginExclusionFactory,
         serializers.QuotaOrderNumberOriginExclusionSerializer,
         dependencies={
             "origin": factories.QuotaOrderNumberOriginFactory,
             "excluded_geographical_area": factories.GeographicalAreaFactory,
         },
-        validity=False,
     )
 
 
-def test_quota_definition_importer_create(imported_fields_match):
+def test_quota_definition_importer(imported_fields_match):
     assert imported_fields_match(
-        factories.QuotaDefinitionFactory.build(
-            order_number=factories.QuotaOrderNumberFactory.create(),
-            monetary_unit=factories.MonetaryUnitFactory.create(),
-            measurement_unit=factories.MeasurementUnitFactory.create(),
-            measurement_unit_qualifier=factories.MeasurementUnitQualifierFactory.create(),
-        ),
-        serializers.QuotaDefinitionImporterSerializer,
-    )
-
-
-def test_quota_definition_importer_update(update_imported_fields_match):
-    assert update_imported_fields_match(
         factories.QuotaDefinitionFactory,
         serializers.QuotaDefinitionImporterSerializer,
         dependencies={
@@ -90,39 +50,19 @@ def test_quota_definition_importer_update(update_imported_fields_match):
     )
 
 
-def test_quota_association_importer_create(imported_fields_match):
+def test_quota_association_importer(imported_fields_match):
     assert imported_fields_match(
-        factories.QuotaAssociationFactory.build(
-            main_quota=factories.QuotaDefinitionFactory.create(),
-            sub_quota=factories.QuotaDefinitionFactory.create(),
-        ),
-        serializers.QuotaAssociationSerializer,
-    )
-
-
-def test_quota_association_importer_update(update_imported_fields_match):
-    assert update_imported_fields_match(
         factories.QuotaAssociationFactory,
         serializers.QuotaAssociationSerializer,
         dependencies={
             "main_quota": factories.QuotaDefinitionFactory,
             "sub_quota": factories.QuotaDefinitionFactory,
         },
-        validity=False,
     )
 
 
-def test_quota_suspension_importer_create(imported_fields_match):
+def test_quota_suspension_importer(imported_fields_match, date_ranges):
     assert imported_fields_match(
-        factories.QuotaSuspensionFactory.build(
-            quota_definition=factories.QuotaDefinitionFactory.create(),
-        ),
-        serializers.QuotaSuspensionSerializer,
-    )
-
-
-def test_quota_suspension_importer_update(update_imported_fields_match, date_ranges):
-    assert update_imported_fields_match(
         factories.QuotaSuspensionFactory,
         serializers.QuotaSuspensionSerializer,
         dependencies={
@@ -132,17 +72,8 @@ def test_quota_suspension_importer_update(update_imported_fields_match, date_ran
     )
 
 
-def test_quota_blocking_importer_create(imported_fields_match):
+def test_quota_blocking_importer(imported_fields_match, date_ranges):
     assert imported_fields_match(
-        factories.QuotaBlockingFactory.build(
-            quota_definition=factories.QuotaDefinitionFactory.create(),
-        ),
-        serializers.QuotaBlockingSerializer,
-    )
-
-
-def test_quota_blocking_importer_update(update_imported_fields_match, date_ranges):
-    assert update_imported_fields_match(
         factories.QuotaBlockingFactory,
         serializers.QuotaBlockingSerializer,
         dependencies={
@@ -153,24 +84,13 @@ def test_quota_blocking_importer_update(update_imported_fields_match, date_range
 
 
 @pytest.mark.parametrize("subrecord_code", ["00", "05", "10", "15", "20", "25", "30"])
-def test_quota_event_importer_create(subrecord_code, valid_user, imported_fields_match):
+def test_quota_event_importer(subrecord_code, imported_fields_match):
     assert imported_fields_match(
-        factories.QuotaEventFactory.build(
-            quota_definition=factories.QuotaDefinitionFactory.create(),
-            subrecord_code=subrecord_code,
-        ),
-        serializers.QuotaEventSerializer,
-    )
-
-
-@pytest.mark.parametrize("subrecord_code", ["00", "05", "10", "15", "20", "25", "30"])
-def test_quota_event_importer_update(subrecord_code, update_imported_fields_match):
-    assert update_imported_fields_match(
         factories.QuotaEventFactory,
         serializers.QuotaEventSerializer,
         dependencies={
             "quota_definition": factories.QuotaDefinitionFactory,
+            "subrecord_code": subrecord_code,
         },
-        kwargs={"subrecord_code": subrecord_code},
         validity=False,
     )

--- a/quotas/tests/test_importer.py
+++ b/quotas/tests/test_importer.py
@@ -68,7 +68,6 @@ def test_quota_suspension_importer(imported_fields_match, date_ranges):
         dependencies={
             "quota_definition": factories.QuotaDefinitionFactory,
         },
-        validity=[date_ranges.normal, date_ranges.adjacent_later],
     )
 
 
@@ -79,7 +78,6 @@ def test_quota_blocking_importer(imported_fields_match, date_ranges):
         dependencies={
             "quota_definition": factories.QuotaDefinitionFactory,
         },
-        validity=[date_ranges.normal, date_ranges.adjacent_later],
     )
 
 
@@ -92,5 +90,4 @@ def test_quota_event_importer(subrecord_code, imported_fields_match):
             "quota_definition": factories.QuotaDefinitionFactory,
             "subrecord_code": subrecord_code,
         },
-        validity=False,
     )

--- a/quotas/tests/test_xml.py
+++ b/quotas/tests/test_xml.py
@@ -2,66 +2,57 @@ import pytest
 
 from common.tests import factories
 from common.tests.util import validate_taric_xml
+from common.xml.namespaces import nsmap
 from quotas.validators import QuotaEventType
 
 pytestmark = pytest.mark.django_db
 
 
 @validate_taric_xml(factories.QuotaOrderNumberFactory, factory_kwargs={"origin": None})
-def test_quota_order_number_xml(api_client, taric_schema, approved_transaction, xml):
-    element = xml.find(".//quota.order.number", xml.nsmap)
+def test_quota_order_number_xml(xml):
+    element = xml.find(".//oub:quota.order.number", nsmap)
     assert element is not None
 
 
 @validate_taric_xml(factories.QuotaOrderNumberOriginFactory)
-def test_quota_order_number_origin_xml(
-    api_client,
-    taric_schema,
-    approved_transaction,
-    xml,
-):
-    element = xml.find(".//quota.order.number.origin", xml.nsmap)
+def test_quota_order_number_origin_xml(xml):
+    element = xml.find(".//oub:quota.order.number.origin", nsmap)
     assert element is not None
 
 
 @validate_taric_xml(factories.QuotaOrderNumberOriginExclusionFactory)
-def test_quota_order_number_origin_exclusion_xml(
-    api_client,
-    taric_schema,
-    approved_transaction,
-    xml,
-):
-    element = xml.find(".//quota.order.number.origin.exclusions", xml.nsmap)
+def test_quota_order_number_origin_exclusion_xml(xml):
+    element = xml.find(".//oub:quota.order.number.origin.exclusions", nsmap)
     assert element is not None
 
 
 @validate_taric_xml(factories.QuotaDefinitionWithQualifierFactory)
-def test_quota_definition_xml(api_client, taric_schema, approved_transaction, xml):
-    element = xml.find(".//quota.definition", xml.nsmap)
+def test_quota_definition_xml(xml):
+    element = xml.find(".//oub:quota.definition", nsmap)
     assert element is not None
-    element = xml.find(".//monetary.unit.code", xml.nsmap)
+    element = xml.find(".//oub:monetary.unit.code", nsmap)
     assert element is not None
-    element = xml.find(".//measurement.unit.code", xml.nsmap)
+    element = xml.find(".//oub:measurement.unit.code", nsmap)
     assert element is not None
-    element = xml.find(".//measurement.unit.qualifier.code", xml.nsmap)
+    element = xml.find(".//oub:measurement.unit.qualifier.code", nsmap)
     assert element is not None
 
 
 @validate_taric_xml(factories.QuotaAssociationFactory)
-def test_quota_association_xml(api_client, taric_schema, approved_transaction, xml):
-    element = xml.find(".//quota.association", xml.nsmap)
+def test_quota_association_xml(xml):
+    element = xml.find(".//oub:quota.association", nsmap)
     assert element is not None
 
 
 @validate_taric_xml(factories.QuotaSuspensionFactory)
-def test_quota_suspension_xml(api_client, taric_schema, approved_transaction, xml):
-    element = xml.find(".//quota.suspension.period", xml.nsmap)
+def test_quota_suspension_xml(xml):
+    element = xml.find(".//oub:quota.suspension.period", nsmap)
     assert element is not None
 
 
 @validate_taric_xml(factories.QuotaBlockingFactory)
-def test_quota_blocking_xml(api_client, taric_schema, approved_transaction, xml):
-    element = xml.find(".//quota.blocking.period", xml.nsmap)
+def test_quota_blocking_xml(xml):
+    element = xml.find(".//oub:quota.blocking.period", nsmap)
     assert element is not None
 
 
@@ -94,7 +85,7 @@ def test_quota_event_xml(
             transaction=approved_transaction,
         ),
     )
-    def test_event_type(api_client, taric_schema, approved_transaction, xml):
+    def test_event_type(xml):
         element = xml.find(f".//{tag}", xml.nsmap)
         assert element is not None
 

--- a/regulations/tests/test_importer.py
+++ b/regulations/tests/test_importer.py
@@ -54,7 +54,7 @@ def create_and_test_m2m_regulation(
                     test_regulation.information_text,
                     test_regulation.public_identifier,
                     test_regulation.url,
-                ]
+                ],
             ),
             "approved": test_regulation.approved,
         },
@@ -69,7 +69,9 @@ def create_and_test_m2m_regulation(
 
     xml = generate_test_import_xml(data)
     process_taric_xml_stream(
-        xml, username=valid_user.username, status=WorkflowStatus.PUBLISHED.value
+        xml,
+        username=valid_user.username,
+        status=WorkflowStatus.PUBLISHED.value,
     )
 
     through_table_instance = through_model.objects.get(
@@ -108,31 +110,15 @@ def create_and_test_m2m_regulation(
     return through_table_instance
 
 
-def test_regulation_group_importer_create(imported_fields_match):
+def test_regulation_group_importer(imported_fields_match):
     assert imported_fields_match(
-        factories.RegulationGroupFactory, serializers.GroupSerializer
+        factories.RegulationGroupFactory,
+        serializers.GroupSerializer,
     )
 
 
-def test_regulation_group_importer_update(update_imported_fields_match):
-    assert update_imported_fields_match(
-        factories.RegulationGroupFactory, serializers.GroupSerializer
-    )
-
-
-def test_regulation_importer_create(imported_fields_match):
-    regulation = factories.RegulationFactory.build(
-        regulation_group=factories.RegulationGroupFactory.create()
-    )
-
+def test_regulation_importer(imported_fields_match):
     assert imported_fields_match(
-        regulation,
-        serializers.RegulationImporterSerializer,
-    )
-
-
-def test_regulation_importer_update(update_imported_fields_match):
-    assert update_imported_fields_match(
         factories.RegulationFactory,
         serializers.RegulationImporterSerializer,
         dependencies={"regulation_group": factories.RegulationGroupFactory},
@@ -141,7 +127,10 @@ def test_regulation_importer_update(update_imported_fields_match):
 
 def test_amendment_importer_create(valid_user):
     create_and_test_m2m_regulation(
-        RoleType.MODIFICATION, "taric/amendment.xml", models.Amendment, valid_user
+        RoleType.MODIFICATION,
+        "taric/amendment.xml",
+        models.Amendment,
+        valid_user,
     )
 
 
@@ -233,7 +222,9 @@ def test_replacement_importer_create(valid_user):
 
     xml = generate_test_import_xml(data)
     process_taric_xml_stream(
-        xml, username=valid_user.username, status=WorkflowStatus.PUBLISHED.value
+        xml,
+        username=valid_user.username,
+        status=WorkflowStatus.PUBLISHED.value,
     )
 
     replacement = models.Replacement.objects.get(
@@ -269,7 +260,9 @@ def test_replacement_importer_update(valid_user):
 
     xml = generate_test_import_xml(data)
     process_taric_xml_stream(
-        xml, username=valid_user.username, status=WorkflowStatus.PUBLISHED.value
+        xml,
+        username=valid_user.username,
+        status=WorkflowStatus.PUBLISHED.value,
     )
 
     replacements = models.Replacement.objects.filter(

--- a/regulations/tests/test_xml.py
+++ b/regulations/tests/test_xml.py
@@ -2,21 +2,20 @@ import pytest
 
 from common.tests import factories
 from common.tests.util import validate_taric_xml
+from common.xml.namespaces import nsmap
 
 pytestmark = pytest.mark.django_db
 
 
 @validate_taric_xml(factories.RegulationFactory)
-def test_regulation_xml(api_client, taric_schema, approved_transaction, xml):
-    element = xml.find(".//base.regulation", xml.nsmap)
+def test_regulation_xml(xml):
+    element = xml.find(".//oub:base.regulation", nsmap)
     assert element is not None
 
 
 @validate_taric_xml(factories.RegulationFactory)
-def test_information_text_contains_url_and_public_id(
-    api_client, taric_schema, approved_transaction, xml
-):
-    text = xml.findtext(".//information.text", namespaces=xml.nsmap)
+def test_information_text_contains_url_and_public_id(xml):
+    text = xml.findtext(".//oub:information.text", namespaces=nsmap)
     assert "|" in text
     assert "https://" in text
     assert "S.I." in text


### PR DESCRIPTION
Here's some self-contained work that has fallen out of the XML performance branch – updates and deduplication of lots of test logic around the import and export features. Merging this now will give a much smaller PR for the XML work later.

> Our importer tests are quite verbose – in particular the same tests are repeated once for creation and again for delete/update. The two tests also have different styles but are functionally equivalent.
>
> There is no real need for this, so this commit removes this duplication. We now instead can simply call `imported_fields_match` once and this will test the importer for all variations of update type.

> Our XML tests validate that the XML we output is valid according to the TARIC3 spec and contain the elements we expect. They do this by checking for tags named correctly. They should also check that the namespace is correct – ultimately, tags that are named correctly but in the wrong namespace are not what we want. 
>
> This commit is a find/replace to add the correct namespaces to all of these checks.