### PR TITLE
View-level tests for models

### DIFF
--- a/footnotes/tests/test_views.py
+++ b/footnotes/tests/test_views.py
@@ -1,0 +1,57 @@
+import pytest
+from django.core.exceptions import ValidationError
+
+from common.tests import factories
+from common.tests.util import raises_if
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.mark.parametrize(
+    ("new_data", "expected_valid"),
+    (
+        ({}, True),
+        ({"start_date_0": lambda d: d + 1}, True),
+        ({"start_date_0": lambda d: d - 1}, False),
+        ({"start_date_1": lambda m: m + 1}, True),
+        ({"start_date_2": lambda y: y + 1}, True),
+    ),
+)
+def test_footnote_update(new_data, expected_valid, use_update_form):
+    with raises_if(ValidationError, not expected_valid):
+        use_update_form(factories.FootnoteFactory(), new_data)
+
+
+@pytest.mark.parametrize(
+    ("new_data", "expected_valid"),
+    (
+        ({}, True),
+        ({"validity_start_0": lambda d: d + 1}, True),
+        ({"validity_start_0": lambda d: d - 1}, True),
+        ({"validity_start_1": lambda m: m + 1}, True),
+        ({"validity_start_2": lambda y: y + 1}, True),
+        ({"description": lambda d: d + "AAA"}, True),
+        ({"description": lambda d: ""}, False),
+    ),
+)
+def test_footnote_description_update(new_data, expected_valid, use_update_form):
+    with raises_if(ValidationError, not expected_valid):
+        use_update_form(factories.FootnoteDescriptionFactory(), new_data)
+
+
+@pytest.mark.parametrize(
+    ("new_data", "workbasket_valid"),
+    (
+        ({}, True),
+        ({"description": lambda d: d + "AAA"}, True),
+        ({"validity_start_0": lambda d: d + 1}, False),
+    ),
+)
+def test_footnote_business_rule_application(
+    new_data,
+    workbasket_valid,
+    use_update_form,
+):
+    description = use_update_form(factories.FootnoteDescriptionFactory(), new_data)
+    with raises_if(ValidationError, not workbasket_valid):
+        description.transaction.workbasket.clean()

--- a/workbaskets/models.py
+++ b/workbaskets/models.py
@@ -94,6 +94,10 @@ class WorkBasket(TimestampedMixin):
         db_index=True,
     )
 
+    @property
+    def approved(self):
+        return self.status in WorkflowStatus.approved_statuses()
+
     def __str__(self):
         return f"({self.pk}) [{self.status}]"
 


### PR DESCRIPTION
This PR suggests an approach for testing our UI-level functionality by testing views. It introduces a simple primitive that can be used to test the update form for a model. 

These test that:
- when the form is loaded, it shows the correct data
- when the form is submitted, the form knows whether the data is invalid or not
- when the form is submitted, the changes are persisted in the correct way
- any business rules are **not** triggered as part of the form submission

The use of lambdas is to decouple the tests from the factory data… in particular I didn't want the parameters to have to be set out explicitly for each model and duplicate the factory. So instead the current value is passed to each lambda and the result can be mutated (or discarded) as appropriate.