### PR TITLE
TP-859: Switch to using an in-memory SQLite export

### DIFF
--- a/exporter/sqlite/__init__.py
+++ b/exporter/sqlite/__init__.py
@@ -25,7 +25,6 @@ date fields, and any other Postgres-specific features are ignored.
 """
 
 from itertools import chain
-from pathlib import Path
 
 from django.apps import apps
 from django.conf import settings
@@ -48,9 +47,8 @@ def make_export_plan(sqlite: runner.Runner) -> plan.Plan:
     return import_script
 
 
-def make_export(path: Path):
-    sqlite = runner.Runner(path)
-    sqlite.make_empty_database()
-
+def make_export() -> bytes:
+    sqlite = runner.Runner.from_empty_database()
     plan = make_export_plan(sqlite)
     sqlite.run_operations(plan.operations)
+    return sqlite.get_bytes()

--- a/exporter/sqlite/plan.py
+++ b/exporter/sqlite/plan.py
@@ -11,7 +11,10 @@ from django.db.models.expressions import Case
 from django.db.models.expressions import Expression
 from django.db.models.expressions import F
 from django.db.models.expressions import When
+from django.db.models.fields import CharField
 from django.db.models.fields import DateField
+from django.db.models.fields import IntegerField
+from django.db.models.fields import TextField
 from django.db.models.functions import Cast
 from django.db.models.functions import Lower
 from django.db.models.functions import Upper
@@ -30,22 +33,29 @@ def column_to_expr(column: str, model: Type[Model]) -> Union[Expression, F]:
     try:
         # Use the column directly if it exists on the model
         field = model._meta.get_field(column)
+        if not issubclass(type(field), (CharField, TextField, IntegerField)):
+            return Cast(field.name, CharField())
         return F(field.name)
     except FieldDoesNotExist:
         field = ValidityMixin.valid_between.field
         if column == "validity_start":
-            return Lower(field.name, output_field=DateField())
+            return Cast(Lower(field.name), output_field=CharField())
         elif column == "validity_end":
             # Our date ranges are inclusive but Postgres stores them as
             # exclusive on the upper bound. Hence we need to subtract a day from
             # the date if we want to get inclusive value.
             return Cast(
-                Upper(field.name, output_field=DateField())
-                - Case(
-                    When(**{f"{field.name}__upper_inc": True}, then=timedelta(days=0)),
-                    default=timedelta(days=1),
+                Cast(
+                    Upper(field.name, output_field=DateField())
+                    - Case(
+                        When(
+                            **{f"{field.name}__upper_inc": True}, then=timedelta(days=0)
+                        ),
+                        default=timedelta(days=1),
+                    ),
+                    output_field=DateField(),
                 ),
-                output_field=DateField(),
+                output_field=CharField(),
             )
         else:
             raise

--- a/exporter/sqlite/tasks.py
+++ b/exporter/sqlite/tasks.py
@@ -1,6 +1,6 @@
 import logging
+from io import BytesIO
 from pathlib import Path
-from tempfile import TemporaryDirectory
 
 from django.conf import settings
 
@@ -35,14 +35,11 @@ def export_and_upload_sqlite() -> bool:
         logger.debug("Database %s already present", export_filename)
         return False
 
-    with TemporaryDirectory(prefix="sqlite") as db_dir:
-        database_path = Path(db_dir) / db_name
-        logger.info("Generating database %s", database_path)
-        sqlite.make_export(database_path)
+    logger.info("Generating database")
+    database = BytesIO(sqlite.make_export())
 
-        logger.info("Uploading database %s", export_filename)
-        with open(database_path, "rb") as database_file:
-            storage.save(export_filename, database_file)
+    logger.info("Uploading database %s", export_filename)
+    storage.save(export_filename, database)
 
-        logger.info("Upload complete")
-        return True
+    logger.info("Upload complete")
+    return True

--- a/manifest.yml
+++ b/manifest.yml
@@ -7,5 +7,4 @@ applications:
     - type: web
       memory: 1G
     - type: worker
-      disk_quota: 8G
-      memory: 1G
+      memory: 8G

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 allure-pytest-bdd==2.8.33
 api-client==1.3.0
+apsw-wheels==3.36.0.post1
 black>=20.8b1
 boto3==1.17.10
 celery[redis]==5.0.5


### PR DESCRIPTION
## Why
We've found it too difficult to provision enough temporary disk space on PaaS to create ~3Gb database. 

## What
This commit changes the export to use an in-memory database instad. We've changed wrappers to use apsw instead of the native library so that we can subsequently deserialize the database into bytes and stream it directly to S3.


<!---
 * Include the JIRA ticket number, eg TP-123, to automatically link.
 * Use 50 characters maximum.
 * Do not end with a full-stop.
--->

<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Use as many lines as you like.
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions or deliberately ignored edge-cases.
--->


<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Explain like I'm 5.
 * Use pictures if you can.
--->


## Checklist
- Requires migrations? No.
- Requires dependency updates? Yes.


<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
