### PR TITLE
XML performance refactor: part 1

### DIFF
--- a/additional_codes/import_parsers.py
+++ b/additional_codes/import_parsers.py
@@ -37,8 +37,8 @@ class AdditionalCodeParser(ValidityMixin, Writable, ElementParser):
     sid = IntElement(Tag("additional.code.sid"))
     type__sid = TextElement(Tag("additional.code.type.id"))
     code = TextElement(Tag("additional.code"))
-    valid_between_lower = TextElement(Tag("validity.start.date"))
-    valid_between_upper = TextElement(Tag("validity.end.date"))
+    valid_between_lower = ValidityMixin.valid_between_lower
+    valid_between_upper = ValidityMixin.valid_between_upper
 
 
 @RecordParser.register_child("additional_code_description_period")
@@ -71,9 +71,10 @@ class AdditionalCodeDescriptionPeriodParser(
     tag = Tag("additional.code.description.period")
 
     sid = TextElement(Tag("additional.code.description.period.sid"))
-    described_additionalcode_sid = TextElement(Tag("additional.code.sid"))
-    described_additionalcode_type_id = TextElement(Tag("additional.code.type.id"))
-    described_additionalcode = TextElement(Tag("additional.code"))
+    described_additionalcode__sid = TextElement(Tag("additional.code.sid"))
+    described_additionalcode__type__sid = TextElement(Tag("additional.code.type.id"))
+    described_additionalcode__code = TextElement(Tag("additional.code"))
+    validity_start = ValidityStartMixin.validity_start
 
 
 @RecordParser.register_child("additional_code_description")
@@ -136,13 +137,13 @@ class AdditionalCodeTypeParser(ValidityMixin, Writable, ElementParser):
     tag = Tag("additional.code.type")
 
     sid = TextElement(Tag("additional.code.type.id"))
+    valid_between_lower = ValidityMixin.valid_between_lower
+    valid_between_upper = ValidityMixin.valid_between_upper
     application_code = TextElement(Tag("application.code"))
-    valid_between_lower = TextElement(Tag("validity.start.date"))
-    valid_between_upper = TextElement(Tag("validity.end.date"))
 
 
 @RecordParser.register_child("additional_code_type_description")
-class AdditionalCodeTypeDescriptionParser(ValidityMixin, Writable, ElementParser):
+class AdditionalCodeTypeDescriptionParser(Writable, ElementParser):
     """
     Example XML:
 
@@ -199,5 +200,7 @@ class FootnoteAssociationAdditionalCodeParser(ValidityMixin, Writable, ElementPa
     additional_code__sid = TextElement(Tag("additional.code.sid"))
     associated_footnote__footnote_type__sid = TextElement(Tag("footnote.type.id"))
     associated_footnote__footnote_id = TextElement(Tag("footnote.id"))
+    valid_between_lower = ValidityMixin.valid_between_lower
+    valid_between_upper = ValidityMixin.valid_between_upper
     additional_code__type__sid = TextElement(Tag("additional.code.type.id"))
     additional_code__code = TextElement(Tag("additional.code"))

--- a/additional_codes/import_parsers.py
+++ b/additional_codes/import_parsers.py
@@ -64,9 +64,9 @@ class AdditionalCodeDescriptionPeriodParser(
     tag = Tag("additional.code.description.period")
 
     sid = TextElement(Tag("additional.code.description.period.sid"))
-    additional_code_sid = TextElement(Tag("additional.code.sid"))
-    additional_code_type_id = TextElement(Tag("additional.code.type.id"))
-    additional_code = TextElement(Tag("additional.code"))
+    described_additionalcode_sid = TextElement(Tag("additional.code.sid"))
+    described_additionalcode_type_id = TextElement(Tag("additional.code.type.id"))
+    described_additionalcode = TextElement(Tag("additional.code"))
 
 
 @RecordParser.register_child("additional_code_description")

--- a/additional_codes/import_parsers.py
+++ b/additional_codes/import_parsers.py
@@ -1,4 +1,5 @@
 from importer.namespaces import Tag
+from importer.parsers import ConstantElement
 from importer.parsers import ElementParser
 from importer.parsers import IntElement
 from importer.parsers import TextElement
@@ -93,6 +94,7 @@ class AdditionalCodeDescriptionParser(Writable, ElementParser):
     tag = Tag("additional.code.description")
 
     sid = TextElement(Tag("additional.code.description.period.sid"))
+    language_id = ConstantElement(Tag("language.id"), value="EN")
     described_additionalcode__sid = TextElement(Tag("additional.code.sid"))
     described_additionalcode__type__sid = TextElement(Tag("additional.code.type.id"))
     described_additionalcode__code = TextElement(Tag("additional.code"))
@@ -148,6 +150,7 @@ class AdditionalCodeTypeDescriptionParser(ValidityMixin, Writable, ElementParser
     tag = Tag("additional.code.type.description")
 
     sid = TextElement(Tag("additional.code.type.id"))
+    language_id = ConstantElement(Tag("language.id"), value="EN")
     description = TextElement(Tag("description"))
 
 

--- a/additional_codes/import_parsers.py
+++ b/additional_codes/import_parsers.py
@@ -29,6 +29,9 @@ class AdditionalCodeParser(ValidityMixin, Writable, ElementParser):
         </xs:element>
     """
 
+    record_code = "245"
+    subrecord_code = "00"
+
     tag = Tag("additional.code")
 
     sid = IntElement(Tag("additional.code.sid"))
@@ -62,6 +65,9 @@ class AdditionalCodeDescriptionPeriodParser(
         </xs:element>
     """
 
+    record_code = "245"
+    subrecord_code = "05"
+
     tag = Tag("additional.code.description.period")
 
     sid = TextElement(Tag("additional.code.description.period.sid"))
@@ -90,6 +96,9 @@ class AdditionalCodeDescriptionParser(Writable, ElementParser):
             </xs:complexType>
         </xs:element>
     """
+
+    record_code = "245"
+    subrecord_code = "10"
 
     tag = Tag("additional.code.description")
 
@@ -121,6 +130,9 @@ class AdditionalCodeTypeParser(ValidityMixin, Writable, ElementParser):
         </xs:element>
     """
 
+    record_code = "120"
+    subrecord_code = "00"
+
     tag = Tag("additional.code.type")
 
     sid = TextElement(Tag("additional.code.type.id"))
@@ -146,6 +158,9 @@ class AdditionalCodeTypeDescriptionParser(ValidityMixin, Writable, ElementParser
             </xs:complexType>
         </xs:element>
     """
+
+    record_code = "120"
+    subrecord_code = "05"
 
     tag = Tag("additional.code.type.description")
 
@@ -175,6 +190,9 @@ class FootnoteAssociationAdditionalCodeParser(ValidityMixin, Writable, ElementPa
             </xs:complexType>
         </xs:element>
     """
+
+    record_code = "245"
+    subrecord_code = "15"
 
     tag = Tag("footnote.association.additional.code")
 

--- a/additional_codes/import_parsers.py
+++ b/additional_codes/import_parsers.py
@@ -149,3 +149,34 @@ class AdditionalCodeTypeDescriptionParser(ValidityMixin, Writable, ElementParser
 
     sid = TextElement(Tag("additional.code.type.id"))
     description = TextElement(Tag("description"))
+
+
+@RecordParser.register_child("footnote_association_additional_code")
+class FootnoteAssociationAdditionalCodeParser(ValidityMixin, Writable, ElementParser):
+    """
+    Example XML:
+
+    .. code-block: XML
+
+        <xs:element name="footnote.association.additional.code" substitutionGroup="abstract.record">
+            <xs:complexType>
+                <xs:sequence>
+                    <xs:element name="additional.code.sid" type="SID"/>
+                    <xs:element name="footnote.type.id" type="FootnoteTypeId"/>
+                    <xs:element name="footnote.id" type="FootnoteId"/>
+                    <xs:element name="validity.start.date" type="Date"/>
+                    <xs:element name="validity.end.date" type="Date" minOccurs="0"/>
+                    <xs:element name="additional.code.type.id" type="AdditionalCodeTypeId"/>
+                    <xs:element name="additional.code" type="AdditionalCode"/>
+                </xs:sequence>
+            </xs:complexType>
+        </xs:element>
+    """
+
+    tag = Tag("footnote.association.additional.code")
+
+    additional_code__sid = TextElement(Tag("additional.code.sid"))
+    associated_footnote__footnote_type__sid = TextElement(Tag("footnote.type.id"))
+    associated_footnote__footnote_id = TextElement(Tag("footnote.id"))
+    additional_code__type__sid = TextElement(Tag("additional.code.type.id"))
+    additional_code__code = TextElement(Tag("additional.code"))

--- a/certificates/import_parsers.py
+++ b/certificates/import_parsers.py
@@ -27,6 +27,9 @@ class CertificateTypeParser(ValidityMixin, Writable, ElementParser):
         </xs:element>
     """
 
+    record_code = "110"
+    subrecord_code = "00"
+
     tag = Tag("certificate.type")
 
     sid = TextElement(Tag("certificate.type.code"))
@@ -49,6 +52,9 @@ class CertificateTypeDescriptionParser(Writable, ElementParser):
             </xs:complexType>
         </xs:element>
     """
+
+    record_code = "110"
+    subrecord_code = "05"
 
     tag = Tag("certificate.type.description")
 
@@ -76,6 +82,9 @@ class CertificateParser(ValidityMixin, Writable, ElementParser):
         </xs:element>
     """
 
+    record_code = "205"
+    subrecord_code = "00"
+
     tag = Tag("certificate")
 
     sid = TextElement(Tag("certificate.code"))
@@ -101,6 +110,9 @@ class CertificateDescriptionParser(Writable, ElementParser):
             </xs:complexType>
         </xs:element>
     """
+
+    record_code = "205"
+    subrecord_code = "10"
 
     tag = Tag("certificate.description")
 
@@ -131,6 +143,9 @@ class CertificateDescriptionPeriodParser(ValidityStartMixin, Writable, ElementPa
             </xs:complexType>
         </xs:element>
     """
+
+    record_code = "205"
+    subrecord_code = "05"
 
     tag = Tag("certificate.description.period")
 

--- a/certificates/import_parsers.py
+++ b/certificates/import_parsers.py
@@ -105,7 +105,7 @@ class CertificateDescriptionParser(Writable, ElementParser):
     sid = IntElement(Tag("certificate.description.period.sid"))
     description = TextElement(Tag("description"))
     described_certificate__sid = TextElement(Tag("certificate.code"))
-    described_certificate__type__sid = TextElement(Tag("certificate.type.code"))
+    described_certificate__certificate_type__sid = TextElement(Tag("certificate.type.code"))
 
 
 @RecordParser.register_child("certificate_description_period")

--- a/certificates/import_parsers.py
+++ b/certificates/import_parsers.py
@@ -1,4 +1,5 @@
 from importer.namespaces import Tag
+from importer.parsers import ConstantElement
 from importer.parsers import ElementParser
 from importer.parsers import IntElement
 from importer.parsers import TextElement
@@ -52,6 +53,7 @@ class CertificateTypeDescriptionParser(Writable, ElementParser):
     tag = Tag("certificate.type.description")
 
     sid = TextElement(Tag("certificate.type.code"))
+    language_id = ConstantElement(Tag("language.id"), value="EN")
     description = TextElement(Tag("description"))
 
 
@@ -103,9 +105,12 @@ class CertificateDescriptionParser(Writable, ElementParser):
     tag = Tag("certificate.description")
 
     sid = IntElement(Tag("certificate.description.period.sid"))
+    language_id = ConstantElement(Tag("language.id"), value="EN")
     description = TextElement(Tag("description"))
     described_certificate__sid = TextElement(Tag("certificate.code"))
-    described_certificate__certificate_type__sid = TextElement(Tag("certificate.type.code"))
+    described_certificate__certificate_type__sid = TextElement(
+        Tag("certificate.type.code"),
+    )
 
 
 @RecordParser.register_child("certificate_description_period")

--- a/certificates/import_parsers.py
+++ b/certificates/import_parsers.py
@@ -33,6 +33,8 @@ class CertificateTypeParser(ValidityMixin, Writable, ElementParser):
     tag = Tag("certificate.type")
 
     sid = TextElement(Tag("certificate.type.code"))
+    valid_between_lower = ValidityMixin.valid_between_lower
+    valid_between_upper = ValidityMixin.valid_between_upper
 
 
 @RecordParser.register_child("certificate_type_description")
@@ -87,8 +89,10 @@ class CertificateParser(ValidityMixin, Writable, ElementParser):
 
     tag = Tag("certificate")
 
-    sid = TextElement(Tag("certificate.code"))
     certificate_type__sid = TextElement(Tag("certificate.type.code"))
+    sid = TextElement(Tag("certificate.code"))
+    valid_between_lower = ValidityMixin.valid_between_lower
+    valid_between_upper = ValidityMixin.valid_between_upper
 
 
 @RecordParser.register_child("certificate_description")
@@ -118,11 +122,11 @@ class CertificateDescriptionParser(Writable, ElementParser):
 
     sid = IntElement(Tag("certificate.description.period.sid"))
     language_id = ConstantElement(Tag("language.id"), value="EN")
-    description = TextElement(Tag("description"))
-    described_certificate__sid = TextElement(Tag("certificate.code"))
     described_certificate__certificate_type__sid = TextElement(
         Tag("certificate.type.code"),
     )
+    described_certificate__sid = TextElement(Tag("certificate.code"))
+    description = TextElement(Tag("description"))
 
 
 @RecordParser.register_child("certificate_description_period")
@@ -150,7 +154,8 @@ class CertificateDescriptionPeriodParser(ValidityStartMixin, Writable, ElementPa
     tag = Tag("certificate.description.period")
 
     sid = IntElement(Tag("certificate.description.period.sid"))
-    described_certificate__sid = TextElement(Tag("certificate.code"))
     described_certificate__certificate_type__sid = TextElement(
         Tag("certificate.type.code"),
     )
+    described_certificate__sid = TextElement(Tag("certificate.code"))
+    validity_start = ValidityStartMixin.validity_start

--- a/commodities/import_handlers.py
+++ b/commodities/import_handlers.py
@@ -159,7 +159,7 @@ class GoodsNomenclatureIndentHandler(BaseHandler):
         {"model": models.GoodsNomenclature, "name": "indented_goods_nomenclature"},
     )
     serializer_class = serializers.GoodsNomenclatureIndentSerializer
-    tag = parsers.GoodsNomenclatureIndentsParser.tag.name
+    tag = parsers.GoodsNomenclatureIndentParser.tag.name
 
     # It is sadly necessary to correct some mistakes in the TARIC data.
     # These codes all do not meet the assumption that the child indent

--- a/commodities/import_parsers.py
+++ b/commodities/import_parsers.py
@@ -2,6 +2,7 @@ import logging
 
 from importer.namespaces import Tag
 from importer.parsers import BooleanElement
+from importer.parsers import ConstantElement
 from importer.parsers import ElementParser
 from importer.parsers import IntElement
 from importer.parsers import TextElement
@@ -136,7 +137,7 @@ class GoodsNomenclatureDescriptionParser(Writable, ElementParser):
     tag = Tag("goods.nomenclature.description")
 
     sid = TextElement(Tag("goods.nomenclature.description.period.sid"))
-    language_id = TextElement(Tag("language.id"))
+    language_id = ConstantElement(Tag("language.id"), value="EN")
     described_goods_nomenclature__sid = TextElement(Tag("goods.nomenclature.sid"))
     described_goods_nomenclature__item_id = TextElement(
         Tag("goods.nomenclature.item.id"),

--- a/commodities/import_parsers.py
+++ b/commodities/import_parsers.py
@@ -35,6 +35,9 @@ class GoodsNomenclatureParser(ValidityMixin, Writable, ElementParser):
         </xs:element>
     """
 
+    record_code = "400"
+    subrecord_code = "00"
+
     tag = Tag("goods.nomenclature")
 
     sid = TextElement(Tag("goods.nomenclature.sid"))
@@ -64,6 +67,9 @@ class GoodsNomenclatureOriginParser(Writable, ElementParser):
             </xs:complexType>
         </xs:element>
     """
+
+    record_code = "400"
+    subrecord_code = "35"
 
     tag = Tag("goods.nomenclature.origin")
 
@@ -97,6 +103,9 @@ class GoodsNomenclatureSuccessorParser(Writable, ElementParser):
             </xs:complexType>
         </xs:element>
     """
+
+    record_code = "400"
+    subrecord_code = "40"
 
     tag = Tag("goods.nomenclature.successor")
 
@@ -133,6 +142,9 @@ class GoodsNomenclatureDescriptionParser(Writable, ElementParser):
             </xs:complexType>
         </xs:element>
     """
+
+    record_code = "400"
+    subrecord_code = "15"
 
     tag = Tag("goods.nomenclature.description")
 
@@ -172,6 +184,9 @@ class GoodsNomenclatureDescriptionPeriodParser(
         </xs:element>
     """
 
+    record_code = "400"
+    subrecord_code = "10"
+
     tag = Tag("goods.nomenclature.description.period")
 
     sid = TextElement(Tag("goods.nomenclature.description.period.sid"))
@@ -204,6 +219,9 @@ class GoodsNomenclatureIndentParser(ValidityStartMixin, Writable, ElementParser)
             </xs:complexType>
         </xs:element>
     """
+
+    record_code = "400"
+    subrecord_code = "05"
 
     tag = Tag("goods.nomenclature.indents")
 
@@ -241,6 +259,9 @@ class FootnoteAssociationGoodsNomenclatureParser(
             </xs:complexType>
         </xs:element>
     """
+
+    record_code = "400"
+    subrecord_code = "20"
 
     tag = Tag("footnote.association.goods.nomenclature")
 

--- a/commodities/import_parsers.py
+++ b/commodities/import_parsers.py
@@ -141,7 +141,7 @@ class GoodsNomenclatureDescriptionParser(Writable, ElementParser):
     described_goods_nomenclature__item_id = TextElement(
         Tag("goods.nomenclature.item.id"),
     )
-    described_goods_nomenclature__productline_suffix = TextElement(
+    described_goods_nomenclature__suffix = TextElement(
         Tag("productline.suffix"),
     )
     description = TextElement(Tag("description"))
@@ -178,13 +178,13 @@ class GoodsNomenclatureDescriptionPeriodParser(
     described_goods_nomenclature__item_id = TextElement(
         Tag("goods.nomenclature.item.id"),
     )
-    described_goods_nomenclature__productline_suffix = TextElement(
+    described_goods_nomenclature__suffix = TextElement(
         Tag("productline.suffix"),
     )
 
 
 @RecordParser.register_child("goods_nomenclature_indent")
-class GoodsNomenclatureIndentsParser(ValidityStartMixin, Writable, ElementParser):
+class GoodsNomenclatureIndentParser(ValidityStartMixin, Writable, ElementParser):
     """
     Example XML:
 

--- a/commodities/import_parsers.py
+++ b/commodities/import_parsers.py
@@ -43,8 +43,8 @@ class GoodsNomenclatureParser(ValidityMixin, Writable, ElementParser):
     sid = TextElement(Tag("goods.nomenclature.sid"))
     item_id = TextElement(Tag("goods.nomenclature.item.id"))
     suffix = TextElement(Tag("producline.suffix"))  # XXX not a typo
-    valid_between_lower = TextElement(Tag("validity.start.date"))
-    valid_between_upper = TextElement(Tag("validity.end.date"))
+    valid_between_lower = ValidityMixin.valid_between_lower
+    valid_between_upper = ValidityMixin.valid_between_upper
     statistical = BooleanElement(Tag("statistical.indicator"))
 
 
@@ -191,6 +191,7 @@ class GoodsNomenclatureDescriptionPeriodParser(
 
     sid = TextElement(Tag("goods.nomenclature.description.period.sid"))
     described_goods_nomenclature__sid = TextElement(Tag("goods.nomenclature.sid"))
+    validity_start = ValidityStartMixin.validity_start
     described_goods_nomenclature__item_id = TextElement(
         Tag("goods.nomenclature.item.id"),
     )
@@ -227,6 +228,7 @@ class GoodsNomenclatureIndentParser(ValidityStartMixin, Writable, ElementParser)
 
     sid = TextElement(Tag("goods.nomenclature.indent.sid"))
     indented_goods_nomenclature__sid = TextElement(Tag("goods.nomenclature.sid"))
+    validity_start = ValidityStartMixin.validity_start
     indent = IntElement(Tag("number.indents"), format="FM00")
     indented_goods_nomenclature__item_id = TextElement(
         Tag("goods.nomenclature.item.id"),
@@ -266,7 +268,11 @@ class FootnoteAssociationGoodsNomenclatureParser(
     tag = Tag("footnote.association.goods.nomenclature")
 
     goods_nomenclature__sid = TextElement(Tag("goods.nomenclature.sid"))
-    associated_footnote__footnote_id = TextElement(Tag("footnote.id"))
     associated_footnote__footnote_type__footnote_type_id = TextElement(
         Tag("footnote.type"),
     )
+    associated_footnote__footnote_id = TextElement(Tag("footnote.id"))
+    valid_between_lower = ValidityMixin.valid_between_lower
+    valid_between_upper = ValidityMixin.valid_between_upper
+    goods_nomenclature__item_id = TextElement(Tag("goods.nomenclature.item.id"))
+    goods_nomenclature__suffix = TextElement(Tag("productline.suffix"))

--- a/commodities/import_parsers.py
+++ b/commodities/import_parsers.py
@@ -1,7 +1,9 @@
 import logging
 
 from importer.namespaces import Tag
+from importer.parsers import BooleanElement
 from importer.parsers import ElementParser
+from importer.parsers import IntElement
 from importer.parsers import TextElement
 from importer.parsers import ValidityMixin
 from importer.parsers import ValidityStartMixin
@@ -39,7 +41,7 @@ class GoodsNomenclatureParser(ValidityMixin, Writable, ElementParser):
     suffix = TextElement(Tag("producline.suffix"))  # XXX not a typo
     valid_between_lower = TextElement(Tag("validity.start.date"))
     valid_between_upper = TextElement(Tag("validity.end.date"))
-    statistical = TextElement(Tag("statistical.indicator"))
+    statistical = BooleanElement(Tag("statistical.indicator"))
 
 
 @RecordParser.register_child("goods_nomenclature_origin")
@@ -206,7 +208,7 @@ class GoodsNomenclatureIndentsParser(ValidityStartMixin, Writable, ElementParser
 
     sid = TextElement(Tag("goods.nomenclature.indent.sid"))
     indented_goods_nomenclature__sid = TextElement(Tag("goods.nomenclature.sid"))
-    indent = TextElement(Tag("number.indents"))
+    indent = IntElement(Tag("number.indents"), format="FM00")
     indented_goods_nomenclature__item_id = TextElement(
         Tag("goods.nomenclature.item.id"),
     )

--- a/footnotes/import_parsers.py
+++ b/footnotes/import_parsers.py
@@ -1,6 +1,7 @@
 import logging
 
 from importer.namespaces import Tag
+from importer.parsers import ConstantElement
 from importer.parsers import ElementParser
 from importer.parsers import IntElement
 from importer.parsers import TextElement
@@ -60,6 +61,7 @@ class FootnoteTypeDescriptionParser(ValidityMixin, Writable, ElementParser):
     tag = Tag("footnote.type.description")
 
     footnote_type_id = TextElement(Tag("footnote.type.id"))
+    language_id = ConstantElement(Tag("language.id"), value="EN")
     description = TextElement(Tag("description"))
 
 
@@ -111,6 +113,7 @@ class FootnoteDescriptionParser(ValidityMixin, Writable, ElementParser):
     tag = Tag("footnote.description")
 
     sid = IntElement(Tag("footnote.description.period.sid"))
+    language_id = ConstantElement(Tag("language.id"), value="EN")
     described_footnote__footnote_type__footnote_type_id = TextElement(
         Tag("footnote.type.id"),
     )

--- a/footnotes/import_parsers.py
+++ b/footnotes/import_parsers.py
@@ -32,6 +32,9 @@ class FootnoteTypeParser(ValidityMixin, Writable, ElementParser):
         </xs:element>
     """
 
+    record_code = "100"
+    subrecord_code = "00"
+
     tag = Tag("footnote.type")
 
     footnote_type_id = TextElement(Tag("footnote.type.id"))
@@ -57,6 +60,9 @@ class FootnoteTypeDescriptionParser(ValidityMixin, Writable, ElementParser):
             </xs:complexType>
         </xs:element>
     """
+
+    record_code = "100"
+    subrecord_code = "05"
 
     tag = Tag("footnote.type.description")
 
@@ -84,6 +90,9 @@ class FootnoteParser(ValidityMixin, Writable, ElementParser):
         </xs:element>
     """
 
+    record_code = "200"
+    subrecord_code = "00"
+
     tag = Tag("footnote")
 
     footnote_type__footnote_type_id = TextElement(Tag("footnote.type.id"))
@@ -109,6 +118,9 @@ class FootnoteDescriptionParser(ValidityMixin, Writable, ElementParser):
             </xs:complexType>
         </xs:element>
     """
+
+    record_code = "200"
+    subrecord_code = "10"
 
     tag = Tag("footnote.description")
 
@@ -139,6 +151,9 @@ class FootnoteDescriptionPeriodParser(ValidityStartMixin, Writable, ElementParse
             </xs:complexType>
         </xs:element>
     """
+
+    record_code = "200"
+    subrecord_code = "05"
 
     tag = Tag("footnote.description.period")
 

--- a/footnotes/import_parsers.py
+++ b/footnotes/import_parsers.py
@@ -38,13 +38,13 @@ class FootnoteTypeParser(ValidityMixin, Writable, ElementParser):
     tag = Tag("footnote.type")
 
     footnote_type_id = TextElement(Tag("footnote.type.id"))
-    valid_between_lower = TextElement(Tag("validity.start.date"))
-    valid_between_upper = TextElement(Tag("validity.end.date"))
+    valid_between_lower = ValidityMixin.valid_between_lower
+    valid_between_upper = ValidityMixin.valid_between_upper
     application_code = TextElement(Tag("application.code"))
 
 
 @RecordParser.register_child("footnote_type_description")
-class FootnoteTypeDescriptionParser(ValidityMixin, Writable, ElementParser):
+class FootnoteTypeDescriptionParser(Writable, ElementParser):
     """
     Example XML:
 
@@ -97,10 +97,12 @@ class FootnoteParser(ValidityMixin, Writable, ElementParser):
 
     footnote_type__footnote_type_id = TextElement(Tag("footnote.type.id"))
     footnote_id = TextElement(Tag("footnote.id"))
+    valid_between_lower = ValidityMixin.valid_between_lower
+    valid_between_upper = ValidityMixin.valid_between_upper
 
 
 @RecordParser.register_child("footnote_description")
-class FootnoteDescriptionParser(ValidityMixin, Writable, ElementParser):
+class FootnoteDescriptionParser(Writable, ElementParser):
     """
     Example XML:
 
@@ -162,3 +164,4 @@ class FootnoteDescriptionPeriodParser(ValidityStartMixin, Writable, ElementParse
         Tag("footnote.type.id"),
     )
     described_footnote__footnote_id = TextElement(Tag("footnote.id"))
+    validity_start = ValidityStartMixin.validity_start

--- a/geo_areas/import_handlers.py
+++ b/geo_areas/import_handlers.py
@@ -52,4 +52,4 @@ class GeographicalMembershipHandler(BaseHandler):
         },
     )
     serializer_class = serializers.GeographicalMembershipSerializer
-    tag = parsers.GeographicalAreaMembershipParser.tag.name
+    tag = parsers.GeographicalMembershipParser.tag.name

--- a/geo_areas/import_parsers.py
+++ b/geo_areas/import_parsers.py
@@ -34,6 +34,9 @@ class GeographicalAreaParser(ValidityMixin, Writable, ElementParser):
         </xs:element>
     """
 
+    record_code = "250"
+    subrecord_code = "00"
+
     tag = Tag("geographical.area")
 
     sid = TextElement(Tag("geographical.area.sid"))
@@ -61,6 +64,9 @@ class GeographicalAreaDescriptionParser(Writable, ElementParser):
             </xs:complexType>
         </xs:element>
     """
+
+    record_code = "250"
+    subrecord_code = "10"
 
     tag = Tag("geographical.area.description")
 
@@ -94,6 +100,9 @@ class GeographicalAreaDescriptionPeriodParser(
         </xs:element>
     """
 
+    record_code = "250"
+    subrecord_code = "05"
+
     tag = Tag("geographical.area.description.period")
 
     sid = IntElement(Tag("geographical.area.description.period.sid"))
@@ -119,6 +128,9 @@ class GeographicalMembershipParser(ValidityMixin, Writable, ElementParser):
             </xs:complexType>
         </xs:element>
     """
+
+    record_code = "250"
+    subrecord_code = "15"
 
     tag = Tag("geographical.area.membership")
 

--- a/geo_areas/import_parsers.py
+++ b/geo_areas/import_parsers.py
@@ -41,6 +41,8 @@ class GeographicalAreaParser(ValidityMixin, Writable, ElementParser):
 
     sid = TextElement(Tag("geographical.area.sid"))
     area_id = TextElement(Tag("geographical.area.id"))
+    valid_between_lower = ValidityMixin.valid_between_lower
+    valid_between_upper = ValidityMixin.valid_between_upper
     area_code = TextElement(Tag("geographical.code"))
     parent__sid = TextElement(Tag("parent.geographical.area.group.sid"))
 
@@ -107,6 +109,7 @@ class GeographicalAreaDescriptionPeriodParser(
 
     sid = IntElement(Tag("geographical.area.description.period.sid"))
     area__sid = TextElement(Tag("geographical.area.sid"))
+    validity_start = ValidityStartMixin.validity_start
     area__area_id = TextElement(Tag("geographical.area.id"))
 
 
@@ -136,3 +139,5 @@ class GeographicalMembershipParser(ValidityMixin, Writable, ElementParser):
 
     member__sid = IntElement(Tag("geographical.area.sid"))
     geo_group__sid = IntElement(Tag("geographical.area.group.sid"))
+    valid_between_lower = ValidityMixin.valid_between_lower
+    valid_between_upper = ValidityMixin.valid_between_upper

--- a/geo_areas/import_parsers.py
+++ b/geo_areas/import_parsers.py
@@ -1,6 +1,7 @@
 import logging
 
 from importer.namespaces import Tag
+from importer.parsers import ConstantElement
 from importer.parsers import ElementParser
 from importer.parsers import IntElement
 from importer.parsers import TextElement
@@ -64,6 +65,7 @@ class GeographicalAreaDescriptionParser(Writable, ElementParser):
     tag = Tag("geographical.area.description")
 
     sid = IntElement(Tag("geographical.area.description.period.sid"))
+    language_id = ConstantElement(Tag("language.id"), value="EN")
     area__sid = TextElement(Tag("geographical.area.sid"))
     area__area_id = TextElement(Tag("geographical.area.id"))
     description = TextElement(Tag("description"))

--- a/geo_areas/import_parsers.py
+++ b/geo_areas/import_parsers.py
@@ -100,7 +100,7 @@ class GeographicalAreaDescriptionPeriodParser(
 
 
 @RecordParser.register_child("geographical_area_membership")
-class GeographicalAreaMembershipParser(ValidityMixin, Writable, ElementParser):
+class GeographicalMembershipParser(ValidityMixin, Writable, ElementParser):
     """
     Example XML:
 

--- a/importer/parsers.py
+++ b/importer/parsers.py
@@ -361,10 +361,8 @@ class CompoundElement(ValueElementMixin, ElementParser):
 class ValidityMixin:
     """Parse validity start and end dates."""
 
-    _additional_components = {
-        RangeLowerElement(Tag("validity.start.date")): "valid_between_lower",
-        RangeUpperElement(Tag("validity.end.date")): "valid_between_upper",
-    }
+    valid_between_lower = RangeLowerElement(Tag("validity.start.date"))
+    valid_between_upper = RangeUpperElement(Tag("validity.end.date"))
 
     def clean(self):
         super().clean()
@@ -383,12 +381,7 @@ class ValidityMixin:
 class ValidityStartMixin:
     """Parse validity start date."""
 
-    _additional_components = {
-        TextElement(Tag("validity.start.date")): "validity_start",
-    }
-
-    def clean(self):
-        super().clean()
+    validity_start = TextElement(Tag("validity.start.date"))
 
 
 class Writable:

--- a/importer/parsers.py
+++ b/importer/parsers.py
@@ -282,6 +282,39 @@ class RangeUpperElement(TextElement):
     """Represents an element that is the upper part of a range."""
 
 
+class CompoundElement(ValueElementMixin, ElementParser):
+    """
+    Represents an element in XML that is actually a concatenation of one or more
+    logical values and separators.
+
+    The separator by default is assumed to be a pipe character. The parsed data
+    will always contain a tuple that is the size of the number of expected
+    fields (the original field and any extras) – if less than the specified
+    number of separators occur the rightmost fields will have value ``None``.
+
+    .. code-block:: XML
+
+        <msg:some.value>one|two|three</msg:some.value>
+    """
+
+    native_type = tuple
+
+    def __init__(
+        self,
+        tag: Tag,
+        *extra_fields: str,
+        separator: str = "|",
+    ):
+        super().__init__(tag)
+        self.extra_fields = extra_fields
+        self.separator = separator
+
+    def clean(self):
+        parts = self.text.split(self.separator, len(self.extra_fields))
+        missing = len(self.extra_fields) - len(parts) + 1
+        self.data = self.native_type([*parts, *([None] * missing)])
+
+
 class ValidityMixin:
     """Parse validity start and end dates."""
 

--- a/importer/parsers.py
+++ b/importer/parsers.py
@@ -214,6 +214,25 @@ class ValueElementMixin:
         self.data = self.native_type(self.text)
 
 
+class ConstantElement(ValueElementMixin, ElementParser):
+    """
+    Represents an element that is always a constant value in the XML.
+
+    The actual value is ignored and not put into the database. The value
+    specified in the constructor will be put back into the XML.
+    """
+
+    def __init__(
+        self,
+        tag: Tag,
+        value: str,  # pylint: disable=unused-argument
+    ) -> None:
+        super().__init__(tag)
+
+    def clean(self):
+        pass
+
+
 class TextElement(ValueElementMixin, ElementParser):
     """
     Represents an element which contains a text value.

--- a/importer/parsers.py
+++ b/importer/parsers.py
@@ -77,6 +77,30 @@ class ElementParser:
         {"child": {"id": 2, "field": "Text"}}
     """
 
+    record_code: str
+    """
+    The type id of this model's type family in the TARIC specification.
+
+    This number groups together a number of different models into 'records'.
+    Where two models share a record code, they are conceptually expressing
+    different properties of the same logical model.
+
+    In theory each :class:`~common.transactions.Transaction` should only contain
+    models with a single :attr:`record_code` (but differing
+    :attr:`subrecord_code`.)
+    """
+
+    subrecord_code: str
+    """
+    The type id of this model in the TARIC specification. The
+    :attr:`subrecord_code` when combined with the :attr:`record_code` uniquely
+    identifies the type within the specification.
+
+    The subrecord code gives the intended order for models in a transaction,
+    with comparatively smaller subrecord codes needing to come before larger
+    ones.
+    """
+
     tag: Optional[Tag] = None
     data_class: type = dict
     end_hook: Optional[Callable[[Any, Element], None]] = None

--- a/importer/tests/test_parsers.py
+++ b/importer/tests/test_parsers.py
@@ -1,6 +1,7 @@
 import xml.etree.ElementTree as etree
 
 from importer.namespaces import Tag
+from importer.parsers import BooleanElement
 from importer.parsers import ElementParser
 from importer.parsers import TextElement
 from importer.parsers import ValidityMixin
@@ -203,3 +204,35 @@ def test_validity_mixin():
             "upper": "2020-01-02",
         },
     }
+
+
+@pytest.mark.parametrize(
+    ("true_value", "false_value", "text", "expected"),
+    (
+        ("1", "0", "1", True),
+        ("1", "0", "0", False),
+        ("Y", "N", "Y", True),
+        ("Y", "N", "N", False),
+        ("1", "0", "", None),
+        ("1", "0", None, None),
+        ("1", "0", "Y", None),
+        ("1", "0", "N", None),
+        ("1", "0", "00001", None),
+        ("1", "0", "11111", None),
+        ("1", "0", "10000", None),
+    ),
+)
+def test_boolean_element_parser(true_value, false_value, text, expected):
+    parser = BooleanElement(
+        Tag("foo"),
+        true_value=true_value,
+        false_value=false_value,
+    )
+
+    el = etree.Element(str(Tag("foo")))
+    el.text = text
+
+    parser.start(el)
+    parser.end(el)
+
+    assert parser.data == expected

--- a/measures/import_parsers.py
+++ b/measures/import_parsers.py
@@ -1,4 +1,5 @@
 from importer.namespaces import Tag
+from importer.parsers import BooleanElement
 from importer.parsers import ElementParser
 from importer.parsers import IntElement
 from importer.parsers import TextElement
@@ -247,7 +248,7 @@ class DutyExpressionParser(ValidityMixin, Writable, ElementParser):
 
     tag = Tag("duty.expression")
 
-    sid = IntElement(Tag("duty.expression.id"))
+    sid = IntElement(Tag("duty.expression.id"), format="FM00")
     duty_amount_applicability_code = IntElement(Tag("duty.amount.applicability.code"))
     measurement_unit_applicability_code = IntElement(
         Tag("measurement.unit.applicability.code"),
@@ -277,7 +278,7 @@ class DutyExpressionDescriptionParser(Writable, ElementParser):
 
     tag = Tag("duty.expression.description")
 
-    sid = IntElement(Tag("duty.expression.id"))
+    sid = DutyExpressionParser.sid
     description = TextElement(Tag("description"))
 
 
@@ -517,7 +518,7 @@ class MeasureParser(ValidityMixin, Writable, ElementParser):
     terminating_regulation__regulation_id = TextElement(
         Tag("justification.regulation.id"),
     )
-    stopped = TextElement(Tag("stopped.flag"))
+    stopped = BooleanElement(Tag("stopped.flag"))
     geographical_area__sid = TextElement(Tag("geographical.area.sid"))
     goods_nomenclature__sid = TextElement(Tag("goods.nomenclature.sid"))
     additional_code__sid = TextElement(Tag("additional.code.sid"))
@@ -547,7 +548,7 @@ class MeasureComponentParser(Writable, ElementParser):
     tag = Tag("measure.component")
 
     component_measure__sid = TextElement(Tag("measure.sid"))
-    duty_expression__sid = IntElement(Tag("duty.expression.id"))
+    duty_expression__sid = DutyExpressionParser.sid
     duty_amount = TextElement(Tag("duty.amount"))
     monetary_unit__code = TextElement(Tag("monetary.unit.code"))
     component_measurement__measurement_unit__code = TextElement(
@@ -629,7 +630,7 @@ class MeasureConditionComponentParser(Writable, ElementParser):
     tag = Tag("measure.condition.component")
 
     condition__sid = TextElement(Tag("measure.condition.sid"))
-    duty_expression__sid = IntElement(Tag("duty.expression.id"))
+    duty_expression__sid = DutyExpressionParser.sid
     duty_amount = TextElement(Tag("duty.amount"))
     monetary_unit__code = TextElement(Tag("monetary.unit.code"))
     component_measurement__measurement_unit__code = TextElement(

--- a/measures/import_parsers.py
+++ b/measures/import_parsers.py
@@ -1,5 +1,6 @@
 from importer.namespaces import Tag
 from importer.parsers import BooleanElement
+from importer.parsers import ConstantElement
 from importer.parsers import ElementParser
 from importer.parsers import IntElement
 from importer.parsers import TextElement
@@ -54,6 +55,7 @@ class MeasureTypeSeriesDescriptionParser(Writable, ElementParser):
     tag = Tag("measure.type.series.description")
 
     sid = TextElement(Tag("measure.type.series.id"))
+    language_id = ConstantElement(Tag("language.id"), value="EN")
     description = TextElement(Tag("description"))
 
 
@@ -101,6 +103,7 @@ class MeasurementUnitDescriptionParser(Writable, ElementParser):
     tag = Tag("measurement.unit.description")
 
     code = TextElement(Tag("measurement.unit.code"))
+    language_id = ConstantElement(Tag("language.id"), value="EN")
     description = TextElement(Tag("description"))
 
 
@@ -148,6 +151,7 @@ class MeasurementUnitQualifierDescriptionParser(Writable, ElementParser):
     tag = Tag("measurement.unit.qualifier.description")
 
     code = TextElement(Tag("measurement.unit.qualifier.code"))
+    language_id = ConstantElement(Tag("language.id"), value="EN")
     description = TextElement(Tag("description"))
 
 
@@ -222,6 +226,7 @@ class MonetaryUnitDescriptionParser(Writable, ElementParser):
     tag = Tag("monetary.unit.description")
 
     code = TextElement(Tag("monetary.unit.code"))
+    language_id = ConstantElement(Tag("language.id"), value="EN")
     description = TextElement(Tag("description"))
 
 
@@ -279,6 +284,7 @@ class DutyExpressionDescriptionParser(Writable, ElementParser):
     tag = Tag("duty.expression.description")
 
     sid = DutyExpressionParser.sid
+    language_id = ConstantElement(Tag("language.id"), value="EN")
     description = TextElement(Tag("description"))
 
 
@@ -342,6 +348,7 @@ class MeasureTypeDescriptionParser(Writable, ElementParser):
     tag = Tag("measure.type.description")
 
     sid = TextElement(Tag("measure.type.id"))
+    language_id = ConstantElement(Tag("language.id"), value="EN")
     description = TextElement(Tag("description"))
 
 
@@ -414,6 +421,7 @@ class MeasureConditionCodeDescriptionParser(Writable, ElementParser):
     tag = Tag("measure.condition.code.description")
 
     code = TextElement(Tag("condition.code"))
+    language_id = ConstantElement(Tag("language.id"), value="EN")
     description = TextElement(Tag("description"))
 
 
@@ -461,6 +469,7 @@ class MeasureActionDescriptionParser(Writable, ElementParser):
     tag = Tag("measure.action.description")
 
     code = TextElement(Tag("action.code"))
+    language_id = ConstantElement(Tag("language.id"), value="EN")
     description = TextElement(Tag("description"))
 
 

--- a/measures/import_parsers.py
+++ b/measures/import_parsers.py
@@ -34,6 +34,8 @@ class MeasureTypeSeriesParser(ValidityMixin, Writable, ElementParser):
     tag = Tag("measure.type.series")
 
     sid = TextElement(Tag("measure.type.series.id"))
+    valid_between_lower = ValidityMixin.valid_between_lower
+    valid_between_upper = ValidityMixin.valid_between_upper
     measure_type_combination = IntElement(Tag("measure.type.combination"))
 
 
@@ -89,6 +91,8 @@ class MeasurementUnitParser(ValidityMixin, Writable, ElementParser):
     tag = Tag("measurement.unit")
 
     code = TextElement(Tag("measurement.unit.code"))
+    valid_between_lower = ValidityMixin.valid_between_lower
+    valid_between_upper = ValidityMixin.valid_between_upper
 
 
 @RecordParser.register_child("measurement_unit_description")
@@ -143,6 +147,8 @@ class MeasurementUnitQualifierParser(ValidityMixin, Writable, ElementParser):
     tag = Tag("measurement.unit.qualifier")
 
     code = TextElement(Tag("measurement.unit.qualifier.code"))
+    valid_between_lower = ValidityMixin.valid_between_lower
+    valid_between_upper = ValidityMixin.valid_between_upper
 
 
 @RecordParser.register_child("measurement_unit_qualifier_description")
@@ -201,6 +207,8 @@ class MeasurementParser(ValidityMixin, Writable, ElementParser):
     measurement_unit_qualifier__code = TextElement(
         Tag("measurement.unit.qualifier.code"),
     )
+    valid_between_lower = ValidityMixin.valid_between_lower
+    valid_between_upper = ValidityMixin.valid_between_upper
 
 
 @RecordParser.register_child("monetary_unit")
@@ -227,6 +235,8 @@ class MonetaryUnitParser(ValidityMixin, Writable, ElementParser):
     tag = Tag("monetary.unit")
 
     code = TextElement(Tag("monetary.unit.code"))
+    valid_between_lower = ValidityMixin.valid_between_lower
+    valid_between_upper = ValidityMixin.valid_between_upper
 
 
 @RecordParser.register_child("monetary_unit_description")
@@ -284,6 +294,8 @@ class DutyExpressionParser(ValidityMixin, Writable, ElementParser):
     tag = Tag("duty.expression")
 
     sid = IntElement(Tag("duty.expression.id"), format="FM00")
+    valid_between_lower = ValidityMixin.valid_between_lower
+    valid_between_upper = ValidityMixin.valid_between_upper
     duty_amount_applicability_code = IntElement(Tag("duty.amount.applicability.code"))
     measurement_unit_applicability_code = IntElement(
         Tag("measurement.unit.applicability.code"),
@@ -352,6 +364,8 @@ class MeasureTypeParser(ValidityMixin, Writable, ElementParser):
     tag = Tag("measure.type")
 
     sid = TextElement(Tag("measure.type.id"))
+    valid_between_lower = ValidityMixin.valid_between_lower
+    valid_between_upper = ValidityMixin.valid_between_upper
     trade_movement_code = IntElement(Tag("trade.movement.code"))
     priority_code = IntElement(Tag("priority.code"))
     measure_component_applicability_code = IntElement(
@@ -417,6 +431,8 @@ class AdditionalCodeTypeMeasureTypeParser(ValidityMixin, Writable, ElementParser
 
     measure_type__sid = TextElement(Tag("measure.type.id"))
     additional_code_type__sid = TextElement(Tag("additional.code.type.id"))
+    valid_between_lower = ValidityMixin.valid_between_lower
+    valid_between_upper = ValidityMixin.valid_between_upper
 
 
 @RecordParser.register_child("measure_condition_code")
@@ -443,6 +459,8 @@ class MeasureConditionCodeParser(ValidityMixin, Writable, ElementParser):
     tag = Tag("measure.condition.code")
 
     code = TextElement(Tag("condition.code"))
+    valid_between_lower = ValidityMixin.valid_between_lower
+    valid_between_upper = ValidityMixin.valid_between_upper
 
 
 @RecordParser.register_child("measure_condition_code_description")
@@ -497,6 +515,8 @@ class MeasureActionParser(ValidityMixin, Writable, ElementParser):
     tag = Tag("measure.action")
 
     code = TextElement(Tag("action.code"))
+    valid_between_lower = ValidityMixin.valid_between_lower
+    valid_between_upper = ValidityMixin.valid_between_upper
 
 
 @RecordParser.register_child("measure_action_description")
@@ -574,12 +594,14 @@ class MeasureParser(ValidityMixin, Writable, ElementParser):
     additional_code__code = TextElement(Tag("additional.code"))
     order_number__order_number = TextElement(Tag("ordernumber"))
     reduction = IntElement(Tag("reduction.indicator"))
+    valid_between_lower = ValidityMixin.valid_between_lower
     generating_regulation__role_type = IntElement(
         Tag("measure.generating.regulation.role"),
     )
     generating_regulation__regulation_id = TextElement(
         Tag("measure.generating.regulation.id"),
     )
+    valid_between_upper = ValidityMixin.valid_between_upper
     terminating_regulation__role_type = IntElement(Tag("justification.regulation.role"))
     terminating_regulation__regulation_id = TextElement(
         Tag("justification.regulation.id"),

--- a/measures/import_parsers.py
+++ b/measures/import_parsers.py
@@ -28,6 +28,9 @@ class MeasureTypeSeriesParser(ValidityMixin, Writable, ElementParser):
         </xs:element>
     """
 
+    record_code = "140"
+    subrecord_code = "00"
+
     tag = Tag("measure.type.series")
 
     sid = TextElement(Tag("measure.type.series.id"))
@@ -51,6 +54,9 @@ class MeasureTypeSeriesDescriptionParser(Writable, ElementParser):
             </xs:complexType>
         </xs:element>
     """
+
+    record_code = "140"
+    subrecord_code = "05"
 
     tag = Tag("measure.type.series.description")
 
@@ -77,6 +83,9 @@ class MeasurementUnitParser(ValidityMixin, Writable, ElementParser):
         </xs:element>
     """
 
+    record_code = "210"
+    subrecord_code = "00"
+
     tag = Tag("measurement.unit")
 
     code = TextElement(Tag("measurement.unit.code"))
@@ -99,6 +108,9 @@ class MeasurementUnitDescriptionParser(Writable, ElementParser):
             </xs:complexType>
         </xs:element>
     """
+
+    record_code = "210"
+    subrecord_code = "05"
 
     tag = Tag("measurement.unit.description")
 
@@ -125,6 +137,9 @@ class MeasurementUnitQualifierParser(ValidityMixin, Writable, ElementParser):
         </xs:element>
     """
 
+    record_code = "215"
+    subrecord_code = "00"
+
     tag = Tag("measurement.unit.qualifier")
 
     code = TextElement(Tag("measurement.unit.qualifier.code"))
@@ -147,6 +162,9 @@ class MeasurementUnitQualifierDescriptionParser(Writable, ElementParser):
             </xs:complexType>
         </xs:element>
     """
+
+    record_code = "215"
+    subrecord_code = "05"
 
     tag = Tag("measurement.unit.qualifier.description")
 
@@ -174,6 +192,9 @@ class MeasurementParser(ValidityMixin, Writable, ElementParser):
         </xs:element>
     """
 
+    record_code = "220"
+    subrecord_code = "00"
+
     tag = Tag("measurement")
 
     measurement_unit__code = TextElement(Tag("measurement.unit.code"))
@@ -200,6 +221,9 @@ class MonetaryUnitParser(ValidityMixin, Writable, ElementParser):
         </xs:element>
     """
 
+    record_code = "225"
+    subrecord_code = "00"
+
     tag = Tag("monetary.unit")
 
     code = TextElement(Tag("monetary.unit.code"))
@@ -222,6 +246,9 @@ class MonetaryUnitDescriptionParser(Writable, ElementParser):
             </xs:complexType>
         </xs:element>
     """
+
+    record_code = "225"
+    subrecord_code = "05"
 
     tag = Tag("monetary.unit.description")
 
@@ -250,6 +277,9 @@ class DutyExpressionParser(ValidityMixin, Writable, ElementParser):
             </xs:complexType>
         </xs:element>
     """
+
+    record_code = "230"
+    subrecord_code = "00"
 
     tag = Tag("duty.expression")
 
@@ -280,6 +310,9 @@ class DutyExpressionDescriptionParser(Writable, ElementParser):
             </xs:complexType>
         </xs:element>
     """
+
+    record_code = "230"
+    subrecord_code = "05"
 
     tag = Tag("duty.expression.description")
 
@@ -313,6 +346,9 @@ class MeasureTypeParser(ValidityMixin, Writable, ElementParser):
         </xs:element>
     """
 
+    record_code = "235"
+    subrecord_code = "00"
+
     tag = Tag("measure.type")
 
     sid = TextElement(Tag("measure.type.id"))
@@ -345,6 +381,9 @@ class MeasureTypeDescriptionParser(Writable, ElementParser):
         </xs:element>
     """
 
+    record_code = "235"
+    subrecord_code = "05"
+
     tag = Tag("measure.type.description")
 
     sid = TextElement(Tag("measure.type.id"))
@@ -371,6 +410,9 @@ class AdditionalCodeTypeMeasureTypeParser(ValidityMixin, Writable, ElementParser
         </xs:element>
     """
 
+    record_code = "240"
+    subrecord_code = "00"
+
     tag = Tag("additional.code.type.measure.type")
 
     measure_type__sid = TextElement(Tag("measure.type.id"))
@@ -395,6 +437,9 @@ class MeasureConditionCodeParser(ValidityMixin, Writable, ElementParser):
         </xs:element>
     """
 
+    record_code = "350"
+    subrecord_code = "00"
+
     tag = Tag("measure.condition.code")
 
     code = TextElement(Tag("condition.code"))
@@ -417,6 +462,9 @@ class MeasureConditionCodeDescriptionParser(Writable, ElementParser):
             </xs:complexType>
         </xs:element>
     """
+
+    record_code = "350"
+    subrecord_code = "05"
 
     tag = Tag("measure.condition.code.description")
 
@@ -443,6 +491,9 @@ class MeasureActionParser(ValidityMixin, Writable, ElementParser):
         </xs:element>
     """
 
+    record_code = "355"
+    subrecord_code = "00"
+
     tag = Tag("measure.action")
 
     code = TextElement(Tag("action.code"))
@@ -465,6 +516,9 @@ class MeasureActionDescriptionParser(Writable, ElementParser):
             </xs:complexType>
         </xs:element>
     """
+
+    record_code = "355"
+    subrecord_code = "05"
 
     tag = Tag("measure.action.description")
 
@@ -506,6 +560,9 @@ class MeasureParser(ValidityMixin, Writable, ElementParser):
             </xs:complexType>
         </xs:element>
     """
+
+    record_code = "430"
+    subrecord_code = "00"
 
     tag = Tag("measure")
 
@@ -554,6 +611,9 @@ class MeasureComponentParser(Writable, ElementParser):
         </xs:element>
     """
 
+    record_code = "430"
+    subrecord_code = "05"
+
     tag = Tag("measure.component")
 
     component_measure__sid = TextElement(Tag("measure.sid"))
@@ -593,6 +653,9 @@ class MeasureConditionParser(Writable, ElementParser):
             </xs:complexType>
         </xs:element>
     """
+
+    record_code = "430"
+    subrecord_code = "10"
 
     tag = Tag("measure.condition")
 
@@ -636,6 +699,9 @@ class MeasureConditionComponentParser(Writable, ElementParser):
         </xs:element>
     """
 
+    record_code = "430"
+    subrecord_code = "11"
+
     tag = Tag("measure.condition.component")
 
     condition__sid = TextElement(Tag("measure.condition.sid"))
@@ -668,6 +734,9 @@ class MeasureExcludedGeographicalAreaParser(Writable, ElementParser):
         </xs:element>
     """
 
+    record_code = "430"
+    subrecord_code = "15"
+
     tag = Tag("measure.excluded.geographical.area")
 
     modified_measure__sid = TextElement(Tag("measure.sid"))
@@ -692,6 +761,9 @@ class FootnoteAssociationMeasureParser(Writable, ElementParser):
             </xs:complexType>
         </xs:element>
     """
+
+    record_code = "430"
+    subrecord_code = "20"
 
     tag = Tag("footnote.association.measure")
 

--- a/quotas/import_handlers.py
+++ b/quotas/import_handlers.py
@@ -83,7 +83,7 @@ class QuotaSuspensionHandler(BaseHandler):
         },
     )
     serializer_class = serializers.QuotaSuspensionSerializer
-    tag = parsers.QuotaSuspensionPeriodParser.tag.name
+    tag = parsers.QuotaSuspensionParser.tag.name
 
 
 class QuotaBlockingHandler(BaseHandler):
@@ -94,7 +94,7 @@ class QuotaBlockingHandler(BaseHandler):
         },
     )
     serializer_class = serializers.QuotaBlockingSerializer
-    tag = parsers.QuotaBlockingPeriodParser.tag.name
+    tag = parsers.QuotaBlockingParser.tag.name
 
 
 class QuotaEventHandler(BaseHandler):
@@ -105,7 +105,7 @@ class QuotaEventHandler(BaseHandler):
 
     def clean(self, data: dict) -> dict:
         data["occurrence_timestamp"] = datetime.fromisoformat(
-            data["occurrence_timestamp"]
+            data["occurrence_timestamp"],
         )
         return super().clean(data)
 

--- a/quotas/import_parsers.py
+++ b/quotas/import_parsers.py
@@ -175,7 +175,7 @@ class QuotaAssociationParser(Writable, ElementParser):
 
 
 @RecordParser.register_child("quota_blocking_period")
-class QuotaBlockingPeriodParser(ValidityMixin, Writable, ElementParser):
+class QuotaBlockingParser(ValidityMixin, Writable, ElementParser):
     """
     Example XML:
 
@@ -206,7 +206,7 @@ class QuotaBlockingPeriodParser(ValidityMixin, Writable, ElementParser):
 
 
 @RecordParser.register_child("quota_suspension_period")
-class QuotaSuspensionPeriodParser(ValidityMixin, Writable, ElementParser):
+class QuotaSuspensionParser(ValidityMixin, Writable, ElementParser):
     """
     Example XML:
 

--- a/quotas/import_parsers.py
+++ b/quotas/import_parsers.py
@@ -1,8 +1,10 @@
 from importer.namespaces import RegexTag
 from importer.namespaces import Tag
+from importer.parsers import BooleanElement
 from importer.parsers import ElementParser
 from importer.parsers import IntElement
-from importer.parsers import InvalidDataError
+from importer.parsers import RangeLowerElement
+from importer.parsers import RangeUpperElement
 from importer.parsers import TextElement
 from importer.parsers import ValidityMixin
 from importer.parsers import Writable
@@ -32,8 +34,11 @@ class QuotaOrderNumberParser(ValidityMixin, Writable, ElementParser):
     subrecord_code = "00"
 
     tag = Tag("quota.order.number")
+
     sid = TextElement(Tag("quota.order.number.sid"))
     order_number = TextElement(Tag("quota.order.number.id"))
+    valid_between_lower = ValidityMixin.valid_between_lower
+    valid_between_upper = ValidityMixin.valid_between_upper
 
     def clean(self):
         super().clean()
@@ -71,6 +76,8 @@ class QuotaOrderNumberOriginParser(ValidityMixin, Writable, ElementParser):
     sid = TextElement(Tag("quota.order.number.origin.sid"))
     order_number__sid = TextElement(Tag("quota.order.number.sid"))
     geographical_area__area_id = TextElement(Tag("geographical.area.id"))
+    valid_between_lower = ValidityMixin.valid_between_lower
+    valid_between_upper = ValidityMixin.valid_between_upper
     geographical_area__sid = TextElement(Tag("geographical.area.sid"))
 
 
@@ -136,6 +143,8 @@ class QuotaDefinitionParser(ValidityMixin, Writable, ElementParser):
 
     sid = TextElement(Tag("quota.definition.sid"))
     order_number__order_number = TextElement(Tag("quota.order.number.id"))
+    valid_between_lower = ValidityMixin.valid_between_lower
+    valid_between_upper = ValidityMixin.valid_between_upper
     order_number__sid = TextElement(Tag("quota.order.number.sid"))
     volume = TextElement(Tag("volume"))
     initial_volume = TextElement(Tag("initial.volume"))
@@ -145,18 +154,13 @@ class QuotaDefinitionParser(ValidityMixin, Writable, ElementParser):
         Tag("measurement.unit.qualifier.code"),
     )
     maximum_precision = TextElement(Tag("maximum.precision"))
-    quota_critical = TextElement(Tag("critical.state"))
+    quota_critical = BooleanElement(
+        Tag("critical.state"),
+        true_value="Y",
+        false_value="N",
+    )
     quota_critical_threshold = TextElement(Tag("critical.threshold"))
     description = TextElement(Tag("description"))
-
-    def clean(self):
-        super().clean()
-        quota_critical = self.data.get("quota_critical")
-        if quota_critical not in {"Y", "N"}:
-            raise InvalidDataError(
-                '"critical.state" tag must contain either "Y" or "N"',
-            )
-        self.data["quota_critical"] = quota_critical == "Y"
 
 
 @RecordParser.register_child("quota_association")
@@ -217,10 +221,10 @@ class QuotaBlockingParser(ValidityMixin, Writable, ElementParser):
 
     sid = IntElement(Tag("quota.blocking.period.sid"))
     quota_definition__sid = IntElement(Tag("quota.definition.sid"))
-    valid_between_lower = TextElement(Tag("blocking.start.date"))
-    valid_between_upper = TextElement(Tag("blocking.end.date"))
-    description = TextElement(Tag("description"))
+    valid_between_lower = RangeLowerElement(Tag("blocking.start.date"))
+    valid_between_upper = RangeUpperElement(Tag("blocking.end.date"))
     blocking_period_type = IntElement(Tag("blocking.period.type"))
+    description = TextElement(Tag("description"))
 
 
 @RecordParser.register_child("quota_suspension_period")
@@ -250,8 +254,8 @@ class QuotaSuspensionParser(ValidityMixin, Writable, ElementParser):
 
     sid = IntElement(Tag("quota.suspension.period.sid"))
     quota_definition__sid = IntElement(Tag("quota.definition.sid"))
-    valid_between_lower = TextElement(Tag("suspension.start.date"))
-    valid_between_upper = TextElement(Tag("suspension.end.date"))
+    valid_between_lower = RangeLowerElement(Tag("suspension.start.date"))
+    valid_between_upper = RangeUpperElement(Tag("suspension.end.date"))
     description = TextElement(Tag("description"))
 
 

--- a/quotas/import_parsers.py
+++ b/quotas/import_parsers.py
@@ -28,6 +28,9 @@ class QuotaOrderNumberParser(ValidityMixin, Writable, ElementParser):
         </xs:element>
     """
 
+    record_code = "360"
+    subrecord_code = "00"
+
     tag = Tag("quota.order.number")
     sid = TextElement(Tag("quota.order.number.sid"))
     order_number = TextElement(Tag("quota.order.number.id"))
@@ -60,6 +63,9 @@ class QuotaOrderNumberOriginParser(ValidityMixin, Writable, ElementParser):
         </xs:element>
     """
 
+    record_code = "360"
+    subrecord_code = "10"
+
     tag = Tag("quota.order.number.origin")
 
     sid = TextElement(Tag("quota.order.number.origin.sid"))
@@ -84,6 +90,9 @@ class QuotaOrderNumberOriginExclusionParser(Writable, ElementParser):
             </xs:complexType>
         </xs:element>
     """
+
+    record_code = "360"
+    subrecord_code = "15"
 
     tag = Tag("quota.order.number.origin.exclusions")
 
@@ -119,6 +128,9 @@ class QuotaDefinitionParser(ValidityMixin, Writable, ElementParser):
             </xs:complexType>
         </xs:element>
     """
+
+    record_code = "370"
+    subrecord_code = "00"
 
     tag = Tag("quota.definition")
 
@@ -166,6 +178,9 @@ class QuotaAssociationParser(Writable, ElementParser):
         </xs:element>
     """
 
+    record_code = "370"
+    subrecord_code = "05"
+
     tag = Tag("quota.association")
 
     main_quota__sid = TextElement(Tag("main.quota.definition.sid"))
@@ -194,6 +209,9 @@ class QuotaBlockingParser(ValidityMixin, Writable, ElementParser):
             </xs:complexType>
         </xs:element>
     """
+
+    record_code = "370"
+    subrecord_code = "10"
 
     tag = Tag("quota.blocking.period")
 
@@ -224,6 +242,9 @@ class QuotaSuspensionParser(ValidityMixin, Writable, ElementParser):
             </xs:complexType>
         </xs:element>
     """
+
+    record_code = "370"
+    subrecord_code = "15"
 
     tag = Tag("quota.suspension.period")
 
@@ -315,6 +336,9 @@ class QuotaEventParser(Writable, ElementParser):
             </xs:complexType>
         </xs:element>
     """
+
+    record_code = "375"
+    subrecord_code = "subrecord_code"
 
     tag = RegexTag(r"quota.([a-z.]+).event")
 

--- a/regulations/import_handlers.py
+++ b/regulations/import_handlers.py
@@ -30,11 +30,9 @@ class RegulationHandler(BaseHandler):
     tag = parsers.BaseRegulationParser.tag.name
 
     def clean(self, data: dict) -> dict:
-        if "|" in data.get("information_text", ""):
-            data["information_text"], data["public_identifier"], data["url"] = data[
-                "information_text"
-            ].split("|")
-
+        data["information_text"], data["public_identifier"], data["url"] = data[
+            "information_text"
+        ]
         return super().clean(data)
 
 
@@ -43,19 +41,17 @@ class BaseRegulationThroughTableHandler(BaseHandler):
     serializer_class = serializers.RegulationImporterSerializer
     tag = "BaseRegulationThroughTableHandler"
 
-    def clean(self, data: dict) -> dict:
-        if "|" in data.get("information_text", ""):
-            data["information_text"], data["public_identifier"], data["url"] = data[
-                "information_text"
-            ].split("|")
-
-        return super().clean(data)
-
 
 class AmendmentRegulationHandler(BaseRegulationThroughTableHandler):
     identifying_fields = ("role_type", "regulation_id")
     serializer_class = serializers.RegulationImporterSerializer
     tag = parsers.ModificationRegulationParser.tag.name
+
+    def clean(self, data: dict) -> dict:
+        data["information_text"], data["public_identifier"], data["url"] = data[
+            "information_text"
+        ]
+        return super().clean(data)
 
     @transaction.atomic
     def save(self, data: dict):
@@ -67,7 +63,7 @@ class AmendmentRegulationHandler(BaseRegulationThroughTableHandler):
                 "enacting_regulation": enacting_regulation,
                 "update_type": data["update_type"],
                 "transaction_id": data["transaction_id"],
-            }
+            },
         )
 
 
@@ -79,6 +75,10 @@ class BaseSuspensionRegulationHandler(BaseRegulationThroughTableHandler):
         self.suspension_data = {}
         if "effective_end_date" in data:
             self.suspension_data["effective_end_date"] = data.pop("effective_end_date")
+        if "information_text" in data:
+            data["information_text"], data["public_identifier"], data["url"] = data[
+                "information_text"
+            ]
         return super().clean(data)
 
     @transaction.atomic
@@ -92,7 +92,7 @@ class BaseSuspensionRegulationHandler(BaseRegulationThroughTableHandler):
                 "update_type": data["update_type"],
                 "transaction_id": data["transaction_id"],
                 **self.suspension_data,
-            }
+            },
         )
 
 

--- a/regulations/import_parsers.py
+++ b/regulations/import_parsers.py
@@ -1,4 +1,5 @@
 from importer.namespaces import Tag
+from importer.parsers import BooleanElement
 from importer.parsers import ElementParser
 from importer.parsers import IntElement
 from importer.parsers import TextElement
@@ -99,9 +100,9 @@ class BaseRegulationParser(ValidityMixin, Writable, ElementParser):
     official_journal_page = IntElement(Tag("officialjournal.page"))
     community_code = IntElement(Tag("community.code"))
     replacement_indicator = IntElement(Tag("replacement.indicator"))
-    stopped = TextElement(Tag("stopped.flag"))
+    stopped = BooleanElement(Tag("stopped.flag"))
     information_text = TextElement(Tag("information.text"))
-    approved = TextElement(Tag("approved.flag"))
+    approved = BooleanElement(Tag("approved.flag"))
     effective_end_date = TextElement(Tag("effective.end.date"))
 
 
@@ -149,9 +150,9 @@ class ModificationRegulationParser(ValidityMixin, Writable, ElementParser):
     target_regulation__role_type = TextElement(Tag("base.regulation.role"))
     target_regulation__regulation_id = TextElement(Tag("base.regulation.id"))
     replacement_indicator = IntElement(Tag("replacement.indicator"))
-    stopped = TextElement(Tag("stopped.flag"))
+    stopped = BooleanElement(Tag("stopped.flag"))
     information_text = TextElement(Tag("information.text"))
-    approved = TextElement(Tag("approved.flag"))
+    approved = BooleanElement(Tag("approved.flag"))
 
 
 @RecordParser.register_child("fts_regulation")
@@ -194,7 +195,7 @@ class FullTemporaryStopRegulationParser(ValidityMixin, Writable, ElementParser):
     effective_end_date = TextElement(Tag("effective.enddate"))
     replacement_indicator = IntElement(Tag("replacement.indicator"))
     information_text = TextElement(Tag("information.text"))
-    approved = TextElement(Tag("approved.flag"))
+    approved = BooleanElement(Tag("approved.flag"))
 
 
 @RecordParser.register_child("fts_action")

--- a/regulations/import_parsers.py
+++ b/regulations/import_parsers.py
@@ -34,6 +34,8 @@ class RegulationGroupParser(ValidityMixin, Writable, ElementParser):
     tag = Tag("regulation.group")
 
     group_id = TextElement(Tag("regulation.group.id"))
+    valid_between_lower = ValidityMixin.valid_between_lower
+    valid_between_upper = ValidityMixin.valid_between_upper
 
 
 @RecordParser.register_child("regulation_group_description")
@@ -105,12 +107,15 @@ class BaseRegulationParser(ValidityMixin, Writable, ElementParser):
     tag = Tag("base.regulation")
 
     role_type = IntElement(Tag("base.regulation.role"))
-    regulation_group__group_id = TextElement(Tag("regulation.group.id"))
     regulation_id = TextElement(Tag("base.regulation.id"))
     published_at = TextElement(Tag("published.date"))
     official_journal_number = TextElement(Tag("officialjournal.number"))
     official_journal_page = IntElement(Tag("officialjournal.page"))
+    valid_between_lower = ValidityMixin.valid_between_lower
+    valid_between_upper = ValidityMixin.valid_between_upper
+    effective_end_date = TextElement(Tag("effective.end.date"))
     community_code = IntElement(Tag("community.code"))
+    regulation_group__group_id = TextElement(Tag("regulation.group.id"))
     replacement_indicator = IntElement(Tag("replacement.indicator"))
     stopped = BooleanElement(Tag("stopped.flag"))
     information_text = CompoundElement(
@@ -119,7 +124,6 @@ class BaseRegulationParser(ValidityMixin, Writable, ElementParser):
         "url",
     )
     approved = BooleanElement(Tag("approved.flag"))
-    effective_end_date = TextElement(Tag("effective.end.date"))
 
 
 @RecordParser.register_child("modification_regulation")
@@ -165,6 +169,8 @@ class ModificationRegulationParser(ValidityMixin, Writable, ElementParser):
     published_at = TextElement(Tag("published.date"))
     official_journal_number = TextElement(Tag("officialjournal.number"))
     official_journal_page = IntElement(Tag("officialjournal.page"))
+    valid_between_lower = ValidityMixin.valid_between_lower
+    valid_between_upper = ValidityMixin.valid_between_upper
     effective_end_date = TextElement(Tag("effective.end.date"))
     target_regulation__role_type = TextElement(Tag("base.regulation.role"))
     target_regulation__regulation_id = TextElement(Tag("base.regulation.id"))
@@ -218,6 +224,8 @@ class FullTemporaryStopRegulationParser(ValidityMixin, Writable, ElementParser):
     published_at = TextElement(Tag("published.date"))
     official_journal_number = TextElement(Tag("officialjournal.number"))
     official_journal_page = IntElement(Tag("officialjournal.page"))
+    valid_between_lower = ValidityMixin.valid_between_lower
+    valid_between_upper = ValidityMixin.valid_between_upper
     effective_end_date = TextElement(Tag("effective.enddate"))
     replacement_indicator = IntElement(Tag("replacement.indicator"))
     information_text = CompoundElement(

--- a/regulations/import_parsers.py
+++ b/regulations/import_parsers.py
@@ -1,5 +1,6 @@
 from importer.namespaces import Tag
 from importer.parsers import BooleanElement
+from importer.parsers import CompoundElement
 from importer.parsers import ElementParser
 from importer.parsers import IntElement
 from importer.parsers import TextElement
@@ -101,7 +102,11 @@ class BaseRegulationParser(ValidityMixin, Writable, ElementParser):
     community_code = IntElement(Tag("community.code"))
     replacement_indicator = IntElement(Tag("replacement.indicator"))
     stopped = BooleanElement(Tag("stopped.flag"))
-    information_text = TextElement(Tag("information.text"))
+    information_text = CompoundElement(
+        Tag("information.text"),
+        "public_identifier",
+        "url",
+    )
     approved = BooleanElement(Tag("approved.flag"))
     effective_end_date = TextElement(Tag("effective.end.date"))
 
@@ -151,7 +156,11 @@ class ModificationRegulationParser(ValidityMixin, Writable, ElementParser):
     target_regulation__regulation_id = TextElement(Tag("base.regulation.id"))
     replacement_indicator = IntElement(Tag("replacement.indicator"))
     stopped = BooleanElement(Tag("stopped.flag"))
-    information_text = TextElement(Tag("information.text"))
+    information_text = CompoundElement(
+        Tag("information.text"),
+        "public_identifier",
+        "url",
+    )
     approved = BooleanElement(Tag("approved.flag"))
 
 
@@ -194,7 +203,11 @@ class FullTemporaryStopRegulationParser(ValidityMixin, Writable, ElementParser):
     official_journal_page = IntElement(Tag("officialjournal.page"))
     effective_end_date = TextElement(Tag("effective.enddate"))
     replacement_indicator = IntElement(Tag("replacement.indicator"))
-    information_text = TextElement(Tag("information.text"))
+    information_text = CompoundElement(
+        Tag("information.text"),
+        "public_identifier",
+        "url",
+    )
     approved = BooleanElement(Tag("approved.flag"))
 
 

--- a/regulations/import_parsers.py
+++ b/regulations/import_parsers.py
@@ -28,6 +28,9 @@ class RegulationGroupParser(ValidityMixin, Writable, ElementParser):
         </xs:element>
     """
 
+    record_code = "150"
+    subrecord_code = "00"
+
     tag = Tag("regulation.group")
 
     group_id = TextElement(Tag("regulation.group.id"))
@@ -50,6 +53,9 @@ class RegulationGroupDescriptionParser(Writable, ElementParser):
             </xs:complexType>
         </xs:element>
     """
+
+    record_code = "150"
+    subrecord_code = "05"
 
     tag = Tag("regulation.group.description")
 
@@ -92,6 +98,9 @@ class BaseRegulationParser(ValidityMixin, Writable, ElementParser):
             </xs:complexType>
         </xs:element>
     """
+
+    record_code = "285"
+    subrecord_code = "00"
 
     tag = Tag("base.regulation")
 
@@ -146,6 +155,9 @@ class ModificationRegulationParser(ValidityMixin, Writable, ElementParser):
         </xs:element>
     """
 
+    record_code = "290"
+    subrecord_code = "00"
+
     tag = Tag("modification.regulation")
 
     role_type = IntElement(Tag("modification.regulation.role"))
@@ -196,6 +208,9 @@ class FullTemporaryStopRegulationParser(ValidityMixin, Writable, ElementParser):
         </xs:element>
     """
 
+    record_code = "300"
+    subrecord_code = "00"
+
     tag = Tag("full.temporary.stop.regulation")
 
     role_type = IntElement(Tag("full.temporary.stop.regulation.role"))
@@ -232,6 +247,9 @@ class FullTemporaryStopActionParser(Writable, ElementParser):
         </xs:element>
     """
 
+    record_code = "305"
+    subrecord_code = "00"
+
     tag = Tag("fts.regulation.action")
 
     role_type = IntElement(Tag("fts.regulation.role"))
@@ -261,6 +279,9 @@ class RegulationReplacementParser(Writable, ElementParser):
             </xs:complexType>
         </xs:element>
     """
+
+    record_code = "305"
+    subrecord_code = "00"
 
     tag = Tag("regulation.replacement")
 

--- a/regulations/import_parsers.py
+++ b/regulations/import_parsers.py
@@ -1,6 +1,7 @@
 from importer.namespaces import Tag
 from importer.parsers import BooleanElement
 from importer.parsers import CompoundElement
+from importer.parsers import ConstantElement
 from importer.parsers import ElementParser
 from importer.parsers import IntElement
 from importer.parsers import TextElement
@@ -53,6 +54,7 @@ class RegulationGroupDescriptionParser(Writable, ElementParser):
     tag = Tag("regulation.group.description")
 
     group_id = TextElement(Tag("regulation.group.id"))
+    language_id = ConstantElement(Tag("language.id"), value="EN")
     description = TextElement(Tag("description"))
 
 


### PR DESCRIPTION
This is the first part of the work (started but not finished in firebreak!) to make better use of the database to generate XML envelope output. I'm trying to get as much stuff out of the way which can be merged early to make the later PR more manageable.

This first set of commits is focused around more accurately representing the XML datamodel in the import parsers. This lets us get rid of some custom logic and provides natural extension points which we will use in a later PR to provide serialisation. On the whole though, not much _behaviour_ has changed here – we are just making the import parsers into more accurate data models.

There is some stuff in here which at first glance seems a bit weird (I'd encourage you to read the commit messages) and that we don't use yet e.g. adding the record and subrecord codes. This all gets used later and I can explain further if the commit messages are not clear enough.