### PR TITLE
TP-703 (edit) Remove MeasureAutoCompleteFilter

### DIFF
--- a/measures/filters.py
+++ b/measures/filters.py
@@ -36,14 +36,6 @@ class GovUKDateFilter(DateFilter):
     field_class = DateInputFieldFixed
 
 
-class MeasureAutoCompleteFilter(AutoCompleteFilter):
-    def __init__(self, *args, **kwargs):
-        attrs = {
-            "display_class": GOV_UK_TWO_THIRDS,
-        }
-        super().__init__(attrs=attrs, *args, **kwargs)
-
-
 class MeasureTypeFilterBackend(TamatoFilterBackend):
     search_fields = (
         StringAgg("sid", delimiter=" "),
@@ -64,46 +56,67 @@ class MeasureFilter(TamatoFilter):
 
     sid = CharFilter(label="ID", widget=forms.TextInput())
 
-    measure_type = MeasureAutoCompleteFilter(
+    measure_type = AutoCompleteFilter(
         label="Type",
         field_name="measure_type__sid",
         queryset=MeasureType.objects.all(),
+        attrs={
+            "display_class": GOV_UK_TWO_THIRDS,
+        },
     )
 
-    goods_nomenclature = MeasureAutoCompleteFilter(
+    goods_nomenclature = AutoCompleteFilter(
         label="Commodity code",
         field_name="goods_nomenclature__item_id",
         queryset=GoodsNomenclature.objects.all(),
+        attrs={
+            "display_class": GOV_UK_TWO_THIRDS,
+        },
     )
 
-    additional_code = MeasureAutoCompleteFilter(
+    additional_code = AutoCompleteFilter(
         label="Additional code",
         field_name="additional_code",
         queryset=AdditionalCode.objects.all(),
+        attrs={
+            "display_class": GOV_UK_TWO_THIRDS,
+        },
     )
 
-    geographical_area = MeasureAutoCompleteFilter(
+    geographical_area = AutoCompleteFilter(
         label="Geographical area",
         field_name="geographical_area",
         queryset=GeographicalArea.objects.all(),
+        attrs={
+            "display_class": GOV_UK_TWO_THIRDS,
+        },
     )
 
-    order_number = MeasureAutoCompleteFilter(
+    order_number = AutoCompleteFilter(
         label="Quota order number",
         field_name="order_number__order_number",
         queryset=QuotaOrderNumber.objects.all(),
+        attrs={
+            "display_class": GOV_UK_TWO_THIRDS,
+        },
     )
 
-    regulation = MeasureAutoCompleteFilter(
+    regulation = AutoCompleteFilter(
         label="Regulation",
         field_name="generating_regulation__regulation_id",
         queryset=Regulation.objects.all(),
+        attrs={
+            "display_class": GOV_UK_TWO_THIRDS,
+        },
     )
 
-    footnote = MeasureAutoCompleteFilter(
+    footnote = AutoCompleteFilter(
         label="Footnote",
         field_name="footnotes",
         queryset=Footnote.objects.all(),
+        attrs={
+            "display_class": GOV_UK_TWO_THIRDS,
+        },
     )
 
     start_date = GovUKDateFilter(


### PR DESCRIPTION
# TP-703 (edit) Remove MeasureAutoCompleteFilter

## Why
Updates #405 by removing the `MeasureAutoCompleteFilter` class, because, as @andyhd pointed out, it doesn't make sense to have styling information added to a filter class.

## What
Removes a new `MeasureAutoCompleteFilter` class, replacing it with the standard `AutoCompleteFilter`