### PR TITLE
Prevent SQLite from using the default db

### DIFF
--- a/exporter/sqlite/runner.py
+++ b/exporter/sqlite/runner.py
@@ -36,6 +36,8 @@ class Runner:
         """
         sqlite_env = os.environ.copy()
         sqlite_env["DATABASE_URL"] = f"sqlite:///{self.db}"
+        # Required to make sure the postgres default isn't set as the DB_URL
+        sqlite_env["VCAP_SERVICES"] = "{}"
 
         run(
             [sys.executable, "manage.py", *args],

--- a/exporter/sqlite/runner.py
+++ b/exporter/sqlite/runner.py
@@ -37,7 +37,8 @@ class Runner:
         sqlite_env = os.environ.copy()
         sqlite_env["DATABASE_URL"] = f"sqlite:///{self.db}"
         # Required to make sure the postgres default isn't set as the DB_URL
-        sqlite_env["VCAP_SERVICES"] = "{}"
+        if sqlite_env.get("VCAP_SERVICES"):
+            sqlite_env["VCAP_SERVICES"].pop("postgres", None)
 
         run(
             [sys.executable, "manage.py", *args],


### PR DESCRIPTION
Unfortunately, #356 didn't fully resolve the SQLite problem. By copying over the env variables, the SQLite runner has access to the VCAP_SERVICES env variable, which causes a DB address overwrite (specifically the postgres details it contains): https://github.com/uktrade/tamato/blob/master/settings/common.py#L220 . 

The alternative might be to set `LD_LIBRARY_PATH` explicitly, instead of copying over all the env variables, but I'm concerned this would mean missing out on other hidden ones, and we continue playing 'whack-a-mole' trying to catch the all.