### PR TITLE
Stop commodity codes being parents of themselves

### DIFF
--- a/commodities/import_handlers.py
+++ b/commodities/import_handlers.py
@@ -193,6 +193,7 @@ class GoodsNomenclatureIndentHandler(BaseHandler):
                 pk=data.pop("indented_goods_nomenclature_id"),
             )
         item_id = data["indented_goods_nomenclature"].item_id
+        suffix = data["indented_goods_nomenclature"].suffix
 
         indent = super().save(data)
         indent = models.GoodsNomenclatureIndent.objects.with_end_date().get(
@@ -255,7 +256,11 @@ class GoodsNomenclatureIndentHandler(BaseHandler):
             else:
                 next_parent = (
                     models.GoodsNomenclatureIndentNode.objects.filter(
-                        indent__indented_goods_nomenclature__item_id__lte=item_id,
+                        Q(indent__indented_goods_nomenclature__item_id__lt=item_id)
+                        | Q(
+                            indent__indented_goods_nomenclature__item_id=item_id,
+                            indent__indented_goods_nomenclature__suffix__lt=suffix,
+                        ),
                         indent__indented_goods_nomenclature__item_id__startswith=chapter_heading,
                         indent__indented_goods_nomenclature__valid_between__contains=start_date,
                         indent__validity_start__lte=start_date,

--- a/commodities/tests/test_xml.py
+++ b/commodities/tests/test_xml.py
@@ -7,7 +7,7 @@ from common.xml.namespaces import nsmap
 pytestmark = pytest.mark.django_db
 
 
-@validate_taric_xml(factories.GoodsNomenclatureFactory)
+@validate_taric_xml(factories.SimpleGoodsNomenclatureFactory)
 def test_goods_nomenclature_xml(xml):
     element = xml.find(".//oub:goods.nomenclature", nsmap)
     assert element is not None

--- a/common/tests/factories.py
+++ b/common/tests/factories.py
@@ -103,7 +103,7 @@ class TransactionFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = "common.Transaction"
 
-    order = 1
+    order = factory.Sequence(lambda x: x + 1)
     import_transaction_id = factory.Sequence(lambda x: x + 1)
     workbasket = factory.SubFactory(SimpleApprovedWorkBasketFactory)
     composite_key = factory.Sequence(str)
@@ -116,7 +116,7 @@ class UnapprovedTransactionFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = "common.Transaction"
 
-    order = 1
+    order = factory.Sequence(lambda x: x + 1)
     import_transaction_id = factory.Sequence(lambda x: x + 1)
     workbasket = factory.SubFactory(WorkBasketFactory)
 
@@ -446,12 +446,9 @@ class SimpleGoodsNomenclatureIndentFactory(
     indent = 0
 
 
-class GoodsNomenclatureIndentFactory(TrackedModelMixin, ValidityStartFactoryMixin):
+class GoodsNomenclatureIndentFactory(SimpleGoodsNomenclatureIndentFactory):
     class Meta:
         model = "commodities.GoodsNomenclatureIndent"
-
-    sid = numeric_sid()
-    indented_goods_nomenclature = factory.SubFactory(SimpleGoodsNomenclatureFactory)
 
     node = factory.RelatedFactory(
         "common.tests.factories.GoodsNomenclatureIndentNodeFactory",
@@ -461,8 +458,6 @@ class GoodsNomenclatureIndentFactory(TrackedModelMixin, ValidityStartFactoryMixi
         ),
         creating_transaction=factory.SelfAttribute("..transaction"),
     )
-
-    indent = 0
 
 
 indent_path_generator = string_generator(4)


### PR DESCRIPTION
There was a bug in the indents importer which meant that a commodity code could end up as a parent of itself if an indent is updated without changing any of its fields. This was because the parent search didn't correctly only allow the item id to be equal in the case that the suffix is also less.

This also fixes up some tests to use the import infrastructure which makes it easy to swap out our XML export mechanism later.