### PR TITLE
Links should not contain colons

### DIFF
--- a/common/jinja2/common/edit_description.jinja
+++ b/common/jinja2/common/edit_description.jinja
@@ -36,7 +36,7 @@
     [
       {"text": "<a href=\'\'></a>"},
       {"text": "Add a hyperlink"},
-      {"html": "This is " ~ "<a href=:\'https://www.gov.uk\'>a hyperlink to gov.uk</a>"|e ~ "<br> becomes <br> <a href=:'https://www.gov.uk'>a hyperlink to gov.uk</a>"},
+      {"html": "This is " ~ "<a href=\'https://www.gov.uk\'>a hyperlink to gov.uk</a>"|e ~ "<br> becomes <br> <a href='https://www.gov.uk'>a hyperlink to gov.uk</a>"},
     ]
     ]
   }) }}


### PR DESCRIPTION
We are currently advising users to add colons to HTML links. This isn't correct and produces links that don't work as intended.