### PR TITLE
Fix for QuerySet.select_related() error in Create Measures

### DIFF
--- a/common/models/records.py
+++ b/common/models/records.py
@@ -240,7 +240,7 @@ class TrackedModelQuerySet(PolymorphicQuerySet, CTEQuerySet):
         Group.
         """
         related_lookups = []
-        for relation in model.relations.keys():
+        for relation in model.models_linked_to.keys():
             if lookups and relation.name not in lookups:
                 continue
             related_lookups.append(f"{prefix}{relation.name}")
@@ -644,7 +644,7 @@ class TrackedModel(PolymorphicModel):
         Returns all the models that are related to this one.
 
         The link can either be stored on this model (so a one-to-one or a many-
-        to-one relationship) or on the related model (so a one-to-many
+        to-one relationship) or on the related model (so a one-to-many (reverse)
         relationship).
         """
         return dict(
@@ -661,7 +661,8 @@ class TrackedModel(PolymorphicModel):
         cls,
     ) -> dict[Union[Field, ForeignObjectRel], type[TrackedModel]]:
         """Returns all the models that are related to this one via a foreign key
-        stored on this model."""
+        stored on this model (one-to-many reverse related models are not
+        included in the returned results)."""
         return dict(
             (f, r)
             for f, r in cls.relations.items()


### PR DESCRIPTION
# TP-947 500 series error in Create Measures

## Why
This is a fix for bug TP-947 which was caused by an attempt to construct a `GeographicalAreaQuerySet` to include the reverse related descriptions objects.

## What
The underlying mechanism within `TrackedModelQuerySet.with_latest_links()` had recently changed
to include reverse relations that could not by applied to `QuerySet.select_related()`. This fix prevents reverse relations
being applied to `QuerySet.select_related()`.

