### PR TITLE
Remove show/hide chevrons

### DIFF
--- a/common/static/common/js/step-by-step-nav.js
+++ b/common/static/common/js/step-by-step-nav.js
@@ -69,8 +69,7 @@ class StepNav {
     var showall = document.createElement('div');
     showall.className = 'gem-c-step-nav__controls govuk-!-display-none-print';
     showall.innerHTML = '<button aria-expanded="false" class="gem-c-step-nav__button gem-c-step-nav__button--controls js-step-controls-button">' +
-      '<span class="gem-c-step-nav__button-text gem-c-step-nav__button-text--all js-step-controls-button-text">' + this.actions.showAllText + '</span>' +
-      '<span class="gem-c-step-nav__chevron js-step-controls-button-icon">' + this.downChevronSvg + '</span>' +
+      this.actions.showAllText +
       '</button>';
 
     var steps = this.element.querySelector('.gem-c-step-nav__steps');
@@ -96,7 +95,6 @@ class StepNav {
         thisSectionSpan.className = 'govuk-visually-hidden';
 
         showHideSpan.appendChild(showHideSpanText);
-        showHideSpan.appendChild(showHideSpanIcon);
 
         commaSpan.innerHTML = ', ';
         thisSectionSpan.innerHTML = ' this section';
@@ -333,8 +331,7 @@ class StepNav {
     // Find out if the number of is-opens == total number of steps
     var shownStepsIsTotalSteps = shownSteps === this.totalSteps;
 
-    this.showOrHideAllButton.querySelector('.js-step-controls-button-text').innerHTML = shownStepsIsTotalSteps ? this.actions.hideAllText : this.actions.showAllText;
-    this.showOrHideAllButton.querySelector('.js-step-controls-button-icon').innerHTML = shownStepsIsTotalSteps ? this.upChevronSvg : this.downChevronSvg;
+    this.showOrHideAllButton.innerHTML = shownStepsIsTotalSteps ? this.actions.hideAllText : this.actions.showAllText;
   }
 }
 
@@ -378,7 +375,6 @@ class StepView {
     var showHideText = this.stepElement.querySelector('.js-toggle-link');
 
     showHideText.querySelector('.js-toggle-link-text').innerHTML = isShown ? this.hideText : this.showText;
-    showHideText.querySelector('.js-toggle-link-icon').innerHTML = isShown ? this.upChevronSvg : this.downChevronSvg;
   }
 
   isShown() {

--- a/common/static/common/scss/_step-by-step-nav.scss
+++ b/common/static/common/scss/_step-by-step-nav.scss
@@ -61,6 +61,7 @@ $top-border: solid 1px govuk-colour("mid-grey", $legacy: "grey-3");
 
 .gem-c-step-nav__controls {
   padding: 3px 3px 0 0;
+  text-align: right;
 }
 
 .gem-c-step-nav__button {
@@ -112,7 +113,6 @@ $top-border: solid 1px govuk-colour("mid-grey", $legacy: "grey-3");
   @include step-nav-font(14, $line-height: 1);
   position: relative;
   z-index: 1; // this and relative position stops focus outline underlap with border of accordion
-  margin: .5em 0 1.5em;
   padding: 0 0 govuk-spacing(1);
 
   &:hover .gem-c-step-nav__button-text {
@@ -249,7 +249,7 @@ $top-border: solid 1px govuk-colour("mid-grey", $legacy: "grey-3");
   box-sizing: border-box;
   position: absolute;
   z-index: 5;
-  top: 3px;
+  top: 15px;
   left: 0;
   width: govuk-em($number-circle-size, 16);
   height: govuk-em($number-circle-size, 16);
@@ -322,14 +322,10 @@ $top-border: solid 1px govuk-colour("mid-grey", $legacy: "grey-3");
 
 .gem-c-step-nav__header {
   border-top: $top-border;
-  padding: govuk-spacing(1) 0 govuk-spacing(6);
+  padding: govuk-spacing(3) 0;
 
   .gem-c-step-nav--large & {
     padding-top: govuk-spacing(2);
-  }
-
-  .js-enabled & {
-    padding: 0;
   }
 
   .gem-c-step-nav--active & {
@@ -364,7 +360,6 @@ $top-border: solid 1px govuk-colour("mid-grey", $legacy: "grey-3");
   display: block;
   color: $govuk-link-colour;
   text-transform: capitalize;
-  padding-bottom: govuk-spacing(6);
 
   .gem-c-step-nav--large & {
     @include step-nav-font(14, $tablet-size: 16, $line-height: 1.2);
@@ -374,7 +369,6 @@ $top-border: solid 1px govuk-colour("mid-grey", $legacy: "grey-3");
 .gem-c-step-nav__panel {
   @include govuk-text-colour;
   @include step-nav-font(16);
-  padding-bottom: govuk-spacing(5);
 
   .gem-c-step-nav--large & {
     @include step-nav-font(16, $tablet-size: 19);

--- a/measures/jinja2/measures/create-wizard-step.jinja
+++ b/measures/jinja2/measures/create-wizard-step.jinja
@@ -48,7 +48,8 @@
         "id": "step-by-step-nav",
         "remember_last_step": True,
         "small": True,
-        "steps": steps
+        "steps": steps,
+        "highlight_step": wizard.steps.step1,
       }) }}
       </div>
     </div>


### PR DESCRIPTION
## The Problem

In testing, users were confused by the chevrons after the "Show all" / "Hide all" and "Show" / "Hide" links.

<img width="424" alt="Screenshot 2021-09-02 at 12 22 04" src="https://user-images.githubusercontent.com/35194/131835210-00bae2e5-f9e6-4dad-9d88-7b16269b1aa5.png">

Also, the active step indicator does not work.

## The Fix

* The chevrons are removed
* The active step indicator is working.

Additionally
* The styling of the step-by-step navigation has been updated to more closely match the design

<img width="431" alt="Screenshot 2021-09-02 at 12 17 54" src="https://user-images.githubusercontent.com/35194/131834612-43990fbd-1c83-4d3b-b636-cdd035b61ee8.png">

NB: the active step indicator does not match the design, but is the default styling of the step-by-step nav component we are using. I think it is a bit more obvious than the indicator in the design.