### PR TITLE
Fix incorrect text in HTML description

### DIFF
--- a/common/jinja2/common/create_description.jinja
+++ b/common/jinja2/common/create_description.jinja
@@ -6,7 +6,6 @@
 {% set description_help_html %}
 
   <p class="govuk-body">
-    {{ described_object._meta.verbose_name }}
     It is possible to use HTML when defining descriptions. The table below shows 
     a few examples of useful codes that you may want to use. Please use HTML sparingly and only where 
     absolutely necessary.


### PR DESCRIPTION
Fixes a data string left in the help text for adding description text.