### PR TITLE
TP-1050: ME12 using reverse relations

### DIFF
--- a/measures/business_rules.py
+++ b/measures/business_rules.py
@@ -542,10 +542,14 @@ class ME12(BusinessRule):
     have a relationship with the measure type."""
 
     def validate(self, measure):
+        AdditionalCodeTypeMeasureType = (
+            measure.measure_type.additional_code_types.through
+        )
         if (
             measure.additional_code
-            and not measure.measure_type.additional_code_types.filter(
-                sid=measure.additional_code.type.sid,
+            and not AdditionalCodeTypeMeasureType.objects.filter(
+                additional_code_type__sid=measure.additional_code.type.sid,
+                measure_type__sid=measure.measure_type.sid,
             ).exists()
         ):
             raise self.violation(measure)

--- a/measures/business_rules.py
+++ b/measures/business_rules.py
@@ -547,10 +547,14 @@ class ME12(BusinessRule):
         )
         if (
             measure.additional_code
-            and not AdditionalCodeTypeMeasureType.objects.filter(
+            and not AdditionalCodeTypeMeasureType.objects.approved_up_to_transaction(
+                measure.transaction,
+            )
+            .filter(
                 additional_code_type__sid=measure.additional_code.type.sid,
                 measure_type__sid=measure.measure_type.sid,
-            ).exists()
+            )
+            .exists()
         ):
             raise self.violation(measure)
 

--- a/measures/business_rules.py
+++ b/measures/business_rules.py
@@ -548,7 +548,7 @@ class ME12(BusinessRule):
         if (
             measure.additional_code
             and not AdditionalCodeTypeMeasureType.objects.approved_up_to_transaction(
-                measure.transaction,
+                self.transaction,
             )
             .filter(
                 additional_code_type__sid=measure.additional_code.type.sid,

--- a/measures/tests/test_business_rules.py
+++ b/measures/tests/test_business_rules.py
@@ -778,6 +778,22 @@ def test_ME12():
     business_rules.ME12(measure.transaction).validate(measure)
 
 
+def test_ME12_after_measure_type_updated():
+    additional_code = factories.AdditionalCodeFactory.create()
+    measure_type = factories.MeasureTypeFactory.create()
+    factories.AdditionalCodeTypeMeasureTypeFactory.create(
+        measure_type=measure_type,
+        additional_code_type=additional_code.type,
+    )
+    measure_type = measure_type.new_version(measure_type.transaction.workbasket)
+    measure = factories.MeasureFactory.create(
+        measure_type=measure_type,
+        additional_code=additional_code,
+    )
+
+    business_rules.ME12(measure.transaction).validate(measure)
+
+
 @requires_meursing_tables
 def test_ME13():
     """If the additional code type is related to a Meursing table plan then only


### PR DESCRIPTION
## Why
- Currently measure business rule ME12 (If the additional code is specified then the additional code type must have a relationship with the measure type.) uses reverses relationships in its query. This has meant that since measure type 105 has been updated, two measures (20151527, 20151528) are now in violation of the rule.

## What
- Updates the rule to use the through model and adds a test for the scenario described above

