### PR TITLE
Enable multiprocessing (pytest-xdist) for python manage.py test.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,3 +83,4 @@ norecursedirs = [
     "node_modules",
     ".local",
 ]
+addopts = "-n=auto"


### PR DESCRIPTION
Enable multiple processes when running `python manage.py test`.