### PR TITLE
Fix update validity business rule to consider transactions in order.

### DIFF
--- a/additional_codes/models.py
+++ b/additional_codes/models.py
@@ -95,16 +95,6 @@ class AdditionalCode(TrackedModel, ValidityMixin):
     def autocomplete_label(self):
         return f"{self} - {self.get_description().description}"
 
-    def in_use(self):
-        # Grab Measure class from measure_set to avoid a circular import.
-        return (
-            self.measure_set.model.objects.filter(
-                additional_code__sid=self.sid,
-            )
-            .approved_up_to_transaction(self.transaction)
-            .exists()
-        )
-
 
 class AdditionalCodeDescription(DescriptionMixin, TrackedModel):
     """

--- a/certificates/models.py
+++ b/certificates/models.py
@@ -33,13 +33,6 @@ class CertificateType(TrackedModel, ValidityMixin):
         UpdateValidity,
     )
 
-    def in_use(self):
-        return (
-            Certificate.objects.filter(certificate_type__sid=self.sid)
-            .approved_up_to_transaction(self.transaction)
-            .exists()
-        )
-
     def __str__(self):
         return self.sid
 
@@ -87,16 +80,6 @@ class Certificate(TrackedModel, ValidityMixin):
     @property
     def autocomplete_label(self):
         return f"{self} - {self.get_description().description}"
-
-    def in_use(self):
-        return (
-            self.measurecondition_set.model.objects.filter(
-                required_certificate__sid=self.sid,
-                required_certificate__certificate_type=self.certificate_type,
-            )
-            .approved_up_to_transaction(self.transaction)
-            .exists()
-        )
 
 
 class CertificateDescription(DescriptionMixin, TrackedModel):

--- a/certificates/tests/test_business_rules.py
+++ b/certificates/tests/test_business_rules.py
@@ -57,8 +57,11 @@ def test_CE4(date_ranges):
     """If a certificate is used in a measure condition then the validity period
     of the certificate must span the validity period of the measure."""
 
-    condition = factories.MeasureConditionWithCertificateFactory.create(
-        required_certificate__valid_between=date_ranges.starts_with_normal,
+    certificate = factories.CertificateFactory.create(
+        valid_between=date_ranges.starts_with_normal,
+    )
+    condition = factories.MeasureConditionFactory.create(
+        required_certificate=certificate,
         dependent_measure__valid_between=date_ranges.normal,
     )
 

--- a/commodities/models/orm.py
+++ b/commodities/models/orm.py
@@ -185,18 +185,14 @@ class GoodsNomenclature(TrackedModel, ValidityMixin):
     def autocomplete_label(self):
         return f"{self} - {self.get_description().description}"
 
-    @property
-    def dependent_measures(self):
+    def get_dependent_measures(self, transaction=None):
         return self.measures.model.objects.filter(
             goods_nomenclature__sid=self.sid,
-        ).approved_up_to_transaction(self.transaction)
+        ).approved_up_to_transaction(transaction)
 
     @property
     def is_taric_code(self) -> bool:
         return self.code.is_taric_code
-
-    def in_use(self):
-        return self.dependent_measures.exists()
 
 
 class GoodsNomenclatureIndent(TrackedModel, ValidityStartMixin):

--- a/commodities/tests/test_scenarios.py
+++ b/commodities/tests/test_scenarios.py
@@ -129,7 +129,7 @@ def test_scenario4_change_time_span(scenario_4: TScenario):
     validate_captured_side_effect(change, association, UpdateType.DELETE)
 
     # NIG30 / NIG31
-    measures = change.candidate.obj.dependent_measures.order_by("id")
+    measures = change.candidate.obj.get_dependent_measures().order_by("id")
 
     # Case 1 - measure that still overlaps with the good's new validity span
     # It should be picked up in side effects with a flag UPDATE
@@ -158,7 +158,7 @@ def test_scenario5_intermediate_suffix(scenario_5: TScenario):
     change = changes[1]
 
     # ME7
-    measure = change.candidate.obj.dependent_measures.first()
+    measure = change.candidate.obj.get_dependent_measures().first()
     validate_captured_side_effect(change, measure, UpdateType.DELETE)
 
 

--- a/common/business_rules.py
+++ b/common/business_rules.py
@@ -491,9 +491,13 @@ class UpdateValidity(BusinessRule):
     """
 
     def validate(self, model):
-        existing_objects = model.__class__.objects.filter(
-            version_group=model.version_group,
-        ).exclude(id=model.id)
+        existing_objects = (
+            model.__class__.objects.filter(
+                version_group=model.version_group,
+            )
+            .exclude(id=model.id)
+            .versions_up_to(self.transaction)
+        )
 
         if existing_objects.exists():
             if model.update_type == UpdateType.CREATE:

--- a/common/models/records.py
+++ b/common/models/records.py
@@ -102,18 +102,18 @@ class TrackedModelQuerySet(PolymorphicQuerySet, CTEQuerySet, ValidityQuerySet):
         """
         return self.filter(is_current__isnull=False, update_type=UpdateType.DELETE)
 
-    def since_transaction(self, transaction_id: int) -> TrackedModelQuerySet:
+    def versions_up_to(self, transaction) -> TrackedModelQuerySet:
         """
-        Get all instances of an object since a certain transaction (i.e. since a
-        particular workbasket was accepted).
+        Get all versions of an object up until and including the passed
+        transaction.
 
-        This will not include objects without a transaction ID - thus excluding rows which
-        have not been accepted yet.
+        If the transaction is in a draft workbasket, this will include all of
+        the approved transactions and any before it in the workbasket.
 
-        If done from the TrackedModel this will return all objects from all transactions since
-        the given transaction.
+        This is similar to `approved_up_to_transaction` except it includes all
+        versions, not just the most recent.
         """
-        return self.filter(transaction__id__gt=transaction_id)
+        return self.filter(self.as_at_transaction_filter(transaction))
 
     def as_at(self, date: date) -> TrackedModelQuerySet:
         """

--- a/common/models/transactions.py
+++ b/common/models/transactions.py
@@ -54,6 +54,15 @@ class TransactionManager(models.Manager):
         )
 
 
+class ApprovedTransactionManager(TransactionManager):
+    def get_queryset(self):
+        return (
+            super()
+            .get_queryset()
+            .filter(partition__in=TransactionPartition.approved_partitions())
+        )
+
+
 class TransactionsAlreadyApproved(Exception):
     pass
 
@@ -190,6 +199,8 @@ class Transaction(TimestampedMixin):
     composite_key = models.CharField(max_length=16, unique=True)
 
     objects = TransactionManager.from_queryset(TransactionQueryset)()
+
+    approved = ApprovedTransactionManager.from_queryset(TransactionQueryset)()
 
     @transition(
         field=partition,

--- a/common/tests/factories.py
+++ b/common/tests/factories.py
@@ -742,6 +742,7 @@ class QuotaOrderNumberOriginFactory(TrackedModelMixin, ValidityFactoryMixin):
     geographical_area = factory.SubFactory(
         GeographicalAreaFactory,
         valid_between=factory.SelfAttribute("..valid_between"),
+        transaction=factory.SelfAttribute("..transaction"),
     )
 
 
@@ -1044,7 +1045,10 @@ class MeasureConditionFactory(TrackedModelMixin):
         model = "measures.MeasureCondition"
 
     sid = numeric_sid()
-    dependent_measure = factory.SubFactory(MeasureFactory)
+    dependent_measure = factory.SubFactory(
+        MeasureFactory,
+        transaction=factory.SelfAttribute("..transaction"),
+    )
     condition_code = factory.SubFactory(MeasureConditionCodeFactory)
     component_sequence_number = factory.Faker("random_int", min=1, max=999)
     duty_amount = factory.Faker("pydecimal", left_digits=7, right_digits=3)
@@ -1066,7 +1070,10 @@ class MeasureConditionComponentFactory(TrackedModelMixin):
     class Meta:
         model = "measures.MeasureConditionComponent"
 
-    condition = factory.SubFactory(MeasureConditionFactory)
+    condition = factory.SubFactory(
+        MeasureConditionFactory,
+        transaction=factory.SelfAttribute("..transaction"),
+    )
     duty_expression = factory.SubFactory(DutyExpressionFactory)
     duty_amount = factory.Faker("pydecimal", left_digits=7, right_digits=3)
     monetary_unit = factory.SubFactory(MonetaryUnitFactory)

--- a/common/tests/test_models.py
+++ b/common/tests/test_models.py
@@ -112,9 +112,14 @@ def test_get_current(model1_with_history, model2_with_history):
     }
 
 
-def test_since_transaction(model1_with_history):
-    transaction = model1_with_history.active_model.transaction
-    assert TrackedModel.objects.since_transaction(transaction.id).count() == 5
+def test_versions_up_to(model1_with_history):
+    """Ensure that versions_up_to returns all versions that are approved up to
+    and including the past transaction, not future ones and not just the
+    latest."""
+    for index, model in enumerate(model1_with_history.all_models):
+        versions = TestModel1.objects.versions_up_to(model.transaction)
+        assert versions.count() == index + 1
+        assert versions.last() == model
 
 
 def test_as_at(date_ranges):

--- a/common/tests/util.py
+++ b/common/tests/util.py
@@ -4,7 +4,6 @@ from datetime import datetime
 from datetime import timezone
 from functools import wraps
 from io import BytesIO
-from itertools import count
 from typing import Any
 from typing import Dict
 from typing import Sequence
@@ -20,6 +19,7 @@ from freezegun import freeze_time
 from lxml import etree
 
 from common.models.records import TrackedModel
+from common.models.transactions import Transaction
 from common.renderers import counter_generator
 from common.serializers import validate_taric_xml_record_order
 from common.util import TaricDateRange
@@ -188,17 +188,15 @@ def assert_many_records_match(
     assert expected_data == imported_data
 
 
-_transaction_counter = count(start=1)
-
-
 def generate_test_import_xml(obj: dict) -> BytesIO:
-
+    last_transaction = Transaction.objects.last()
+    next_transaction_id = (last_transaction.order if last_transaction else 0) + 1
     xml = render_to_string(
         template_name="workbaskets/taric/transaction_detail.xml",
         context={
-            "envelope_id": next(_transaction_counter),
+            "envelope_id": next_transaction_id,
             "tracked_models": [obj],
-            "transaction_id": next(_transaction_counter),
+            "transaction_id": next_transaction_id,
             "message_counter": counter_generator(),
             "counter_generator": counter_generator,
         },

--- a/conftest.py
+++ b/conftest.py
@@ -715,6 +715,14 @@ def check_first_update_validation(request):
     def check(factory):
         instance = factory.create(update_type=update_type)
 
+        # Create a future instance – the business rule should ignore this
+        # but the test for CREATE will fail if it does not.
+        factory.create(
+            update_type=UpdateType.UPDATE,
+            transaction__workbasket=instance.transaction.workbasket,
+            transaction__order=instance.transaction.order + 1,
+        )
+
         with raises_if(UpdateValidity.Violation, expected_error):
             UpdateValidity(instance.transaction).validate(instance)
 

--- a/footnotes/business_rules.py
+++ b/footnotes/business_rules.py
@@ -77,21 +77,21 @@ class FO11(PreventDeleteIfInUse):
     """When a footnote is used in a measure then the footnote may not be
     deleted."""
 
-    in_use_check = "used_in_measure"
+    via_relation = "footnoteassociationmeasure"
 
 
 class FO12(PreventDeleteIfInUse):
     """When a footnote is used in a goods nomenclature then the footnote may not
     be deleted."""
 
-    in_use_check = "used_in_goods_nomenclature"
+    via_relation = "footnoteassociationgoodsnomenclature"
 
 
 class FO15(PreventDeleteIfInUse):
     """When a footnote is used in an additional code then the footnote may not
     be deleted."""
 
-    in_use_check = "used_in_additional_code"
+    via_relation = "footnoteassociationadditionalcode"
 
 
 class FO17(ValidityPeriodContained):

--- a/footnotes/models.py
+++ b/footnotes/models.py
@@ -1,5 +1,3 @@
-from typing import Type
-
 from django.db import models
 from django.db.models import Max
 
@@ -53,15 +51,6 @@ class FootnoteType(TrackedModel, ValidityMixin):
     def __str__(self):
         return self.footnote_type_id
 
-    def in_use(self):
-        return (
-            Footnote.objects.filter(
-                footnote_type__footnote_type_id=self.footnote_type_id,
-            )
-            .approved_up_to_transaction(self.transaction)
-            .exists()
-        )
-
 
 class Footnote(TrackedModel, ValidityMixin):
     """A footnote relates to a piece of text, and either clarifies it (in the
@@ -103,32 +92,6 @@ class Footnote(TrackedModel, ValidityMixin):
     @property
     def autocomplete_label(self):
         return f"{self} - {self.get_description().description}"
-
-    def _used_in(self, dependent_type: Type[TrackedModel]):
-        return (
-            dependent_type.objects.filter(
-                associated_footnote__footnote_id=self.footnote_id,
-                associated_footnote__footnote_type__footnote_type_id=self.footnote_type.footnote_type_id,
-            )
-            .approved_up_to_transaction(self.transaction)
-            .exists()
-        )
-
-    def used_in_additional_code(self):
-        return self._used_in(self.footnoteassociationadditionalcode_set.model)
-
-    def used_in_goods_nomenclature(self):
-        return self._used_in(self.footnoteassociationgoodsnomenclature_set.model)
-
-    def used_in_measure(self):
-        return self._used_in(self.footnoteassociationmeasure_set.model)
-
-    def in_use(self):
-        return (
-            self.used_in_additional_code()
-            or self.used_in_goods_nomenclature()
-            or self.used_in_measure()
-        )
 
     class Meta:
         ordering = ["footnote_type__footnote_type_id", "footnote_id"]

--- a/footnotes/tests/test_models.py
+++ b/footnotes/tests/test_models.py
@@ -17,7 +17,7 @@ def test_footnote_type_in_use(in_use_check_respects_deletes):
 def test_footnote_used_in_additional_code(in_use_check_respects_deletes):
     assert in_use_check_respects_deletes(
         factories.FootnoteFactory,
-        "used_in_additional_code",
+        "in_use",
         factories.FootnoteAssociationAdditionalCodeFactory,
         "associated_footnote",
     )
@@ -26,7 +26,7 @@ def test_footnote_used_in_additional_code(in_use_check_respects_deletes):
 def test_footnote_used_in_goods_nomenclature(in_use_check_respects_deletes):
     assert in_use_check_respects_deletes(
         factories.FootnoteFactory,
-        "used_in_goods_nomenclature",
+        "in_use",
         factories.FootnoteAssociationGoodsNomenclatureFactory,
         "associated_footnote",
     )
@@ -35,7 +35,7 @@ def test_footnote_used_in_goods_nomenclature(in_use_check_respects_deletes):
 def test_footnote_used_in_measure(in_use_check_respects_deletes):
     assert in_use_check_respects_deletes(
         factories.FootnoteFactory,
-        "used_in_measure",
+        "in_use",
         factories.FootnoteAssociationMeasureFactory,
         "associated_footnote",
     )

--- a/geo_areas/business_rules.py
+++ b/geo_areas/business_rules.py
@@ -279,12 +279,14 @@ class GA21(PreventDeleteIfInUse):
     origin/destination or as an excluded geographical area.
     """
 
+    via_relation = "measures"
+
 
 class GA22(PreventDeleteIfInUse):
     """A geographical area cannot be deleted if it is referenced as a parent
     geographical area group."""
 
-    in_use_check = "is_a_parent"
+    via_relation = "geographicalarea"
 
 
 class GA23(PreventDeleteIfInUse):

--- a/geo_areas/models.py
+++ b/geo_areas/models.py
@@ -93,24 +93,6 @@ class GeographicalArea(TrackedModel, ValidityMixin):
             .select_related("member", "geo_group")
         )
 
-    def in_use(self):
-        return (
-            self.measures.model.objects.filter(
-                geographical_area__sid=self.sid,
-            )
-            .approved_up_to_transaction(self.transaction)
-            .exists()
-        )
-
-    def is_a_parent(self):
-        return (
-            GeographicalArea.objects.filter(
-                parent__sid=self.sid,
-            )
-            .approved_up_to_transaction(self.transaction)
-            .exists()
-        )
-
     def is_single_region_or_country(self):
         return self.area_code == AreaCode.COUNTRY or self.area_code == AreaCode.REGION
 
@@ -190,14 +172,8 @@ class GeographicalMembership(TrackedModel, ValidityMixin):
         else:
             raise ValueError(f"{area} is not part of membership {self}")
 
-    def member_used_in_measure_exclusion(self):
-        return (
-            self.member.measureexcludedgeographicalarea_set.model.objects.filter(
-                excluded_geographical_area__sid=self.member.sid,
-            )
-            .approved_up_to_transaction(self.transaction)
-            .exists()
-        )
+    def member_used_in_measure_exclusion(self, transaction):
+        return self.member.in_use(transaction, "measureexcludedgeographicalarea")
 
 
 class GeographicalAreaDescription(DescriptionMixin, TrackedModel):

--- a/measures/business_rules.py
+++ b/measures/business_rules.py
@@ -78,6 +78,8 @@ class MT4(MustExist):
 class MT7(PreventDeleteIfInUse):
     """A measure type cannot be deleted if it is in use in a measure."""
 
+    via_relation = "measure"
+
 
 class MT10(ValidityPeriodContained):
     """The validity period of the measure type series must span the validity
@@ -105,8 +107,6 @@ class MC3(MeasureValidityPeriodContained):
 class MC4(PreventDeleteIfInUse):
     """The measure condition code cannot be deleted if it is used in a measure
     condition component."""
-
-    in_use_check = "used_in_component"
 
 
 # 355 - MEASURE ACTION
@@ -693,8 +693,8 @@ class ME40(BusinessRule):
     """
 
     def validate(self, measure):
-        has_components = measure.has_components()
-        has_condition_components = measure.has_condition_components()
+        has_components = measure.has_components(self.transaction)
+        has_condition_components = measure.has_condition_components(self.transaction)
 
         if measure.measure_type.components_mandatory and not (
             has_components or has_condition_components
@@ -801,7 +801,7 @@ class ComponentApplicability(BusinessRule):
             )
             if (
                 components.filter(inapplicable)
-                .approved_up_to_transaction(measure.transaction)
+                .approved_up_to_transaction(self.transaction)
                 .exists()
             ):
                 raise self.violation(measure, self.messages[code].format(self))

--- a/measures/business_rules.py
+++ b/measures/business_rules.py
@@ -920,8 +920,7 @@ class ME58(BusinessRule):
 
         if (
             type(measure_condition)
-            .objects.with_workbasket(measure_condition.transaction.workbasket)
-            .exclude(pk=measure_condition.pk or None)
+            .objects.exclude(pk=measure_condition.pk or None)
             .excluding_versions_of(version_group=measure_condition.version_group)
             .filter(
                 condition_code__code=measure_condition.condition_code.code,
@@ -929,7 +928,7 @@ class ME58(BusinessRule):
                 required_certificate__certificate_type__sid=measure_condition.required_certificate.certificate_type.sid,
                 dependent_measure__sid=measure_condition.dependent_measure.sid,
             )
-            .approved_up_to_transaction(measure_condition.transaction)
+            .approved_up_to_transaction(self.transaction)
             .exists()
         ):
             raise self.violation(measure_condition)

--- a/quotas/business_rules.py
+++ b/quotas/business_rules.py
@@ -128,11 +128,15 @@ class ON10(ValidityPeriodContains):
 class ON11(PreventDeleteIfInUse):
     """The quota order number cannot be deleted if it is used in a measure."""
 
+    via_relation = "measure"
+
 
 @only_applicable_after("2007-12-31")
 class ON12(PreventDeleteIfInUse):
     """The quota order number origin cannot be deleted if it is used in a
     measure."""
+
+    in_use_check = "order_number_in_use"
 
 
 class ON13(BusinessRule):

--- a/quotas/models.py
+++ b/quotas/models.py
@@ -77,15 +77,6 @@ class QuotaOrderNumber(TrackedModel, ValidityMixin):
     def autocomplete_label(self):
         return str(self)
 
-    def in_use(self):
-        return (
-            self.measure_set.model.objects.filter(
-                order_number__sid=self.sid,
-            )
-            .approved_up_to_transaction(self.transaction)
-            .exists()
-        )
-
     @property
     def is_origin_quota(self):
         return any(self.required_certificates.all())
@@ -127,14 +118,8 @@ class QuotaOrderNumberOrigin(TrackedModel, ValidityMixin):
         UpdateValidity,
     )
 
-    def in_use(self):
-        return (
-            self.order_number.measure_set.model.objects.filter(
-                order_number__sid=self.order_number.sid,
-            )
-            .approved_up_to_transaction(self.transaction)
-            .exists()
-        )
+    def order_number_in_use(self, transaction):
+        return self.order_number.in_use(transaction)
 
 
 class QuotaOrderNumberOriginExclusion(TrackedModel):

--- a/quotas/tests/test_models.py
+++ b/quotas/tests/test_models.py
@@ -17,7 +17,7 @@ def test_quota_order_number_in_use(in_use_check_respects_deletes):
 def test_quota_order_number_origin_in_use(in_use_check_respects_deletes):
     assert in_use_check_respects_deletes(
         factories.QuotaOrderNumberOriginFactory,
-        "in_use",
+        "order_number_in_use",
         factories.MeasureFactory,
         "order_number",
         through="order_number",

--- a/regulations/business_rules.py
+++ b/regulations/business_rules.py
@@ -32,7 +32,7 @@ class ROIMB8(BusinessRule):
                 generating_regulation__regulation_id=regulation.regulation_id,
                 generating_regulation__role_type=regulation.role_type,
             )
-            .approved_up_to_transaction(regulation.transaction)
+            .approved_up_to_transaction(self.transaction)
             .exclude(
                 valid_between__contained_by=regulation.valid_between,
             )

--- a/regulations/models.py
+++ b/regulations/models.py
@@ -238,6 +238,7 @@ class Regulation(TrackedModel, ValidityMixin):
 
     def used_as_terminating_regulation_or_draft_generating_and_terminating_regulation(
         self,
+        transaction,
     ):
         if self.role_type != validators.RoleType.BASE:
             return
@@ -252,7 +253,7 @@ class Regulation(TrackedModel, ValidityMixin):
                 generating_regulation__regulation_id=self.regulation_id,
                 generating_regulation__role_type=self.role_type,
             )
-            .approved_up_to_transaction(transaction=self.transaction)
+            .approved_up_to_transaction(transaction)
             .exists()
         )
 


### PR DESCRIPTION
## Why
We have a business rule that is applied to all models that ensures, per version group, we only have:
- The first version being a CREATE
- Subsequent versions being an UPDATE or DELETE
- No further versions after a DELETE

At the moment this business rule only expects to be run against the very latest version, and does not work when we run it against earlier versions. This happens routinely when we CREATE and then UPDATE a model in the same workbasket, because when we run the rule against the CREATE it picks up the UPDATE too.

Instead, the business rule needs to be transaction-aware – i.e. only consider data that exists as of a certain transaction.

<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Use as many lines as you like.
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions or deliberately ignored edge-cases.
--->

## What
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Explain like I'm 5.
 * Use pictures if you can.
--->
This PR creates a new filter called `up_to_transaction` – which is simplified using @stuaxo's work on partitions. This is broadly the same filter as is required for `approved_up_to_transaction` but split out and able to take a join prefix, so that method is also refactored to use it.

**Please read the commit messages for more context!**

## Checklist
- Requires migrations? No.
- Requires dependency updates? No.


<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
