### PR TITLE
Forced upgrade to django-staff-sso-client 3.1.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ django-polymorphic==3.0.0
 django-redis==4.12.1
 django-rest-polymorphic==0.1.9
 django-sequences==2.6
-django-staff-sso-client==3.1.0
+django-staff-sso-client==3.1.1
 django-storages==1.11.1
 django-treebeard==4.5.1
 django-webpack-loader==1.0.0


### PR DESCRIPTION
This is because the way that a new version of pip resolves packages is more strict and doesn't allow wheel only packages anymore. The client team have issued a fix which requires a point version upgrade.

See also: https://ditdigitalteam.slack.com/archives/C1Q2EKZK3/p1633009272197500
<!---
 * Include the JIRA ticket number, eg TP-123, to automatically link.
 * Use 50 characters maximum.
 * Do not end with a full-stop.
--->




## Checklist
- Requires migrations? No
- Requires dependency updates? Yes


<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
