### PR TITLE
Rename new_draft->new_version and add a docstring.

### DIFF
--- a/commodities/tests/test_business_rules.py
+++ b/commodities/tests/test_business_rules.py
@@ -78,7 +78,7 @@ def test_NIG5(workbasket):
     with pytest.raises(BusinessRuleViolation):
         business_rules.NIG5(bad_good.transaction).validate(bad_good)
 
-    deleted_good = bad_good.new_draft(workbasket, update_type=UpdateType.DELETE)
+    deleted_good = bad_good.new_version(workbasket, update_type=UpdateType.DELETE)
     business_rules.NIG5(deleted_good.transaction).validate(deleted_good)
 
     good_good = factories.GoodsNomenclatureFactory.create(

--- a/common/tests/test_business_rules.py
+++ b/common/tests/test_business_rules.py
@@ -97,7 +97,7 @@ def test_rule_with_no_overlaps(rule):
 
 def test_rule_with_versions(rule, workbasket):
     version1 = factories.TestModel1Factory.create()
-    version2 = version1.new_draft(workbasket)
+    version2 = version1.new_version(workbasket)
     rule(version1.transaction).validate(version1)
     rule(version2.transaction).validate(version2)
 
@@ -134,7 +134,7 @@ def test_prevent_delete_if_in_use(approved_transaction):
         BusinessRuleChecker([model], model.transaction).validate()
 
         workbasket = factories.WorkBasketFactory.create()
-        model = model.new_draft(workbasket, update_type=UpdateType.DELETE)
+        model = model.new_version(workbasket, update_type=UpdateType.DELETE)
         model.in_use = MagicMock(return_value=True)
 
         with pytest.raises(BusinessRuleViolation):

--- a/common/tests/test_models.py
+++ b/common/tests/test_models.py
@@ -296,7 +296,7 @@ def test_save(sample_model):
 def test_new_draft_uses_passed_transaction(sample_model):
     transaction_count = Transaction.objects.count()
     new_transaction = sample_model.transaction.workbasket.new_transaction()
-    new_model = sample_model.new_draft(
+    new_model = sample_model.new_version(
         sample_model.transaction.workbasket,
         transaction=new_transaction,
     )
@@ -345,7 +345,7 @@ def test_get_descriptions_with_update(sample_model, valid_user):
         described_record=sample_model,
     )
     workbasket = factories.WorkBasketFactory.create()
-    new_description = description.new_draft(workbasket)
+    new_description = description.new_version(workbasket)
 
     description_queryset = sample_model.get_descriptions()
     assert description in description_queryset

--- a/common/views.py
+++ b/common/views.py
@@ -199,7 +199,7 @@ class TrackedModelDetailMixin:
             raise Http404(f"No {self.model.__name__} matching the query {self.kwargs}")
 
         if self.request.method == "POST":
-            obj = obj.new_draft(
+            obj = obj.new_version(
                 WorkBasket.current(self.request),
                 save=False,
             )

--- a/conftest.py
+++ b/conftest.py
@@ -569,7 +569,7 @@ def delete_record():
     """Provides a function for deleting a record."""
 
     def delete(model):
-        return model.new_draft(
+        return model.new_version(
             factories.WorkBasketFactory(),
             update_type=UpdateType.DELETE,
         )
@@ -637,7 +637,7 @@ def in_use_check_respects_deletes(valid_user):
         workbasket.save()
         assert in_use(), f"Approved {instance!r} not in use"
 
-        dependant.new_draft(
+        dependant.new_version(
             workbasket,
             update_type=UpdateType.DELETE,
         )

--- a/measures/models.py
+++ b/measures/models.py
@@ -637,7 +637,7 @@ class Measure(TrackedModel, ValidityMixin):
             if not self.terminating_regulation:
                 update_params["terminating_regulation"] = self.generating_regulation
 
-        return self.new_draft(workbasket, **update_params)
+        return self.new_version(workbasket, **update_params)
 
 
 class MeasureComponent(TrackedModel):

--- a/quotas/tests/test_business_rules.py
+++ b/quotas/tests/test_business_rules.py
@@ -391,7 +391,6 @@ def test_QD15():
 def test_prevent_quota_definition_deletion(
     unapproved_transaction,
     date_ranges,
-    update_type,
     date_range,
     error_expected,
 ):
@@ -404,13 +403,11 @@ def test_prevent_quota_definition_deletion(
         valid_between=getattr(date_ranges, date_range),
     )
 
-    deleted = quota_definition.new_draft(
+    deleted = quota_definition.new_version(
         workbasket=unapproved_transaction.workbasket,
         transaction=unapproved_transaction,
-        update_type=update_type,
+        update_type=UpdateType.DELETE,
     )
-
-    error_expected = error_expected and update_type == UpdateType.DELETE
 
     with raises_if(BusinessRuleViolation, error_expected):
         business_rules.PreventQuotaDefinitionDeletion(deleted.transaction).validate(
@@ -450,7 +447,7 @@ def test_linking_models_must_refer_to_a_non_deleted_sub_quota(
     linking_model = factory.create()
     quota_definition = getattr(linking_model, quota_attr)
 
-    deleted = quota_definition.new_draft(
+    deleted = quota_definition.new_version(
         workbasket=unapproved_transaction.workbasket,
         transaction=unapproved_transaction,
         update_type=UpdateType.DELETE,
@@ -460,7 +457,7 @@ def test_linking_models_must_refer_to_a_non_deleted_sub_quota(
 
     linking_model.update_type = UpdateType.DELETE
     linking_model.save(force_write=True)
-    deleted = quota_definition.new_draft(
+    deleted = quota_definition.new_version(
         workbasket=unapproved_transaction.workbasket,
         transaction=unapproved_transaction,
         update_type=UpdateType.DELETE,

--- a/regulations/tests/test_business_rules.py
+++ b/regulations/tests/test_business_rules.py
@@ -126,7 +126,7 @@ def test_ROIMB44(id, approved, change_flag, expect_error):
     )
 
     if change_flag:
-        regulation = regulation.new_draft(
+        regulation = regulation.new_version(
             approved=not regulation.approved,
             workbasket=factories.WorkBasketFactory.create(),
         )

--- a/workbaskets/tests/test_models.py
+++ b/workbaskets/tests/test_models.py
@@ -577,7 +577,7 @@ def test_get_tracked_models(new_workbasket):
 
 def test_workbasket_accepted_updates_current_tracked_models(new_workbasket, valid_user):
     original_footnote = factories.FootnoteFactory.create()
-    new_footnote = original_footnote.new_draft(workbasket=new_workbasket)
+    new_footnote = original_footnote.new_version(workbasket=new_workbasket)
 
     assert new_footnote.version_group.current_version.pk == original_footnote.pk
     new_workbasket.submit_for_approval()
@@ -590,7 +590,7 @@ def test_workbasket_accepted_updates_current_tracked_models(new_workbasket, vali
 
 def test_workbasket_errored_updates_tracked_models(new_workbasket, valid_user):
     original_footnote = factories.FootnoteFactory.create()
-    new_footnote = original_footnote.new_draft(workbasket=new_workbasket)
+    new_footnote = original_footnote.new_version(workbasket=new_workbasket)
 
     assert new_footnote.version_group.current_version.pk == original_footnote.pk
     new_workbasket.submit_for_approval()


### PR DESCRIPTION
This is a small API change that came out of  discussions with @simonwo around updates.

Renames new_draft -> new_version, (since we don't have a strong concept of drafts in the code at the moment), and more importantly adds a docstring for this.

The docstring was an edit based on an original from Simon:
```
Returns a new version of the object with all of its existing data except where overridden by keyword arguments. This is the function that should be used to update existing models.

The new version will be part of a new transaction in the passed workbasket. If transaction is specified, it will hold the model instead and a new transaction is not created. Ifupdate_type is specified it must be either UPDATE or DELETE – it is UPDATE by default. If save is False, the model won't be saved.
```