### PR TITLE
TP-788: Fix edits after publishing workbasket

### DIFF
--- a/common/forms.py
+++ b/common/forms.py
@@ -46,7 +46,10 @@ class DateInputFieldFixed(DateInputField):
     def compress(self, data_list):
         day, month, year = data_list or [None, None, None]
         if day and month and year:
-            return date(day=int(day), month=int(month), year=int(year))
+            try:
+                return date(day=int(day), month=int(month), year=int(year))
+            except ValueError as e:
+                raise ValidationError(str(e).capitalize()) from e
         else:
             return None
 

--- a/workbaskets/jinja2/includes/workbaskets/workbasket-detail.jinja
+++ b/workbaskets/jinja2/includes/workbaskets/workbasket-detail.jinja
@@ -8,7 +8,7 @@
     {% set change_count = workbasket.tracked_models.count() %}
     <p class="govuk-body align-left">{{ change_count }} change{{ pluralize(change_count) }}</p>
     <p class="govuk-body align-right">
-        <a href="{{ url('workbaskets:submit_workbasket', args=[workbasket.pk] ) }}" class="govuk-link">Publish all changes</a>
+        <a href="{{ url('workbaskets:workbasket-ui-submit', args=[workbasket.pk] ) }}" class="govuk-link">Publish all changes</a>
     </p>
     {% set table_rows = [] %}
     {% for obj in page_obj.object_list %}

--- a/workbaskets/jinja2/includes/workbaskets/workbasket-list.jinja
+++ b/workbaskets/jinja2/includes/workbaskets/workbasket-list.jinja
@@ -3,7 +3,7 @@
 {% from "components/table/macro.njk" import govukTable %}
 
 <div class="filter-layout">
-  <form class="filter-layout__filters" method="get" action="{{ url("workbasket-ui-list") }}">
+  <form class="filter-layout__filters" method="get" action="{{ url("workbaskets:workbasket-ui-list") }}">
     {{ govukInput({
       "id": "search",
       "name": "search",

--- a/workbaskets/jinja2/workbaskets/list.jinja
+++ b/workbaskets/jinja2/workbaskets/list.jinja
@@ -18,5 +18,5 @@
     Alternatively, <a href="">create a new workbasket</a>.
   </p>
 
-  {% include "includes/workbasket-list.jinja" %}
+  {% include "includes/workbaskets/workbasket-list.jinja" %}
 {% endblock %}

--- a/workbaskets/models.py
+++ b/workbaskets/models.py
@@ -223,7 +223,13 @@ class WorkBasket(TimestampedMixin):
         """Get the current workbasket in the session."""
 
         if "workbasket" in request.session:
-            return cls.from_json(request.session["workbasket"])
+            workbasket = cls.from_json(request.session["workbasket"])
+
+            if workbasket.status in WorkflowStatus.approved_statuses():
+                del request.session["workbasket"]
+                return None
+
+            return workbasket
 
     def clean(self):
         errors = []

--- a/workbaskets/tests/test_views.py
+++ b/workbaskets/tests/test_views.py
@@ -1,23 +1,70 @@
 import pytest
 from django.urls import reverse
 
+from common.tests import factories
+from common.tests.util import validity_period_post_data
+from common.validators import UpdateType
+from workbaskets.models import WorkBasket
 from workbaskets.validators import WorkflowStatus
 
+pytestmark = pytest.mark.django_db
 
-@pytest.mark.django_db
-def test_submit_workbasket(unapproved_transaction, valid_user_client):
+
+def test_submit_workbasket(unapproved_transaction, valid_user, client):
     workbasket = unapproved_transaction.workbasket
 
     url = reverse(
-        "workbaskets:submit_workbasket",
-        kwargs={"workbasket_pk": workbasket.pk},
+        "workbaskets:workbasket-ui-submit",
+        kwargs={"pk": workbasket.pk},
     )
 
-    response = valid_user_client.get(url)
+    client.force_login(valid_user)
+    response = client.get(url)
 
     assert response.status_code == 302
     assert response.url == reverse("index")
-    assert workbasket.status == WorkflowStatus.NEW_IN_PROGRESS
+
     workbasket.refresh_from_db()
     assert workbasket.status == WorkflowStatus.SENT_TO_CDS
     assert workbasket.approver is not None
+
+    assert client.session["workbasket"]["status"] == WorkflowStatus.SENT_TO_CDS
+
+
+def test_edit_after_submit(workbasket, valid_user, client, date_ranges):
+    client.force_login(valid_user)
+
+    # submit a workbasket containing a newly created footnote
+    with workbasket.new_transaction():
+        footnote = factories.FootnoteFactory.create(
+            update_type=UpdateType.CREATE,
+        )
+    response = client.get(
+        reverse(
+            "workbaskets:workbasket-ui-submit",
+            kwargs={"pk": workbasket.pk},
+        ),
+    )
+    assert response.status_code == 302
+
+    # edit the footnote
+    response = client.post(
+        footnote.get_url("edit"),
+        validity_period_post_data(
+            date_ranges.later.lower,
+            date_ranges.later.upper,
+        ),
+    )
+    assert response.status_code == 302
+
+    # check that the session workbasket has been replaced by a new one
+    new_workbasket = WorkBasket.from_json(client.session["workbasket"])
+    new_workbasket.refresh_from_db()
+    assert new_workbasket.pk != workbasket.pk
+
+    # check that the footnote edit is in the new session workbasket
+    assert new_workbasket.transactions.count() == 1
+    tx = new_workbasket.transactions.first()
+    assert tx.tracked_models.count() == 1
+    new_footnote_version = tx.tracked_models.first()
+    assert new_footnote_version.pk != footnote.pk

--- a/workbaskets/urls.py
+++ b/workbaskets/urls.py
@@ -9,15 +9,25 @@ app_name = "workbaskets"
 api_router = routers.DefaultRouter()
 api_router.register(r"workbaskets", views.WorkBasketViewSet)
 
-ui_router = routers.DefaultRouter()
-ui_router.register(r"workbaskets", views.WorkBasketUIViewSet, basename="workbasket-ui")
+ui_patterns = [
+    path(
+        "",
+        views.WorkBasketList.as_view(),
+        name="workbasket-ui-list",
+    ),
+    path(
+        f"<pk>/",
+        views.WorkBasketDetail.as_view(),
+        name="workbasket-ui-detail",
+    ),
+    path(
+        f"<pk>/submit/",
+        views.WorkBasketSubmit.as_view(),
+        name="workbasket-ui-submit",
+    ),
+]
 
 urlpatterns = [
-    path("", include(ui_router.urls)),
-    path(
-        "submit/<int:workbasket_pk>",
-        views.submit_workbasket_view,
-        name="submit_workbasket",
-    ),
+    path("workbaskets/", include(ui_patterns)),
     path("api/", include(api_router.urls)),
 ]

--- a/workbaskets/views/decorators.py
+++ b/workbaskets/views/decorators.py
@@ -10,9 +10,15 @@ def require_current_workbasket(view_func):
     @wraps(view_func)
     def check_for_current_workbasket(request, *args, **kwargs):
         if WorkBasket.current(request) is None:
-            request.session["workbasket"] = (
-                WorkBasket.objects.is_not_approved().get().to_json()
-            )
+            try:
+                workbasket = WorkBasket.objects.is_not_approved().get()
+            except WorkBasket.DoesNotExist:
+                workbasket = WorkBasket.objects.create(
+                    author=request.user,
+                )
+
+            request.session["workbasket"] = workbasket.to_json()
+
         return view_func(request, *args, **kwargs)
 
     return check_for_current_workbasket


### PR DESCRIPTION
After successfully editing and publishing a change, subsequent edits do not appear in
the list of tariff changes on the home page.

This is due to the workbasket not being updated in the user session. Subsequent edits
are appended to the already-published workbasket. The home page only lists the contents
of the current workbasket, which is a new and empty one after publishing the last one.

This change ensures that the session is updated on publishing the workbasket, and that
subsequent edits are correctly appended to the new unpublished workbasket.

Before testing make sure to clear your session by logging out and back in again.