### PR TITLE
TP-695 Fix api calls for edit measures

### DIFF
--- a/additional_codes/serializers.py
+++ b/additional_codes/serializers.py
@@ -59,6 +59,7 @@ class AdditionalCodeSerializer(ValiditySerializerMixin, TrackedModelSerializerMi
     class Meta:
         model = models.AdditionalCode
         fields = [
+            "id",
             "sid",
             "type",
             "code",

--- a/additional_codes/views.py
+++ b/additional_codes/views.py
@@ -32,12 +32,6 @@ class AdditionalCodeViewSet(viewsets.ReadOnlyModelViewSet):
     )
     serializer_class = AdditionalCodeSerializer
     filter_backends = [AdditionalCodeFilterBackend]
-    search_fields = [
-        "type__sid",
-        "code",
-        "sid",
-        "descriptions__description",
-    ]
 
 
 class AdditionalCodeTypeViewSet(viewsets.ReadOnlyModelViewSet):

--- a/commodities/filters.py
+++ b/commodities/filters.py
@@ -1,0 +1,10 @@
+from django.contrib.postgres.aggregates import StringAgg
+
+from common.filters import TamatoFilterBackend
+
+
+class GoodsNomenclatureFilterBackend(TamatoFilterBackend):
+    search_fields = (
+        StringAgg("item_id", delimiter=" "),
+        StringAgg("descriptions__description", delimiter=" "),
+    )  # XXX order is significant

--- a/commodities/serializers.py
+++ b/commodities/serializers.py
@@ -25,13 +25,38 @@ class SimpleGoodsNomenclatureSerializer(
         ]
 
 
+class SimpleGoodsNomenclatureDescriptionSerializer(
+    TrackedModelSerializerMixin,
+    ValidityStartSerializerMixin,
+):
+    class Meta:
+        model = models.GoodsNomenclatureDescription
+        fields = [
+            "sid",
+            "description",
+            "update_type",
+            "record_code",
+            "subrecord_code",
+            "period_record_code",
+            "period_subrecord_code",
+            "taric_template",
+            "start_date",
+            "validity_start",
+        ]
+
+
 @TrackedModelSerializer.register_polymorphic_model
 class GoodsNomenclatureSerializer(TrackedModelSerializerMixin, ValiditySerializerMixin):
     sid = serializers.IntegerField()
+    descriptions = SimpleGoodsNomenclatureDescriptionSerializer(
+        many=True,
+        required=False,
+    )
 
     class Meta:
         model = models.GoodsNomenclature
         fields = [
+            "id",
             "sid",
             "item_id",
             "suffix",
@@ -40,6 +65,7 @@ class GoodsNomenclatureSerializer(TrackedModelSerializerMixin, ValiditySerialize
             "record_code",
             "subrecord_code",
             "taric_template",
+            "descriptions",
             "start_date",
             "end_date",
             "valid_between",

--- a/commodities/views.py
+++ b/commodities/views.py
@@ -3,12 +3,15 @@ from rest_framework import viewsets
 
 from commodities import models
 from commodities import serializers
+from commodities.filters import GoodsNomenclatureFilterBackend
 
 
 class GoodsNomenclatureViewset(viewsets.ReadOnlyModelViewSet):
     """API endpoint that allows Goods Nomenclature to be viewed."""
 
-    queryset = models.GoodsNomenclature.objects.all()
+    queryset = models.GoodsNomenclature.objects.latest_approved().prefetch_related(
+        "descriptions",
+    )
     serializer_class = serializers.GoodsNomenclatureSerializer
     permission_classes = [permissions.IsAuthenticated]
-    search_fields = ["sid", "item_id"]
+    filter_backends = [GoodsNomenclatureFilterBackend]

--- a/measures/filters.py
+++ b/measures/filters.py
@@ -1,4 +1,5 @@
 from django import forms
+from django.contrib.postgres.aggregates import StringAgg
 from django.db.models import DateField
 from django.db.models import Q
 from django.db.models.functions import Lower
@@ -10,6 +11,7 @@ from django_filters import DateFilter
 
 from additional_codes.filters import COMBINED_ADDITIONAL_CODE_AND_TYPE_ID
 from common.filters import TamatoFilter
+from common.filters import TamatoFilterBackend
 from common.forms import DateInputFieldFixed
 from footnotes.filters import COMBINED_FOOTNOTE_AND_TYPE_ID
 from measures.forms import MeasureFilterForm
@@ -24,6 +26,13 @@ BEFORE_EXACT_AFTER_CHOICES = (
 
 class GovUKDateFilter(DateFilter):
     field_class = DateInputFieldFixed
+
+
+class MeasureTypeFilterBackend(TamatoFilterBackend):
+    search_fields = (
+        StringAgg("sid", delimiter=" "),
+        StringAgg("description", delimiter=" "),
+    )  # XXX order is significant
 
 
 class MeasureFilter(TamatoFilter):

--- a/measures/serializers.py
+++ b/measures/serializers.py
@@ -20,10 +20,10 @@ from regulations.serializers import RegulationSerializer
 @TrackedModelSerializer.register_polymorphic_model
 class MeasureTypeSeriesSerializer(TrackedModelSerializerMixin, ValiditySerializerMixin):
     sid = serializers.CharField(
-        validators=[validators.measure_type_series_id_validator]
+        validators=[validators.measure_type_series_id_validator],
     )
     measure_type_combination = serializers.ChoiceField(
-        choices=validators.MeasureTypeCombination.choices
+        choices=validators.MeasureTypeCombination.choices,
     )
 
     class Meta:
@@ -48,13 +48,13 @@ class MeasureTypeSeriesSerializer(TrackedModelSerializerMixin, ValiditySerialize
 class DutyExpressionSerializer(TrackedModelSerializerMixin, ValiditySerializerMixin):
     sid = serializers.ChoiceField(choices=validators.DutyExpressionId.choices)
     duty_amount_applicability_code = serializers.ChoiceField(
-        choices=validators.ApplicabilityCode.choices
+        choices=validators.ApplicabilityCode.choices,
     )
     measurement_unit_applicability_code = serializers.ChoiceField(
-        choices=validators.ApplicabilityCode.choices
+        choices=validators.ApplicabilityCode.choices,
     )
     monetary_unit_applicability_code = serializers.ChoiceField(
-        choices=validators.ApplicabilityCode.choices
+        choices=validators.ApplicabilityCode.choices,
     )
 
     class Meta:
@@ -82,24 +82,25 @@ class MeasureTypeSerializer(TrackedModelSerializerMixin, ValiditySerializerMixin
     measure_type_series = MeasureTypeSeriesSerializer(read_only=True)
     sid = serializers.CharField(validators=[validators.measure_type_id_validator])
     trade_movement_code = serializers.ChoiceField(
-        choices=validators.ImportExportCode.choices
+        choices=validators.ImportExportCode.choices,
     )
     priority_code = serializers.IntegerField(
-        validators=[validators.validate_priority_code]
+        validators=[validators.validate_priority_code],
     )
     measure_component_applicability_code = serializers.ChoiceField(
-        choices=validators.ApplicabilityCode.choices
+        choices=validators.ApplicabilityCode.choices,
     )
     order_number_capture_code = serializers.ChoiceField(
-        choices=validators.OrderNumberCaptureCode.choices
+        choices=validators.OrderNumberCaptureCode.choices,
     )
     measure_explosion_level = serializers.IntegerField(
-        validators=[validators.validate_measure_explosion_level]
+        validators=[validators.validate_measure_explosion_level],
     )
 
     class Meta:
         model = models.MeasureType
         fields = [
+            "id",
             "sid",
             "trade_movement_code",
             "priority_code",
@@ -124,7 +125,8 @@ class MeasureTypeSerializer(TrackedModelSerializerMixin, ValiditySerializerMixin
 
 @TrackedModelSerializer.register_polymorphic_model
 class AdditionalCodeTypeMeasureTypeSerializer(
-    TrackedModelSerializerMixin, ValiditySerializerMixin
+    TrackedModelSerializerMixin,
+    ValiditySerializerMixin,
 ):
     measure_type = MeasureTypeSerializer(read_only=True)
     additional_code_type = AdditionalCodeTypeSerializer(read_only=True)
@@ -146,10 +148,11 @@ class AdditionalCodeTypeMeasureTypeSerializer(
 
 @TrackedModelSerializer.register_polymorphic_model
 class MeasureConditionCodeSerializer(
-    TrackedModelSerializerMixin, ValiditySerializerMixin
+    TrackedModelSerializerMixin,
+    ValiditySerializerMixin,
 ):
     code = serializers.CharField(
-        validators=[validators.measure_condition_code_validator]
+        validators=[validators.measure_condition_code_validator],
     )
 
     class Meta:
@@ -205,7 +208,9 @@ class MeasureSerializer(TrackedModelSerializerMixin, ValiditySerializerMixin):
         required=False,
     )
     export_refund_nomenclature_sid = serializers.IntegerField(
-        min_value=1, max_value=99999999, required=False
+        min_value=1,
+        max_value=99999999,
+        required=False,
     )
 
     class Meta:
@@ -266,7 +271,7 @@ class MeasureConditionSerializer(TrackedModelSerializerMixin):
     action = MeasureActionSerializer(read_only=True)
     required_certificate = CertificateSerializer(read_only=True)
     component_sequence_number = serializers.IntegerField(
-        validators=[validators.validate_component_sequence_number]
+        validators=[validators.validate_component_sequence_number],
     )
 
     class Meta:

--- a/measures/urls.py
+++ b/measures/urls.py
@@ -1,7 +1,11 @@
 from django.urls import include
 from django.urls import path
+from rest_framework import routers
 
 from measures import views
+
+api_router = routers.DefaultRouter()
+api_router.register(r"measure_types", views.MeasureTypeViewSet)
 
 ui_patterns = [
     path(
@@ -19,4 +23,5 @@ ui_patterns = [
 
 urlpatterns = [
     path("measures/", include(ui_patterns)),
+    path("api/", include(api_router.urls)),
 ]

--- a/measures/views.py
+++ b/measures/views.py
@@ -1,7 +1,19 @@
+from rest_framework import viewsets
+
 from common.views import TamatoListView
 from common.views import TrackedModelDetailView
 from measures import models
 from measures.filters import MeasureFilter
+from measures.filters import MeasureTypeFilterBackend
+from measures.serializers import MeasureTypeSerializer
+
+
+class MeasureTypeViewSet(viewsets.ReadOnlyModelViewSet):
+    """API endpoint that allows measure types to be viewed."""
+
+    queryset = models.MeasureType.objects.latest_approved()
+    serializer_class = MeasureTypeSerializer
+    filter_backends = [MeasureTypeFilterBackend]
 
 
 class MeasureList(TamatoListView):

--- a/quotas/filters.py
+++ b/quotas/filters.py
@@ -5,9 +5,14 @@ from django_filters import MultipleChoiceFilter
 
 from common.filters import MultiValueCharFilter
 from common.filters import TamatoFilter
+from common.filters import TamatoFilterBackend
 from quotas import models
 from quotas import validators
 from quotas.forms import QuotaFilterForm
+
+
+class OrderNumberFilterBackend(TamatoFilterBackend):
+    search_fields = ("order_number",)  # XXX order is significant
 
 
 class QuotaFilter(TamatoFilter):

--- a/quotas/serializers.py
+++ b/quotas/serializers.py
@@ -19,6 +19,7 @@ class QuotaOrderNumberSerializer(TrackedModelSerializerMixin, ValiditySerializer
     class Meta:
         model = models.QuotaOrderNumber
         fields = [
+            "id",
             "sid",
             "order_number",
             "mechanism",

--- a/quotas/views.py
+++ b/quotas/views.py
@@ -5,14 +5,17 @@ from common.views import TamatoListView
 from common.views import TrackedModelDetailView
 from quotas import models
 from quotas import serializers
+from quotas.filters import OrderNumberFilterBackend
 from quotas.filters import QuotaFilter
 
 
 class QuotaOrderNumberViewset(viewsets.ReadOnlyModelViewSet):
+    """API endpoint that allows quota order numbers to be viewed."""
+
     queryset = models.QuotaOrderNumber.objects.has_approved_state()
     serializer_class = serializers.QuotaOrderNumberSerializer
     permission_classes = [permissions.IsAuthenticated]
-    search_fields = ["sid", "order_number", "mechanism", "category"]
+    filter_backends = [OrderNumberFilterBackend]
 
 
 class QuotaOrderNumberOriginViewset(viewsets.ReadOnlyModelViewSet):

--- a/regulations/serializers.py
+++ b/regulations/serializers.py
@@ -12,7 +12,8 @@ from regulations import validators
 @TrackedModelSerializer.register_polymorphic_model
 class GroupSerializer(ValiditySerializerMixin, TrackedModelSerializerMixin):
     group_id = serializers.CharField(
-        max_length=3, validators=[RegexValidator(r"[A-Z][A-Z][A-Z]")]
+        max_length=3,
+        validators=[RegexValidator(r"[A-Z][A-Z][A-Z]")],
     )
 
     class Meta:
@@ -39,7 +40,8 @@ class NestedRegulationSerializer(serializers.HyperlinkedModelSerializer):
 
 @TrackedModelSerializer.register_polymorphic_model
 class AmendmentSerializer(
-    serializers.HyperlinkedModelSerializer, TrackedModelSerializerMixin
+    serializers.HyperlinkedModelSerializer,
+    TrackedModelSerializerMixin,
 ):
     class Meta:
         model = models.Amendment
@@ -63,7 +65,8 @@ class NestedAmendmentSerializer(serializers.HyperlinkedModelSerializer):
 
 @TrackedModelSerializer.register_polymorphic_model
 class ReplacementSerializer(
-    serializers.HyperlinkedModelSerializer, TrackedModelSerializerMixin
+    serializers.HyperlinkedModelSerializer,
+    TrackedModelSerializerMixin,
 ):
     class Meta:
         model = models.Replacement
@@ -90,7 +93,8 @@ class NestedReplacementSerializer(serializers.HyperlinkedModelSerializer):
 
 @TrackedModelSerializer.register_polymorphic_model
 class ExtensionSerializer(
-    serializers.HyperlinkedModelSerializer, TrackedModelSerializerMixin
+    serializers.HyperlinkedModelSerializer,
+    TrackedModelSerializerMixin,
 ):
     class Meta:
         model = models.Extension
@@ -115,7 +119,8 @@ class NestedExtensionSerializer(serializers.HyperlinkedModelSerializer):
 
 @TrackedModelSerializer.register_polymorphic_model
 class SuspensionSerializer(
-    serializers.HyperlinkedModelSerializer, TrackedModelSerializerMixin
+    serializers.HyperlinkedModelSerializer,
+    TrackedModelSerializerMixin,
 ):
     class Meta:
         model = models.Suspension
@@ -140,7 +145,8 @@ class NestedSuspensionSerializer(serializers.HyperlinkedModelSerializer):
 
 @TrackedModelSerializer.register_polymorphic_model
 class TerminationSerializer(
-    serializers.HyperlinkedModelSerializer, TrackedModelSerializerMixin
+    serializers.HyperlinkedModelSerializer,
+    TrackedModelSerializerMixin,
 ):
     class Meta:
         model = models.Termination
@@ -164,7 +170,8 @@ class NestedTerminationSerializer(serializers.HyperlinkedModelSerializer):
 
 
 class RegulationImporterSerializer(
-    ValiditySerializerMixin, TrackedModelSerializerMixin
+    ValiditySerializerMixin,
+    TrackedModelSerializerMixin,
 ):
     role_type = serializers.IntegerField(read_only=False)
     regulation_group = GroupSerializer(required=False)
@@ -253,6 +260,7 @@ class RegulationSerializer(
     class Meta:
         model = models.Regulation
         fields = [
+            "id",
             "url",
             "role_type",
             "regulation_id",
@@ -289,7 +297,8 @@ class RegulationSerializer(
 
 
 class ReplacementImporterSerializer(
-    serializers.HyperlinkedModelSerializer, TrackedModelSerializerMixin
+    serializers.HyperlinkedModelSerializer,
+    TrackedModelSerializerMixin,
 ):
     enacting_regulation = RegulationSerializer(required=False)
     target_regulation = RegulationSerializer(required=False)

--- a/regulations/views.py
+++ b/regulations/views.py
@@ -15,7 +15,6 @@ class RegulationViewSet(viewsets.ReadOnlyModelViewSet):
     queryset = Regulation.objects.latest_approved().select_related("regulation_group")
     serializer_class = RegulationSerializer
     filter_backends = [RegulationFilterBackend]
-    search_fields = ["regulation_id", "pk"]
 
 
 class RegulationList(TamatoListView):


### PR DESCRIPTION
## Summary 
Just cleaning up the APIs to search on the parameters related to what we're looking for in the autocompletes, given that they aren't used elsewhere? 
## Notes
The search criteria is meant to match how the search suggestion strings display currently, this is likely to change after some UR and we learn how they use the search.