### PR TITLE
Replace node-sass with Dart Sass

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "file-loader": "^6.2.0",
     "govuk-frontend": "^3.13.0",
     "mini-css-extract-plugin": "^1.6.0",
-    "node-sass": "^6.0.1",
+    "sass": "^1.38.2",
     "sass-loader": "^12.1.0",
     "style-loader": "^3.0.0",
     "webpack": "^5.40.0",


### PR DESCRIPTION
The Sass maintainers recommend using Dart Sass instead of Node Sass.

Implementing this change has the added benefit of making Sass work on my
M1 Mac.

* [LibSass is deprecated](https://sass-lang.com/blog/libsass-is-deprecated)