### PR TITLE
Allow any object with validity dates to be terminated.

### DIFF
--- a/common/tests/test_models.py
+++ b/common/tests/test_models.py
@@ -301,7 +301,38 @@ def test_save(sample_model):
     sample_model.save(force_write=True)
 
 
-def test_new_draft_uses_passed_transaction(sample_model):
+@pytest.mark.parametrize(
+    ("initial_dates"),
+    ("normal", "no_end"),
+    ids=("has_end_date", "has_no_end_date"),
+)
+@pytest.mark.parametrize(
+    ("termination_range"),
+    ("earlier", "overlap_normal", "later"),
+    ids=("before_start", "during_validity", "after_existing_end"),
+)
+def test_terminate(
+    validity_factory,
+    date_ranges,
+    workbasket,
+    termination_range,
+    initial_dates,
+):
+    if validity_factory is factories.GoodsNomenclatureIndentNodeFactory:
+        pytest.xfail("Does not implement terminate")
+
+    model = validity_factory.create(valid_between=getattr(date_ranges, initial_dates))
+    termination_date = getattr(date_ranges, termination_range).upper
+    terminated_model = model.terminate(workbasket, termination_date)
+
+    if terminated_model.update_type == UpdateType.DELETE:
+        assert terminated_model.valid_between.lower >= termination_date
+    else:
+        assert terminated_model.valid_between.upper_inf is False
+        assert terminated_model.valid_between.upper <= termination_date
+
+
+def test_new_version_uses_passed_transaction(sample_model):
     transaction_count = Transaction.objects.count()
     new_transaction = sample_model.transaction.workbasket.new_transaction()
     new_model = sample_model.new_version(

--- a/conftest.py
+++ b/conftest.py
@@ -250,6 +250,17 @@ def trackedmodel_factory(request):
 
 
 @pytest.fixture(
+    params=factories.ValidityFactoryMixin.__subclasses__(),
+    ids=[
+        factory._meta.model.__name__
+        for factory in factories.ValidityFactoryMixin.__subclasses__()
+    ],
+)
+def validity_factory(request):
+    return request.param
+
+
+@pytest.fixture(
     params=(
         factories.AdditionalCodeDescriptionFactory,
         factories.CertificateDescriptionFactory,

--- a/measures/models.py
+++ b/measures/models.py
@@ -661,27 +661,11 @@ class Measure(TrackedModel, ValidityMixin):
         deleted instead. If the measure will already have ended by this date,
         then does nothing.
         """
-        starts_after_date = self.valid_between.lower >= when
-        ends_before_date = (
-            not self.valid_between.upper_inf and self.valid_between.upper < when
-        )
-
-        if ends_before_date:
-            return self
-
         update_params = {}
-        if starts_after_date:
-            update_params["update_type"] = UpdateType.DELETE
-        else:
-            update_params["update_type"] = UpdateType.UPDATE
-            update_params["valid_between"] = TaricDateRange(
-                lower=self.valid_between.lower,
-                upper=when,
-            )
-            if not self.terminating_regulation:
-                update_params["terminating_regulation"] = self.generating_regulation
+        if not self.terminating_regulation:
+            update_params["terminating_regulation"] = self.generating_regulation
 
-        return self.new_version(workbasket, **update_params)
+        return super().terminate(workbasket, when, **update_params)
 
     def save(self, *args, force_write=False, **kwargs):
         """If the commodity code is being changed on an existing measure, the

--- a/regulations/models.py
+++ b/regulations/models.py
@@ -56,7 +56,7 @@ class Group(TrackedModel, ValidityMixin):
         return f"{self.group_id}: {self.description}"
 
 
-class Regulation(TrackedModel):
+class Regulation(TrackedModel, ValidityMixin):
     """
     The main legal acts at the basis of the Union tariff and commercial
     legislation are regulations and decisions.


### PR DESCRIPTION
## Why
<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Use as many lines as you like.
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions or deliberately ignored edge-cases.
--->
At the moment we have a "terminate" method that just works for measures. Actually, termination is something that you can do on anything that is a `TrackedModel` and has a `valid_between` field. So this PR makes this a more general operation that we can use everywhere.

## What
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Explain like I'm 5.
 * Use pictures if you can.
--->
Factors out terminate method, and makes sure that you can call it on every appropriate model (note that it doens't apply to `GoodsNomenclatureIndentNode` because it's not a `TrackedModel`).

## Checklist
- Requires migrations? No.
- Requires dependency updates? No.


<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
