### PR TITLE
Positive cases for "fuzzy" business rule tests

### DIFF
--- a/additional_codes/tests/test_business_rules.py
+++ b/additional_codes/tests/test_business_rules.py
@@ -16,14 +16,13 @@ pytestmark = pytest.mark.django_db
 
 
 @pytest.mark.xfail(reason="CT1 disabled")
-def test_CT1(make_duplicate_record):
+def test_CT1(assert_handles_duplicates):
     """The additional code type must be unique."""
 
-    additional_code_type = make_duplicate_record(factories.AdditionalCodeTypeFactory)
-    with pytest.raises(BusinessRuleViolation):
-        business_rules.CT1(additional_code_type.transaction).validate(
-            additional_code_type,
-        )
+    assert_handles_duplicates(
+        factories.AdditionalCodeTypeFactory,
+        business_rules.CT1,
+    )
 
 
 @requires_meursing_tables
@@ -50,17 +49,15 @@ def test_CT4(date_ranges):
 # Additional Code
 
 
-def test_ACN1(make_duplicate_record):
+def test_ACN1(assert_handles_duplicates):
     """The combination of additional code type + additional code + start date
     must be unique."""
 
-    duplicate = make_duplicate_record(
+    assert_handles_duplicates(
         factories.AdditionalCodeFactory,
+        business_rules.ACN1,
         identifying_fields=["code", "type", "valid_between__lower"],
     )
-
-    with pytest.raises(BusinessRuleViolation):
-        business_rules.ACN1(duplicate.transaction).validate(duplicate)
 
 
 def test_ACN2_type_must_exist(reference_nonexistent_record):

--- a/certificates/tests/test_business_rules.py
+++ b/certificates/tests/test_business_rules.py
@@ -8,13 +8,13 @@ from common.tests import factories
 pytestmark = pytest.mark.django_db
 
 
-def test_CET1(make_duplicate_record):
+def test_CET1(assert_handles_duplicates):
     """The type of the Certificate must be unique."""
 
-    duplicate = make_duplicate_record(factories.CertificateTypeFactory)
-
-    with pytest.raises(BusinessRuleViolation):
-        business_rules.CET1(duplicate.transaction).validate(duplicate)
+    assert_handles_duplicates(
+        factories.CertificateTypeFactory,
+        business_rules.CET1,
+    )
 
 
 def test_CET2(delete_record):
@@ -36,16 +36,14 @@ def test_CET3(date_ranges):
 
 
 @pytest.mark.xfail(reason="CE2 disabled")
-def test_CE2(make_duplicate_record):
+def test_CE2(assert_handles_duplicates):
     """The combination certificate type and code must be unique."""
 
-    duplicate = make_duplicate_record(
+    assert_handles_duplicates(
         factories.CertificateFactory,
+        business_rules.CE2,
         identifying_fields=("sid", "certificate_type"),
     )
-
-    with pytest.raises(BusinessRuleViolation):
-        business_rules.CE2(duplicate.transaction).validate(duplicate)
 
 
 def test_CE3(date_ranges):

--- a/footnotes/tests/test_business_rules.py
+++ b/footnotes/tests/test_business_rules.py
@@ -12,13 +12,13 @@ pytestmark = pytest.mark.django_db
 # Footnote Type
 
 
-def test_FOT1(make_duplicate_record):
+def test_FOT1(assert_handles_duplicates):
     """The type of the footnote must be unique."""
 
-    duplicate = make_duplicate_record(factories.FootnoteTypeFactory)
-
-    with pytest.raises(BusinessRuleViolation):
-        business_rules.FOT1(duplicate.transaction).validate(duplicate)
+    assert_handles_duplicates(
+        factories.FootnoteTypeFactory,
+        business_rules.FOT1,
+    )
 
 
 def test_FOT2(delete_record):
@@ -41,13 +41,13 @@ def test_FOT3(date_ranges):
 # Footnote
 
 
-def test_FO2(make_duplicate_record):
+def test_FO2(assert_handles_duplicates):
     """The combination footnote type and code must be unique."""
 
-    duplicate = make_duplicate_record(factories.FootnoteFactory)
-
-    with pytest.raises(BusinessRuleViolation):
-        business_rules.FO2(duplicate.transaction).validate(duplicate)
+    assert_handles_duplicates(
+        factories.FootnoteFactory,
+        business_rules.FO2,
+    )
 
 
 def test_FO3(date_ranges):

--- a/geo_areas/tests/test_business_rules.py
+++ b/geo_areas/tests/test_business_rules.py
@@ -20,17 +20,15 @@ def child():
 
 
 @pytest.mark.xfail(reason="GA1 disabled")
-def test_GA1(make_duplicate_record):
+def test_GA1(assert_handles_duplicates):
     """The combination geographical area id + validity start date must be
     unique."""
 
-    duplicate = make_duplicate_record(
+    assert_handles_duplicates(
         factories.GeographicalAreaFactory,
+        business_rules.GA1,
         identifying_fields=("area_id", "valid_between__lower"),
     )
-
-    with pytest.raises(BusinessRuleViolation):
-        business_rules.GA1(duplicate.transaction).validate(duplicate)
 
 
 def test_GA2(date_ranges):

--- a/regulations/tests/test_business_rules.py
+++ b/regulations/tests/test_business_rules.py
@@ -10,15 +10,15 @@ from regulations.validators import RoleType
 pytestmark = pytest.mark.django_db
 
 
-def test_ROIMB1(make_duplicate_record):
+def test_ROIMB1(assert_handles_duplicates):
     """The (regulation id + role id) must be unique."""
     # Effectively this means that the regulation ID needs to be unique as we are always
     # going to be using role ID 1.
 
-    duplicate = make_duplicate_record(factories.BaseRegulationFactory)
-
-    with pytest.raises(BusinessRuleViolation):
-        business_rules.ROIMB1(duplicate.transaction).validate(duplicate)
+    assert_handles_duplicates(
+        factories.BaseRegulationFactory,
+        business_rules.ROIMB1,
+    )
 
 
 def test_ROIMB3(date_ranges):


### PR DESCRIPTION
Some of our business rules are only tested fully by fuzzy test cases that sometimes exercise all code paths and sometimes do not. This makes the code coverage vibrate around the true value as some lines are only randomly covered.

So this commit adds positive test cases to:

- ON6
- ME70
- QA5
- ME40
- all uniqueness business rules