### PR TITLE
Run all indirect business rules on workbasket clean

### DIFF
--- a/common/models/mixins/description.py
+++ b/common/models/mixins/description.py
@@ -25,7 +25,7 @@ class DescriptionMixin(ValidityStartMixin):
 
     @classproperty
     def described_object_field(cls) -> Field:
-        for rel, _ in cls.get_relations():
+        for rel in cls.relations.keys():
             if rel.name.startswith("described_"):
                 return rel
         raise TypeError(f"{cls} should have a described field.")

--- a/common/tests/test_business_rules.py
+++ b/common/tests/test_business_rules.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock
 from unittest.mock import patch
 
 import pytest
+from django.core.exceptions import ValidationError
 
 from common.business_rules import BusinessRule
 from common.business_rules import BusinessRuleChecker
@@ -174,7 +175,7 @@ def test_prevent_delete_if_in_use(approved_transaction):
         model = model.new_version(workbasket, update_type=UpdateType.DELETE)
         model.in_use = MagicMock(return_value=True)
 
-        with pytest.raises(BusinessRuleViolation):
+        with pytest.raises(ValidationError):
             BusinessRuleChecker([model], model.transaction).validate()
 
     assert model.in_use.called

--- a/exporter/views.py
+++ b/exporter/views.py
@@ -79,7 +79,7 @@ def tracked_model_to_activity_stream_item(obj: TrackedModel):
     # Find all the relations to remove and replace with activity stream IDs.
     exclusions = []
     extra_data = {}
-    for relation, _ in obj.get_relations():
+    for relation, _ in obj.models_linked_to.items():
         exclusions.append(relation.name)
         relation_obj = getattr(obj, relation.name, None)
         if relation_obj:

--- a/importer/utils.py
+++ b/importer/utils.py
@@ -118,7 +118,7 @@ def build_dependency_tree(use_subrecord_codes: bool = False) -> Dict[str, Set[st
             if record_code not in dependency_map:
                 dependency_map[record_code] = set()
 
-            for _, relation in subclass.get_relations():
+            for relation in subclass.relations.values():
                 relation_codes = get_record_codes(relation)
 
                 for relation_code in relation_codes:


### PR DESCRIPTION
Previously this only detected a small subset of relations and so didn't run many indirect business rules. It now correctly returns relations and runs all of the appropriate indirect business rules.