### PR TITLE
Generate envelope sequences

### DIFF
--- a/common/filters.py
+++ b/common/filters.py
@@ -41,7 +41,7 @@ def field_to_layout(field_name, field):
     """
     Converts fields into their GDS styled counterparts.
 
-    If the counterpart is unknown, return the field_name as default
+    If the counterpart is unknown, return the name as default
     """
     if isinstance(field, forms.CharField):
         return Field.text(field_name, label_size=Size.SMALL)

--- a/common/models/transactions.py
+++ b/common/models/transactions.py
@@ -7,6 +7,7 @@ from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.core.serializers.json import DjangoJSONEncoder
 from django.db import models
+from django_cte import CTEQuerySet
 
 from common.business_rules import BusinessRuleChecker
 from common.business_rules import BusinessRuleViolation
@@ -30,7 +31,7 @@ class TransactionManager(models.Manager):
         )
 
 
-class TransactionQueryset(models.QuerySet):
+class TransactionQueryset(CTEQuerySet):
     def ordered_tracked_models(self):
         """TrackedModel in order of their transactions creation order."""
 
@@ -38,7 +39,7 @@ class TransactionQueryset(models.QuerySet):
             transaction__in=self,
         ).order_by(
             "transaction__order",
-        )  # order_by record_code, subrecord_code already happened in get_queryset
+        )  # order_by record_code, subrecord_code already happened in TransactionManager.get_queryset
         return tracked_models
 
 
@@ -60,7 +61,7 @@ class Transaction(TimestampedMixin):
         related_name="transactions",
     )
 
-    # The order this transaction appears within the workbasket
+    # For draft transactions, order is per workbasket, once published order is global.
     order = models.IntegerField()
 
     composite_key = models.CharField(max_length=16, unique=True)

--- a/conftest.py
+++ b/conftest.py
@@ -294,7 +294,7 @@ def must_exist():
     exist.
 
     Usage:
-        assert must_exist("field_name", LinkedModelFactory, ModelFactory)
+        assert must_exist("name", LinkedModelFactory, ModelFactory)
     """
 
     # TODO drop the `dependency_name` argument, as with validity_period_contained
@@ -319,11 +319,11 @@ def validity_period_contained(date_ranges):
     within the validity period of the specified model.
 
     Usage:
-        assert validity_period_contained("field_name", ContainerModelFactory, ContainedModelFactory)
+        assert validity_period_contained("name", ContainerModelFactory, ContainedModelFactory)
     """
 
     # TODO drop the `dependency_name` argument, inspect the model for a ForeignKey to
-    # the specified container model. Add `field_name` kwarg for disambiguation if
+    # the specified container model. Add `name` kwarg for disambiguation if
     # multiple ForeignKeys.
 
     def check(dependency_name, dependency_factory, dependent_factory):

--- a/exporter/management/commands/summarise_envelope.py
+++ b/exporter/management/commands/summarise_envelope.py
@@ -1,0 +1,42 @@
+import logging
+from typing import Any
+from typing import Optional
+
+from django.core.management import BaseCommand
+from django.core.management.base import CommandParser
+
+from taric.models import Envelope
+
+logger = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    def add_arguments(self, parser: CommandParser) -> None:
+        parser.add_argument(
+            "envelope_id",
+            help="Envelope id [6 digit number], defaults to most recent envelope.",
+            type=int,
+            default=None,
+            action="store",
+            nargs="?",
+        )
+        parser.add_argument(
+            "--list-envelopes",
+            action="store_const",
+            const=True,
+            default=False,
+        )
+
+        return super().add_arguments(parser)
+
+    def handle(self, *args: Any, **options: Any) -> Optional[str]:
+        if options["list_envelopes"]:
+            for envelope in Envelope.objects.all():
+                self.stdout.write(f"{envelope.envelope_id}")
+        else:
+            if options["envelope_id"] is None:
+                envelope = Envelope.objects.last()
+            else:
+                envelope = Envelope.objects.get(envelope_id=options["envelope_id"])
+
+            # TODO output sequences

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ celery[redis]==5.0.5
 coverage[toml]==5.4
 crispy-forms-gds==0.2.2
 dj-database-url==0.5.0
-django==3.1.12
+django==3.2.6
 django-dotenv==1.4.2
 drf-extra-fields==3.0.2
 django-cte==1.1.5

--- a/workbaskets/validators.py
+++ b/workbaskets/validators.py
@@ -1,5 +1,10 @@
 from django.db import models
 
+# class TransactionStatus(models.TextChoices):
+#     DRAFT = "Draft"
+#
+#     PUBLISHED = ""
+
 
 class WorkflowStatus(models.TextChoices):
     # Newly started, but not yet submitted into workflow


### PR DESCRIPTION
This is a *very* draft PR about generating summaries of envelopes (currently so draft that, the mentioned feature is not in the PR currently, and needs bringing across from a notebook).



To be able create summaries that output sequences:

Here's how it could look for a fictional model "Goods" and "Certs":
```
Goods:
Updated T51-T58  T64-T65

Certs:
Updated C646-C650
Created C651
```

To find sequences, a countable field needs to be chosen from the models `identifying_fields`, currently this must be a `SignedIntSID` or `NumericIntSID`.