### PR TITLE
TP-825 - Add Update Type business rules

### DIFF
--- a/additional_codes/models.py
+++ b/additional_codes/models.py
@@ -3,6 +3,7 @@ from django.db.models import Max
 
 from additional_codes import business_rules
 from additional_codes import validators
+from common.business_rules import UpdateValidity
 from common.fields import ShortDescription
 from common.fields import SignedIntSID
 from common.models import TrackedModel
@@ -46,7 +47,7 @@ class AdditionalCodeType(TrackedModel, ValidityMixin):
         business_rules.ACN17,
         measures_business_rules.ME12,
     )
-    business_rules = (business_rules.CT1,)
+    business_rules = (business_rules.CT1, UpdateValidity)
 
     def __str__(self):
         return f"AdditionalcodeType {self.sid}: {self.description}"
@@ -83,6 +84,7 @@ class AdditionalCode(TrackedModel, ValidityMixin):
         business_rules.ACN13,
         business_rules.ACN14,
         business_rules.ACN17,
+        UpdateValidity,
     )
 
     def __str__(self):

--- a/additional_codes/models.py
+++ b/additional_codes/models.py
@@ -161,3 +161,4 @@ class FootnoteAssociationAdditionalCode(TrackedModel, ValidityMixin):
         "footnotes.Footnote",
         on_delete=models.PROTECT,
     )
+    business_rules = (UpdateValidity,)

--- a/additional_codes/tests/test_models.py
+++ b/additional_codes/tests/test_models.py
@@ -12,3 +12,12 @@ def test_additional_code_in_use(in_use_check_respects_deletes):
         factories.MeasureFactory,
         "additional_code",
     )
+
+
+def test_additional_code_update_types(check_update_validation):
+    assert check_update_validation(factories.AdditionalCodeTypeFactory)
+    assert check_update_validation(
+        factories.AdditionalCodeFactory,
+        description_factory=factories.AdditionalCodeDescriptionFactory,
+    )
+    assert check_update_validation(factories.AdditionalCodeDescriptionFactory)

--- a/additional_codes/tests/test_models.py
+++ b/additional_codes/tests/test_models.py
@@ -15,19 +15,17 @@ def test_additional_code_in_use(in_use_check_respects_deletes):
 
 
 @pytest.mark.parametrize(
-    ["factory", "description_factory"],
+    "factory",
     [
-        (factories.AdditionalCodeTypeFactory, None),
-        (factories.AdditionalCodeFactory, factories.AdditionalCodeDescriptionFactory),
-        (factories.AdditionalCodeDescriptionFactory, None),
+        factories.AdditionalCodeTypeFactory,
+        factories.AdditionalCodeFactory,
+        factories.AdditionalCodeDescriptionFactory,
     ],
 )
 def test_additional_code_update_types(
     factory,
-    description_factory,
     check_update_validation,
 ):
     assert check_update_validation(
         factory,
-        description_factory=description_factory,
     )

--- a/additional_codes/tests/test_models.py
+++ b/additional_codes/tests/test_models.py
@@ -20,6 +20,7 @@ def test_additional_code_in_use(in_use_check_respects_deletes):
         factories.AdditionalCodeTypeFactory,
         factories.AdditionalCodeFactory,
         factories.AdditionalCodeDescriptionFactory,
+        factories.FootnoteAssociationAdditionalCodeFactory,
     ],
 )
 def test_additional_code_update_types(

--- a/additional_codes/tests/test_models.py
+++ b/additional_codes/tests/test_models.py
@@ -14,10 +14,20 @@ def test_additional_code_in_use(in_use_check_respects_deletes):
     )
 
 
-def test_additional_code_update_types(check_update_validation):
-    assert check_update_validation(factories.AdditionalCodeTypeFactory)
+@pytest.mark.parametrize(
+    ["factory", "description_factory"],
+    [
+        (factories.AdditionalCodeTypeFactory, None),
+        (factories.AdditionalCodeFactory, factories.AdditionalCodeDescriptionFactory),
+        (factories.AdditionalCodeDescriptionFactory, None),
+    ],
+)
+def test_additional_code_update_types(
+    factory,
+    description_factory,
+    check_update_validation,
+):
     assert check_update_validation(
-        factories.AdditionalCodeFactory,
-        description_factory=factories.AdditionalCodeDescriptionFactory,
+        factory,
+        description_factory=description_factory,
     )
-    assert check_update_validation(factories.AdditionalCodeDescriptionFactory)

--- a/certificates/models.py
+++ b/certificates/models.py
@@ -29,6 +29,7 @@ class CertificateType(TrackedModel, ValidityMixin):
     business_rules = (
         business_rules.CET1,
         business_rules.CET2,
+        business_rules.UpdateValidity,
     )
 
     def in_use(self):
@@ -72,6 +73,7 @@ class Certificate(TrackedModel, ValidityMixin):
         business_rules.CE5,
         business_rules.CE6,
         business_rules.CE7,
+        business_rules.UpdateValidity,
     )
 
     @property
@@ -109,7 +111,7 @@ class CertificateDescription(DescriptionMixin, TrackedModel):
     )
 
     indirect_business_rules = (business_rules.CE6,)
-    business_rules = ()
+    business_rules = (business_rules.UpdateValidity,)
 
     def save(self, *args, **kwargs):
         if getattr(self, "sid") is None:

--- a/certificates/models.py
+++ b/certificates/models.py
@@ -3,6 +3,7 @@ from django.db.models import Max
 
 from certificates import business_rules
 from certificates import validators
+from common.business_rules import UpdateValidity
 from common.fields import ShortDescription
 from common.fields import SignedIntSID
 from common.models import TrackedModel
@@ -29,7 +30,7 @@ class CertificateType(TrackedModel, ValidityMixin):
     business_rules = (
         business_rules.CET1,
         business_rules.CET2,
-        business_rules.UpdateValidity,
+        UpdateValidity,
     )
 
     def in_use(self):
@@ -73,7 +74,7 @@ class Certificate(TrackedModel, ValidityMixin):
         business_rules.CE5,
         business_rules.CE6,
         business_rules.CE7,
-        business_rules.UpdateValidity,
+        UpdateValidity,
     )
 
     @property
@@ -111,7 +112,7 @@ class CertificateDescription(DescriptionMixin, TrackedModel):
     )
 
     indirect_business_rules = (business_rules.CE6,)
-    business_rules = (business_rules.UpdateValidity,)
+    business_rules = (UpdateValidity,)
 
     def save(self, *args, **kwargs):
         if getattr(self, "sid") is None:

--- a/certificates/tests/test_business_rules.py
+++ b/certificates/tests/test_business_rules.py
@@ -4,7 +4,6 @@ from django.db import DataError
 from certificates import business_rules
 from common.business_rules import BusinessRuleViolation
 from common.tests import factories
-from common.validators import UpdateType
 
 pytestmark = pytest.mark.django_db
 
@@ -145,59 +144,3 @@ def test_CE7(date_ranges):
             valid_between=date_ranges.overlap_normal,
         )
         business_rules.CE7(certificate.transaction).validate(certificate)
-
-
-def test_CertificateUpdateValidity_first_update_must_be_Create():
-    """The first update to a certificate must be of type Create."""
-    certificate = factories.CertificateFactory.create(update_type=UpdateType.DELETE)
-
-    with pytest.raises(BusinessRuleViolation):
-        business_rules.UpdateValidity(certificate.transaction).validate(certificate)
-
-
-def test_CertificateUpdateValidity_later_updates_must_not_be_Create():
-    """Updates to a Certificate after the first update must not be of type
-    Create."""
-    first_certificate = factories.CertificateFactory.create()
-    second_certificate = factories.CertificateFactory.create(
-        update_type=UpdateType.CREATE,
-        version_group=first_certificate.version_group,
-    )
-
-    with pytest.raises(BusinessRuleViolation):
-        business_rules.UpdateValidity(second_certificate.transaction).validate(
-            second_certificate,
-        )
-
-
-def test_CertificateUpdateValidity_must_not_update_after_Delete():
-    """There must not be updates to a Certificate version group after an update
-    of type Delete."""
-    first_certificate = factories.CertificateFactory.create(
-        update_type=UpdateType.DELETE,
-    )
-    second_certificate = factories.CertificateFactory.create(
-        update_type=UpdateType.UPDATE,
-        version_group=first_certificate.version_group,
-    )
-
-    with pytest.raises(BusinessRuleViolation):
-        business_rules.UpdateValidity(second_certificate.transaction).validate(
-            second_certificate,
-        )
-
-
-def test_CertificateUpdateValidity_only_one_version_per_transaction():
-    """The transaction must contain no more than one update to each Certificate
-    version group."""
-    first_certificate = factories.CertificateFactory.create()
-    second_certificate = factories.CertificateFactory.create(
-        update_type=UpdateType.UPDATE,
-        version_group=first_certificate.version_group,
-        transaction=first_certificate.transaction,
-    )
-
-    with pytest.raises(BusinessRuleViolation):
-        business_rules.UpdateValidity(second_certificate.transaction).validate(
-            second_certificate,
-        )

--- a/certificates/tests/test_models.py
+++ b/certificates/tests/test_models.py
@@ -21,3 +21,19 @@ def test_certificate_in_user(in_use_check_respects_deletes):
         factories.MeasureConditionFactory,
         "required_certificate",
     )
+
+
+@pytest.mark.parametrize(
+    ["factory", "description_factory"],
+    [
+        (factories.CertificateTypeFactory, None),
+        (factories.CertificateFactory, factories.CertificateDescriptionFactory),
+        (factories.CertificateDescriptionFactory, None),
+    ],
+)
+def test_certificate_update_types(
+    factory,
+    description_factory,
+    check_update_validation,
+):
+    assert check_update_validation(factory, description_factory=description_factory)

--- a/certificates/tests/test_models.py
+++ b/certificates/tests/test_models.py
@@ -24,16 +24,15 @@ def test_certificate_in_user(in_use_check_respects_deletes):
 
 
 @pytest.mark.parametrize(
-    ["factory", "description_factory"],
+    "factory",
     [
-        (factories.CertificateTypeFactory, None),
-        (factories.CertificateFactory, factories.CertificateDescriptionFactory),
-        (factories.CertificateDescriptionFactory, None),
+        factories.CertificateTypeFactory,
+        factories.CertificateFactory,
+        factories.CertificateDescriptionFactory,
     ],
 )
 def test_certificate_update_types(
     factory,
-    description_factory,
     check_update_validation,
 ):
-    assert check_update_validation(factory, description_factory=description_factory)
+    assert check_update_validation(factory)

--- a/commodities/models.py
+++ b/commodities/models.py
@@ -11,6 +11,7 @@ from treebeard.mp_tree import MP_Node
 from commodities import business_rules
 from commodities import validators
 from commodities.querysets import GoodsNomenclatureIndentQuerySet
+from common.business_rules import UpdateValidity
 from common.models import NumericSID
 from common.models import TrackedModel
 from common.models.mixins.description import DescriptionMixin
@@ -85,6 +86,7 @@ class GoodsNomenclature(TrackedModel, ValidityMixin):
         business_rules.NIG31,
         business_rules.NIG34,
         business_rules.NIG35,
+        UpdateValidity,
     )
 
     class Meta:
@@ -122,7 +124,7 @@ class GoodsNomenclatureIndent(TrackedModel, ValidityStartMixin):
     )
 
     indirect_business_rules = (business_rules.NIG11,)
-    business_rules = (business_rules.NIG2,)
+    business_rules = (business_rules.NIG2, UpdateValidity)
 
     validity_over = "indented_goods_nomenclature"
 
@@ -308,6 +310,8 @@ class GoodsNomenclatureDescription(TrackedModel, DescriptionMixin):
 
     indirect_business_rules = (business_rules.NIG12,)
 
+    business_rules = (UpdateValidity,)
+
     class Meta:
         ordering = ("validity_start",)
 
@@ -341,7 +345,7 @@ class GoodsNomenclatureOrigin(TrackedModel):
     )
 
     indirect_business_rules = (business_rules.NIG5,)
-    business_rules = (business_rules.NIG7,)
+    business_rules = (business_rules.NIG7, UpdateValidity)
 
     def __str__(self):
         return (
@@ -377,7 +381,7 @@ class GoodsNomenclatureSuccessor(TrackedModel):
         "absorbed_into_goods_nomenclature__sid",
     )
 
-    business_rules = (business_rules.NIG10,)
+    business_rules = (business_rules.NIG10, UpdateValidity)
 
     def __str__(self):
         return (
@@ -407,4 +411,5 @@ class FootnoteAssociationGoodsNomenclature(TrackedModel, ValidityMixin):
         business_rules.NIG22,
         business_rules.NIG23,
         business_rules.NIG24,
+        UpdateValidity,
     )

--- a/commodities/tests/test_models.py
+++ b/commodities/tests/test_models.py
@@ -12,3 +12,18 @@ def test_goods_nomenclature_in_use(in_use_check_respects_deletes):
         factories.MeasureFactory,
         "goods_nomenclature",
     )
+
+
+@pytest.mark.parametrize(
+    "factory",
+    [
+        factories.GoodsNomenclatureFactory,
+        factories.GoodsNomenclatureIndentFactory,
+        factories.GoodsNomenclatureDescriptionFactory,
+        factories.GoodsNomenclatureOriginFactory,
+        factories.GoodsNomenclatureSuccessorFactory,
+        factories.FootnoteAssociationGoodsNomenclatureFactory,
+    ],
+)
+def test_commodities_update_types(factory, check_update_validation):
+    assert check_update_validation(factory)

--- a/common/business_rules.py
+++ b/common/business_rules.py
@@ -430,18 +430,30 @@ class UpdateValidity(BusinessRule):
 
         if existing_objects.exists():
             if model.update_type == UpdateType.CREATE:
-                raise self.violation(model)
+                raise self.violation(
+                    model,
+                    "Only the first object update can be of type Create.",
+                )
 
             if any(
                 version.update_type == UpdateType.DELETE for version in existing_objects
             ):
-                raise self.violation(model)
+                raise self.violation(
+                    model,
+                    "An object must not be updated after an update version of Delete.",
+                )
 
             if any(
                 version.transaction == self.transaction for version in existing_objects
             ):
-                raise self.violation(model)
+                raise self.violation(
+                    model,
+                    "Only one version of an object can be updated in a single transaction.",
+                )
 
         else:
             if model.update_type != UpdateType.CREATE:
-                raise self.violation(model)
+                raise self.violation(
+                    model,
+                    "The first update of an object must be of type Create.",
+                )

--- a/common/business_rules.py
+++ b/common/business_rules.py
@@ -411,3 +411,37 @@ class FootnoteApplicability(BusinessRule):
             not in applicable_model.footnote_application_codes
         ):
             raise self.violation(model)
+
+
+class UpdateValidity(BusinessRule):
+    """
+    The update type of this object must be valid.
+
+    The first update must be of type Create. Subsequent updates must not be of
+    type Create. After an update of type Delete, there must be no further
+    updates. Only one version of the object may be updated in a single
+    transaction.
+    """
+
+    def validate(self, model):
+        existing_objects = model.__class__.objects.filter(
+            version_group=model.version_group,
+        ).exclude(sid=model.sid)
+
+        if existing_objects.exists():
+            if model.update_type == UpdateType.CREATE:
+                raise self.violation(model)
+
+            if any(
+                version.update_type == UpdateType.DELETE for version in existing_objects
+            ):
+                raise self.violation(model)
+
+            if any(
+                version.transaction == self.transaction for version in existing_objects
+            ):
+                raise self.violation(model)
+
+        else:
+            if model.update_type != UpdateType.CREATE:
+                raise self.violation(model)

--- a/common/business_rules.py
+++ b/common/business_rules.py
@@ -424,12 +424,9 @@ class UpdateValidity(BusinessRule):
     """
 
     def validate(self, model):
-        identifying_fields = model.identifying_fields
-        query = dict(get_field_tuple(model, field) for field in identifying_fields)
-
         existing_objects = model.__class__.objects.filter(
             version_group=model.version_group,
-        ).exclude(**query)
+        ).exclude(id=model.id)
 
         if existing_objects.exists():
             if model.update_type == UpdateType.CREATE:

--- a/common/business_rules.py
+++ b/common/business_rules.py
@@ -424,9 +424,12 @@ class UpdateValidity(BusinessRule):
     """
 
     def validate(self, model):
+        identifying_fields = model.identifying_fields
+        query = dict(get_field_tuple(model, field) for field in identifying_fields)
+
         existing_objects = model.__class__.objects.filter(
             version_group=model.version_group,
-        ).exclude(sid=model.sid)
+        ).exclude(**query)
 
         if existing_objects.exists():
             if model.update_type == UpdateType.CREATE:

--- a/common/models/mixins/description.py
+++ b/common/models/mixins/description.py
@@ -5,6 +5,7 @@ from django.urls import NoReverseMatch
 from django.urls import reverse
 from polymorphic.managers import PolymorphicManager
 
+from common.business_rules import UpdateValidity
 from common.models.mixins.validity import ValidityStartMixin
 from common.models.mixins.validity import ValidityStartQueryset
 from common.models.records import TrackedModelQuerySet
@@ -16,6 +17,7 @@ class DescriptionQueryset(ValidityStartQueryset, TrackedModelQuerySet):
 
 class DescriptionMixin(ValidityStartMixin):
     objects = PolymorphicManager.from_queryset(DescriptionQueryset)()
+    business_rules = (UpdateValidity,)
 
     @cached_property
     def described_object_field(self) -> Field:

--- a/common/tests/factories.py
+++ b/common/tests/factories.py
@@ -15,6 +15,7 @@ from common.tests.models import TestModelDescription1
 from common.tests.util import Dates
 from common.validators import ApplicabilityCode
 from common.validators import UpdateType
+from geo_areas.validators import AreaCode
 from importer.models import ImporterChunkStatus
 from measures.validators import DutyExpressionId
 from measures.validators import ImportExportCode
@@ -221,12 +222,30 @@ class AmendmentFactory(TrackedModelMixin):
     enacting_regulation = factory.SubFactory(RegulationFactory)
 
 
+class ExtensionFactory(TrackedModelMixin):
+    class Meta:
+        model = "regulations.Extension"
+
+    target_regulation = factory.SubFactory(RegulationFactory)
+    enacting_regulation = factory.SubFactory(RegulationFactory)
+
+
 class SuspensionFactory(TrackedModelMixin):
     class Meta:
         model = "regulations.Suspension"
 
     target_regulation = factory.SubFactory(RegulationFactory)
     enacting_regulation = factory.SubFactory(RegulationFactory)
+
+
+class TerminationFactory(TrackedModelMixin):
+    class Meta:
+        model = "regulations.Termination"
+
+    target_regulation = factory.SubFactory(RegulationFactory)
+    enacting_regulation = factory.SubFactory(RegulationFactory)
+
+    effective_date = Dates().datetime_now
 
 
 class ReplacementFactory(TrackedModelMixin):
@@ -571,6 +590,7 @@ class QuotaOrderNumberFactory(TrackedModelMixin, ValidityFactoryMixin):
     order_number = string_sequence(6, characters=string.digits)
     mechanism = 0
     category = 1
+    valid_between = date_ranges("normal")
 
     origin = factory.RelatedFactory(
         "common.tests.factories.QuotaOrderNumberOriginFactory",
@@ -605,8 +625,14 @@ class QuotaOrderNumberOriginExclusionFactory(TrackedModelMixin):
     class Meta:
         model = "quotas.QuotaOrderNumberOriginExclusion"
 
-    origin = factory.SubFactory(QuotaOrderNumberOriginFactory)
-    excluded_geographical_area = factory.SubFactory(GeographicalAreaFactory)
+    excluded_geographical_area = factory.SubFactory(
+        GeographicalAreaFactory,
+        area_code=AreaCode.GROUP,
+    )
+    origin = factory.SubFactory(
+        QuotaOrderNumberOriginFactory,
+        geographical_area=factory.SelfAttribute("..excluded_geographical_area"),
+    )
 
 
 class QuotaDefinitionFactory(TrackedModelMixin, ValidityFactoryMixin):

--- a/common/tests/test_business_rules.py
+++ b/common/tests/test_business_rules.py
@@ -11,6 +11,7 @@ from common.business_rules import BusinessRuleViolation
 from common.business_rules import NoOverlapping
 from common.business_rules import PreventDeleteIfInUse
 from common.business_rules import UniqueIdentifyingFields
+from common.business_rules import UpdateValidity
 from common.tests import factories
 from common.validators import UpdateType
 
@@ -141,3 +142,59 @@ def test_prevent_delete_if_in_use(approved_transaction):
             BusinessRuleChecker([model], model.transaction).validate()
 
     assert model.in_use.called
+
+
+def test_UpdateValidity_first_update_must_be_Create():
+    """The first update to an object must be of type Create."""
+    version = factories.TestModel1Factory.create(update_type=UpdateType.DELETE)
+
+    with pytest.raises(BusinessRuleViolation):
+        UpdateValidity(version.transaction).validate(version)
+
+
+def test_UpdateValidity_later_updates_must_not_be_Create():
+    """Updates to an object after the first update must not be of type
+    Create."""
+    first_version = factories.TestModel1Factory.create()
+    second_version = factories.TestModel1Factory.create(
+        update_type=UpdateType.CREATE,
+        version_group=first_version.version_group,
+    )
+
+    with pytest.raises(BusinessRuleViolation):
+        UpdateValidity(second_version.transaction).validate(
+            second_version,
+        )
+
+
+def test_UpdateValidity_must_not_update_after_Delete():
+    """There must not be updates to an object version group after an update of
+    type Delete."""
+    first_version = factories.TestModel1Factory.create(
+        update_type=UpdateType.DELETE,
+    )
+    second_version = factories.TestModel1Factory.create(
+        update_type=UpdateType.UPDATE,
+        version_group=first_version.version_group,
+    )
+
+    with pytest.raises(BusinessRuleViolation):
+        UpdateValidity(second_version.transaction).validate(
+            second_version,
+        )
+
+
+def test_UpdateValidity_only_one_version_per_transaction():
+    """The transaction must contain no more than one update to each Certificate
+    version group."""
+    first_version = factories.TestModel1Factory.create()
+    second_version = factories.TestModel1Factory.create(
+        update_type=UpdateType.UPDATE,
+        version_group=first_version.version_group,
+        transaction=first_version.transaction,
+    )
+
+    with pytest.raises(BusinessRuleViolation):
+        UpdateValidity(second_version.transaction).validate(
+            second_version,
+        )

--- a/common/tests/test_business_rules.py
+++ b/common/tests/test_business_rules.py
@@ -148,7 +148,10 @@ def test_UpdateValidity_first_update_must_be_Create():
     """The first update to an object must be of type Create."""
     version = factories.TestModel1Factory.create(update_type=UpdateType.DELETE)
 
-    with pytest.raises(BusinessRuleViolation):
+    with pytest.raises(
+        BusinessRuleViolation,
+        match="The first update of an object must be of type Create.",
+    ):
         UpdateValidity(version.transaction).validate(version)
 
 
@@ -161,10 +164,11 @@ def test_UpdateValidity_later_updates_must_not_be_Create():
         version_group=first_version.version_group,
     )
 
-    with pytest.raises(BusinessRuleViolation):
-        UpdateValidity(second_version.transaction).validate(
-            second_version,
-        )
+    with pytest.raises(
+        BusinessRuleViolation,
+        match="Only the first object update can be of type Create.",
+    ):
+        UpdateValidity(second_version.transaction).validate(second_version)
 
 
 def test_UpdateValidity_must_not_update_after_Delete():
@@ -178,7 +182,10 @@ def test_UpdateValidity_must_not_update_after_Delete():
         version_group=first_version.version_group,
     )
 
-    with pytest.raises(BusinessRuleViolation):
+    with pytest.raises(
+        BusinessRuleViolation,
+        match="An object must not be updated after an update version of Delete.",
+    ):
         UpdateValidity(second_version.transaction).validate(
             second_version,
         )
@@ -194,7 +201,8 @@ def test_UpdateValidity_only_one_version_per_transaction():
         transaction=first_version.transaction,
     )
 
-    with pytest.raises(BusinessRuleViolation):
-        UpdateValidity(second_version.transaction).validate(
-            second_version,
-        )
+    with pytest.raises(
+        BusinessRuleViolation,
+        match="Only one version of an object can be updated in a single transaction.",
+    ):
+        UpdateValidity(second_version.transaction).validate(second_version)

--- a/conftest.py
+++ b/conftest.py
@@ -796,6 +796,7 @@ def check_update_validation(
         assert check_only_one_version_updated_in_transaction(
             factory,
         )
+        assert UpdateValidity in factory._meta.model.business_rules
         return True
 
     return check

--- a/footnotes/models.py
+++ b/footnotes/models.py
@@ -3,6 +3,7 @@ from typing import Type
 from django.db import models
 from django.db.models import Max
 
+from common.business_rules import UpdateValidity
 from common.fields import ShortDescription
 from common.fields import SignedIntSID
 from common.models import TrackedModel
@@ -45,6 +46,7 @@ class FootnoteType(TrackedModel, ValidityMixin):
     business_rules = (
         business_rules.FOT1,
         business_rules.FOT2,
+        UpdateValidity,
     )
 
     def __str__(self):
@@ -91,6 +93,7 @@ class Footnote(TrackedModel, ValidityMixin):
         business_rules.FO12,
         business_rules.FO15,
         business_rules.FO17,
+        UpdateValidity,
     )
 
     def __str__(self):

--- a/footnotes/tests/test_models.py
+++ b/footnotes/tests/test_models.py
@@ -39,3 +39,15 @@ def test_footnote_used_in_measure(in_use_check_respects_deletes):
         factories.FootnoteAssociationMeasureFactory,
         "associated_footnote",
     )
+
+
+@pytest.mark.parametrize(
+    "factory",
+    [
+        factories.FootnoteTypeFactory,
+        factories.FootnoteFactory,
+        factories.FootnoteDescriptionFactory,
+    ],
+)
+def test_footnote_update_types(factory, check_update_validation):
+    assert check_update_validation(factory)

--- a/geo_areas/models.py
+++ b/geo_areas/models.py
@@ -3,6 +3,7 @@ from django.db.models import CheckConstraint
 from django.db.models import Max
 from django.db.models import Q
 
+from common.business_rules import UpdateValidity
 from common.fields import ShortDescription
 from common.fields import SignedIntSID
 from common.models import TrackedModel
@@ -71,6 +72,7 @@ class GeographicalArea(TrackedModel, ValidityMixin):
         business_rules.GA11,
         business_rules.GA21,
         business_rules.GA22,
+        UpdateValidity,
     )
 
     def get_current_memberships(self):
@@ -156,6 +158,7 @@ class GeographicalMembership(TrackedModel, ValidityMixin):
         business_rules.GA18,
         business_rules.GA20,
         business_rules.GA23,
+        UpdateValidity,
     )
 
     def other(self, area: GeographicalArea) -> GeographicalArea:

--- a/geo_areas/tests/test_models.py
+++ b/geo_areas/tests/test_models.py
@@ -68,3 +68,18 @@ def test_geo_area_in_use(in_use_check_respects_deletes):
         factories.MeasureFactory,
         "geographical_area",
     )
+
+
+@pytest.mark.parametrize(
+    "factory",
+    [
+        factories.GeographicalAreaFactory,
+        factories.GeographicalMembershipFactory,
+        factories.GeographicalAreaDescriptionFactory,
+    ],
+)
+def test_geo_area_update_types(
+    factory,
+    check_update_validation,
+):
+    assert check_update_validation(factory)

--- a/measures/models.py
+++ b/measures/models.py
@@ -4,6 +4,7 @@ from typing import Set
 from django.db import models
 from polymorphic.managers import PolymorphicManager
 
+from common.business_rules import UpdateValidity
 from common.fields import ApplicabilityCode
 from common.fields import ShortDescription
 from common.fields import SignedIntSID
@@ -48,6 +49,7 @@ class MeasureTypeSeries(TrackedModel, ValidityMixin):
     business_rules = (
         business_rules.MTS1,
         business_rules.MTS2,
+        UpdateValidity,
     )
 
     def in_use(self):
@@ -84,6 +86,8 @@ class MeasurementUnit(TrackedModel, ValidityMixin):
         business_rules.ME63,
     )
 
+    business_rules = (UpdateValidity,)
+
 
 class MeasurementUnitQualifier(TrackedModel, ValidityMixin):
     """
@@ -115,6 +119,8 @@ class MeasurementUnitQualifier(TrackedModel, ValidityMixin):
         quotas_business_rules.QD11,
     )
 
+    business_rules = (UpdateValidity,)
+
 
 class Measurement(TrackedModel, ValidityMixin):
     """
@@ -145,6 +151,8 @@ class Measurement(TrackedModel, ValidityMixin):
         business_rules.ME62,
     )
 
+    business_rules = (UpdateValidity,)
+
 
 class MonetaryUnit(TrackedModel, ValidityMixin):
     """The monetary unit identifies the currency code used in the system."""
@@ -171,6 +179,8 @@ class MonetaryUnit(TrackedModel, ValidityMixin):
         business_rules.ME61,
         quotas_business_rules.QD8,
     )
+
+    business_rules = (UpdateValidity,)
 
 
 class DutyExpression(TrackedModel, ValidityMixin):
@@ -210,6 +220,8 @@ class DutyExpression(TrackedModel, ValidityMixin):
         business_rules.ME110,
         business_rules.ME111,
     )
+
+    business_rules = (UpdateValidity,)
 
 
 class MeasureType(TrackedModel, ValidityMixin):
@@ -268,6 +280,7 @@ class MeasureType(TrackedModel, ValidityMixin):
         business_rules.MT4,
         business_rules.MT7,
         business_rules.MT10,
+        UpdateValidity,
     )
 
     def __str__(self):
@@ -320,6 +333,8 @@ class AdditionalCodeTypeMeasureType(TrackedModel, ValidityMixin):
 
     identifying_fields = ("measure_type", "additional_code_type")
 
+    business_rules = (UpdateValidity,)
+
 
 class MeasureConditionCode(TrackedModel, ValidityMixin):
     """A measure condition code identifies a broad area where conditions are
@@ -344,6 +359,7 @@ class MeasureConditionCode(TrackedModel, ValidityMixin):
     business_rules = (
         business_rules.MC1,
         business_rules.MC4,
+        UpdateValidity,
     )
 
     def used_in_component(self):
@@ -386,6 +402,7 @@ class MeasureAction(TrackedModel, ValidityMixin):
     business_rules = (
         business_rules.MA1,
         business_rules.MA2,
+        UpdateValidity,
     )
 
     def in_use(self):
@@ -527,6 +544,7 @@ class Measure(TrackedModel, ValidityMixin):
         business_rules.ME110,
         business_rules.ME111,
         business_rules.ME104,
+        UpdateValidity,
     )
 
     objects = PolymorphicManager.from_queryset(MeasuresQuerySet)()
@@ -688,6 +706,7 @@ class MeasureComponent(TrackedModel):
         business_rules.ME50,
         business_rules.ME51,
         business_rules.ME52,
+        UpdateValidity,
     )
 
 
@@ -767,6 +786,7 @@ class MeasureCondition(TrackedModel):
         business_rules.ME62,
         business_rules.ME63,
         business_rules.ME64,
+        UpdateValidity,
     )
 
     class Meta:
@@ -882,6 +902,7 @@ class MeasureConditionComponent(TrackedModel):
         business_rules.ME105,
         business_rules.ME106,
         business_rules.ME108,
+        UpdateValidity,
     )
 
 
@@ -909,6 +930,7 @@ class MeasureExcludedGeographicalArea(TrackedModel):
         business_rules.ME66,
         business_rules.ME67,
         business_rules.ME68,
+        UpdateValidity,
     )
 
 
@@ -936,4 +958,5 @@ class FootnoteAssociationMeasure(TrackedModel):
         business_rules.ME70,
         business_rules.ME71,
         business_rules.ME73,
+        UpdateValidity,
     )

--- a/measures/tests/test_models.py
+++ b/measures/tests/test_models.py
@@ -1,6 +1,9 @@
+from decimal import Decimal
+
 import pytest
 
 from common.tests import factories
+from common.validators import UpdateType
 
 pytestmark = pytest.mark.django_db
 

--- a/measures/tests/test_models.py
+++ b/measures/tests/test_models.py
@@ -1,9 +1,6 @@
-from decimal import Decimal
-
 import pytest
 
 from common.tests import factories
-from common.validators import UpdateType
 
 pytestmark = pytest.mark.django_db
 
@@ -159,4 +156,34 @@ def test_measure_action_in_use(in_use_check_respects_deletes):
         "in_use",
         factories.MeasureConditionComponentFactory,
         "condition__action",
+    )
+
+
+@pytest.mark.parametrize(
+    "factory",
+    [
+        factories.MeasureTypeSeriesFactory,
+        factories.MeasurementUnitFactory,
+        factories.MeasurementUnitQualifierFactory,
+        factories.MeasurementFactory,
+        factories.MonetaryUnitFactory,
+        factories.DutyExpressionFactory,
+        factories.MeasureTypeFactory,
+        factories.AdditionalCodeTypeMeasureTypeFactory,
+        factories.MeasureConditionCodeFactory,
+        factories.MeasureActionFactory,
+        factories.MeasureFactory,
+        factories.MeasureComponentFactory,
+        factories.MeasureConditionFactory,
+        factories.MeasureConditionComponentFactory,
+        factories.MeasureExcludedGeographicalAreaFactory,
+        factories.FootnoteAssociationMeasureFactory,
+    ],
+)
+def test_measure_update_types(
+    factory,
+    check_update_validation,
+):
+    assert check_update_validation(
+        factory,
     )

--- a/quotas/models.py
+++ b/quotas/models.py
@@ -4,6 +4,7 @@ from django.core.serializers.json import DjangoJSONEncoder
 from django.db import models
 from polymorphic.managers import PolymorphicManager
 
+from common.business_rules import UpdateValidity
 from common.fields import ShortDescription
 from common.fields import SignedIntSID
 from common.models import TrackedModel
@@ -57,13 +58,14 @@ class QuotaOrderNumber(TrackedModel, ValidityMixin):
         business_rules.QD1,
         business_rules.QD7,
         business_rules.CertificateValidityPeriodMustSpanQuotaOrderNumber,
+        business_rules.CertificatesMustExist,
     )
     business_rules = (
         business_rules.ON1,
         business_rules.ON2,
         business_rules.ON9,
         business_rules.ON11,
-        business_rules.CertificatesMustExist,
+        UpdateValidity,
     )
 
     objects = PolymorphicManager.from_queryset(querysets.QuotaOrderNumberQuerySet)()
@@ -118,6 +120,7 @@ class QuotaOrderNumberOrigin(TrackedModel, ValidityMixin):
         business_rules.ON7,
         business_rules.ON10,
         business_rules.ON12,
+        UpdateValidity,
     )
 
     def in_use(self):
@@ -148,6 +151,7 @@ class QuotaOrderNumberOriginExclusion(TrackedModel):
     business_rules = (
         business_rules.ON13,
         business_rules.ON14,
+        UpdateValidity,
     )
 
 
@@ -219,6 +223,7 @@ class QuotaDefinition(TrackedModel, ValidityMixin):
         business_rules.QuotaAssociationMustReferToANonDeletedSubQuota,
         business_rules.QuotaSuspensionMustReferToANonDeletedQuotaDefinition,
         business_rules.QuotaBlockingPeriodMustReferToANonDeletedQuotaDefinition,
+        UpdateValidity,
     )
 
     def __str__(self):
@@ -261,6 +266,7 @@ class QuotaAssociation(TrackedModel):
         business_rules.QA4,
         business_rules.QA5,
         business_rules.QA6,
+        UpdateValidity,
     )
 
 
@@ -274,7 +280,7 @@ class QuotaSuspension(TrackedModel, ValidityMixin):
     quota_definition = models.ForeignKey(QuotaDefinition, on_delete=models.PROTECT)
     description = ShortDescription()
 
-    business_rules = (business_rules.QSP2,)
+    business_rules = (business_rules.QSP2, UpdateValidity)
 
 
 class QuotaBlocking(TrackedModel, ValidityMixin):
@@ -290,7 +296,7 @@ class QuotaBlocking(TrackedModel, ValidityMixin):
     )
     description = ShortDescription()
 
-    business_rules = (business_rules.QBP2,)
+    business_rules = (business_rules.QBP2, UpdateValidity)
 
 
 class QuotaEvent(TrackedModel):
@@ -312,3 +318,5 @@ class QuotaEvent(TrackedModel):
     data = models.JSONField(default=dict, encoder=DjangoJSONEncoder)
 
     identifying_fields = ("subrecord_code", "quota_definition__sid")
+
+    business_rules = (UpdateValidity,)

--- a/quotas/tests/test_models.py
+++ b/quotas/tests/test_models.py
@@ -22,3 +22,25 @@ def test_quota_order_number_origin_in_use(in_use_check_respects_deletes):
         "order_number",
         through="order_number",
     )
+
+
+@pytest.mark.parametrize(
+    "factory",
+    [
+        factories.QuotaOrderNumberFactory,
+        factories.QuotaOrderNumberOriginFactory,
+        factories.QuotaOrderNumberOriginExclusionFactory,
+        factories.QuotaDefinitionFactory,
+        factories.QuotaAssociationFactory,
+        factories.QuotaSuspensionFactory,
+        factories.QuotaBlockingFactory,
+        factories.QuotaEventFactory,
+    ],
+)
+def test_quota_update_types(
+    factory,
+    check_update_validation,
+):
+    assert check_update_validation(
+        factory,
+    )

--- a/regulations/models.py
+++ b/regulations/models.py
@@ -2,6 +2,7 @@ from django.core.validators import MaxValueValidator
 from django.core.validators import RegexValidator
 from django.db import models
 
+from common.business_rules import UpdateValidity
 from common.fields import ShortDescription
 from common.fields import TaricDateRangeField
 from common.models import TrackedModel
@@ -46,6 +47,8 @@ class Group(TrackedModel, ValidityMixin):
         business_rules.ROIMB4,
         business_rules.ROIMB47,
     )
+
+    business_rules = (UpdateValidity,)
 
 
 class Regulation(TrackedModel):
@@ -194,6 +197,7 @@ class Regulation(TrackedModel):
         business_rules.ROIMB44,
         business_rules.ROIMB46,
         business_rules.ROIMB47,
+        UpdateValidity,
     )
 
     @property
@@ -265,6 +269,8 @@ class Amendment(TrackedModel):
         "target_regulation__regulation_id",
     )
 
+    business_rules = (UpdateValidity,)
+
 
 class Extension(TrackedModel):
     """
@@ -297,6 +303,8 @@ class Extension(TrackedModel):
     effective_end_date = models.DateField(null=True, blank=True)
 
     identifying_fields = ("enacting_regulation_id", "target_regulation_id")
+
+    business_rules = (UpdateValidity,)
 
 
 class Suspension(TrackedModel):
@@ -332,6 +340,8 @@ class Suspension(TrackedModel):
         "target_regulation__regulation_id",
     )
 
+    business_rules = (UpdateValidity,)
+
 
 class Termination(TrackedModel):
     """
@@ -364,6 +374,8 @@ class Termination(TrackedModel):
     effective_date = models.DateField()
 
     identifying_fields = ("enacting_regulation_id", "target_regulation_id")
+
+    business_rules = (UpdateValidity,)
 
 
 class Replacement(TrackedModel):
@@ -405,3 +417,5 @@ class Replacement(TrackedModel):
     chapter_heading = models.CharField(max_length=2, null=True, blank=True)
 
     identifying_fields = ("enacting_regulation_id", "target_regulation_id")
+
+    business_rules = (UpdateValidity,)

--- a/regulations/tests/test_models.py
+++ b/regulations/tests/test_models.py
@@ -1,0 +1,26 @@
+import pytest
+
+from common.tests import factories
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.mark.parametrize(
+    "factory",
+    [
+        factories.RegulationGroupFactory,
+        factories.RegulationFactory,
+        factories.AmendmentFactory,
+        factories.ExtensionFactory,
+        factories.SuspensionFactory,
+        factories.TerminationFactory,
+        factories.ReplacementFactory,
+    ],
+)
+def test_regulation_update_types(
+    factory,
+    check_update_validation,
+):
+    assert check_update_validation(
+        factory,
+    )

--- a/workbaskets/tests/test_models.py
+++ b/workbaskets/tests/test_models.py
@@ -6,6 +6,7 @@ from django_fsm import TransitionNotAllowed
 
 from common.models import TrackedModel
 from common.tests import factories
+from common.validators import UpdateType
 from workbaskets.validators import WorkflowStatus
 
 pytestmark = pytest.mark.django_db
@@ -671,7 +672,10 @@ def test_get_tracked_models(new_workbasket):
 
 def test_workbasket_accepted_updates_current_tracked_models(new_workbasket, valid_user):
     original_footnote = factories.FootnoteFactory.create()
-    new_footnote = original_footnote.new_version(workbasket=new_workbasket)
+    new_footnote = original_footnote.new_version(
+        workbasket=new_workbasket,
+        update_type=UpdateType.UPDATE,
+    )
 
     assert new_footnote.version_group.current_version.pk == original_footnote.pk
 
@@ -690,8 +694,10 @@ def test_workbasket_accepted_updates_current_tracked_models(new_workbasket, vali
 
 def test_workbasket_errored_updates_tracked_models(new_workbasket, valid_user):
     original_footnote = factories.FootnoteFactory.create()
-    new_footnote = original_footnote.new_version(workbasket=new_workbasket)
-
+    new_footnote = original_footnote.new_version(
+        workbasket=new_workbasket,
+        update_type=UpdateType.UPDATE,
+    )
     assert new_footnote.version_group.current_version.pk == original_footnote.pk
 
     with mock.patch(


### PR DESCRIPTION
Adds business rules to Update Types:

- The first update must be of type Create.
- Subsequent updates must not be of type Create. 
- After an update of type Delete, there must be no further updates. 
- Only one version of the object may be updated in a single transaction.