### PR TITLE
More test cases for fuzzy business rule tests

### DIFF
--- a/commodities/tests/test_business_rules.py
+++ b/commodities/tests/test_business_rules.py
@@ -356,14 +356,9 @@ def test_NIG24(date_ranges, valid_between, expect_error):
         goods_nomenclature=existing.goods_nomenclature,
         valid_between=getattr(date_ranges, valid_between),
     )
-    try:
+
+    with raises_if(BusinessRuleViolation, expect_error):
         business_rules.NIG24(association.transaction).validate(association)
-    except BusinessRuleViolation:
-        if not expect_error:
-            raise
-    else:
-        if expect_error:
-            pytest.fail("DID NOT RAISE BusinessRuleViolation")
 
 
 def test_NIG30(spanning_dates):


### PR DESCRIPTION
In #319 we attempted to stabilize our coverage report by adding some positive test cases to business rule tests. We didn't catch them all, so this commit adds more positive test cases to business rules without them.

Also includes cleaning up some more `raises_if` duplication and unused test code.