### PR TITLE
Access PaaS hosted DB via SSH

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -144,3 +144,6 @@ webpack-stats.json
 .vscode/
 
 *.gz
+
+# temporary db credentials files
+*-db.json

--- a/Makefile
+++ b/Makefile
@@ -102,3 +102,27 @@ docker-test:
 ## build-docs: Build the project documentation
 build-docs html:
 	@sphinx-build . docs/_build -c docs/ -b html
+
+
+paas-login:
+	@echo "> Login to PaaS"
+	@cf login -a api.london.cloud.service.gov.uk --sso
+
+
+%-db.json:
+	@echo "> Get ${app}-db service key..."
+	@cf service-key ${app}-db EXTERNAL_ACCESS_KEY | tail -n9 > ${app}-db.json
+
+
+paas-db-tunnel: ${app}-db.json
+	@echo "> SSH Tunnel to ${app}-db..."
+	$(eval host := $(shell jq -r '.host' < ${app}-db.json))
+	$(eval port := $(shell jq -r '.port' < ${app}-db.json))
+	@cf ssh -N -L $(port)1:$(host):$(port) ${app}
+
+
+paas-db-tunnel-shell: ${app}-db.json
+	$(eval user := $(shell jq -r '.username' < ${app}-db.json))
+	$(eval pass := $(shell jq -r '.password' < ${app}-db.json))
+	$(eval name := $(shell jq -r '.name' < ${app}-db.json))
+	@PGPASSWORD=$(pass) psql -h localhost -p 54321 -U $(user) $(name)

--- a/README.md
+++ b/README.md
@@ -178,6 +178,51 @@ Output defaults to stdout if filename is - or is not supplied.
 
 The app is hosted using GOV.UK PaaS and is deployed with Jenkins.
 
+### Accessing databases in GOV.UK PaaS
+
+To access databases hosted in GOV.UK PaaS directly, you will need a PaaS login and the
+[cf CLI tool](https://docs.cloudfoundry.org/cf-cli/install-go-cli.html). There are a couple of useful `Makefile` targets to make creating an SSH
+tunnel to the databases easier.
+
+NB this requires [`jq`](https://stedolan.github.io/jq/) to be installed too.
+
+```sh
+$ make paas-login
+> Login to PaaS
+API endpoint: api.london.cloud.service.gov.uk
+
+Temporary Authentication Code ( Get one at https://login.london.cloud.service.gov.uk/passcode ): 
+```
+Open the URL above to login and get a code, then paste it into the terminal. You will then be prompted to select a space:
+```sh
+Targeted org dit-staging.
+
+Select a space:
+1. tariffs-dev
+2. tariffs-staging
+3. tariffs-training
+4. tariffs-uat
+
+Space (enter to skip):
+```
+
+Then, start the SSH tunnel
+```sh
+$ make paas-db-tunnel app=tamato-staging
+> Get tamato-staging-db service key...
+> SSH Tunnel to tamato-staging-db...
+```
+At this point, you can connect your local database client to `127.0.0.1:54321`, the credentials are stored in `${app}-db.json` in the current directory - **DO NOT ADD THIS FILE TO THE REPO!**
+
+To close the tunnel, hit Ctrl-c.
+
+For convenience, the following command parses the JSON file and connects using the `psql` client. Run this in another terminal, in the same directory as the JSON file.
+```sh
+$ make paas-db-tunnel-shell app=tamato-staging
+```
+
+Make sure to delete the `${app}-db.json` file after use.
+
 ## How to write tests
 
 Tests are written with Pytest


### PR DESCRIPTION
Connecting to the databases in our GOV.UK PaaS hosted environments can be fiddly, requiring multiple CloudFoundry CLI commands and copy-pasting JSON values into command line arguments.

This change adds a few `Makefile` targets so that the process is streamlined a little.

For example:
```sh
$ make paas-login
> Login to PaaS
API endpoint: api.london.cloud.service.gov.uk

Temporary Authentication Code ( Get one at https://login.london.cloud.service.gov.uk/passcode ): 
```
Open the URL above to login and get a code, then paste it into the terminal. You will then be prompted to select a space:
```sh
Targeted org dit-staging.

Select a space:
1. tariffs-dev
2. tariffs-staging
3. tariffs-training
4. tariffs-uat

Space (enter to skip):
```

Then, start the SSH tunnel
```sh
$ make paas-db-tunnel app=tamato-staging
> Get tamato-staging-db service key...
> SSH Tunnel to tamato-staging-db...
```
At this point, you can connect your local database client to `127.0.0.1:54321`, the credentials are stored in `${app}-db.json` in the current directory - **DO NOT ADD THIS FILE TO THE REPO!**

To close the tunnel, hit Ctrl-c.

For convenience, the following command parses the JSON file and connects using the `psql` client. Run this in another terminal, in the same directory as the JSON file.
```sh
$ make paas-db-tunnel-shell app=tamato-staging
```

Make sure to delete the `${app}-db.json` file after use.