### PR TITLE
DRAFT: Tp 888 extend edit measures to allow editing footnotes 

### DIFF
--- a/measures/forms.py
+++ b/measures/forms.py
@@ -78,12 +78,6 @@ class MeasureForm(ValidityPeriodForm):
         required=False,
         empty_label=None,
     )
-    footnote = AutoCompleteField(
-        label="Add a footnote",
-        help_text="Start typing the ID of the footnote or terms used in the description",
-        queryset=Footnote.objects.all(),
-        required=False,
-    )
 
     def __init__(self, *args, **kwargs):
         self.request = kwargs.pop("request", None)

--- a/measures/forms.py
+++ b/measures/forms.py
@@ -78,6 +78,12 @@ class MeasureForm(ValidityPeriodForm):
         required=False,
         empty_label=None,
     )
+    footnote = AutoCompleteField(
+        label="Add a footnote",
+        help_text="Start typing the ID of the footnote or terms used in the description",
+        queryset=Footnote.objects.all(),
+        required=False,
+    )
 
     def __init__(self, *args, **kwargs):
         self.request = kwargs.pop("request", None)

--- a/measures/jinja2/measures/create-footnotes-formset.jinja
+++ b/measures/jinja2/measures/create-footnotes-formset.jinja
@@ -1,0 +1,48 @@
+{% if form.instance.footnotes.all() %}
+        {% set table_rows = [] %}
+        {% for footnote in form.instance.footnotes.all() %}
+            {% set footnote_link -%}
+            <a class="govuk-link govuk-!-font-weight-bold" href="{{ footnote.get_url() }}">{{ footnote|string }}</a>
+            {%- endset %}
+            {% set remove_button -%}
+            <a href="#">Remove</a>
+            {%- endset %}
+            {{ table_rows.append([
+            {"html": footnote_link},
+            {"text": footnote.get_description().description|default("")},
+            {"html": remove_button}
+            ]) or "" }}
+        {% endfor %}
+        {{ govukTable({
+            "head": [
+            {"text": "ID"},
+            {"text": "Description"},
+            {"text": ""}
+            ],
+            "rows": table_rows,
+            "caption": "Footnotes currently assigned to the measure",
+            "captionClasses": "govuk-table__caption--m"
+        }) }}
+    {% else %}
+        <p class="govuk__para">No footnotes found.</p>
+    {% endif %}
+
+{{ crispy(formset.management_form, no_form_tags) }}
+    <label class="govuk-label">Add a footnote</label>
+    <div id="sort-code-hint" class="govuk-hint">Start typing the ID of the footnote or terms used in the description</div>
+    {% for form in formset %}
+        {{ crispy(form) }}
+    {% endfor %}
+
+    {% if formset.data[formset.prefix ~ "-ADD"] %}
+        {{ crispy(formset.empty_form)|replace("__prefix__", formset.forms|length)|safe }}
+    {% endif %}
+
+    {% call govukFieldset({"legend": {}, "classes": "govuk-!-padding-top-3"}) %}
+        {{ govukButton({
+        "text": "Add another footnote",
+        "classes": "govuk-button--secondary",
+        "value": "1",
+        "name": formset.prefix ~ "-ADD",
+        }) }}
+    {% endcall %}

--- a/measures/jinja2/measures/create-formset.jinja
+++ b/measures/jinja2/measures/create-formset.jinja
@@ -16,7 +16,7 @@
     {{ crispy(formset.empty_form)|replace("__prefix__", formset.forms|length)|safe }}
   {% endif %}
 
-  {% call govukFieldset({"legend": {}}) %}
+  {% call govukFieldset({"legend": {}, "classes": "govuk-!-padding-top-3"}) %}
     {{ govukButton({
       "text": "Add new",
       "classes": "govuk-button--secondary",

--- a/measures/jinja2/measures/create-review.jinja
+++ b/measures/jinja2/measures/create-review.jinja
@@ -5,29 +5,49 @@
 {% set page_title = step_metadata[wizard.steps.current].title %}
 
 {% macro review_step(step) %}
-  <h2 class="govuk-heading-m">{{ step_metadata[step].link_text }}</h2>
+  {% set link_text = step_metadata[step].link_text %}
+  <h2 class="govuk-heading-m">{{ link_text }}</h2>
   {% set rows = [] %}
   {% set data = view.get_cleaned_data_for_step(step) %}
+
   {% set ignore %}
   {{ caller(rows, data) }}
   {% endset %}
+
   {% set row_data = [] %}
-  {% for label, value in rows %}
+  {% if rows %}
+    {% for label, value in rows %}
+      {{ row_data.append({
+        "key": {"text": label},
+        "value": {"text": value},
+        "actions": {
+          "items": [
+            {
+              "text": "Change",
+              "visuallyHiddenText": label|lower,
+              "href": view.get_step_url(step),
+              "attributes": {}
+            }
+          ]
+        }
+      }) or "" }}
+    {% endfor %}
+  {% else %}
     {{ row_data.append({
-      "key": {"text": label},
-      "value": {"text": value},
+      "key": {"text": link_text},
+      "value": {"text": "None"},
       "actions": {
         "items": [
           {
             "text": "Change",
-            "visuallyHiddenText": label|lower,
+            "visuallyHiddenText": link_text,
             "href": view.get_step_url(step),
             "attributes": {}
           }
         ]
       }
     }) or "" }}
-  {% endfor %}
+  {% endif %}
   {{ govukSummaryList({"rows": row_data, "classes": "govuk-!-margin-bottom-9"}) }}
 {% endmacro %}
 
@@ -51,11 +71,14 @@
   {% endcall %}
 
   {% call(rows, data) review_step("conditions") %}
-    {% for item in data  %}
-      {% if not item.DELETE %}
-        {{ rows.append(("Condition code", item.condition_code)) }}
-      {% endif %}
-    {% endfor %}
+    {# Conditions are optional, so cater for empty data. #}
+    {% if data %}
+      {% for item in data  %}
+        {% if not item.DELETE %}
+          {{ rows.append(("Condition code", item.condition_code)) }}
+        {% endif %}
+      {% endfor %}
+    {% endif %}
   {% endcall %}
 
   {% call(rows, data) review_step("duties") %}
@@ -63,11 +86,14 @@
   {% endcall %}
 
   {% call(rows, data) review_step("footnotes") %}
-    {% for item in data %}
-      {% if not item.DELETE %}
-        {{ rows.append(("Footnote", item.footnote ~ " - " ~ item.footnote.get_description().description|safe)) }}
-      {% endif %}
-    {% endfor %}
+    {# Footnotes are optional, so cater for empty data. #}
+    {% if data %}
+      {% for item in data %}
+        {% if not item.DELETE %}
+          {{ rows.append(("Footnote", item.footnote ~ " - " ~ item.footnote.get_description().description|safe)) }}
+        {% endif %}
+      {% endfor %}
+    {% endif %}
   {% endcall %}
 
   {{ govukButton({"text": "Create"}) }}

--- a/measures/jinja2/measures/edit.jinja
+++ b/measures/jinja2/measures/edit.jinja
@@ -6,6 +6,7 @@
 {% from "components/button/macro.njk" import govukButton %}
 {% from "components/input/macro.njk" import govukInput %}
 {% from "components/table/macro.njk" import govukTable %}
+{% from "components/fieldset/macro.njk" import govukFieldset %}
 
 
 {% set page_title = "Edit " ~ object._meta.verbose_name ~ " details" %}
@@ -28,6 +29,12 @@
       "summaryText": "Help with measure validity period",
       "text": "Enter the start date for the measure’s validity period. The end date will inherit from the measure generating regulation or an earlier end date can be specified."
       }) }}
+{% endset %}
+
+{% set footnotes_html %}
+    
+    {% include "measures/create-footnotes-formset.jinja" %}
+
 {% endset %}
 
 {% set geographical_area_html %}
@@ -69,44 +76,6 @@
     }) }}
 {% endset %}
 
-{% set footnotes_html %}
-    {% if form.instance.footnotes.all() %}
-        {% set table_rows = [] %}
-        {% for footnote in form.instance.footnotes.all() %}
-            {% set footnote_link -%}
-            <a class="govuk-link govuk-!-font-weight-bold" href="{{ footnote.get_url() }}">{{ footnote|string }}</a>
-            {%- endset %}
-            {% set remove_button -%}
-            <a href="#">Remove</a>
-            {%- endset %}
-            {{ table_rows.append([
-            {"html": footnote_link},
-            {"text": footnote.get_description().description|default("")},
-            {"html": remove_button}
-            ]) or "" }}
-        {% endfor %}
-        {{ govukTable({
-            "head": [
-            {"text": "ID"},
-            {"text": "Description"},
-            {"text": ""}
-            ],
-            "rows": table_rows,
-            "caption": "Footnotes currently assigned to the measure",
-            "captionClasses": "govuk-table__caption--m"
-        }) }}
-    {% else %}
-        <p class="govuk__para">No footnotes found.</p>
-    {% endif %}
-    <div class="govuk-form-group">
-        <label class="govuk-label">{{ form.footnote.label }}</label>
-        <div id="sort-code-hint" class="govuk-hint">{{ form.footnote.help_text }}</div>
-        {{ form.footnote }}
-    </div>
-    <div class="govuk-form-group">
-        <a href="#" class="govuk-button govuk-button--secondary">Add another footnote</a>
-    </div>
-{% endset %}
 
 {% block form %}
   {% call django_form(action=object.get_url("edit")) %}

--- a/measures/jinja2/measures/edit.jinja
+++ b/measures/jinja2/measures/edit.jinja
@@ -5,6 +5,7 @@
 {% from "components/radios/macro.njk" import govukRadios %}
 {% from "components/button/macro.njk" import govukButton %}
 {% from "components/input/macro.njk" import govukInput %}
+{% from "components/table/macro.njk" import govukTable %}
 
 
 {% set page_title = "Edit " ~ object._meta.verbose_name ~ " details" %}
@@ -68,6 +69,45 @@
     }) }}
 {% endset %}
 
+{% set footnotes_html %}
+    {% if form.instance.footnotes.all() %}
+        {% set table_rows = [] %}
+        {% for footnote in form.instance.footnotes.all() %}
+            {% set footnote_link -%}
+            <a class="govuk-link govuk-!-font-weight-bold" href="{{ footnote.get_url() }}">{{ footnote|string }}</a>
+            {%- endset %}
+            {% set remove_button -%}
+            <a href="#">Remove</a>
+            {%- endset %}
+            {{ table_rows.append([
+            {"html": footnote_link},
+            {"text": footnote.get_description().description|default("")},
+            {"html": remove_button}
+            ]) or "" }}
+        {% endfor %}
+        {{ govukTable({
+            "head": [
+            {"text": "ID"},
+            {"text": "Description"},
+            {"text": ""}
+            ],
+            "rows": table_rows,
+            "caption": "Footnotes currently assigned to the measure",
+            "captionClasses": "govuk-table__caption--m"
+        }) }}
+    {% else %}
+        <p class="govuk__para">No footnotes found.</p>
+    {% endif %}
+    <div class="govuk-form-group">
+        <label class="govuk-label">{{ form.footnote.label }}</label>
+        <div id="sort-code-hint" class="govuk-hint">{{ form.footnote.help_text }}</div>
+        {{ form.footnote }}
+    </div>
+    <div class="govuk-form-group">
+        <a href="#" class="govuk-button govuk-button--secondary">Add another footnote</a>
+    </div>
+{% endset %}
+
 {% block form %}
   {% call django_form(action=object.get_url("edit")) %}
     <div class="govuk-grid-row">
@@ -107,6 +147,13 @@
                         "heading": {"text": "Geographical area"},
                         "content": {
                             "html": geographical_area_html
+                        },
+                        "summary": {}
+                    },
+                    {
+                        "heading": {"text": "Footnotes"},
+                        "content": {
+                            "html": footnotes_html
                         },
                         "summary": {}
                     },

--- a/measures/views.py
+++ b/measures/views.py
@@ -274,6 +274,14 @@ class MeasureUpdate(
 
         return form
 
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["formset"] = forms.MeasureFootnotesFormSet()
+        context["no_form_tags"] = FormHelper()
+        context["no_form_tags"].form_tag = False
+
+        return context
+
 
 class MeasureConfirmUpdate(MeasureMixin, TrackedModelDetailView):
     template_name = "common/confirm_update.jinja"

--- a/measures/views.py
+++ b/measures/views.py
@@ -67,6 +67,8 @@ class MeasureDetail(MeasureMixin, TrackedModelDetailView):
 class MeasureCreateWizard(
     NamedUrlSessionWizardView,
 ):
+    storage_name = "measures.wizard.MeasureCreateSessionStorage"
+
     STEPS = [
         (
             "start",

--- a/measures/wizard.py
+++ b/measures/wizard.py
@@ -1,0 +1,14 @@
+from formtools.wizard.storage.session import SessionStorage
+
+
+class MeasureCreateSessionStorage(SessionStorage):
+    """Session storage subclass used by the wizard view used to save only "real"
+    data, which shouldn't include the ADD and DELETE elements that are used to
+    manage form state."""
+
+    def set_step_data(self, step, cleaned_data):
+        for key in list(cleaned_data):
+            # Don't save ADD and DELETE fields in the session.
+            if key.endswith(f"-ADD") or key.endswith(f"-DELETE"):
+                cleaned_data.pop(key)
+        super().set_step_data(step, cleaned_data)


### PR DESCRIPTION
## Why
- Upcoming TOPS tickets require the ability to add or remove footnotes on an existing measure.
- Creating a draft because I'm currently blocked and would appreciate any advice on how to get the "Add another footnote" logic working on the edit form. Currently pressing "Add another footnote" button posts the edit form data when we need it to work like the footnotes section when creating a new measure.

## What
- A draft of current approach: passing existing MeasureFootnotesFormSet into MeasureUpdate view and borrowing from create-formset.jinja to display this as part of the edit accordion
- Also includes some changes merged in from Paul's branch here https://github.com/uktrade/tamato/pull/383

<img width="823" alt="Screenshot 2021-09-29 at 14 05 08" src="https://user-images.githubusercontent.com/46938749/135274068-7d3a07a0-d605-4825-8ea5-4debd86c88d6.png">