### PR TITLE
Backport 3.9 typehints to 3.8 so tests can run under Pyston (faster p…

### DIFF
--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.9]
+        python-version: [3.8]
 
     services:
       postgres:

--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.9]
+        python-version: [3.8]
 
     services:
       postgres:

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Browse to http://localhost:8000/
 Skip this section if running under docker.
 
 The following dependencies are required to run this app:
- * Python 3.9.x
+ * Python 3.8.x
  * Node 14.16.x
  * Postgres 12.x
  * Redis 5.x
@@ -134,6 +134,40 @@ To run with coverage use the following:
     ./manage.py test -- --cov
 
 When running tests the settings module defaults to settings.test
+
+
+### Tips to run tests faster
+
+#### Run tests in parallel:
+
+When running locally it's possible to run tests in parallel using pytest-xdist.
+pytest-rerunfailures is also needed as a small number of tests clash when running in parallel and will fail.
+As re-running failing tests is a workaround, parallelization is undesirable under CI.
+
+Install dependencies:
+
+    pip install pytest-xdist pytest-rerunfailures
+
+Run the tests:
+
+    pytest -n=8 --reruns 8 --reruns-delay 4
+
+The example above is for a CPU with 8 threads, set "n" to a number less than or equal to the number of threads on the test machine.
+
+
+#### Run tests in Pyston instead of CPython:
+
+Pyston is a faster python implementation that aims for compatibility with the default CPython implementation.  
+Ad-hoc testing on one laptop showed tests completed in 6 minutes in CPython and 4 with Pyston. 
+
+Download and install a release from here: https://github.com/pyston/pyston/releases
+
+ - Create a python environment using venv[1]
+-  Install Tamato and it's dependencies to it.
+ - Run tests as usual.
+
+
+[1] The version of virtualenv on Ubuntu 20.04 is old and incompatible, it is advisable to use venv instead here: `$ pyston -mvenv`
 
 
 ## Environment Variables

--- a/common/business_rules.py
+++ b/common/business_rules.py
@@ -6,6 +6,7 @@ from functools import wraps
 from typing import Iterable
 from typing import Mapping
 from typing import Optional
+from typing import Tuple
 from typing import Type
 from typing import Union
 
@@ -121,7 +122,7 @@ class BusinessRule(metaclass=BusinessRuleBase):
 
 class BusinessRuleChecker:
     def __init__(self, models: Iterable[TrackedModel], transaction):
-        self.checks: set[tuple[type[BusinessRule], TrackedModel]] = set()
+        self.checks: set[Tuple[Type[BusinessRule], TrackedModel]] = set()
 
         self.transaction = transaction
 

--- a/common/tests/util.py
+++ b/common/tests/util.py
@@ -5,6 +5,7 @@ from datetime import timezone
 from functools import wraps
 from io import BytesIO
 from itertools import count
+from typing import Dict
 
 import pytest
 from dateutil.parser import parse as parse_date
@@ -342,7 +343,7 @@ def only_applicable_after(cutoff):
     return decorator
 
 
-def validity_period_post_data(start: date, end: date) -> dict[str, int]:
+def validity_period_post_data(start: date, end: date) -> Dict[str, int]:
     """
     Construct a POST data fragment for the validity period start and end dates
     of a ValidityPeriodForm from the given date objects, eg:

--- a/importer/tests/test_nursery.py
+++ b/importer/tests/test_nursery.py
@@ -71,7 +71,13 @@ def test_nursery_caches_object(object_nursery, handler_class):
 
 
 @pytest.mark.django_db
-def test_nursery_gets_object_from_cache(object_nursery):
+def test_nursery_gets_object_from_cache(settings, object_nursery):
+    settings.CACHES = {
+        "default": {
+            "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+        },
+    }
+
     instance = factories.FootnoteFactory.create()
     object_nursery.cache_object(instance)
 

--- a/measures/querysets.py
+++ b/measures/querysets.py
@@ -143,6 +143,7 @@ class DutySentenceMixin(QuerySet):
                     ),
                 ),
                 delimiter=" ",
+                ordering="components__duty_expression__sid",
             ),
         )
 

--- a/measures/tests/test_querysets.py
+++ b/measures/tests/test_querysets.py
@@ -1,5 +1,8 @@
+from typing import Any
+from typing import Callable
 from typing import Dict
 from typing import List
+from typing import Sequence
 from typing import Tuple
 
 import factory
@@ -29,11 +32,23 @@ pytestmark = pytest.mark.django_db
         factories.MeasureConditionFactory._meta.model.__name__,
     ),
 )
+@pytest.mark.parametrize(
+    ("reorder"),
+    (
+        lambda x: x,
+        lambda x: reversed(x),
+    ),
+    ids=(
+        "normal",
+        "reversed",
+    ),
+)
 def test_duty_sentence_generation(
     component_factory: factory.django.DjangoModelFactory,
     model_factory: factory.django.DjangoModelFactory,
     field: str,
     reversible_duty_sentence_data: Tuple[str, List[Dict]],
+    reorder: Callable[[Sequence[Any]], Sequence[Any]],
 ):
     """
     Links components to the same model and tests the resulting single duty
@@ -47,7 +62,7 @@ def test_duty_sentence_generation(
     expected, component_data = reversible_duty_sentence_data
 
     model = model_factory()
-    for kwargs in component_data:
+    for kwargs in reorder(component_data):
         component_factory(
             **{field: model},
             **kwargs,

--- a/measures/views.py
+++ b/measures/views.py
@@ -1,3 +1,5 @@
+from typing import Type
+
 from rest_framework import viewsets
 
 from common.models import TrackedModel
@@ -28,7 +30,7 @@ class MeasureTypeViewSet(viewsets.ReadOnlyModelViewSet):
 
 
 class MeasureMixin:
-    model: type[TrackedModel] = Measure
+    model: Type[TrackedModel] = Measure
 
     def get_queryset(self):
         tx = WorkBasket.get_current_transaction(self.request)

--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.9.x
+python-3.8.x

--- a/settings/test.py
+++ b/settings/test.py
@@ -25,7 +25,7 @@ AWS_S3_REGION_NAME = os.environ.get("TEST_AWS_S3_REGION_NAME", "eu-west-2")
 # Cache settings - put things in memory to minimise dependencies.
 CACHES = {
     "default": {
-        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+        "BACKEND": "django.core.cache.backends.dummy.DummyCache",
     },
 }
 


### PR DESCRIPTION
Backport typehints to 3.8, which allows Pyston to run.

It turns out there wasn't much to do to port this, and we didn't even need strip-hints :)

This also adds info to the readme about running tests in parallel.