### PR TITLE
TP-1041: Enable selective workbasket xml export

### DIFF
--- a/exporter/management/commands/dump_transactions.py
+++ b/exporter/management/commands/dump_transactions.py
@@ -50,7 +50,8 @@ class Command(BaseCommand):
                 "Override the default selection of APPROVED workbaskets "
                 "with a comma-separated list of workbasket ids."
             ),
-            type="str",
+            nargs="*",
+            type=int,
             default=None,
             action="store",
         )
@@ -59,7 +60,6 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         workbasket_ids = options.get("workbasket_ids")
         if workbasket_ids:
-            workbasket_ids = tuple(map(int, workbasket_ids.split(",")))
             query = dict(id__in=workbasket_ids)
         else:
             query = dict(status=WorkflowStatus.APPROVED)

--- a/exporter/management/commands/dump_transactions.py
+++ b/exporter/management/commands/dump_transactions.py
@@ -44,9 +44,27 @@ class Command(BaseCommand):
             help="Directory to output to, defaults to the current directory.",
         )
 
+        parser.add_argument(
+            "workbasket_ids",
+            help=(
+                "Override the default selection of APPROVED workbaskets "
+                "with a comma-separated list of workbasket ids."
+            ),
+            type="str",
+            default=None,
+            action="store",
+        )
+
     @atomic
     def handle(self, *args, **options):
-        workbaskets = WorkBasket.objects.filter(status=WorkflowStatus.APPROVED)
+        workbasket_ids = options.get("workbasket_ids")
+        if workbasket_ids:
+            workbasket_ids = tuple(map(int, workbasket_ids.split(",")))
+            query = dict(id__in=workbasket_ids)
+        else:
+            query = dict(status=WorkflowStatus.APPROVED)
+
+        workbaskets = WorkBasket.objects.filter(**query)
         if not workbaskets:
             sys.exit("Nothing to upload:  No workbaskets with status APPROVED.")
 


### PR DESCRIPTION
# TP-1041: Selective workbasket xml export

## Why
At the moment, the management command in `dump_transactions.py` automatically picks up workbaskets with an APPROVED status.
In the context of HS22, where we may want to lump several workbaskets with EU commodity change imports and MTPO create measures imports, we need to also allow users to select the specific workbaskets they want to package for publishing

## What
- Tweak `Command()` in  the `dump_transactions` management script to accept a list of comma-separated workbasket id-s as an additional optional argument
- Tweak the django db query to fetch the custom workbaskets if the optional argument is provided, and APPROVED workbaskets (existing default behaviour) if not
