### PR TITLE
Fix rule preventing quota definition deletions

### DIFF
--- a/quotas/business_rules.py
+++ b/quotas/business_rules.py
@@ -217,7 +217,7 @@ class PreventQuotaDefinitionDeletion(BusinessRule):
 
     def validate(self, quota_definition):
         if quota_definition.update_type == UpdateType.DELETE:
-            if quota_definition.valid_between.lower >= date.today():
+            if quota_definition.valid_between.lower <= date.today():
                 raise self.violation(quota_definition)
 
 


### PR DESCRIPTION
This rule was the wrong way around – quota definitions that have *started* cannot be deleted but ones that have *not started* yet can be.