### PR TITLE
TP-742: Basic error handling

### DIFF
--- a/additional_codes/business_rules.py
+++ b/additional_codes/business_rules.py
@@ -16,8 +16,8 @@ class CT1(UniqueIdentifyingFields):
 
 
 class ACN1(UniqueIdentifyingFields):
-    """The combination of additional code type + additional code + start date
-    must be unique."""
+    """The combination of additional code type, additional code ID and start
+    date must be unique."""
 
     identifying_fields = ("type", "code", "valid_between__lower")
 
@@ -50,8 +50,8 @@ class ACN2(BusinessRule):
 
 class ACN4(NoOverlapping):
     """The validity period of the additional code must not overlap any other
-    additional code with the same additional code type + additional code + start
-    date."""
+    additional code with the same additional code type, additional code ID and
+    start date."""
 
     identifying_fields = (
         "type__sid",

--- a/additional_codes/forms.py
+++ b/additional_codes/forms.py
@@ -7,26 +7,15 @@ from crispy_forms_gds.layout import Submit
 from django import forms
 
 from additional_codes import models
-from common.forms import DateInputFieldFixed
 from common.forms import DescriptionForm
-from common.forms import GovukDateRangeField
-from common.util import TaricDateRange
+from common.forms import ValidityPeriodForm
 
 
-class AdditionalCodeForm(forms.ModelForm):
+class AdditionalCodeForm(ValidityPeriodForm):
     code = forms.CharField(
         label="Additional code ID",
         required=False,
     )
-    start_date = DateInputFieldFixed(
-        label="Start date",
-    )
-    end_date = DateInputFieldFixed(
-        help_text="Leave empty if an additional code is needed for an unlimited time",
-        label="End date",
-        required=False,
-    )
-    valid_between = GovukDateRangeField(required=False)
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -47,21 +36,17 @@ class AdditionalCodeForm(forms.ModelForm):
             self.fields["type"].disabled = True
             self.fields["type"].help_text = "You can't edit this"
 
-            if self.instance.valid_between.lower:
-                self.fields["start_date"].initial = self.instance.valid_between.lower
-            if self.instance.valid_between.upper:
-                self.fields["end_date"].initial = self.instance.valid_between.upper
-
         self.helper = FormHelper(self)
+        self.helper.label_size = Size.SMALL
+        self.helper.legend_size = Size.SMALL
         self.helper.layout = Layout(
             Field.text(
                 "code",
                 field_width=Fixed.TEN,
-                label_size=Size.SMALL,
             ),
-            Field("type", context={"label_size": "govuk-label--s"}),
-            Field("start_date", context={"legend_size": "govuk-label--s"}),
-            Field("end_date", context={"legend_size": "govuk-label--s"}),
+            Field("type"),
+            Field("start_date"),
+            Field("end_date"),
             Submit("submit", "Save"),
         )
 
@@ -73,14 +58,8 @@ class AdditionalCodeForm(forms.ModelForm):
 
         # get type from instance if not submitted
         ctype = cleaned_data.get("type")
-
         if not ctype and self.instance and self.instance.type:
             ctype = self.instance.type
-
-        # combine start and end dates into date range
-        start_date = cleaned_data.pop("start_date", None)
-        end_date = cleaned_data.pop("end_date", None)
-        cleaned_data["valid_between"] = TaricDateRange(start_date, end_date)
 
         return cleaned_data
 

--- a/additional_codes/tests/bdd/conftest.py
+++ b/additional_codes/tests/bdd/conftest.py
@@ -28,3 +28,18 @@ def additional_code_X000(date_ranges):
         validity_start=date_ranges.overlap_normal.lower,
     )
     return ac
+
+
+@given("a previous additional code X000", target_fixture="old_additional_code")
+def old_additional_code(date_ranges, additional_code_X000):
+    ac = factories.AdditionalCodeFactory.create(
+        code=additional_code_X000.code,
+        type=additional_code_X000.type,
+        valid_between=date_ranges.earlier,
+    )
+    factories.AdditionalCodeDescriptionFactory.create(
+        described_additionalcode=ac,
+        description="This was an older usage of X000",
+        validity_start=date_ranges.earlier.lower,
+    )
+    return ac

--- a/additional_codes/tests/bdd/features/edit_additional_codes.feature
+++ b/additional_codes/tests/bdd/features/edit_additional_codes.feature
@@ -17,3 +17,14 @@ Scenario: Edit permission denied
     Given I am logged in as David
     When I edit additional code X000
     Then I am not permitted to edit
+
+Scenario: Setting end date before start date errors
+    Given I am logged in as Carol
+    When I set the end date before the start date on additional code X000
+    Then I see the form error message "The end date must be the same as or after the start date."
+
+Scenario: Violate business rule
+    Given I am logged in as Carol
+    And a previous additional code X000
+    When I set the start date of additional code X000 to overlap the previous additional code
+    Then I see the form error message "The validity period of the additional code must not overlap any other additional code with the same additional code type, additional code ID and start date."

--- a/additional_codes/tests/bdd/test_edit_additional_codes.py
+++ b/additional_codes/tests/bdd/test_edit_additional_codes.py
@@ -1,7 +1,12 @@
+from datetime import date
+from datetime import timedelta
+
 import pytest
 from pytest_bdd import scenarios
 from pytest_bdd import then
 from pytest_bdd import when
+
+from common.tests.util import validity_period_post_data
 
 pytestmark = pytest.mark.django_db
 
@@ -22,3 +27,28 @@ def edit_permission_denied(model_edit_page):
 @then("I see an edit form")
 def edit_permission_granted(model_edit_page):
     assert model_edit_page.status_code == 200
+
+
+@pytest.fixture
+@when("I set the end date before the start date on additional code X000")
+def end_date_before_start(client, response, additional_code_X000):
+    response["response"] = client.post(
+        additional_code_X000.get_url("edit"),
+        validity_period_post_data(
+            start=date(2021, 1, 1),
+            end=date(1979, 1, 1),
+        ),
+    )
+
+
+@when(
+    "I set the start date of additional code X000 to overlap the previous additional code",
+)
+def submit_overlapping(client, response, additional_code_X000, old_additional_code):
+    response["response"] = client.post(
+        additional_code_X000.get_url("edit"),
+        validity_period_post_data(
+            start=old_additional_code.valid_between.lower,
+            end=old_additional_code.valid_between.upper + timedelta(days=1),
+        ),
+    )

--- a/additional_codes/views.py
+++ b/additional_codes/views.py
@@ -3,6 +3,7 @@ from typing import Type
 from rest_framework import permissions
 from rest_framework import viewsets
 
+from additional_codes import business_rules
 from additional_codes.filters import AdditionalCodeFilter
 from additional_codes.filters import AdditionalCodeFilterBackend
 from additional_codes.forms import AdditionalCodeDescriptionForm
@@ -13,6 +14,7 @@ from additional_codes.models import AdditionalCodeType
 from additional_codes.serializers import AdditionalCodeSerializer
 from additional_codes.serializers import AdditionalCodeTypeSerializer
 from common.models import TrackedModel
+from common.views import BusinessRulesMixin
 from common.views import TamatoListView
 from common.views import TrackedModelDetailMixin
 from common.views import TrackedModelDetailView
@@ -91,10 +93,20 @@ class AdditionalCodeDetail(AdditionalCodeMixin, TrackedModelDetailView):
 
 class AdditionalCodeUpdate(
     AdditionalCodeMixin,
+    BusinessRulesMixin,
     TrackedModelDetailMixin,
     DraftUpdateView,
 ):
     form_class = AdditionalCodeForm
+
+    validate_business_rules = (
+        business_rules.ACN1,
+        business_rules.ACN2,
+        business_rules.ACN4,
+        business_rules.ACN13,
+        business_rules.ACN17,
+        # business_rules.ACN5,  # XXX should it be checked here?
+    )
 
 
 class AdditionalCodeUpdateDescription(

--- a/certificates/forms.py
+++ b/certificates/forms.py
@@ -8,27 +8,17 @@ from django import forms
 from django.core.exceptions import ValidationError
 
 from certificates import models
-from common.forms import DateInputFieldFixed
 from common.forms import DescriptionForm
 from common.forms import GovukDateRangeField
-from common.util import TaricDateRange
+from common.forms import ValidityPeriodForm
 
 
-class CertificateForm(forms.ModelForm):
+class CertificateForm(ValidityPeriodForm):
     code = forms.CharField(
         label="Certificate ID",
         required=False,
     )
-    start_date = DateInputFieldFixed(
-        label="Start date",
-    )
-    end_date = DateInputFieldFixed(
-        help_text="Leave empty if a certificate is needed for an unlimited time",
-        label="End date",
-        required=False,
-    )
     sid = forms.CharField(required=False)
-    valid_between = GovukDateRangeField(required=False)
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -45,11 +35,6 @@ class CertificateForm(forms.ModelForm):
 
             self.fields["certificate_type"].disabled = True
             self.fields["certificate_type"].help_text = "You can't edit this"
-
-            if self.instance.valid_between.lower:
-                self.fields["start_date"].initial = self.instance.valid_between.lower
-            if self.instance.valid_between.upper:
-                self.fields["end_date"].initial = self.instance.valid_between.upper
 
         self.helper = FormHelper(self)
         self.helper.label_size = Size.SMALL
@@ -86,11 +71,6 @@ class CertificateForm(forms.ModelForm):
 
         if not ctype:
             raise ValidationError({"certificate_type": "Certificate type is required"})
-
-        # combine start and end dates into date range
-        start_date = cleaned_data.pop("start_date", None)
-        end_date = cleaned_data.pop("end_date", None)
-        cleaned_data["valid_between"] = TaricDateRange(start_date, end_date)
 
         return cleaned_data
 

--- a/certificates/tests/bdd/features/edit.feature
+++ b/certificates/tests/bdd/features/edit.feature
@@ -17,3 +17,8 @@ Scenario: Edit permission denied
     Given I am logged in as David
     When I edit certificate X000
     Then I am not permitted to edit
+
+Scenario: Setting end date before start date errors
+    Given I am logged in as Carol
+    When I set the end date before the start date on certificate X000
+    Then I see the form error message "The end date must be the same as or after the start date."

--- a/certificates/tests/bdd/test_edit_certificates.py
+++ b/certificates/tests/bdd/test_edit_certificates.py
@@ -22,3 +22,19 @@ def edit_permission_denied(model_edit_page):
 @then("I see an edit form")
 def edit_permission_granted(model_edit_page):
     assert model_edit_page.status_code == 200
+
+
+@pytest.fixture
+@when("I set the end date before the start date on certificate X000")
+def end_date_before_start(client, response, certificate_X000):
+    response["response"] = client.post(
+        certificate_X000.get_url("edit"),
+        {
+            "start_date_0": "1",
+            "start_date_1": "1",
+            "start_date_2": "2021",
+            "end_date_0": "1",
+            "end_date_1": "1",
+            "end_date_2": "1979",
+        },
+    )

--- a/certificates/views.py
+++ b/certificates/views.py
@@ -3,12 +3,14 @@ from typing import Type
 from rest_framework import permissions
 from rest_framework import viewsets
 
+from certificates import business_rules
 from certificates import forms
 from certificates import models
 from certificates.filters import CertificateFilter
 from certificates.serializers import CertificateSerializer
 from certificates.serializers import CertificateTypeSerializer
 from common.models import TrackedModel
+from common.views import BusinessRulesMixin
 from common.views import TamatoListView
 from common.views import TrackedModelDetailMixin
 from common.views import TrackedModelDetailView
@@ -66,10 +68,18 @@ class CertificateDetail(CertificateMixin, TrackedModelDetailView):
 
 class CertificateUpdate(
     CertificateMixin,
+    BusinessRulesMixin,
     TrackedModelDetailMixin,
     DraftUpdateView,
 ):
     form_class = forms.CertificateForm
+
+    validate_business_rules = (
+        business_rules.CE2,
+        business_rules.CE4,
+        # business_rules.CE6,  # XXX should it be checked here?
+        business_rules.CE7,
+    )
 
 
 class CertificateConfirmUpdate(CertificateMixin, TrackedModelDetailView):

--- a/common/business_rules.py
+++ b/common/business_rules.py
@@ -87,7 +87,7 @@ class BusinessRule(metaclass=BusinessRuleBase):
 
     Violation: Type[BusinessRuleViolation]
 
-    def __init__(self, transaction):
+    def __init__(self, transaction=None):
         self.transaction = transaction
 
     @classmethod
@@ -186,7 +186,7 @@ class UniqueIdentifyingFields(BusinessRule):
         if (
             model.__class__.objects.filter(**query)
             .approved_up_to_transaction(self.transaction)
-            .exclude(id=model.id)
+            .exclude(version_group=model.version_group)
             .exists()
         ):
             raise self.violation(model)
@@ -206,7 +206,7 @@ class NoOverlapping(BusinessRule):
         if (
             model.__class__.objects.filter(**query)
             .approved_up_to_transaction(self.transaction)
-            .exclude(id=model.id)
+            .exclude(version_group=model.version_group)
             .exists()
         ):
             raise self.violation(model)

--- a/common/jinja2.py
+++ b/common/jinja2.py
@@ -43,6 +43,8 @@ class GovukFrontendExtension(NunjucksExtension):
                 r"params.countMessage",
                 r"params.formGroup",
                 r"params.legend",
+                r"params.prefix",
+                r"params.suffix",
             ]
             source = re.sub(
                 r"(" + r"|".join(nested_attrs) + r")\.",

--- a/common/models/records.py
+++ b/common/models/records.py
@@ -688,3 +688,9 @@ class TrackedModel(PolymorphicModel):
         if not prefix:
             prefix = self._meta.verbose_name.replace(" ", "_")
         return prefix
+
+    def get_indefinite_article(self):
+        """Returns "a" or "an" based on the verbose_name."""
+
+        # XXX naive, but works for all current models
+        return "an" if self._meta.verbose_name[0] in ["a", "e", "i", "o", "u"] else "a"

--- a/common/tests/factories.py
+++ b/common/tests/factories.py
@@ -312,6 +312,8 @@ class CertificateDescriptionFactory(TrackedModelMixin, ValidityStartFactoryMixin
 
 
 class TestModel1Factory(TrackedModelMixin, ValidityFactoryMixin):
+    __test__ = False
+
     class Meta:
         model = TestModel1
 
@@ -328,6 +330,8 @@ class TestModelDescription1Factory(TrackedModelMixin, ValidityFactoryMixin):
 
 
 class TestModel2Factory(TrackedModelMixin, ValidityFactoryMixin):
+    __test__ = False
+
     class Meta:
         model = TestModel2
 
@@ -336,6 +340,8 @@ class TestModel2Factory(TrackedModelMixin, ValidityFactoryMixin):
 
 
 class TestModel3Factory(TrackedModelMixin, ValidityFactoryMixin):
+    __test__ = False
+
     class Meta:
         model = TestModel3
 

--- a/common/tests/util.py
+++ b/common/tests/util.py
@@ -1,4 +1,5 @@
 import contextlib
+from datetime import date
 from datetime import datetime
 from datetime import timezone
 from functools import wraps
@@ -307,3 +308,28 @@ def only_applicable_after(cutoff):
         return do_test
 
     return decorator
+
+
+def validity_period_post_data(start: date, end: date) -> dict[str, int]:
+    """
+    Construct a POST data fragment for the validity period start and end dates
+    of a ValidityPeriodForm from the given date objects, eg:
+
+    >>> validity_period_post_data(
+    >>>     datetime.date(2021, 1, 2),
+    >>>     datetime.date(2022, 3, 4),
+    >>> )
+    {
+        "start_date_0": 1,
+        "start_date_1": 2,
+        "start_date_2": 2021,
+        "end_date_0": 4,
+        "end_date_1": 3,
+        "end_date_2": 2022,
+    }
+    """
+    return {
+        f"{name}_{i}": part
+        for name, date in (("start_date", start), ("end_date", end))
+        for i, part in enumerate([date.day, date.month, date.year])
+    }

--- a/conftest.py
+++ b/conftest.py
@@ -17,11 +17,13 @@ from django.contrib.auth.models import Group
 from django.contrib.auth.models import Permission
 from django.core.exceptions import ObjectDoesNotExist
 from django.core.exceptions import ValidationError
+from django.test.html import parse_html
 from factory.django import DjangoModelFactory
 from lxml import etree
 from moto import mock_s3
 from pytest_bdd import given
 from pytest_bdd import parsers
+from pytest_bdd import then
 from rest_framework.test import APIClient
 
 from common.models import TrackedModel
@@ -644,3 +646,15 @@ def in_use_check_respects_deletes(valid_user):
         return True
 
     return check
+
+
+@pytest.fixture
+def response():
+    """Hacky fixture to enable passing the client response between BDD steps."""
+    return {}
+
+
+@then(parsers.parse('I see the form error message "{error_message}"'))
+def form_error_shown(response, error_message):
+    response_html = parse_html(response["response"].content.decode())
+    assert error_message in response_html

--- a/footnotes/tests/bdd/features/edit-footnote.feature
+++ b/footnotes/tests/bdd/features/edit-footnote.feature
@@ -1,4 +1,4 @@
-@bdd @todo
+@bdd
 Feature: Edit Footnote
 
 Background:
@@ -8,25 +8,19 @@ Background:
     And there is a current workbasket
 
 
-Scenario: View Footnote edit screen
+Scenario: Edit permission granted
     Given I am logged in as Bob
-    When I go to edit footnote NC000
-    Then I should be presented with a form with an <enabled> <field> field
-
-    Examples:
-    | field | enabled |
-    | id_footnote_type | disabled |
-    | id_footnote_id | disabled |
-    | id_valid_between_0 | enabled |
-    | id_valid_between_1 | enabled |
+    When I edit footnote NC000
+    Then I see an edit form
 
 
-Scenario: Update Footnote
+Scenario: Setting end date before start date errors
     Given I am logged in as Bob
-    When I submit a <change> to footnote NC000
-    Then I should be presented with a footnote update screen
+    When I set the end date before the start date on footnote NC000
+    Then I see the form error message "The end date must be the same as or after the start date."
 
-    Examples:
-    | change     |
-    | start date |
-    | end date   |
+
+Scenario: Violate business rule
+    Given I am logged in as Bob
+    When I set the start date of footnote NC000 to predate the footnote type
+    Then I see the form error message "The validity period of the footnote type must span the validity period of the footnote."

--- a/footnotes/tests/bdd/test_edit_footnote.py
+++ b/footnotes/tests/bdd/test_edit_footnote.py
@@ -1,11 +1,13 @@
 """Edit Footnote feature tests."""
-import re
+from datetime import date
+from datetime import timedelta
 
 import pytest
-from dateutil.relativedelta import relativedelta
 from pytest_bdd import scenarios
 from pytest_bdd import then
 from pytest_bdd import when
+
+from common.tests.util import validity_period_post_data
 
 pytestmark = pytest.mark.django_db
 
@@ -14,56 +16,34 @@ scenarios("features/edit-footnote.feature")
 
 
 @pytest.fixture
-@when("I go to edit footnote NC000")
+@when("I edit footnote NC000")
 def footnote_edit_screen(client, footnote_NC000):
     return client.get(footnote_NC000.get_url("edit"))
 
 
+@then("I see an edit form")
+def edit_permission_granted(footnote_edit_screen):
+    assert footnote_edit_screen.status_code == 200
+
+
 @pytest.fixture
-@when("I submit a <change> to footnote NC000")
-def submit_footnote_NC000(client, footnote_NC000, change):
-    existing = footnote_NC000.valid_between
-
-    def make_payload(lower=None, upper=None):
-        payload = {}
-        if lower:
-            payload.update(
-                valid_between_0_0=lower.day,
-                valid_between_0_1=lower.month,
-                valid_between_0_2=lower.year,
-            )
-        if upper:
-            payload.update(
-                valid_between_1_0=upper.day,
-                valid_between_1_1=upper.month,
-                valid_between_1_2=upper.year,
-            )
-        return payload
-
-    change_payload = {
-        "start date": make_payload(existing.lower + relativedelta(days=+1)),
-        "end date": make_payload(
-            existing.lower,
-            existing.upper + relativedelta(months=+1),
+@when("I set the end date before the start date on footnote NC000")
+def end_date_before_start(client, response, footnote_NC000):
+    response["response"] = client.post(
+        footnote_NC000.get_url("edit"),
+        validity_period_post_data(
+            start=date(2021, 1, 1),
+            end=date(1979, 1, 1),
         ),
-    }
-    return client.post(footnote_NC000.get_url("edit"), change_payload[change])
+    )
 
 
-@then("I should be presented with a footnote update screen")
-def i_should_be_presented_with_a_footnote_update_screen(
-    submit_footnote_NC000,
-    footnote_NC000,
-):
-    """I should be presented with a footnote update screen."""
-    assert submit_footnote_NC000.status_code == 302
-    assert submit_footnote_NC000.url.endswith("/confirm-update/")
-
-
-@then("I should be presented with a form with an <enabled> <field> field")
-def check_fields(enabled, field, footnote_edit_screen):
-    content = footnote_edit_screen.content.decode()
-    matches = re.findall(r'<[^>]*id="' + field + r'"[^>]*>', content)
-    assert matches
-    if enabled == "disabled":
-        assert "disabled" in matches[0]
+@when("I set the start date of footnote NC000 to predate the footnote type")
+def submit_predating(client, response, footnote_NC000):
+    response["response"] = client.post(
+        footnote_NC000.get_url("edit"),
+        validity_period_post_data(
+            start=footnote_NC000.footnote_type.valid_between.lower - timedelta(days=1),
+            end=footnote_NC000.valid_between.upper,
+        ),
+    )

--- a/footnotes/views.py
+++ b/footnotes/views.py
@@ -4,9 +4,11 @@ from rest_framework import permissions
 from rest_framework import viewsets
 
 from common.models import TrackedModel
+from common.views import BusinessRulesMixin
 from common.views import TamatoListView
 from common.views import TrackedModelDetailMixin
 from common.views import TrackedModelDetailView
+from footnotes import business_rules
 from footnotes import forms
 from footnotes import models
 from footnotes.filters import FootnoteFilter
@@ -89,10 +91,20 @@ class FootnoteDetail(FootnoteMixin, TrackedModelDetailView):
 
 class FootnoteUpdate(
     FootnoteMixin,
+    BusinessRulesMixin,
     TrackedModelDetailMixin,
     DraftUpdateView,
 ):
     form_class = forms.FootnoteForm
+
+    validate_business_rules = (
+        business_rules.FO2,
+        # business_rules.FO4,  # XXX should it be checked here?
+        business_rules.FO5,
+        business_rules.FO6,
+        business_rules.FO9,
+        business_rules.FO17,
+    )
 
 
 class FootnoteConfirmUpdate(FootnoteMixin, TrackedModelDetailView):


### PR DESCRIPTION
This PR addresses both TP-705 and TP-742

Edit forms currently only provide simple field validation (eg, SID matches a regular expression).

We need to prevent users accidentally adding invalid data to the database which would violate the business rules. To prevent this at the earliest opportunity, this commit adds checks for the following:

* When start date is after end date on models which have a validity period
* Selected business rules - some business rules can only be checked across all models in a transaction, some do not make sense in a create/edit form (eg PreventDeleteIfInUse rules)

If these checks fail, the form is redisplayed with error messages, allowing the user to correct the mistakes:
![image](https://user-images.githubusercontent.com/35194/118643261-354b2900-b7d4-11eb-8d72-b4eb44939900.png)
![image](https://user-images.githubusercontent.com/35194/118643290-4136eb00-b7d4-11eb-9da4-2b163508478d.png)
