### PR TITLE
TP-907

### DIFF
--- a/measures/forms.py
+++ b/measures/forms.py
@@ -337,7 +337,7 @@ class AddAnother(forms.BaseFormSet):
     preserved.
     """
 
-    extra = 1
+    extra = 0
     can_order = False
     can_delete = True
     max_num = 1000
@@ -414,13 +414,18 @@ class AddAnother(forms.BaseFormSet):
         to redisplay the formset with an extra empty form or the selected form
         removed."""
 
+        # An empty set of forms is valid.
+        if not self.total_form_count():
+            return True
+
         # reshow the form with an extra empty form if "Add another" was submitted
         if f"{self.prefix}-ADD" in self.data:
             return False
 
         # reshow the form with the deleted form(s) removed if "Delete" was submitted
-        if any(field for field in self.data if field.endswith("-DELETE")):
-            return False
+        for field in self.data:
+            if field.endswith("-DELETE"):
+                return False
 
         return super().is_valid()
 

--- a/measures/jinja2/measures/create-formset.jinja
+++ b/measures/jinja2/measures/create-formset.jinja
@@ -16,7 +16,7 @@
     {{ crispy(formset.empty_form)|replace("__prefix__", formset.forms|length)|safe }}
   {% endif %}
 
-  {% call govukFieldset({"legend": {}}) %}
+  {% call govukFieldset({"legend": {}, "classes": "govuk-!-padding-top-3"}) %}
     {{ govukButton({
       "text": "Add new",
       "classes": "govuk-button--secondary",

--- a/measures/jinja2/measures/create-review.jinja
+++ b/measures/jinja2/measures/create-review.jinja
@@ -5,29 +5,49 @@
 {% set page_title = step_metadata[wizard.steps.current].title %}
 
 {% macro review_step(step) %}
-  <h2 class="govuk-heading-m">{{ step_metadata[step].link_text }}</h2>
+  {% set link_text = step_metadata[step].link_text %}
+  <h2 class="govuk-heading-m">{{ link_text }}</h2>
   {% set rows = [] %}
   {% set data = view.get_cleaned_data_for_step(step) %}
+
   {% set ignore %}
   {{ caller(rows, data) }}
   {% endset %}
+
   {% set row_data = [] %}
-  {% for label, value in rows %}
+  {% if rows %}
+    {% for label, value in rows %}
+      {{ row_data.append({
+        "key": {"text": label},
+        "value": {"text": value},
+        "actions": {
+          "items": [
+            {
+              "text": "Change",
+              "visuallyHiddenText": label|lower,
+              "href": view.get_step_url(step),
+              "attributes": {}
+            }
+          ]
+        }
+      }) or "" }}
+    {% endfor %}
+  {% else %}
     {{ row_data.append({
-      "key": {"text": label},
-      "value": {"text": value},
+      "key": {"text": link_text},
+      "value": {"text": "None"},
       "actions": {
         "items": [
           {
             "text": "Change",
-            "visuallyHiddenText": label|lower,
+            "visuallyHiddenText": link_text,
             "href": view.get_step_url(step),
             "attributes": {}
           }
         ]
       }
     }) or "" }}
-  {% endfor %}
+  {% endif %}
   {{ govukSummaryList({"rows": row_data, "classes": "govuk-!-margin-bottom-9"}) }}
 {% endmacro %}
 
@@ -51,11 +71,14 @@
   {% endcall %}
 
   {% call(rows, data) review_step("conditions") %}
-    {% for item in data  %}
-      {% if not item.DELETE %}
-        {{ rows.append(("Condition code", item.condition_code)) }}
-      {% endif %}
-    {% endfor %}
+    {# Conditions are optional, so cater for empty data. #}
+    {% if data %}
+      {% for item in data  %}
+        {% if not item.DELETE %}
+          {{ rows.append(("Condition code", item.condition_code)) }}
+        {% endif %}
+      {% endfor %}
+    {% endif %}
   {% endcall %}
 
   {% call(rows, data) review_step("duties") %}
@@ -63,11 +86,14 @@
   {% endcall %}
 
   {% call(rows, data) review_step("footnotes") %}
-    {% for item in data %}
-      {% if not item.DELETE %}
-        {{ rows.append(("Footnote", item.footnote ~ " - " ~ item.footnote.get_description().description|safe)) }}
-      {% endif %}
-    {% endfor %}
+    {# Footnotes are optional, so cater for empty data. #}
+    {% if data %}
+      {% for item in data %}
+        {% if not item.DELETE %}
+          {{ rows.append(("Footnote", item.footnote ~ " - " ~ item.footnote.get_description().description|safe)) }}
+        {% endif %}
+      {% endfor %}
+    {% endif %}
   {% endcall %}
 
   {{ govukButton({"text": "Create"}) }}


### PR DESCRIPTION
# TP-907 Optional footnotes and conditions

## Why
It should be possible to create a measure without any conditions or footnotes. The UI does not permit that at the moment and so this PR enables that capability.

## What
Add support in forms to allow empty conditions and footnotes to validate correctly.
Add support in Jinja2 templates to correctly display initial, single form in formsets of conditions and footnotes.
Correctly display empty conditions and footnotes on create measures summary page.
As per new design instructions, add space between the last form in the formset and the “Add new” button to convey to the user that it is not directly associated with the final form.
