### PR TITLE
Enable python-xdist with --dist=loadfile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,13 +72,12 @@ run: collectstatic migrate
 test-fast:
 	@echo
 	@echo "> Running tests..."
-	${PYTHON} manage.py test --failfast
+	${PYTHON} python -m pytest -x -n=auto --dist=loadfile --cov --cov-report html:htmlcov --cov-report=term --cov-report=xml
 
 test:
 	@echo
 	@echo "> Running tests..."
-	@coverage run --source='.' manage.py test -- --alluredir=allure-results --nomigrations
-	@coverage xml
+	@python -m pytest -n=auto --dist=loadfile --alluredir=allure-results --nomigrations --cov --cov-report html:htmlcov --cov-report=term --cov-report=xml
 
 ## docker-image: Build docker image
 docker-image:
@@ -97,7 +96,7 @@ docker-test:
 	@echo
 	@echo "> Running tests in Docker..."
 	@docker-compose run \
-		${PROJECT} sh -c "docker/wait_for_db && ${PYTHON} manage.py test -- --cov"
+		${PROJECT} sh -c "docker/wait_for_db && ${PYTHON} manage.py test -- -n=auto --dist=loadfile --cov"
 
 ## build-docs: Build the project documentation
 build-docs html:

--- a/requirements.txt
+++ b/requirements.txt
@@ -37,8 +37,10 @@ psycopg2-binary==2.8.6
 pygments>=2.8
 pytest==6.2.2
 pytest-bdd==4.0.2
+pytest-cov==2.12.1
 pytest-django==4.1.0
 pytest-responses==0.5.0
+pytest-xdist==2.3.0
 requests-oauthlib==1.3.0
 responses==0.12.1
 sentry-sdk==0.20.2


### PR DESCRIPTION
Use python-xdist[1] to split the tests across many processes.

For a splitting strategy, we choose --dist=loadfile, which loads a file into one process and won't split the tests further, this is pretty conservative and should keep any state that we accidentally share in that file just as we do now.

As a downside `--dist-loadfile` will have slightly worse performance, if one of our files has lots of tests that are especially slow.
I'm anticipating we can move off this later.

[1] python-xdist can split tests over separate machines or processes, using different strategies - in this case we use it to spin up different processes.