### PR TITLE
TP-1045 Allow passing partition schema by name to avoid serialisation over ce…

### DIFF
--- a/importer/forms.py
+++ b/importer/forms.py
@@ -5,11 +5,11 @@ from django import forms
 from django.contrib.auth.models import User
 from django.db import transaction
 
+import settings
 from importer import models
 from importer.chunker import chunk_taric
 from importer.management.commands.run_import_batch import run_batch
 from importer.namespaces import TARIC_RECORD_GROUPS
-from workbaskets.models import get_partition_scheme
 from workbaskets.validators import WorkflowStatus
 
 
@@ -44,7 +44,7 @@ class UploadTaricForm(forms.ModelForm):
         run_batch(
             batch=batch.name,
             status=self.data["status"],
-            partition_scheme=get_partition_scheme(),
+            partition_scheme_setting=settings.TRANSACTION_SCHEMA,
             username=user.username,
         )
 

--- a/importer/management/commands/import_taric.py
+++ b/importer/management/commands/import_taric.py
@@ -1,11 +1,9 @@
 from django.core.management import BaseCommand
 
-from common.models.transactions import TransactionPartition
 from importer.management.commands.chunk_taric import chunk_taric
 from importer.management.commands.chunk_taric import setup_batch
 from importer.management.commands.run_import_batch import run_batch
 from workbaskets.models import TRANSACTION_PARTITION_SCHEMES
-from workbaskets.models import TransactionPartitionScheme
 from workbaskets.validators import WorkflowStatus
 
 
@@ -13,7 +11,7 @@ def import_taric(
     taric3_file: str,
     username: str,
     status: str,
-    partition_scheme: TransactionPartitionScheme,
+    partition_scheme_setting: str,
     name: str,
     split_codes: bool = False,
     dependencies=None,
@@ -26,7 +24,7 @@ def import_taric(
     with open(taric3_file, "rb") as seed_file:
         batch = chunk_taric(seed_file, batch)
 
-    run_batch(batch.name, status, partition_scheme, username)
+    run_batch(batch.name, status, partition_scheme_setting, username)
 
 
 class Command(BaseCommand):
@@ -86,7 +84,7 @@ class Command(BaseCommand):
             taric3_file=options["taric3_file"],
             username=options["username"],
             status=options["status"],
-            partition_scheme=TransactionPartition[options["partition_scheme"]],
+            partition_scheme_setting=options["partition_scheme"],
             name=options["name"],
             split_codes=options["split_codes"],
             dependencies=options["dependencies"],

--- a/importer/management/commands/run_import_batch.py
+++ b/importer/management/commands/run_import_batch.py
@@ -1,22 +1,25 @@
 from django.core.management import BaseCommand
 
-from common.models.transactions import TransactionPartition
 from importer import models
 from importer.tasks import find_and_run_next_batch_chunks
 from workbaskets.models import TRANSACTION_PARTITION_SCHEMES
-from workbaskets.models import TransactionPartitionScheme
 from workbaskets.validators import WorkflowStatus
 
 
 def run_batch(
     batch: str,
     status: str,
-    partition_scheme: TransactionPartitionScheme,
+    partition_scheme_setting: str,
     username: str,
 ):
     import_batch = models.ImportBatch.objects.get(name=batch)
 
-    find_and_run_next_batch_chunks(import_batch, status, partition_scheme, username)
+    find_and_run_next_batch_chunks(
+        import_batch,
+        status,
+        partition_scheme_setting,
+        username,
+    )
 
 
 class Command(BaseCommand):
@@ -58,6 +61,6 @@ class Command(BaseCommand):
         run_batch(
             batch=options["batch"],
             status=options["status"],
-            partition_scheme=TransactionPartition[options["partition_scheme"]],
+            partition_scheme_setting=options["partition_scheme"],
             username=options["username"],
         )

--- a/importer/tests/test_tasks.py
+++ b/importer/tests/test_tasks.py
@@ -2,7 +2,6 @@ from unittest import mock
 
 import pytest
 
-from common.models.transactions import TransactionPartition
 from common.tests import factories
 from importer import tasks
 from importer.models import ImporterChunkStatus
@@ -21,7 +20,7 @@ def test_import_chunk(
     tasks.import_chunk(
         chunk.pk,
         "PUBLISHED",
-        REVISION_ONLY,
+        "REVISION_ONLY",
         valid_user.username,
     )
 
@@ -41,7 +40,7 @@ def test_import_chunk_failed(valid_user, chunk):
         tasks.import_chunk(
             chunk.pk,
             "PUBLISHED",
-            TransactionPartition.REVISION.value,
+            "REVISION_ONLY",
             valid_user.username,
         )
     except KeyError:
@@ -61,7 +60,7 @@ def test_setup_chunk_task_already_running(mock_import_chunk, batch, valid_user):
     tasks.setup_chunk_task(
         batch,
         "PUBLISHED",
-        REVISION_ONLY,
+        "REVISION_ONLY",
         valid_user.username,
     )
 
@@ -74,7 +73,7 @@ def test_setup_chunk_task_no_chunks(mock_import_chunk, batch, valid_user):
     tasks.setup_chunk_task(
         batch,
         "PUBLISHED",
-        REVISION_ONLY,
+        "REVISION_ONLY",
         valid_user.username,
     )
 
@@ -87,7 +86,7 @@ def test_setup_chunk_task(mock_import_chunk, chunk, valid_user):
     tasks.setup_chunk_task(
         chunk.batch,
         "PUBLISHED",
-        REVISION_ONLY,
+        "REVISION_ONLY",
         valid_user.username,
     )
 
@@ -97,7 +96,7 @@ def test_setup_chunk_task(mock_import_chunk, chunk, valid_user):
     mock_import_chunk.delay.assert_called_once_with(
         chunk.pk,
         "PUBLISHED",
-        REVISION_ONLY,
+        "REVISION_ONLY",
         valid_user.username,
     )
 
@@ -114,7 +113,7 @@ def test_find_and_run_next_batch_chunks_already_running(
     tasks.find_and_run_next_batch_chunks(
         batch,
         "PUBLISHED",
-        REVISION_ONLY,
+        "REVISION_ONLY",
         valid_user.username,
     )
 
@@ -136,7 +135,7 @@ def test_find_and_run_next_batch_chunks_finished_runs_dependencies(
     tasks.find_and_run_next_batch_chunks(
         batch_dependency.depends_on,
         "PUBLISHED",
-        REVISION_ONLY,
+        "REVISION_ONLY",
         valid_user.username,
     )
     batch = batch_dependency.dependent_batch
@@ -147,7 +146,7 @@ def test_find_and_run_next_batch_chunks_finished_runs_dependencies(
     mock_import_chunk.delay.assert_called_once_with(
         batch.chunks.first().pk,
         "PUBLISHED",
-        REVISION_ONLY,
+        "REVISION_ONLY",
         valid_user.username,
     )
 
@@ -161,7 +160,7 @@ def test_find_and_run_next_batch_chunks(mock_import_chunk, batch, valid_user):
     tasks.find_and_run_next_batch_chunks(
         batch,
         "PUBLISHED",
-        REVISION_ONLY,
+        "REVISION_ONLY",
         valid_user.username,
     )
 
@@ -170,6 +169,6 @@ def test_find_and_run_next_batch_chunks(mock_import_chunk, batch, valid_user):
     mock_import_chunk.delay.assert_called_once_with(
         batch.chunks.first().pk,
         "PUBLISHED",
-        REVISION_ONLY,
+        "REVISION_ONLY",
         valid_user.username,
     )

--- a/workbaskets/tests/test_models.py
+++ b/workbaskets/tests/test_models.py
@@ -159,8 +159,8 @@ def test_user_partition_scheme_passes_approved_workbaskets(
 @pytest.mark.parametrize(
     "partition_scheme,expected_partition,command_line_name",
     [
-        (SEED_ONLY, TransactionPartition.SEED_FILE, "seed"),
-        (REVISION_ONLY, TransactionPartition.REVISION, "revision"),
+        (SEED_ONLY, TransactionPartition.SEED_FILE, "SEED_ONLY"),
+        (REVISION_ONLY, TransactionPartition.REVISION, "REVISION_ONLY"),
     ],
 )
 def test_user_partitions_have_expected_values(


### PR DESCRIPTION
Pass schemas by name so that celery is happy.

Note: this changes the command line use slightly (see the help), to the IMO slightly less friendly ALL_CAPS names, but it seemed better than maintaining two sets of names and making the name resolution even more complex.