### PR TITLE
TP-859 Make SQLite runner inherit main process env

### DIFF
--- a/exporter/sqlite/runner.py
+++ b/exporter/sqlite/runner.py
@@ -1,5 +1,6 @@
 import decimal
 import logging
+import os
 import sqlite3
 import sys
 from pathlib import Path
@@ -33,13 +34,14 @@ class Runner:
         True, allowing SQLite specific functionality to be switched on and off
         using the value of this setting.
         """
+        sqlite_env = os.environ.copy()
+        sqlite_env["DATABASE_URL"] = f"sqlite:///{self.db}"
+
         run(
             [sys.executable, "manage.py", *args],
             cwd=settings.BASE_DIR,
             capture_output=False,
-            env={
-                "DATABASE_URL": f"sqlite:///{self.db}",
-            },
+            env=sqlite_env,
         )
 
     def make_empty_database(self):


### PR DESCRIPTION
There is a problem with the SQLite celery task where shared Python libraries aren't being found. Having confirmed that these libraries do exist where they're expected to in the app environment, I think that what is happening is that the SQLite runner is not accessing them. This PR makes the main process environment available to the SQLite runner, which should help it find libraries located in directories listed in $LD_LIBRARY_PATH.