### PR TITLE
Tp 949 get returned more than one workbasket

### DIFF
--- a/common/tests/test_views.py
+++ b/common/tests/test_views.py
@@ -50,8 +50,8 @@ def test_handles_multiple_unapproved_workbaskets(valid_user_client, new_workbask
     )
     transaction = factories.TransactionFactory.create(workbasket=workbasket)
     with transaction:
-        for _ in range(2):
-            factories.FootnoteTypeFactory.create()
+        factories.FootnoteTypeFactory.create_batch(2)
+
     assert WorkBasket.objects.is_not_approved().count() == 2
 
     response = valid_user_client.get(reverse("index"))

--- a/common/views.py
+++ b/common/views.py
@@ -30,9 +30,9 @@ from workbaskets.views.mixins import WithCurrentWorkBasket
 
 
 def index(request):
-    try:
-        workbasket = WorkBasket.objects.is_not_approved().get()
-    except WorkBasket.DoesNotExist:
+    workbasket = WorkBasket.objects.is_not_approved().last()
+
+    if not workbasket:
         workbasket = WorkBasket.objects.create(
             title=f"Workbasket {WorkBasket.objects.last().pk+1}",
             author=request.user,

--- a/workbaskets/views/decorators.py
+++ b/workbaskets/views/decorators.py
@@ -10,9 +10,8 @@ def require_current_workbasket(view_func):
     @wraps(view_func)
     def check_for_current_workbasket(request, *args, **kwargs):
         if WorkBasket.current(request) is None:
-            try:
-                workbasket = WorkBasket.objects.is_not_approved().get()
-            except WorkBasket.DoesNotExist:
+            workbasket = WorkBasket.objects.is_not_approved().last()
+            if not workbasket:
                 workbasket = WorkBasket.objects.create(
                     author=request.user,
                 )


### PR DESCRIPTION
## Why
Same error as https://github.com/uktrade/tamato/pull/378

## What
Replaces get() with last() when getting unapproved Workbaskets in require_current_workbasket decorator