### PR TITLE
TP-875 Running tests in random order exposes more failing tests.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,12 +72,12 @@ run: collectstatic migrate
 test-fast:
 	@echo
 	@echo "> Running tests..."
-	${PYTHON} manage.py test --failfast
+	${PYTHON} manage.py test --failfast -- --random-order
 
 test:
 	@echo
 	@echo "> Running tests..."
-	@coverage run --source='.' manage.py test -- --alluredir=allure-results --nomigrations
+	@coverage run --source='.' manage.py test -- --random-order --alluredir=allure-results --nomigrations
 	@coverage xml
 
 ## docker-image: Build docker image

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,7 @@ line_length = 88
 force_single_line = true
 
 [tool.pytest.ini_options]
+PYTEST_ADDOPTS="--random-order"
 DJANGO_SETTINGS_MODULE = "settings.test"
 norecursedirs = [
     "venv",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,3 +3,4 @@
 django_debug_toolbar
 pre-commit
 pytest-celery
+pytest-random-order

--- a/requirements.txt
+++ b/requirements.txt
@@ -38,6 +38,7 @@ pygments>=2.8
 pytest==6.2.2
 pytest-bdd==4.0.2
 pytest-django==4.1.0
+pytest-random-order==1.0.4
 pytest-responses==0.5.0
 requests-oauthlib==1.3.0
 responses==0.12.1


### PR DESCRIPTION
**DRAFT PR**:  Until we are sure all the failing tests pass.

This PR is to show which tests fail with `--random-order`.

Fixes will appear in other PRs until `--random-order` can consistently without failing (e.g. for some number of hours on a dev machine).

This will help shake out bugs related to shared state as a stepping stone towards running tests with `pytest-xdist` which has a much faster runtime.

To run with `--random-order` locally on your current branch:

Install pytest random order:

`$ pip install pytest-random-order` 

Examples of running tests in a loop until a failure occurs:

`$ while pytest -s -v --random-order; do :; done`

`$ while pytest -s -v --random-order measures; do :; done`

`$ while pytest -s -v --random-order measures/tests/test_importer.py; do :; done`

Note:  
Failures are mostly due to shared state, running just one test, or even just one module will not always trigger a failure.
Running in a random order runs surfaces new combinations and failures that running in a static order does not.

Running tests in [Pyston](https://github.com/pyston/pyston) completes 30% faster, but it's also useful to verify in CPython.

Currently, Pyston implements Python 3.8, so we have temporarily backported our type hints, once 3.9 is supported we can move to 3.9 again.