### PR TITLE
Tp 794 install google tag manager in to service

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,7 @@ Download and install a release from here: https://github.com/pyston/pyston/relea
 | SQLITE_S3_SECRET_ACCESS_KEY | AWS secret key, used for SQLite storage bucket uploads                                                                                  |
 | SQLITE_S3_ENDPOINT_URL      | AWS s3 endpoint url, used for SQLite storage bucket uploads                                                                             |
 | SQLITE_STORAGE_DIRECTORY    | Destination directory in s3 bucket for the SQLite storage bucket                                                                        |
+| GOOGLE_ANALYTICS_ID         | The id used to configure Google Tag Manager in production |
 
 
 ## Using the importer

--- a/common/jinja2/layouts/_generic.jinja
+++ b/common/jinja2/layouts/_generic.jinja
@@ -31,7 +31,7 @@
   {% if settings.GOOGLE_ANALYTICS_ID %}
     <!-- Google Tag Manager (noscript) -->
       <noscript>
-        <iframe src="https://www.googletagmanager.com/ns.html?id="{{ settings.GOOGLE_ANALYTICS_ID }}""height="0" width="0" style="display:none;visibility:hidden"></iframe>
+        <iframe src="https://www.googletagmanager.com/ns.html?id={{ settings.GOOGLE_ANALYTICS_ID }}"height="0" width="0" style="display:none;visibility:hidden"></iframe>
       </noscript>
     <!-- End Google Tag Manager (noscript) -->
   {% endif %}

--- a/common/jinja2/layouts/_generic.jinja
+++ b/common/jinja2/layouts/_generic.jinja
@@ -8,7 +8,7 @@
         new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
         j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-        })(window,document,'script','dataLayer', {{settings.GOOGLE_ANALYTICS_ID}});
+        })(window,document,'script','dataLayer', "{{ settings.GOOGLE_ANALYTICS_ID }}");
       </script>
     <!-- End Google Tag Manager -->
   {% endif %}
@@ -31,7 +31,7 @@
   {% if settings.GOOGLE_ANALYTICS_ID %}
     <!-- Google Tag Manager (noscript) -->
       <noscript>
-        <iframe src="https://www.googletagmanager.com/ns.html?id={{settings.GOOGLE_ANALYTICS_ID}}"height="0" width="0" style="display:none;visibility:hidden"></iframe>
+        <iframe src="https://www.googletagmanager.com/ns.html?id="{{ settings.GOOGLE_ANALYTICS_ID }}""height="0" width="0" style="display:none;visibility:hidden"></iframe>
       </noscript>
     <!-- End Google Tag Manager (noscript) -->
   {% endif %}

--- a/common/jinja2/layouts/_generic.jinja
+++ b/common/jinja2/layouts/_generic.jinja
@@ -1,6 +1,18 @@
 {% extends "template.njk" %}
 
 {% block head %}
+  {% if settings.GOOGLE_ANALYTICS_ID %}
+    <!-- Google Tag Manager -->
+      <script>
+        (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+        new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+        j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+        'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+        })(window,document,'script','dataLayer', {{settings.GOOGLE_ANALYTICS_ID}});
+      </script>
+    <!-- End Google Tag Manager -->
+  {% endif %}
+  
   <!--[if !IE 8]><!-->
     {{ render_bundle("main", "css") }}
   <!--<![endif]-->
@@ -14,6 +26,16 @@
 {% set bodyClasses = "" %}
 {% set containerClasses = "" %}
 {% set mainClasses = 'govuk-main-wrapper--auto-spacing' %}
+
+{% block bodyStart %}
+  {% if settings.GOOGLE_ANALYTICS_ID %}
+    <!-- Google Tag Manager (noscript) -->
+      <noscript>
+        <iframe src="https://www.googletagmanager.com/ns.html?id={{settings.GOOGLE_ANALYTICS_ID}}"height="0" width="0" style="display:none;visibility:hidden"></iframe>
+      </noscript>
+    <!-- End Google Tag Manager (noscript) -->
+  {% endif %}
+{% endblock %}
 
 {% block bodyEnd %}
   {{ render_bundle("main", "js") }}

--- a/settings/common.py
+++ b/settings/common.py
@@ -346,6 +346,9 @@ CELERY_BEAT_SCHEDULE = {
     },
 }
 
+# -- Google Tag Manager
+GOOGLE_ANALYTICS_ID = os.environ.get("GOOGLE_ANALYTICS_ID", None)
+
 # -- Logging
 
 LOGGING = {

--- a/settings/common.py
+++ b/settings/common.py
@@ -347,7 +347,7 @@ CELERY_BEAT_SCHEDULE = {
 }
 
 # -- Google Tag Manager
-GOOGLE_ANALYTICS_ID = os.environ.get("GOOGLE_ANALYTICS_ID", None)
+GOOGLE_ANALYTICS_ID = os.environ.get("GOOGLE_ANALYTICS_ID")
 
 # -- Logging
 


### PR DESCRIPTION
## Why

This change is required, in order to support go-live for the service

## What

- In _generic.jinja conditionally add Google Tag Manager script into <head> and noscript into <body> on the basis of whether GOOGLE_ANALYTICS_ID environment variable has been set.
- In settings/common.py add GOOGLE_ANALYTICS_ID environment variable. This should be set in AWS EBS for production only.

## Checklist
- Needs GOOGLE_ANALYTICS_ID to be set as environment variable in AWS EBS prod before deployment.

(Original ticket https://uktrade.atlassian.net/browse/TP-794)
