### PR TITLE
TP-1039: Get rid of the getattr override in TrackedModel

### DIFF
--- a/common/models/records.py
+++ b/common/models/records.py
@@ -678,30 +678,6 @@ class TrackedModel(PolymorphicModel):
             if (f.many_to_one or f.one_to_one) and not f.auto_created and f.concrete
         )
 
-    def __getattr__(self, item: str):
-        """
-        Add the ability to get the current instance of a related object through
-        an attribute. For example if a model is like so:
-
-        .. code:: python
-            class ExampleModel(TrackedModel):
-                # must be a TrackedModel
-                other_model = models.ForeignKey(OtherModel, on_delete=models.PROTECT)
-
-        The latest version of the relation can be accessed via:
-
-        .. code:: python
-            example_model = ExampleModel.objects.first()
-            example_model.other_model_current  # Gets the latest version
-        """
-
-        if item.endswith("_current"):
-            field_name = item[:-8]
-            if field_name in [field.name for field in self.relations.keys()]:
-                return getattr(self, field_name).current_version
-
-        return self.__getattribute__(item)
-
     _meta: Options
 
     @classproperty

--- a/common/tests/test_models.py
+++ b/common/tests/test_models.py
@@ -240,7 +240,7 @@ def test_get_latest_relation_with_latest_links(
     with django_assert_num_queries(1):
         instance = TestModel3.objects.all().with_latest_links()[0]
         fetched_oldest_link = instance.linked_model
-        fetched_latest_link = instance.linked_model_current
+        fetched_latest_link = instance.linked_model.current_version
 
     assert oldest_link.pk == fetched_oldest_link.pk
     assert latest_link.pk == fetched_latest_link.pk
@@ -269,7 +269,7 @@ def test_get_latest_relation_without_latest_links(
     with django_assert_num_queries(4):
         instance = TestModel3.objects.all().select_related("linked_model")[0]
         fetched_oldest_link = instance.linked_model
-        fetched_latest_link = instance.linked_model_current
+        fetched_latest_link = instance.linked_model.current_version
 
     assert oldest_link == fetched_oldest_link
     assert latest_link == fetched_latest_link

--- a/geo_areas/business_rules.py
+++ b/geo_areas/business_rules.py
@@ -255,7 +255,7 @@ class GA20(BusinessRule):
         if not membership.geo_group.parent:
             return
 
-        parent = membership.geo_group.parent_current
+        parent = membership.geo_group.parent.current_version
 
         if (
             parent.members.filter(


### PR DESCRIPTION
# TP-1039: Get rid of the getattr override in TrackedModel

## Why
We need to purge  the `_getattr_` override in `TrackedModel`. Reasons:
Its sole purpose is to pr

- ovide syntax sugar of sorts, when people can just ask for .current_version when they need to without this overkill override of getattr (that's ALL the override does! - gives you .current_version when you ask for field_current)
- It actually doesn't work well as model.relations would return RelatedManager and ManyRelatedManager in many cases so getattr(self, field_name).current_version would fail there
- It actually could cause recursion issues if a model has a lookup field to itself (as can happen ), because... it calls getattr!  )
- It's only used in one business rule and a couple of tests, so i've swapped out these to call .current_version
- It causes pains when debugging - hasattr calls getattr and returns false upon AttributeError - this is typically ok as debuggers know to ignore that, but when you override getattr and call getattribute directly in your code, either the debugger will stop at each exception when hasattr is False or you have to turn off exceptions, but that's not what you want as a tradeoff

## What
Remove  the getattr override from TrackedModel and fix the few places throughout the codebase where it was previously used.
