### PR TITLE
Business rule fixes

### DIFF
--- a/commodities/business_rules.py
+++ b/commodities/business_rules.py
@@ -10,6 +10,8 @@ from common.business_rules import FootnoteApplicability
 from common.business_rules import NoOverlapping
 from common.business_rules import PreventDeleteIfInUse
 from common.business_rules import ValidityPeriodContained
+from common.business_rules import only_applicable_after
+from common.business_rules import skip_when_deleted
 from common.util import validity_range_contains_range
 from common.validators import UpdateType
 
@@ -38,6 +40,8 @@ class NIG2(BusinessRule):
                 raise self.violation(indent)
 
 
+@skip_when_deleted
+@only_applicable_after(date(2010, 1, 1))
 class NIG5(BusinessRule):
     """
     When creating a goods nomenclature code, an origin must exist.
@@ -58,14 +62,8 @@ class NIG5(BusinessRule):
 
         from commodities.models import GoodsNomenclatureOrigin
 
-        if good.update_type == UpdateType.DELETE:
-            return
-
-        lower_bound = date(2010, 1, 1)
-
         if not (
-            good.valid_between.lower <= lower_bound
-            or good.indents.filter(nodes__depth=1).exists()
+            good.indents.filter(nodes__depth=1).exists()
             or GoodsNomenclatureOrigin.objects.filter(
                 new_goods_nomenclature__sid=good.sid,
             )
@@ -106,6 +104,7 @@ class NIG7(BusinessRule):
             )
 
 
+@skip_when_deleted
 class NIG10(BusinessRule):
     """The successor must be applicable the day after the end date of the old
     code."""

--- a/commodities/tests/test_business_rules.py
+++ b/commodities/tests/test_business_rules.py
@@ -334,32 +334,33 @@ def test_NIG24(date_ranges, valid_between, expect_error):
             pytest.fail("DID NOT RAISE BusinessRuleViolation")
 
 
-def test_NIG30(date_ranges):
+def test_NIG30(spanning_dates):
     """When a goods nomenclature is used in a goods measure then the validity
     period of the goods nomenclature must span the validity period of the goods
     measure."""
+    commodity_range, measure_range, fully_contained = spanning_dates
 
     measure = factories.MeasureFactory.create(
-        goods_nomenclature__valid_between=date_ranges.normal,
-        valid_between=date_ranges.overlap_normal,
+        goods_nomenclature__valid_between=commodity_range,
+        valid_between=measure_range,
     )
 
-    with pytest.raises(BusinessRuleViolation):
+    with raises_if(business_rules.NIG30.Violation, not fully_contained):
         business_rules.NIG30(measure.transaction).validate(measure.goods_nomenclature)
 
 
-def test_NIG31(date_ranges):
+def test_NIG31(spanning_dates):
     """When a goods nomenclature is used in an additional nomenclature measure
     then the validity period of the goods nomenclature must span the validity
     period of the additional nomenclature measure."""
+    commodity_range, measure_range, fully_contained = spanning_dates
 
     measure = factories.MeasureWithAdditionalCodeFactory.create(
-        additional_code__valid_between=date_ranges.overlap_normal,
-        goods_nomenclature__valid_between=date_ranges.normal,
-        valid_between=date_ranges.normal,
+        goods_nomenclature__valid_between=commodity_range,
+        valid_between=measure_range,
     )
 
-    with pytest.raises(BusinessRuleViolation):
+    with raises_if(business_rules.NIG31.Violation, not fully_contained):
         business_rules.NIG31(measure.transaction).validate(measure.goods_nomenclature)
 
 

--- a/commodities/tests/test_business_rules.py
+++ b/commodities/tests/test_business_rules.py
@@ -109,18 +109,13 @@ def test_NIG7(date_ranges, valid_between, expect_error):
             valid_between,
         ),
     )
-    try:
+
+    with raises_if(BusinessRuleViolation, expect_error):
         business_rules.NIG7(origin.transaction).validate(origin)
-    except BusinessRuleViolation:
-        if not expect_error:
-            raise
-    else:
-        if expect_error:
-            pytest.fail("DID NOT RAISE BusinessRuleViolation")
 
 
 @pytest.mark.parametrize(
-    "valid_between, expect_error",
+    ("valid_between", "expect_error"),
     [
         ("later", True),
         ("earlier", True),
@@ -129,7 +124,7 @@ def test_NIG7(date_ranges, valid_between, expect_error):
         ("overlap_normal_earlier", False),
     ],
 )
-def test_NIG10(date_ranges, valid_between, expect_error):
+def test_NIG10(date_ranges, update_type, valid_between, expect_error):
     """The successor must be applicable the day after the end date of the old
     code."""
     successor = factories.GoodsNomenclatureSuccessorFactory.create(
@@ -138,7 +133,10 @@ def test_NIG10(date_ranges, valid_between, expect_error):
             date_ranges,
             valid_between,
         ),
+        update_type=update_type,
     )
+
+    expect_error = expect_error and update_type != UpdateType.DELETE
     with raises_if(BusinessRuleViolation, expect_error):
         business_rules.NIG10(successor.transaction).validate(successor)
 

--- a/common/business_rules.py
+++ b/common/business_rules.py
@@ -174,6 +174,22 @@ def only_applicable_after(cutoff: Union[date, datetime, str]):
     return decorator
 
 
+def skip_when_deleted(cls):
+    """If the object passed to the business rule is deleted, do not run the rule
+    and report no violations."""
+    _original_validate = cls.validate
+
+    @wraps(_original_validate)
+    def validate(self, model):
+        if model.update_type == UpdateType.DELETE:
+            log.debug("Skipping %s: object is deleted", cls.__name__)
+        else:
+            _original_validate(self, model)
+
+    cls.validate = validate
+    return cls
+
+
 class UniqueIdentifyingFields(BusinessRule):
     """Rule enforcing identifying fields are unique."""
 

--- a/conftest.py
+++ b/conftest.py
@@ -1,5 +1,4 @@
 import contextlib
-from datetime import date
 from functools import lru_cache
 from typing import Any
 from typing import Callable
@@ -37,7 +36,6 @@ from common.tests.util import generate_test_import_xml
 from common.tests.util import make_duplicate_record
 from common.tests.util import make_non_duplicate_record
 from common.tests.util import raises_if
-from common.util import TaricDateRange
 from common.validators import UpdateType
 from exporter.storages import HMRCStorage
 from importer.nursery import get_nursery
@@ -89,20 +87,31 @@ def celery_config():
 
 
 @pytest.fixture(
-    params=[
-        ("2020-05-18", "2020-05-17", True),
-        ("2020-05-18", "2020-05-18", False),
-        ("2020-05-18", "2020-05-19", False),
-    ],
+    params=(
+        ("normal", "normal", True),
+        ("normal", "overlap_normal", False),
+        ("overlap_normal", "normal", False),
+        ("big", "normal", True),
+        ("later", "normal", False),
+    ),
+    ids=(
+        "equal_dates",
+        "overlaps_end",
+        "overlaps_start",
+        "contains",
+        "no_overlap",
+    ),
 )
-def validity_range(request):
-    start, end, expect_error = request.param
+def spanning_dates(request, date_ranges):
+    """Returns a pair of date ranges for a container object and a contained
+    object, and a flag indicating whether the container date ranges completely
+    spans the contained date range."""
+
+    container_validity, contained_validity, container_spans_contained = request.param
     return (
-        TaricDateRange(
-            date.fromisoformat(start),
-            date.fromisoformat(end),
-        ),
-        expect_error,
+        getattr(date_ranges, container_validity),
+        getattr(date_ranges, contained_validity),
+        container_spans_contained,
     )
 
 

--- a/measures/business_rules.py
+++ b/measures/business_rules.py
@@ -14,10 +14,10 @@ from common.business_rules import UniqueIdentifyingFields
 from common.business_rules import ValidityPeriodContained
 from common.business_rules import ValidityPeriodContains
 from common.business_rules import only_applicable_after
+from common.business_rules import skip_when_deleted
 from common.util import TaricDateRange
 from common.util import validity_range_contains_range
 from common.validators import ApplicabilityCode
-from common.validators import UpdateType
 from geo_areas.validators import AreaCode
 from quotas.validators import AdministrationMechanism
 
@@ -298,6 +298,7 @@ class ME25(BusinessRule):
             raise self.violation(measure)
 
 
+@skip_when_deleted
 class ME32(BusinessRule):
     """
     There may be no overlap in time with other measure occurrences with a goods
@@ -308,10 +309,7 @@ class ME32(BusinessRule):
     """
 
     def validate(self, measure):
-        if (
-            measure.goods_nomenclature is None
-            or measure.update_type == UpdateType.DELETE
-        ):
+        if measure.goods_nomenclature is None:
             return
 
         # build the query for measures matching the given measure


### PR DESCRIPTION
* Fixes interpretation of NIG31 – previously this looked at the dates of the additional code and the goods nomenclature, but it should have been looking at the measure.
* Fixes NIG10 to not fire for successors that are deleted (and introduces a new primitive for this).