### PR TITLE
__str__ don't die if a field has validity_start instead of valid_between

### DIFF
--- a/common/models/mixins/description.py
+++ b/common/models/mixins/description.py
@@ -48,7 +48,7 @@ class DescriptionMixin(ValidityStartMixin):
         return self.identifying_fields_to_string(
             identifying_fields=(
                 self.described_object_field.name,
-                "valid_between",
+                "validity_start",
             ),
         )
 

--- a/common/tests/test_models.py
+++ b/common/tests/test_models.py
@@ -368,3 +368,21 @@ def test_get_descriptions_with_update(sample_model, valid_user):
 
     assert new_description in description_queryset
     assert description not in description_queryset
+
+
+@pytest.mark.parametrize(
+    "factory",
+    factories.TrackedModelMixin.__subclasses__(),
+    ids=[
+        factory._meta.model.__name__
+        for factory in factories.TrackedModelMixin.__subclasses__()
+    ],
+)
+def test_trackedmodel_str(factory):
+    """Verify no __str__ methods of TrackedModel classes crash or return non-
+    strings."""
+    instance = factory.create()
+    result = instance.__str__()
+
+    assert isinstance(result, str)
+    assert len(result.strip())


### PR DESCRIPTION
Description `__str__` should not raise an exception a field has validity_between instead of validity_start.

Fixes an error that was occuring as one of the fields still referenced valid_between.

AttributeError: 'AdditionalCodeDescription' object has no attribute 'valid_between'

Add very basic test that checks every TrackedModel subclass, via @simonwo

