### PR TITLE
TP-949 - Multiple Workbaskets returned error

### DIFF
--- a/common/views.py
+++ b/common/views.py
@@ -30,9 +30,9 @@ from workbaskets.views.mixins import WithCurrentWorkBasket
 
 
 def index(request):
-    try:
-        workbasket = WorkBasket.objects.is_not_approved().get()
-    except WorkBasket.DoesNotExist:
+    workbasket = WorkBasket.objects.is_not_approved().last()
+
+    if not workbasket:
         workbasket = WorkBasket.objects.create(
             title=f"Workbasket {WorkBasket.objects.last().pk+1}",
             author=request.user,


### PR DESCRIPTION
## Why
- Currently the index page errors if more than one unapproved WorkBasket is found. 
- Instead of throwing an error we should get the most recent unapproved WorkBasket instead.

## What
- Replaces get() with last() when getting unapproved Workbaskets in common/views
- Replaces try / except DoesNotExist block with if statement, since last() will not trigger a DoesNotExist exception
- Adds test for multiple unapproved workbaskets

Original ticket: https://uktrade.atlassian.net/browse/TP-949
