### PR TITLE
Tp 929 remove automatic triggering of workbasket export

### DIFF
--- a/common/views.py
+++ b/common/views.py
@@ -31,7 +31,7 @@ from workbaskets.views.mixins import WithCurrentWorkBasket
 
 def index(request):
     try:
-        workbasket = WorkBasket.objects.is_not_approved().get()
+        workbasket = WorkBasket.objects.is_not_approved().last()
     except WorkBasket.DoesNotExist:
         workbasket = WorkBasket.objects.create(
             title=f"Workbasket {WorkBasket.objects.last().pk+1}",

--- a/common/views.py
+++ b/common/views.py
@@ -31,7 +31,7 @@ from workbaskets.views.mixins import WithCurrentWorkBasket
 
 def index(request):
     try:
-        workbasket = WorkBasket.objects.is_not_approved().last()
+        workbasket = WorkBasket.objects.is_not_approved().get()
     except WorkBasket.DoesNotExist:
         workbasket = WorkBasket.objects.create(
             title=f"Workbasket {WorkBasket.objects.last().pk+1}",

--- a/conftest.py
+++ b/conftest.py
@@ -852,3 +852,9 @@ def response():
 def form_error_shown(response, error_message):
     response_html = parse_html(response["response"].content.decode())
     assert error_message in response_html
+
+
+@pytest.fixture
+def staff_user():
+    user = factories.UserFactory.create(is_staff=True)
+    return user

--- a/workbaskets/admin.py
+++ b/workbaskets/admin.py
@@ -1,6 +1,28 @@
 from django.contrib import admin
+from django.http import HttpResponseRedirect
+from django.http.response import HttpResponseForbidden
+from django.urls import path
+
+from exporter.tasks import upload_workbaskets
 from workbaskets.models import WorkBasket
+from workbaskets.validators import WorkflowStatus
 
 class WorkBasketAdmin(admin.ModelAdmin):
-    pass
+    change_list_template = "workbasket_change_list.html"
+
+    def get_urls(self):
+        urls = super().get_urls()
+        export_url = path('upload/', self.upload)
+        
+        return [export_url] + urls
+    
+    def upload(self, request):
+        if not request.user.is_superuser:
+            return HttpResponseForbidden('Only superusers may export workbaskets')
+        
+        upload_workbaskets.delay()
+        self.message_user(request, f"Uploading workbaskets with status of '{WorkflowStatus.READY_FOR_EXPORT.label}'")
+        return HttpResponseRedirect("../")
+
+
 admin.site.register(WorkBasket, WorkBasketAdmin)

--- a/workbaskets/admin.py
+++ b/workbaskets/admin.py
@@ -7,21 +7,25 @@ from exporter.tasks import upload_workbaskets
 from workbaskets.models import WorkBasket
 from workbaskets.validators import WorkflowStatus
 
+
 class WorkBasketAdmin(admin.ModelAdmin):
     change_list_template = "workbasket_change_list.html"
 
     def get_urls(self):
         urls = super().get_urls()
-        export_url = path('upload/', self.upload)
-        
-        return [export_url] + urls
-    
+        upload_url = path("upload/", self.upload)
+
+        return [upload_url] + urls
+
     def upload(self, request):
         if not request.user.is_superuser:
-            return HttpResponseForbidden('Only superusers may export workbaskets')
-        
+            return HttpResponseForbidden("Only superusers may upload workbaskets")
+
         upload_workbaskets.delay()
-        self.message_user(request, f"Uploading workbaskets with status of '{WorkflowStatus.READY_FOR_EXPORT.label}'")
+        self.message_user(
+            request,
+            f"Uploading workbaskets with status of '{WorkflowStatus.READY_FOR_EXPORT.label}'",
+        )
         return HttpResponseRedirect("../")
 
 

--- a/workbaskets/admin.py
+++ b/workbaskets/admin.py
@@ -1,0 +1,6 @@
+from django.contrib import admin
+from workbaskets.models import WorkBasket
+
+class WorkBasketAdmin(admin.ModelAdmin):
+    pass
+admin.site.register(WorkBasket, WorkBasketAdmin)

--- a/workbaskets/models.py
+++ b/workbaskets/models.py
@@ -148,11 +148,6 @@ class WorkBasket(TimestampedMixin):
             version_group.current_version = obj
             version_group.save()
 
-        # imported lower down to avoid circular import error
-        from exporter.tasks import upload_workbaskets
-
-        upload_workbaskets.delay()
-
     @transition(
         field=status,
         source=WorkflowStatus.READY_FOR_EXPORT,

--- a/workbaskets/templates/workbasket_change_list.html
+++ b/workbaskets/templates/workbasket_change_list.html
@@ -4,7 +4,7 @@
     <div>
         <form action={% url 'admin:upload' %} method="POST">
             {% csrf_token %}
-                <button type="submit" style="cursor:pointer">Export workbaskets</button>
+                <button class="button" type="submit">Export workbaskets</button>
         </form>
     </div>
     <br />

--- a/workbaskets/templates/workbasket_change_list.html
+++ b/workbaskets/templates/workbasket_change_list.html
@@ -2,7 +2,7 @@
 
 {% block object-tools %}
     <div>
-        <form action="upload/" method="POST">
+        <form action={% url 'admin:upload' %} method="POST">
             {% csrf_token %}
                 <button type="submit" style="cursor:pointer">Export workbaskets</button>
         </form>

--- a/workbaskets/templates/workbasket_change_list.html
+++ b/workbaskets/templates/workbasket_change_list.html
@@ -1,0 +1,12 @@
+{% extends 'admin/change_list.html' %}
+
+{% block object-tools %}
+    <div>
+        <form action="upload/" method="POST">
+            {% csrf_token %}
+                <button type="submit" style="cursor:pointer">Export workbaskets</button>
+        </form>
+    </div>
+    <br />
+    {{ block.super }}
+{% endblock %}

--- a/workbaskets/tests/test_admin.py
+++ b/workbaskets/tests/test_admin.py
@@ -6,15 +6,18 @@ from django.urls import reverse
 pytestmark = pytest.mark.django_db
 
 
-def test_upload_returns_302_for_valid_staff_user(self, staff_user, client):
+def test_upload_returns_302_for_valid_staff_user(staff_user, client):
     client.force_login(staff_user)
-    response = client.post(reverse("admin:upload"))
+    with mock.patch(
+        "exporter.tasks.upload_workbaskets.delay",
+    ):
+        response = client.post(reverse("admin:upload"))
 
-    assert response.status_code == 302
-    assert response.url == reverse("admin:workbaskets_workbasket_changelist")
+        assert response.status_code == 302
+        assert response.url == reverse("admin:workbaskets_workbasket_changelist")
 
 
-def test_upload_redirects_non_staff_to_login(self, client, valid_user):
+def test_upload_redirects_non_staff_to_login(client, valid_user):
     client.force_login(valid_user)
     response = client.post(reverse("admin:upload"))
 
@@ -22,7 +25,7 @@ def test_upload_redirects_non_staff_to_login(self, client, valid_user):
     assert response.url == f"{reverse('admin:login')}?next={reverse('admin:upload')}"
 
 
-def test_upload_doesnt_call_task_for_non_staff(self, client, valid_user):
+def test_upload_doesnt_call_task_for_non_staff(client, valid_user):
     client.force_login(valid_user)
     with mock.patch(
         "exporter.tasks.upload_workbaskets.delay",
@@ -32,7 +35,7 @@ def test_upload_doesnt_call_task_for_non_staff(self, client, valid_user):
         mock_task.assert_not_called()
 
 
-def test_upload_calls_task(self, staff_user, client):
+def test_upload_calls_task(staff_user, client):
     with mock.patch(
         "exporter.tasks.upload_workbaskets.delay",
     ) as mock_task:

--- a/workbaskets/tests/test_admin.py
+++ b/workbaskets/tests/test_admin.py
@@ -1,28 +1,30 @@
+from unittest import mock
+
 import pytest
-from unittest import mock 
 
 from common.tests.factories import UserFactory
 
 pytestmark = pytest.mark.django_db
+
 
 class TestWorkBasketUpload:
     @classmethod
     def setup_class(cls):
         cls.url = "/admin/workbaskets/workbasket/upload/"
 
-    def test_upload_returns_302_for_valid_user(self, valid_user, client):
+    def test_upload_returns_302_for_valid_superuser(self, valid_user, client):
         valid_user.is_superuser = True
         valid_user.save()
         client.force_login(valid_user)
-        response = client.get(self.url)
+        response = client.post(self.url)
 
         assert response.status_code == 302
         assert response.url == "../"
 
-    def test_upload_returns_error_for_non_superuser(self, client):
+    def test_upload_returns_403_error_for_non_superuser(self, client):
         non_superuser = UserFactory.create(is_superuser=False)
         client.force_login(non_superuser)
-        response = client.get(self.url)
+        response = client.post(self.url)
 
         assert response.status_code == 403
 
@@ -33,7 +35,6 @@ class TestWorkBasketUpload:
             valid_user.is_superuser = True
             valid_user.save()
             client.force_login(valid_user)
-            client.get(self.url)
+            client.post(self.url)
 
             mock_task.assert_called_once_with()
-            

--- a/workbaskets/tests/test_admin.py
+++ b/workbaskets/tests/test_admin.py
@@ -6,39 +6,37 @@ from django.urls import reverse
 pytestmark = pytest.mark.django_db
 
 
-class TestWorkBasketUpload:
-    @classmethod
-    def setup_class(cls):
-        cls.url = reverse("admin:upload")
+def test_upload_returns_302_for_valid_staff_user(self, staff_user, client):
+    client.force_login(staff_user)
+    response = client.post(reverse("admin:upload"))
 
-    def test_upload_returns_302_for_valid_staff_user(self, staff_user, client):
+    assert response.status_code == 302
+    assert response.url == reverse("admin:workbaskets_workbasket_changelist")
+
+
+def test_upload_redirects_non_staff_to_login(self, client, valid_user):
+    client.force_login(valid_user)
+    response = client.post(reverse("admin:upload"))
+
+    assert response.status_code == 302
+    assert response.url == f"{reverse('admin:login')}?next={reverse('admin:upload')}"
+
+
+def test_upload_doesnt_call_task_for_non_staff(self, client, valid_user):
+    client.force_login(valid_user)
+    with mock.patch(
+        "exporter.tasks.upload_workbaskets.delay",
+    ) as mock_task:
+        client.post(reverse("admin:upload"))
+
+        mock_task.assert_not_called()
+
+
+def test_upload_calls_task(self, staff_user, client):
+    with mock.patch(
+        "exporter.tasks.upload_workbaskets.delay",
+    ) as mock_task:
         client.force_login(staff_user)
-        response = client.post(self.url)
+        client.post(reverse("admin:upload"))
 
-        assert response.status_code == 302
-        assert response.url == reverse("admin:workbaskets_workbasket_changelist")
-
-    def test_upload_redirects_non_staff_to_login(self, client, valid_user):
-        client.force_login(valid_user)
-        response = client.post(self.url)
-
-        assert response.status_code == 302
-        assert response.url == f"{reverse('admin:login')}?next={self.url}"
-
-    def test_upload_doesnt_call_task_for_non_staff(self, client, valid_user):
-        client.force_login(valid_user)
-        with mock.patch(
-            "exporter.tasks.upload_workbaskets.delay",
-        ) as mock_task:
-            client.post(self.url)
-
-            mock_task.assert_not_called()
-
-    def test_upload_calls_task(self, staff_user, client):
-        with mock.patch(
-            "exporter.tasks.upload_workbaskets.delay",
-        ) as mock_task:
-            client.force_login(staff_user)
-            client.post(self.url)
-
-            mock_task.assert_called_once()
+        mock_task.assert_called_once()

--- a/workbaskets/tests/test_admin.py
+++ b/workbaskets/tests/test_admin.py
@@ -1,0 +1,39 @@
+import pytest
+from unittest import mock 
+
+from common.tests.factories import UserFactory
+
+pytestmark = pytest.mark.django_db
+
+class TestWorkBasketUpload:
+    @classmethod
+    def setup_class(cls):
+        cls.url = "/admin/workbaskets/workbasket/upload/"
+
+    def test_upload_returns_302_for_valid_user(self, valid_user, client):
+        valid_user.is_superuser = True
+        valid_user.save()
+        client.force_login(valid_user)
+        response = client.get(self.url)
+
+        assert response.status_code == 302
+        assert response.url == "../"
+
+    def test_upload_returns_error_for_non_superuser(self, client):
+        non_superuser = UserFactory.create(is_superuser=False)
+        client.force_login(non_superuser)
+        response = client.get(self.url)
+
+        assert response.status_code == 403
+
+    def test_upload_calls_task(self, valid_user, client):
+        with mock.patch(
+            "exporter.tasks.upload_workbaskets.delay",
+        ) as mock_task:
+            valid_user.is_superuser = True
+            valid_user.save()
+            client.force_login(valid_user)
+            client.get(self.url)
+
+            mock_task.assert_called_once_with()
+            

--- a/workbaskets/tests/test_models.py
+++ b/workbaskets/tests/test_models.py
@@ -1,5 +1,4 @@
 from contextlib import nullcontext as does_not_raise
-from unittest import mock
 
 import pytest
 from django_fsm import TransitionNotAllowed
@@ -547,7 +546,7 @@ def test_workbasket_transactions():
             WorkflowStatus.PUBLISHED,
             "cds_error",
             WorkflowStatus.CDS_ERROR,
-            pytest.raises(TransitionNotAllowed),     
+            pytest.raises(TransitionNotAllowed),
         ),
     ],
 )
@@ -560,7 +559,7 @@ def test_workbasket_submit(
     valid_user,
 ):
     new_workbasket.status = start_status
-    
+
     transition_method = getattr(new_workbasket, transition)
     with expect_error:
         if transition_method.__name__ == "approve":
@@ -568,7 +567,7 @@ def test_workbasket_submit(
         else:
             transition_method()
         assert new_workbasket.status == target_status
-        
+
 
 def test_get_tracked_models(new_workbasket):
     for _ in range(2):
@@ -587,7 +586,6 @@ def test_workbasket_accepted_updates_current_tracked_models(new_workbasket, vali
 
     assert new_footnote.version_group.current_version.pk == original_footnote.pk
 
-    
     new_workbasket.submit_for_approval()
     new_footnote.refresh_from_db()
     assert new_footnote.version_group.current_version.pk == original_footnote.pk

--- a/workbaskets/tests/test_models.py
+++ b/workbaskets/tests/test_models.py
@@ -36,7 +36,7 @@ def test_workbasket_transactions():
 
 
 @pytest.mark.parametrize(
-    "start_status,transition,target_status,expect_error,expect_upload",
+    "start_status,transition,target_status,expect_error",
     [
         # Submission
         (
@@ -44,84 +44,72 @@ def test_workbasket_transactions():
             "submit_for_approval",
             WorkflowStatus.AWAITING_APPROVAL,
             does_not_raise(),
-            False,
         ),
         (
             WorkflowStatus.EDITING,
             "submit_for_approval",
             WorkflowStatus.AWAITING_APPROVAL,
             does_not_raise(),
-            False,
         ),
         (
             WorkflowStatus.APPROVAL_REJECTED,
             "submit_for_approval",
             WorkflowStatus.AWAITING_APPROVAL,
             pytest.raises(TransitionNotAllowed),
-            False,
         ),
         (
             WorkflowStatus.READY_FOR_EXPORT,
             "submit_for_approval",
             WorkflowStatus.AWAITING_APPROVAL,
             pytest.raises(TransitionNotAllowed),
-            False,
         ),
         (
             WorkflowStatus.AWAITING_CDS_UPLOAD_CREATE_NEW,
             "submit_for_approval",
             WorkflowStatus.AWAITING_APPROVAL,
             pytest.raises(TransitionNotAllowed),
-            False,
         ),
         (
             WorkflowStatus.AWAITING_CDS_UPLOAD_EDIT,
             "submit_for_approval",
             WorkflowStatus.AWAITING_APPROVAL,
             pytest.raises(TransitionNotAllowed),
-            False,
         ),
         (
             WorkflowStatus.AWAITING_CDS_UPLOAD_OVERWRITE,
             "submit_for_approval",
             WorkflowStatus.AWAITING_APPROVAL,
             pytest.raises(TransitionNotAllowed),
-            False,
         ),
         (
             WorkflowStatus.AWAITING_CDS_UPLOAD_DELETE,
             "submit_for_approval",
             WorkflowStatus.AWAITING_APPROVAL,
             pytest.raises(TransitionNotAllowed),
-            False,
         ),
         (
             WorkflowStatus.SENT_TO_CDS,
             "submit_for_approval",
             WorkflowStatus.AWAITING_APPROVAL,
             pytest.raises(TransitionNotAllowed),
-            False,
         ),
         (
             WorkflowStatus.SENT_TO_CDS_DELETE,
             "submit_for_approval",
             WorkflowStatus.AWAITING_APPROVAL,
             pytest.raises(TransitionNotAllowed),
-            False,
         ),
         (
             WorkflowStatus.PUBLISHED,
             "submit_for_approval",
             WorkflowStatus.AWAITING_APPROVAL,
             pytest.raises(TransitionNotAllowed),
-            False,
         ),
         (
             WorkflowStatus.CDS_ERROR,
             "submit_for_approval",
             WorkflowStatus.AWAITING_APPROVAL,
             pytest.raises(TransitionNotAllowed),
-            False,
         ),
         # Withdraw
         (
@@ -129,84 +117,72 @@ def test_workbasket_transactions():
             "withdraw",
             WorkflowStatus.EDITING,
             pytest.raises(TransitionNotAllowed),
-            False,
         ),
         (
             WorkflowStatus.AWAITING_APPROVAL,
             "withdraw",
             WorkflowStatus.EDITING,
             does_not_raise(),
-            False,
         ),
         (
             WorkflowStatus.APPROVAL_REJECTED,
             "withdraw",
             WorkflowStatus.EDITING,
             does_not_raise(),
-            False,
         ),
         (
             WorkflowStatus.READY_FOR_EXPORT,
             "withdraw",
             WorkflowStatus.EDITING,
             pytest.raises(TransitionNotAllowed),
-            False,
         ),
         (
             WorkflowStatus.AWAITING_CDS_UPLOAD_CREATE_NEW,
             "withdraw",
             WorkflowStatus.EDITING,
             pytest.raises(TransitionNotAllowed),
-            False,
         ),
         (
             WorkflowStatus.AWAITING_CDS_UPLOAD_EDIT,
             "withdraw",
             WorkflowStatus.EDITING,
             pytest.raises(TransitionNotAllowed),
-            False,
         ),
         (
             WorkflowStatus.AWAITING_CDS_UPLOAD_OVERWRITE,
             "withdraw",
             WorkflowStatus.EDITING,
             pytest.raises(TransitionNotAllowed),
-            False,
         ),
         (
             WorkflowStatus.AWAITING_CDS_UPLOAD_DELETE,
             "withdraw",
             WorkflowStatus.EDITING,
             pytest.raises(TransitionNotAllowed),
-            False,
         ),
         (
             WorkflowStatus.SENT_TO_CDS,
             "withdraw",
             WorkflowStatus.EDITING,
             pytest.raises(TransitionNotAllowed),
-            False,
         ),
         (
             WorkflowStatus.SENT_TO_CDS_DELETE,
             "withdraw",
             WorkflowStatus.EDITING,
             pytest.raises(TransitionNotAllowed),
-            False,
         ),
         (
             WorkflowStatus.PUBLISHED,
             "withdraw",
             WorkflowStatus.EDITING,
             pytest.raises(TransitionNotAllowed),
-            False,
         ),
         (
             WorkflowStatus.CDS_ERROR,
             "withdraw",
             WorkflowStatus.EDITING,
             does_not_raise(),
-            False,
         ),
         # Rejection
         (
@@ -214,84 +190,72 @@ def test_workbasket_transactions():
             "reject",
             WorkflowStatus.APPROVAL_REJECTED,
             pytest.raises(TransitionNotAllowed),
-            False,
         ),
         (
             WorkflowStatus.EDITING,
             "reject",
             WorkflowStatus.APPROVAL_REJECTED,
             pytest.raises(TransitionNotAllowed),
-            False,
         ),
         (
             WorkflowStatus.AWAITING_APPROVAL,
             "reject",
             WorkflowStatus.APPROVAL_REJECTED,
             does_not_raise(),
-            False,
         ),
         (
             WorkflowStatus.READY_FOR_EXPORT,
             "reject",
             WorkflowStatus.APPROVAL_REJECTED,
             pytest.raises(TransitionNotAllowed),
-            False,
         ),
         (
             WorkflowStatus.AWAITING_CDS_UPLOAD_CREATE_NEW,
             "reject",
             WorkflowStatus.APPROVAL_REJECTED,
             pytest.raises(TransitionNotAllowed),
-            False,
         ),
         (
             WorkflowStatus.AWAITING_CDS_UPLOAD_EDIT,
             "reject",
             WorkflowStatus.APPROVAL_REJECTED,
             pytest.raises(TransitionNotAllowed),
-            False,
         ),
         (
             WorkflowStatus.AWAITING_CDS_UPLOAD_OVERWRITE,
             "reject",
             WorkflowStatus.APPROVAL_REJECTED,
             pytest.raises(TransitionNotAllowed),
-            False,
         ),
         (
             WorkflowStatus.AWAITING_CDS_UPLOAD_DELETE,
             "reject",
             WorkflowStatus.APPROVAL_REJECTED,
             pytest.raises(TransitionNotAllowed),
-            False,
         ),
         (
             WorkflowStatus.SENT_TO_CDS,
             "reject",
             WorkflowStatus.APPROVAL_REJECTED,
             pytest.raises(TransitionNotAllowed),
-            False,
         ),
         (
             WorkflowStatus.SENT_TO_CDS_DELETE,
             "reject",
             WorkflowStatus.APPROVAL_REJECTED,
             pytest.raises(TransitionNotAllowed),
-            False,
         ),
         (
             WorkflowStatus.PUBLISHED,
             "reject",
             WorkflowStatus.APPROVAL_REJECTED,
             pytest.raises(TransitionNotAllowed),
-            False,
         ),
         (
             WorkflowStatus.CDS_ERROR,
             "reject",
             WorkflowStatus.APPROVAL_REJECTED,
             pytest.raises(TransitionNotAllowed),
-            False,
         ),
         # Approval
         (
@@ -299,84 +263,72 @@ def test_workbasket_transactions():
             "approve",
             WorkflowStatus.READY_FOR_EXPORT,
             pytest.raises(TransitionNotAllowed),
-            False,
         ),
         (
             WorkflowStatus.EDITING,
             "approve",
             WorkflowStatus.READY_FOR_EXPORT,
             pytest.raises(TransitionNotAllowed),
-            False,
         ),
         (
             WorkflowStatus.AWAITING_APPROVAL,
             "approve",
             WorkflowStatus.READY_FOR_EXPORT,
             does_not_raise(),
-            True,
         ),
         (
             WorkflowStatus.APPROVAL_REJECTED,
             "approve",
             WorkflowStatus.READY_FOR_EXPORT,
             pytest.raises(TransitionNotAllowed),
-            False,
         ),
         (
             WorkflowStatus.AWAITING_CDS_UPLOAD_CREATE_NEW,
             "approve",
             WorkflowStatus.READY_FOR_EXPORT,
             pytest.raises(TransitionNotAllowed),
-            False,
         ),
         (
             WorkflowStatus.AWAITING_CDS_UPLOAD_EDIT,
             "approve",
             WorkflowStatus.READY_FOR_EXPORT,
             pytest.raises(TransitionNotAllowed),
-            False,
         ),
         (
             WorkflowStatus.AWAITING_CDS_UPLOAD_OVERWRITE,
             "approve",
             WorkflowStatus.READY_FOR_EXPORT,
             pytest.raises(TransitionNotAllowed),
-            False,
         ),
         (
             WorkflowStatus.AWAITING_CDS_UPLOAD_DELETE,
             "approve",
             WorkflowStatus.READY_FOR_EXPORT,
             pytest.raises(TransitionNotAllowed),
-            False,
         ),
         (
             WorkflowStatus.SENT_TO_CDS,
             "approve",
             WorkflowStatus.READY_FOR_EXPORT,
             pytest.raises(TransitionNotAllowed),
-            False,
         ),
         (
             WorkflowStatus.SENT_TO_CDS_DELETE,
             "approve",
             WorkflowStatus.READY_FOR_EXPORT,
             pytest.raises(TransitionNotAllowed),
-            False,
         ),
         (
             WorkflowStatus.PUBLISHED,
             "approve",
             WorkflowStatus.READY_FOR_EXPORT,
             pytest.raises(TransitionNotAllowed),
-            False,
         ),
         (
             WorkflowStatus.CDS_ERROR,
             "approve",
             WorkflowStatus.READY_FOR_EXPORT,
             pytest.raises(TransitionNotAllowed),
-            False,
         ),
         # Export
         (
@@ -384,84 +336,72 @@ def test_workbasket_transactions():
             "export_to_cds",
             WorkflowStatus.SENT_TO_CDS,
             pytest.raises(TransitionNotAllowed),
-            False,
         ),
         (
             WorkflowStatus.EDITING,
             "export_to_cds",
             WorkflowStatus.SENT_TO_CDS,
             pytest.raises(TransitionNotAllowed),
-            False,
         ),
         (
             WorkflowStatus.AWAITING_APPROVAL,
             "export_to_cds",
             WorkflowStatus.SENT_TO_CDS,
             pytest.raises(TransitionNotAllowed),
-            False,
         ),
         (
             WorkflowStatus.APPROVAL_REJECTED,
             "export_to_cds",
             WorkflowStatus.SENT_TO_CDS,
             pytest.raises(TransitionNotAllowed),
-            False,
         ),
         (
             WorkflowStatus.READY_FOR_EXPORT,
             "export_to_cds",
             WorkflowStatus.SENT_TO_CDS,
             does_not_raise(),
-            False,
         ),
         (
             WorkflowStatus.AWAITING_CDS_UPLOAD_CREATE_NEW,
             "export_to_cds",
             WorkflowStatus.SENT_TO_CDS,
             pytest.raises(TransitionNotAllowed),
-            False,
         ),
         (
             WorkflowStatus.AWAITING_CDS_UPLOAD_EDIT,
             "export_to_cds",
             WorkflowStatus.SENT_TO_CDS,
             pytest.raises(TransitionNotAllowed),
-            False,
         ),
         (
             WorkflowStatus.AWAITING_CDS_UPLOAD_OVERWRITE,
             "export_to_cds",
             WorkflowStatus.SENT_TO_CDS,
             pytest.raises(TransitionNotAllowed),
-            False,
         ),
         (
             WorkflowStatus.AWAITING_CDS_UPLOAD_DELETE,
             "export_to_cds",
             WorkflowStatus.SENT_TO_CDS,
             pytest.raises(TransitionNotAllowed),
-            False,
         ),
         (
             WorkflowStatus.SENT_TO_CDS_DELETE,
             "export_to_cds",
             WorkflowStatus.SENT_TO_CDS,
             pytest.raises(TransitionNotAllowed),
-            False,
         ),
         (
             WorkflowStatus.PUBLISHED,
             "export_to_cds",
             WorkflowStatus.SENT_TO_CDS,
             pytest.raises(TransitionNotAllowed),
-            False,
         ),
         (
             WorkflowStatus.CDS_ERROR,
             "export_to_cds",
             WorkflowStatus.SENT_TO_CDS,
             pytest.raises(TransitionNotAllowed),
-            False,
         ),
         # Confirmed
         (
@@ -469,84 +409,72 @@ def test_workbasket_transactions():
             "cds_confirmed",
             WorkflowStatus.PUBLISHED,
             pytest.raises(TransitionNotAllowed),
-            False,
         ),
         (
             WorkflowStatus.EDITING,
             "cds_confirmed",
             WorkflowStatus.PUBLISHED,
             pytest.raises(TransitionNotAllowed),
-            False,
         ),
         (
             WorkflowStatus.AWAITING_APPROVAL,
             "cds_confirmed",
             WorkflowStatus.PUBLISHED,
             pytest.raises(TransitionNotAllowed),
-            False,
         ),
         (
             WorkflowStatus.APPROVAL_REJECTED,
             "cds_confirmed",
             WorkflowStatus.PUBLISHED,
             pytest.raises(TransitionNotAllowed),
-            False,
         ),
         (
             WorkflowStatus.READY_FOR_EXPORT,
             "cds_confirmed",
             WorkflowStatus.PUBLISHED,
             pytest.raises(TransitionNotAllowed),
-            False,
         ),
         (
             WorkflowStatus.AWAITING_CDS_UPLOAD_CREATE_NEW,
             "cds_confirmed",
             WorkflowStatus.PUBLISHED,
             pytest.raises(TransitionNotAllowed),
-            False,
         ),
         (
             WorkflowStatus.AWAITING_CDS_UPLOAD_EDIT,
             "cds_confirmed",
             WorkflowStatus.PUBLISHED,
             pytest.raises(TransitionNotAllowed),
-            False,
         ),
         (
             WorkflowStatus.AWAITING_CDS_UPLOAD_OVERWRITE,
             "cds_confirmed",
             WorkflowStatus.PUBLISHED,
             pytest.raises(TransitionNotAllowed),
-            False,
         ),
         (
             WorkflowStatus.AWAITING_CDS_UPLOAD_DELETE,
             "cds_confirmed",
             WorkflowStatus.PUBLISHED,
             pytest.raises(TransitionNotAllowed),
-            False,
         ),
         (
             WorkflowStatus.SENT_TO_CDS,
             "cds_confirmed",
             WorkflowStatus.PUBLISHED,
             does_not_raise(),
-            False,
         ),
         (
             WorkflowStatus.SENT_TO_CDS_DELETE,
             "cds_confirmed",
             WorkflowStatus.PUBLISHED,
             pytest.raises(TransitionNotAllowed),
-            False,
         ),
         (
             WorkflowStatus.CDS_ERROR,
             "cds_confirmed",
             WorkflowStatus.PUBLISHED,
             pytest.raises(TransitionNotAllowed),
-            False,
         ),
         # Errored
         (
@@ -554,84 +482,72 @@ def test_workbasket_transactions():
             "cds_error",
             WorkflowStatus.CDS_ERROR,
             pytest.raises(TransitionNotAllowed),
-            False,
         ),
         (
             WorkflowStatus.EDITING,
             "cds_error",
             WorkflowStatus.CDS_ERROR,
             pytest.raises(TransitionNotAllowed),
-            False,
         ),
         (
             WorkflowStatus.AWAITING_APPROVAL,
             "cds_error",
             WorkflowStatus.CDS_ERROR,
             pytest.raises(TransitionNotAllowed),
-            False,
         ),
         (
             WorkflowStatus.APPROVAL_REJECTED,
             "cds_error",
             WorkflowStatus.CDS_ERROR,
             pytest.raises(TransitionNotAllowed),
-            False,
         ),
         (
             WorkflowStatus.READY_FOR_EXPORT,
             "cds_error",
             WorkflowStatus.CDS_ERROR,
             pytest.raises(TransitionNotAllowed),
-            False,
         ),
         (
             WorkflowStatus.AWAITING_CDS_UPLOAD_CREATE_NEW,
             "cds_error",
             WorkflowStatus.CDS_ERROR,
             pytest.raises(TransitionNotAllowed),
-            False,
         ),
         (
             WorkflowStatus.AWAITING_CDS_UPLOAD_EDIT,
             "cds_error",
             WorkflowStatus.CDS_ERROR,
             pytest.raises(TransitionNotAllowed),
-            False,
         ),
         (
             WorkflowStatus.AWAITING_CDS_UPLOAD_OVERWRITE,
             "cds_error",
             WorkflowStatus.CDS_ERROR,
             pytest.raises(TransitionNotAllowed),
-            False,
         ),
         (
             WorkflowStatus.AWAITING_CDS_UPLOAD_DELETE,
             "cds_error",
             WorkflowStatus.CDS_ERROR,
             pytest.raises(TransitionNotAllowed),
-            False,
         ),
         (
             WorkflowStatus.SENT_TO_CDS,
             "cds_error",
             WorkflowStatus.CDS_ERROR,
             does_not_raise(),
-            False,
         ),
         (
             WorkflowStatus.SENT_TO_CDS_DELETE,
             "cds_error",
             WorkflowStatus.CDS_ERROR,
             pytest.raises(TransitionNotAllowed),
-            False,
         ),
         (
             WorkflowStatus.PUBLISHED,
             "cds_error",
             WorkflowStatus.CDS_ERROR,
-            pytest.raises(TransitionNotAllowed),
-            False,
+            pytest.raises(TransitionNotAllowed),     
         ),
     ],
 )
@@ -641,26 +557,18 @@ def test_workbasket_submit(
     transition,
     target_status,
     expect_error,
-    expect_upload,
     valid_user,
 ):
     new_workbasket.status = start_status
-    with mock.patch(
-        "exporter.tasks.upload_workbaskets.delay",
-    ) as mock_save:
-        transition_method = getattr(new_workbasket, transition)
-        with expect_error:
-            if transition_method.__name__ == "approve":
-                transition_method(valid_user)
-            else:
-                transition_method()
-            assert new_workbasket.status == target_status
-
-            if expect_upload:
-                mock_save.assert_called_once_with()
-            else:
-                mock_save.assert_not_called()
-
+    
+    transition_method = getattr(new_workbasket, transition)
+    with expect_error:
+        if transition_method.__name__ == "approve":
+            transition_method(valid_user)
+        else:
+            transition_method()
+        assert new_workbasket.status == target_status
+        
 
 def test_get_tracked_models(new_workbasket):
     for _ in range(2):
@@ -679,17 +587,13 @@ def test_workbasket_accepted_updates_current_tracked_models(new_workbasket, vali
 
     assert new_footnote.version_group.current_version.pk == original_footnote.pk
 
-    with mock.patch(
-        "exporter.tasks.upload_workbaskets.delay",
-    ) as mock_save:
-        new_workbasket.submit_for_approval()
-        new_footnote.refresh_from_db()
-        assert new_footnote.version_group.current_version.pk == original_footnote.pk
-        new_workbasket.approve(valid_user)
-        new_footnote.refresh_from_db()
-        assert new_footnote.version_group.current_version.pk == new_footnote.pk
-
-        mock_save.assert_called_once_with()
+    
+    new_workbasket.submit_for_approval()
+    new_footnote.refresh_from_db()
+    assert new_footnote.version_group.current_version.pk == original_footnote.pk
+    new_workbasket.approve(valid_user)
+    new_footnote.refresh_from_db()
+    assert new_footnote.version_group.current_version.pk == new_footnote.pk
 
 
 def test_workbasket_errored_updates_tracked_models(new_workbasket, valid_user):
@@ -700,20 +604,15 @@ def test_workbasket_errored_updates_tracked_models(new_workbasket, valid_user):
     )
     assert new_footnote.version_group.current_version.pk == original_footnote.pk
 
-    with mock.patch(
-        "exporter.tasks.upload_workbaskets.delay",
-    ) as mock_save:
-        new_workbasket.submit_for_approval()
-        new_footnote.refresh_from_db()
-        assert new_footnote.version_group.current_version.pk == original_footnote.pk
-        new_workbasket.approve(valid_user)
-        new_footnote.refresh_from_db()
-        assert new_footnote.version_group.current_version.pk == new_footnote.pk
-        new_workbasket.export_to_cds()
-        new_footnote.refresh_from_db()
-        assert new_footnote.version_group.current_version.pk == new_footnote.pk
-        new_workbasket.cds_error()
-        new_footnote.refresh_from_db()
-        assert new_footnote.version_group.current_version.pk == original_footnote.pk
-
-        mock_save.assert_called_once_with()
+    new_workbasket.submit_for_approval()
+    new_footnote.refresh_from_db()
+    assert new_footnote.version_group.current_version.pk == original_footnote.pk
+    new_workbasket.approve(valid_user)
+    new_footnote.refresh_from_db()
+    assert new_footnote.version_group.current_version.pk == new_footnote.pk
+    new_workbasket.export_to_cds()
+    new_footnote.refresh_from_db()
+    assert new_footnote.version_group.current_version.pk == new_footnote.pk
+    new_workbasket.cds_error()
+    new_footnote.refresh_from_db()
+    assert new_footnote.version_group.current_version.pk == original_footnote.pk

--- a/workbaskets/tests/test_views.py
+++ b/workbaskets/tests/test_views.py
@@ -1,5 +1,3 @@
-from unittest import mock
-
 import pytest
 from django.urls import reverse
 
@@ -31,7 +29,6 @@ def test_submit_workbasket(unapproved_transaction, valid_user, client):
     assert workbasket.approver is not None
 
     assert client.session["workbasket"]["status"] == WorkflowStatus.SENT_TO_CDS
-
 
 
 def test_edit_after_submit(workbasket, valid_user, client, date_ranges):

--- a/workbaskets/tests/test_views.py
+++ b/workbaskets/tests/test_views.py
@@ -13,29 +13,25 @@ pytestmark = pytest.mark.django_db
 
 
 def test_submit_workbasket(unapproved_transaction, valid_user, client):
-    with mock.patch(
-        "exporter.tasks.upload_workbaskets",
-    ) as mock_save:
-        workbasket = unapproved_transaction.workbasket
+    workbasket = unapproved_transaction.workbasket
 
-        url = reverse(
-            "workbaskets:workbasket-ui-submit",
-            kwargs={"pk": workbasket.pk},
-        )
+    url = reverse(
+        "workbaskets:workbasket-ui-submit",
+        kwargs={"pk": workbasket.pk},
+    )
 
-        client.force_login(valid_user)
-        response = client.get(url)
+    client.force_login(valid_user)
+    response = client.get(url)
 
-        assert response.status_code == 302
-        assert response.url == reverse("index")
+    assert response.status_code == 302
+    assert response.url == reverse("index")
 
-        workbasket.refresh_from_db()
-        assert workbasket.status == WorkflowStatus.SENT_TO_CDS
-        assert workbasket.approver is not None
+    workbasket.refresh_from_db()
+    assert workbasket.status == WorkflowStatus.SENT_TO_CDS
+    assert workbasket.approver is not None
 
-        assert client.session["workbasket"]["status"] == WorkflowStatus.SENT_TO_CDS
+    assert client.session["workbasket"]["status"] == WorkflowStatus.SENT_TO_CDS
 
-        mock_save.delay.assert_called_once_with()
 
 
 def test_edit_after_submit(workbasket, valid_user, client, date_ranges):
@@ -47,16 +43,13 @@ def test_edit_after_submit(workbasket, valid_user, client, date_ranges):
             update_type=UpdateType.CREATE,
         )
 
-    with mock.patch(
-        "exporter.tasks.upload_workbaskets.delay",
-    ):
-        response = client.get(
-            reverse(
-                "workbaskets:workbasket-ui-submit",
-                kwargs={"pk": workbasket.pk},
-            ),
-        )
-        assert response.status_code == 302
+    response = client.get(
+        reverse(
+            "workbaskets:workbasket-ui-submit",
+            kwargs={"pk": workbasket.pk},
+        ),
+    )
+    assert response.status_code == 302
 
     # edit the footnote
     response = client.post(


### PR DESCRIPTION
- Removing code calling upload_workbaskets task from WorkBasket model approve method
- Updating existing tests
- Adding WorkBasket to admin
- Adding custom button Workbasket list page. This button calls the upload_workbaskets task. (See screenshot below)
- Adding tests for custom button

<img width="1177" alt="Screenshot 2021-09-06 at 14 26 24" src="https://user-images.githubusercontent.com/46938749/132350633-3a8df307-02eb-4fdb-aa26-8876248da5de.png">

