### PR TITLE
Use v3 syntax for the manifest

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -1,7 +1,11 @@
 ---
 applications:
-  - memory: 1G
-    buildpacks:
+  - buildpacks:
       - https://github.com/cloudfoundry/nodejs-buildpack.git#v1.7.56
       - python_buildpack
-    disk_quota: 8192M
+    processes:
+    - type: web
+      memory: 1G
+    - type: worker
+      disk_quota: 8G
+      memory: 1G


### PR DESCRIPTION
When looking into the disk-space issue for our worker, the Gov PaaS team recommended using the [latest version](https://v3-apidocs.cloudfoundry.org/version/3.97.0/index.html#the-manifest-schema) of the `manifest.py` schema.