### PR TITLE
Revert "TP 650 - Schedule workbasket upload to bucket"

### DIFF
--- a/common/tests/test_models.py
+++ b/common/tests/test_models.py
@@ -1,5 +1,4 @@
 from typing import List
-from unittest.mock import patch
 
 import pytest
 from pytest_django.asserts import assertQuerysetEqual  # noqa
@@ -360,10 +359,7 @@ def test_get_descriptions_with_update(sample_model, valid_user):
     assert description not in description_queryset
 
     workbasket.submit_for_approval()
-    with patch(
-        "exporter.tasks.upload_workbaskets.delay",
-    ):
-        workbasket.approve(valid_user)
+    workbasket.approve(valid_user)
     description_queryset = sample_model.get_descriptions()
 
     assert new_description in description_queryset

--- a/conftest.py
+++ b/conftest.py
@@ -633,10 +633,7 @@ def in_use_check_respects_deletes(valid_user):
             dependant = dependant_factory.create(**create_kwargs, **extra_kwargs)
         assert not in_use(), f"Unapproved {instance!r} already in use"
 
-        with patch(
-            "exporter.tasks.upload_workbaskets.delay",
-        ):
-            workbasket.approve(valid_user)
+        workbasket.approve(valid_user)
         workbasket.save()
         assert in_use(), f"Approved {instance!r} not in use"
 

--- a/docs/exporter/celery-tasks.rst
+++ b/docs/exporter/celery-tasks.rst
@@ -1,7 +1,7 @@
 Celery Tasks
 ^^^^^^^^^^^^
 
-Celery Tasks for the exporter are triggered on setting Workbaskets READY_FOR_EXPORT, the upload_transactions management command, or via the celery commandline or GUI.
+Celery Tasks for the exporter are triggered on setting Workbaskets READY_FOR_EXPORT [TBD], the upload_transactions management command, or via the celery commandline or GUI.
 
 upload_workbaskets
 ------------------

--- a/workbaskets/models.py
+++ b/workbaskets/models.py
@@ -144,11 +144,6 @@ class WorkBasket(TimestampedMixin):
             version_group.current_version = obj
             version_group.save()
 
-        # imported lower down to avoid circular import error
-        from exporter.tasks import upload_workbaskets
-
-        upload_workbaskets.delay()
-
     @transition(
         field=status,
         source=WorkflowStatus.READY_FOR_EXPORT,

--- a/workbaskets/tests/test_models.py
+++ b/workbaskets/tests/test_models.py
@@ -1,5 +1,4 @@
 from contextlib import nullcontext as does_not_raise
-from unittest import mock
 
 import pytest
 from django_fsm import TransitionNotAllowed
@@ -35,7 +34,7 @@ def test_workbasket_transactions():
 
 
 @pytest.mark.parametrize(
-    "start_status,transition,target_status,expect_error,expect_upload",
+    "start_status,transition,target_status,expect_error",
     [
         # Submission
         (
@@ -43,84 +42,72 @@ def test_workbasket_transactions():
             "submit_for_approval",
             WorkflowStatus.AWAITING_APPROVAL,
             does_not_raise(),
-            False,
         ),
         (
             WorkflowStatus.EDITING,
             "submit_for_approval",
             WorkflowStatus.AWAITING_APPROVAL,
             does_not_raise(),
-            False,
         ),
         (
             WorkflowStatus.APPROVAL_REJECTED,
             "submit_for_approval",
             WorkflowStatus.AWAITING_APPROVAL,
             pytest.raises(TransitionNotAllowed),
-            False,
         ),
         (
             WorkflowStatus.READY_FOR_EXPORT,
             "submit_for_approval",
             WorkflowStatus.AWAITING_APPROVAL,
             pytest.raises(TransitionNotAllowed),
-            False,
         ),
         (
             WorkflowStatus.AWAITING_CDS_UPLOAD_CREATE_NEW,
             "submit_for_approval",
             WorkflowStatus.AWAITING_APPROVAL,
             pytest.raises(TransitionNotAllowed),
-            False,
         ),
         (
             WorkflowStatus.AWAITING_CDS_UPLOAD_EDIT,
             "submit_for_approval",
             WorkflowStatus.AWAITING_APPROVAL,
             pytest.raises(TransitionNotAllowed),
-            False,
         ),
         (
             WorkflowStatus.AWAITING_CDS_UPLOAD_OVERWRITE,
             "submit_for_approval",
             WorkflowStatus.AWAITING_APPROVAL,
             pytest.raises(TransitionNotAllowed),
-            False,
         ),
         (
             WorkflowStatus.AWAITING_CDS_UPLOAD_DELETE,
             "submit_for_approval",
             WorkflowStatus.AWAITING_APPROVAL,
             pytest.raises(TransitionNotAllowed),
-            False,
         ),
         (
             WorkflowStatus.SENT_TO_CDS,
             "submit_for_approval",
             WorkflowStatus.AWAITING_APPROVAL,
             pytest.raises(TransitionNotAllowed),
-            False,
         ),
         (
             WorkflowStatus.SENT_TO_CDS_DELETE,
             "submit_for_approval",
             WorkflowStatus.AWAITING_APPROVAL,
             pytest.raises(TransitionNotAllowed),
-            False,
         ),
         (
             WorkflowStatus.PUBLISHED,
             "submit_for_approval",
             WorkflowStatus.AWAITING_APPROVAL,
             pytest.raises(TransitionNotAllowed),
-            False,
         ),
         (
             WorkflowStatus.CDS_ERROR,
             "submit_for_approval",
             WorkflowStatus.AWAITING_APPROVAL,
             pytest.raises(TransitionNotAllowed),
-            False,
         ),
         # Withdraw
         (
@@ -128,84 +115,72 @@ def test_workbasket_transactions():
             "withdraw",
             WorkflowStatus.EDITING,
             pytest.raises(TransitionNotAllowed),
-            False,
         ),
         (
             WorkflowStatus.AWAITING_APPROVAL,
             "withdraw",
             WorkflowStatus.EDITING,
             does_not_raise(),
-            False,
         ),
         (
             WorkflowStatus.APPROVAL_REJECTED,
             "withdraw",
             WorkflowStatus.EDITING,
             does_not_raise(),
-            False,
         ),
         (
             WorkflowStatus.READY_FOR_EXPORT,
             "withdraw",
             WorkflowStatus.EDITING,
             pytest.raises(TransitionNotAllowed),
-            False,
         ),
         (
             WorkflowStatus.AWAITING_CDS_UPLOAD_CREATE_NEW,
             "withdraw",
             WorkflowStatus.EDITING,
             pytest.raises(TransitionNotAllowed),
-            False,
         ),
         (
             WorkflowStatus.AWAITING_CDS_UPLOAD_EDIT,
             "withdraw",
             WorkflowStatus.EDITING,
             pytest.raises(TransitionNotAllowed),
-            False,
         ),
         (
             WorkflowStatus.AWAITING_CDS_UPLOAD_OVERWRITE,
             "withdraw",
             WorkflowStatus.EDITING,
             pytest.raises(TransitionNotAllowed),
-            False,
         ),
         (
             WorkflowStatus.AWAITING_CDS_UPLOAD_DELETE,
             "withdraw",
             WorkflowStatus.EDITING,
             pytest.raises(TransitionNotAllowed),
-            False,
         ),
         (
             WorkflowStatus.SENT_TO_CDS,
             "withdraw",
             WorkflowStatus.EDITING,
             pytest.raises(TransitionNotAllowed),
-            False,
         ),
         (
             WorkflowStatus.SENT_TO_CDS_DELETE,
             "withdraw",
             WorkflowStatus.EDITING,
             pytest.raises(TransitionNotAllowed),
-            False,
         ),
         (
             WorkflowStatus.PUBLISHED,
             "withdraw",
             WorkflowStatus.EDITING,
             pytest.raises(TransitionNotAllowed),
-            False,
         ),
         (
             WorkflowStatus.CDS_ERROR,
             "withdraw",
             WorkflowStatus.EDITING,
             does_not_raise(),
-            False,
         ),
         # Rejection
         (
@@ -213,84 +188,72 @@ def test_workbasket_transactions():
             "reject",
             WorkflowStatus.APPROVAL_REJECTED,
             pytest.raises(TransitionNotAllowed),
-            False,
         ),
         (
             WorkflowStatus.EDITING,
             "reject",
             WorkflowStatus.APPROVAL_REJECTED,
             pytest.raises(TransitionNotAllowed),
-            False,
         ),
         (
             WorkflowStatus.AWAITING_APPROVAL,
             "reject",
             WorkflowStatus.APPROVAL_REJECTED,
             does_not_raise(),
-            False,
         ),
         (
             WorkflowStatus.READY_FOR_EXPORT,
             "reject",
             WorkflowStatus.APPROVAL_REJECTED,
             pytest.raises(TransitionNotAllowed),
-            False,
         ),
         (
             WorkflowStatus.AWAITING_CDS_UPLOAD_CREATE_NEW,
             "reject",
             WorkflowStatus.APPROVAL_REJECTED,
             pytest.raises(TransitionNotAllowed),
-            False,
         ),
         (
             WorkflowStatus.AWAITING_CDS_UPLOAD_EDIT,
             "reject",
             WorkflowStatus.APPROVAL_REJECTED,
             pytest.raises(TransitionNotAllowed),
-            False,
         ),
         (
             WorkflowStatus.AWAITING_CDS_UPLOAD_OVERWRITE,
             "reject",
             WorkflowStatus.APPROVAL_REJECTED,
             pytest.raises(TransitionNotAllowed),
-            False,
         ),
         (
             WorkflowStatus.AWAITING_CDS_UPLOAD_DELETE,
             "reject",
             WorkflowStatus.APPROVAL_REJECTED,
             pytest.raises(TransitionNotAllowed),
-            False,
         ),
         (
             WorkflowStatus.SENT_TO_CDS,
             "reject",
             WorkflowStatus.APPROVAL_REJECTED,
             pytest.raises(TransitionNotAllowed),
-            False,
         ),
         (
             WorkflowStatus.SENT_TO_CDS_DELETE,
             "reject",
             WorkflowStatus.APPROVAL_REJECTED,
             pytest.raises(TransitionNotAllowed),
-            False,
         ),
         (
             WorkflowStatus.PUBLISHED,
             "reject",
             WorkflowStatus.APPROVAL_REJECTED,
             pytest.raises(TransitionNotAllowed),
-            False,
         ),
         (
             WorkflowStatus.CDS_ERROR,
             "reject",
             WorkflowStatus.APPROVAL_REJECTED,
             pytest.raises(TransitionNotAllowed),
-            False,
         ),
         # Approval
         (
@@ -298,84 +261,72 @@ def test_workbasket_transactions():
             "approve",
             WorkflowStatus.READY_FOR_EXPORT,
             pytest.raises(TransitionNotAllowed),
-            False,
         ),
         (
             WorkflowStatus.EDITING,
             "approve",
             WorkflowStatus.READY_FOR_EXPORT,
             pytest.raises(TransitionNotAllowed),
-            False,
         ),
         (
             WorkflowStatus.AWAITING_APPROVAL,
             "approve",
             WorkflowStatus.READY_FOR_EXPORT,
             does_not_raise(),
-            True,
         ),
         (
             WorkflowStatus.APPROVAL_REJECTED,
             "approve",
             WorkflowStatus.READY_FOR_EXPORT,
             pytest.raises(TransitionNotAllowed),
-            False,
         ),
         (
             WorkflowStatus.AWAITING_CDS_UPLOAD_CREATE_NEW,
             "approve",
             WorkflowStatus.READY_FOR_EXPORT,
             pytest.raises(TransitionNotAllowed),
-            False,
         ),
         (
             WorkflowStatus.AWAITING_CDS_UPLOAD_EDIT,
             "approve",
             WorkflowStatus.READY_FOR_EXPORT,
             pytest.raises(TransitionNotAllowed),
-            False,
         ),
         (
             WorkflowStatus.AWAITING_CDS_UPLOAD_OVERWRITE,
             "approve",
             WorkflowStatus.READY_FOR_EXPORT,
             pytest.raises(TransitionNotAllowed),
-            False,
         ),
         (
             WorkflowStatus.AWAITING_CDS_UPLOAD_DELETE,
             "approve",
             WorkflowStatus.READY_FOR_EXPORT,
             pytest.raises(TransitionNotAllowed),
-            False,
         ),
         (
             WorkflowStatus.SENT_TO_CDS,
             "approve",
             WorkflowStatus.READY_FOR_EXPORT,
             pytest.raises(TransitionNotAllowed),
-            False,
         ),
         (
             WorkflowStatus.SENT_TO_CDS_DELETE,
             "approve",
             WorkflowStatus.READY_FOR_EXPORT,
             pytest.raises(TransitionNotAllowed),
-            False,
         ),
         (
             WorkflowStatus.PUBLISHED,
             "approve",
             WorkflowStatus.READY_FOR_EXPORT,
             pytest.raises(TransitionNotAllowed),
-            False,
         ),
         (
             WorkflowStatus.CDS_ERROR,
             "approve",
             WorkflowStatus.READY_FOR_EXPORT,
             pytest.raises(TransitionNotAllowed),
-            False,
         ),
         # Export
         (
@@ -383,84 +334,72 @@ def test_workbasket_transactions():
             "export_to_cds",
             WorkflowStatus.SENT_TO_CDS,
             pytest.raises(TransitionNotAllowed),
-            False,
         ),
         (
             WorkflowStatus.EDITING,
             "export_to_cds",
             WorkflowStatus.SENT_TO_CDS,
             pytest.raises(TransitionNotAllowed),
-            False,
         ),
         (
             WorkflowStatus.AWAITING_APPROVAL,
             "export_to_cds",
             WorkflowStatus.SENT_TO_CDS,
             pytest.raises(TransitionNotAllowed),
-            False,
         ),
         (
             WorkflowStatus.APPROVAL_REJECTED,
             "export_to_cds",
             WorkflowStatus.SENT_TO_CDS,
             pytest.raises(TransitionNotAllowed),
-            False,
         ),
         (
             WorkflowStatus.READY_FOR_EXPORT,
             "export_to_cds",
             WorkflowStatus.SENT_TO_CDS,
             does_not_raise(),
-            False,
         ),
         (
             WorkflowStatus.AWAITING_CDS_UPLOAD_CREATE_NEW,
             "export_to_cds",
             WorkflowStatus.SENT_TO_CDS,
             pytest.raises(TransitionNotAllowed),
-            False,
         ),
         (
             WorkflowStatus.AWAITING_CDS_UPLOAD_EDIT,
             "export_to_cds",
             WorkflowStatus.SENT_TO_CDS,
             pytest.raises(TransitionNotAllowed),
-            False,
         ),
         (
             WorkflowStatus.AWAITING_CDS_UPLOAD_OVERWRITE,
             "export_to_cds",
             WorkflowStatus.SENT_TO_CDS,
             pytest.raises(TransitionNotAllowed),
-            False,
         ),
         (
             WorkflowStatus.AWAITING_CDS_UPLOAD_DELETE,
             "export_to_cds",
             WorkflowStatus.SENT_TO_CDS,
             pytest.raises(TransitionNotAllowed),
-            False,
         ),
         (
             WorkflowStatus.SENT_TO_CDS_DELETE,
             "export_to_cds",
             WorkflowStatus.SENT_TO_CDS,
             pytest.raises(TransitionNotAllowed),
-            False,
         ),
         (
             WorkflowStatus.PUBLISHED,
             "export_to_cds",
             WorkflowStatus.SENT_TO_CDS,
             pytest.raises(TransitionNotAllowed),
-            False,
         ),
         (
             WorkflowStatus.CDS_ERROR,
             "export_to_cds",
             WorkflowStatus.SENT_TO_CDS,
             pytest.raises(TransitionNotAllowed),
-            False,
         ),
         # Confirmed
         (
@@ -468,84 +407,72 @@ def test_workbasket_transactions():
             "cds_confirmed",
             WorkflowStatus.PUBLISHED,
             pytest.raises(TransitionNotAllowed),
-            False,
         ),
         (
             WorkflowStatus.EDITING,
             "cds_confirmed",
             WorkflowStatus.PUBLISHED,
             pytest.raises(TransitionNotAllowed),
-            False,
         ),
         (
             WorkflowStatus.AWAITING_APPROVAL,
             "cds_confirmed",
             WorkflowStatus.PUBLISHED,
             pytest.raises(TransitionNotAllowed),
-            False,
         ),
         (
             WorkflowStatus.APPROVAL_REJECTED,
             "cds_confirmed",
             WorkflowStatus.PUBLISHED,
             pytest.raises(TransitionNotAllowed),
-            False,
         ),
         (
             WorkflowStatus.READY_FOR_EXPORT,
             "cds_confirmed",
             WorkflowStatus.PUBLISHED,
             pytest.raises(TransitionNotAllowed),
-            False,
         ),
         (
             WorkflowStatus.AWAITING_CDS_UPLOAD_CREATE_NEW,
             "cds_confirmed",
             WorkflowStatus.PUBLISHED,
             pytest.raises(TransitionNotAllowed),
-            False,
         ),
         (
             WorkflowStatus.AWAITING_CDS_UPLOAD_EDIT,
             "cds_confirmed",
             WorkflowStatus.PUBLISHED,
             pytest.raises(TransitionNotAllowed),
-            False,
         ),
         (
             WorkflowStatus.AWAITING_CDS_UPLOAD_OVERWRITE,
             "cds_confirmed",
             WorkflowStatus.PUBLISHED,
             pytest.raises(TransitionNotAllowed),
-            False,
         ),
         (
             WorkflowStatus.AWAITING_CDS_UPLOAD_DELETE,
             "cds_confirmed",
             WorkflowStatus.PUBLISHED,
             pytest.raises(TransitionNotAllowed),
-            False,
         ),
         (
             WorkflowStatus.SENT_TO_CDS,
             "cds_confirmed",
             WorkflowStatus.PUBLISHED,
             does_not_raise(),
-            False,
         ),
         (
             WorkflowStatus.SENT_TO_CDS_DELETE,
             "cds_confirmed",
             WorkflowStatus.PUBLISHED,
             pytest.raises(TransitionNotAllowed),
-            False,
         ),
         (
             WorkflowStatus.CDS_ERROR,
             "cds_confirmed",
             WorkflowStatus.PUBLISHED,
             pytest.raises(TransitionNotAllowed),
-            False,
         ),
         # Errored
         (
@@ -553,84 +480,72 @@ def test_workbasket_transactions():
             "cds_error",
             WorkflowStatus.CDS_ERROR,
             pytest.raises(TransitionNotAllowed),
-            False,
         ),
         (
             WorkflowStatus.EDITING,
             "cds_error",
             WorkflowStatus.CDS_ERROR,
             pytest.raises(TransitionNotAllowed),
-            False,
         ),
         (
             WorkflowStatus.AWAITING_APPROVAL,
             "cds_error",
             WorkflowStatus.CDS_ERROR,
             pytest.raises(TransitionNotAllowed),
-            False,
         ),
         (
             WorkflowStatus.APPROVAL_REJECTED,
             "cds_error",
             WorkflowStatus.CDS_ERROR,
             pytest.raises(TransitionNotAllowed),
-            False,
         ),
         (
             WorkflowStatus.READY_FOR_EXPORT,
             "cds_error",
             WorkflowStatus.CDS_ERROR,
             pytest.raises(TransitionNotAllowed),
-            False,
         ),
         (
             WorkflowStatus.AWAITING_CDS_UPLOAD_CREATE_NEW,
             "cds_error",
             WorkflowStatus.CDS_ERROR,
             pytest.raises(TransitionNotAllowed),
-            False,
         ),
         (
             WorkflowStatus.AWAITING_CDS_UPLOAD_EDIT,
             "cds_error",
             WorkflowStatus.CDS_ERROR,
             pytest.raises(TransitionNotAllowed),
-            False,
         ),
         (
             WorkflowStatus.AWAITING_CDS_UPLOAD_OVERWRITE,
             "cds_error",
             WorkflowStatus.CDS_ERROR,
             pytest.raises(TransitionNotAllowed),
-            False,
         ),
         (
             WorkflowStatus.AWAITING_CDS_UPLOAD_DELETE,
             "cds_error",
             WorkflowStatus.CDS_ERROR,
             pytest.raises(TransitionNotAllowed),
-            False,
         ),
         (
             WorkflowStatus.SENT_TO_CDS,
             "cds_error",
             WorkflowStatus.CDS_ERROR,
             does_not_raise(),
-            False,
         ),
         (
             WorkflowStatus.SENT_TO_CDS_DELETE,
             "cds_error",
             WorkflowStatus.CDS_ERROR,
             pytest.raises(TransitionNotAllowed),
-            False,
         ),
         (
             WorkflowStatus.PUBLISHED,
             "cds_error",
             WorkflowStatus.CDS_ERROR,
             pytest.raises(TransitionNotAllowed),
-            False,
         ),
     ],
 )
@@ -640,25 +555,16 @@ def test_workbasket_submit(
     transition,
     target_status,
     expect_error,
-    expect_upload,
     valid_user,
 ):
     new_workbasket.status = start_status
-    with mock.patch(
-        "exporter.tasks.upload_workbaskets.delay",
-    ) as mock_save:
-        transition_method = getattr(new_workbasket, transition)
-        with expect_error:
-            if transition_method.__name__ == "approve":
-                transition_method(valid_user)
-            else:
-                transition_method()
-            assert new_workbasket.status == target_status
-
-            if expect_upload:
-                mock_save.assert_called_once_with()
-            else:
-                mock_save.assert_not_called()
+    transition_method = getattr(new_workbasket, transition)
+    with expect_error:
+        if transition_method.__name__ == "approve":
+            transition_method(valid_user)
+        else:
+            transition_method()
+        assert new_workbasket.status == target_status
 
 
 def test_get_tracked_models(new_workbasket):
@@ -674,18 +580,12 @@ def test_workbasket_accepted_updates_current_tracked_models(new_workbasket, vali
     new_footnote = original_footnote.new_version(workbasket=new_workbasket)
 
     assert new_footnote.version_group.current_version.pk == original_footnote.pk
-
-    with mock.patch(
-        "exporter.tasks.upload_workbaskets.delay",
-    ) as mock_save:
-        new_workbasket.submit_for_approval()
-        new_footnote.refresh_from_db()
-        assert new_footnote.version_group.current_version.pk == original_footnote.pk
-        new_workbasket.approve(valid_user)
-        new_footnote.refresh_from_db()
-        assert new_footnote.version_group.current_version.pk == new_footnote.pk
-
-        mock_save.assert_called_once_with()
+    new_workbasket.submit_for_approval()
+    new_footnote.refresh_from_db()
+    assert new_footnote.version_group.current_version.pk == original_footnote.pk
+    new_workbasket.approve(valid_user)
+    new_footnote.refresh_from_db()
+    assert new_footnote.version_group.current_version.pk == new_footnote.pk
 
 
 def test_workbasket_errored_updates_tracked_models(new_workbasket, valid_user):
@@ -693,21 +593,15 @@ def test_workbasket_errored_updates_tracked_models(new_workbasket, valid_user):
     new_footnote = original_footnote.new_version(workbasket=new_workbasket)
 
     assert new_footnote.version_group.current_version.pk == original_footnote.pk
-
-    with mock.patch(
-        "exporter.tasks.upload_workbaskets.delay",
-    ) as mock_save:
-        new_workbasket.submit_for_approval()
-        new_footnote.refresh_from_db()
-        assert new_footnote.version_group.current_version.pk == original_footnote.pk
-        new_workbasket.approve(valid_user)
-        new_footnote.refresh_from_db()
-        assert new_footnote.version_group.current_version.pk == new_footnote.pk
-        new_workbasket.export_to_cds()
-        new_footnote.refresh_from_db()
-        assert new_footnote.version_group.current_version.pk == new_footnote.pk
-        new_workbasket.cds_error()
-        new_footnote.refresh_from_db()
-        assert new_footnote.version_group.current_version.pk == original_footnote.pk
-
-        mock_save.assert_called_once_with()
+    new_workbasket.submit_for_approval()
+    new_footnote.refresh_from_db()
+    assert new_footnote.version_group.current_version.pk == original_footnote.pk
+    new_workbasket.approve(valid_user)
+    new_footnote.refresh_from_db()
+    assert new_footnote.version_group.current_version.pk == new_footnote.pk
+    new_workbasket.export_to_cds()
+    new_footnote.refresh_from_db()
+    assert new_footnote.version_group.current_version.pk == new_footnote.pk
+    new_workbasket.cds_error()
+    new_footnote.refresh_from_db()
+    assert new_footnote.version_group.current_version.pk == original_footnote.pk

--- a/workbaskets/tests/test_views.py
+++ b/workbaskets/tests/test_views.py
@@ -1,5 +1,3 @@
-from unittest import mock
-
 import pytest
 from django.urls import reverse
 
@@ -13,29 +11,24 @@ pytestmark = pytest.mark.django_db
 
 
 def test_submit_workbasket(unapproved_transaction, valid_user, client):
-    with mock.patch(
-        "exporter.tasks.upload_workbaskets",
-    ) as mock_save:
-        workbasket = unapproved_transaction.workbasket
+    workbasket = unapproved_transaction.workbasket
 
-        url = reverse(
-            "workbaskets:workbasket-ui-submit",
-            kwargs={"pk": workbasket.pk},
-        )
+    url = reverse(
+        "workbaskets:workbasket-ui-submit",
+        kwargs={"pk": workbasket.pk},
+    )
 
-        client.force_login(valid_user)
-        response = client.get(url)
+    client.force_login(valid_user)
+    response = client.get(url)
 
-        assert response.status_code == 302
-        assert response.url == reverse("index")
+    assert response.status_code == 302
+    assert response.url == reverse("index")
 
-        workbasket.refresh_from_db()
-        assert workbasket.status == WorkflowStatus.SENT_TO_CDS
-        assert workbasket.approver is not None
+    workbasket.refresh_from_db()
+    assert workbasket.status == WorkflowStatus.SENT_TO_CDS
+    assert workbasket.approver is not None
 
-        assert client.session["workbasket"]["status"] == WorkflowStatus.SENT_TO_CDS
-
-        mock_save.delay.assert_called_once_with()
+    assert client.session["workbasket"]["status"] == WorkflowStatus.SENT_TO_CDS
 
 
 def test_edit_after_submit(workbasket, valid_user, client, date_ranges):
@@ -46,17 +39,13 @@ def test_edit_after_submit(workbasket, valid_user, client, date_ranges):
         footnote = factories.FootnoteFactory.create(
             update_type=UpdateType.CREATE,
         )
-
-    with mock.patch(
-        "exporter.tasks.upload_workbaskets.delay",
-    ):
-        response = client.get(
-            reverse(
-                "workbaskets:workbasket-ui-submit",
-                kwargs={"pk": workbasket.pk},
-            ),
-        )
-        assert response.status_code == 302
+    response = client.get(
+        reverse(
+            "workbaskets:workbasket-ui-submit",
+            kwargs={"pk": workbasket.pk},
+        ),
+    )
+    assert response.status_code == 302
 
     # edit the footnote
     response = client.post(


### PR DESCRIPTION
Reverts scheduling workbasket until we can be sure HMRC upload is turned off.