### PR TITLE
Fix bug in measures migration when data already present.

### DIFF
--- a/measures/migrations/0009_add_abbrev_to_unit_qualifier_with_code_n.py
+++ b/measures/migrations/0009_add_abbrev_to_unit_qualifier_with_code_n.py
@@ -5,19 +5,21 @@ from django.db import migrations
 
 def forwards(apps, schema_editor):
     MeasurementUnitQualifier = apps.get_model("measures", "MeasurementUnitQualifier")
-    code_n_qualifier = MeasurementUnitQualifier.objects.filter(code="N").first()
-    # Migrations are run before seeding the db, so a check is needed to ensure the qualifier exists before trying to update
-    if code_n_qualifier:
-        code_n_qualifier.abbreviation = "net"
-        code_n_qualifier.save()
+    # Originally this used MeasurementUnitQualifier.objects.filter(code="N").first()
+    # but this tries to access valid_between which may not be created yet and then things
+    # break.
+    MeasurementUnitQualifier.objects.filter(code="N").update(abbreviation="net")
+
+
+def backwards(app, schema_editor):
+    pass
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("measures", "0008_auto_20210628_1641"),
     ]
 
     operations = [
-        migrations.RunPython(forwards),
+        migrations.RunPython(forwards, backwards),
     ]


### PR DESCRIPTION
When data was present an exception could occur during measures migration.

```python
python manage.py migrate measures    stu@computer  10880  15:02:59 
Operations to perform:
Apply all migrations: measures
Running migrations:
Applying measures.0008_auto_20210628_1641... OK
Applying measures.0009_add_abbrev_to_unit_qualifier_with_code_n...Traceback (most recent call last):
File "/home/stu/.virtualenvs/dit-pyston/lib/pyston3.8/site-packages/django/db/backends/utils.py", line 84, in _execute
return self.cursor.execute(sql, params)
psycopg2.errors.UndefinedColumn: column measures_measurementunitqualifier.valid_between does not exist
LINE 1: ..._measurementunitqualifier"."trackedmodel_ptr_id", "measures_...
^




The above exception was the direct cause of the following exception:



Traceback (most recent call last):
File "manage.py", line 27, in <module>
main()
File "manage.py", line 22, in main
execute_from_command_line(sys.argv)
File "/home/stu/.virtualenvs/dit-pyston/lib/pyston3.8/site-packages/django/core/management/__init__.py", line 401, in execute_from_command_line
utility.execute()
File "/home/stu/.virtualenvs/dit-pyston/lib/pyston3.8/site-packages/django/core/management/__init__.py", line 395, in execute
self.fetch_command(subcommand).run_from_argv(self.argv)
File "/home/stu/.virtualenvs/dit-pyston/lib/pyston3.8/site-packages/django/core/management/base.py", line 330, in run_from_argv
self.execute(*args, **cmd_options)
File "/home/stu/.virtualenvs/dit-pyston/lib/pyston3.8/site-packages/django/core/management/base.py", line 371, in execute
output = self.handle(*args, **options)
File "/home/stu/.virtualenvs/dit-pyston/lib/pyston3.8/site-packages/django/core/management/base.py", line 85, in wrapped
res = handle_func(*args, **kwargs)
File "/home/stu/.virtualenvs/dit-pyston/lib/pyston3.8/site-packages/django/core/management/commands/migrate.py", line 243, in handle
post_migrate_state = executor.migrate(
File "/home/stu/.virtualenvs/dit-pyston/lib/pyston3.8/site-packages/django/db/migrations/executor.py", line 117, in migrate
state = self._migrate_all_forwards(state, plan, full_plan, fake=fake, fake_initial=fake_initial)
File "/home/stu/.virtualenvs/dit-pyston/lib/pyston3.8/site-packages/django/db/migrations/executor.py", line 147, in _migrate_all_forwards
state = self.apply_migration(state, migration, fake=fake, fake_initial=fake_initial)
File "/home/stu/.virtualenvs/dit-pyston/lib/pyston3.8/site-packages/django/db/migrations/executor.py", line 227, in apply_migration
state = migration.apply(state, schema_editor)
File "/home/stu/.virtualenvs/dit-pyston/lib/pyston3.8/site-packages/django/db/migrations/migration.py", line 124, in apply
operation.database_forwards(self.app_label, schema_editor, old_state, project_state)
File "/home/stu/.virtualenvs/dit-pyston/lib/pyston3.8/site-packages/django/db/migrations/operations/special.py", line 190, in database_forwards
self.code(from_state.apps, schema_editor)
File "/home/stu/projects/work/dit/tamato/measures/migrations/0009_add_abbrev_to_unit_qualifier_with_code_n.py", line 8, in forwards
code_n_qualifier = MeasurementUnitQualifier.objects.filter(code="N").first()
File "/home/stu/.virtualenvs/dit-pyston/lib/pyston3.8/site-packages/django/db/models/query.py", line 678, in first
for obj in (self if self.ordered else self.order_by('pk'))[:1]:
File "/home/stu/.virtualenvs/dit-pyston/lib/pyston3.8/site-packages/django/db/models/query.py", line 287, in __iter__
self._fetch_all()
File "/home/stu/.virtualenvs/dit-pyston/lib/pyston3.8/site-packages/django/db/models/query.py", line 1308, in _fetch_all
self._result_cache = list(self._iterable_class(self))
File "/home/stu/.virtualenvs/dit-pyston/lib/pyston3.8/site-packages/django/db/models/query.py", line 53, in __iter__
results = compiler.execute_sql(chunked_fetch=self.chunked_fetch, chunk_size=self.chunk_size)
File "/home/stu/.virtualenvs/dit-pyston/lib/pyston3.8/site-packages/django/db/models/sql/compiler.py", line 1156, in execute_sql
cursor.execute(sql, params)
File "/home/stu/.virtualenvs/dit-pyston/lib/pyston3.8/site-packages/django/db/backends/utils.py", line 66, in execute
return self._execute_with_wrappers(sql, params, many=False, executor=self._execute)
File "/home/stu/.virtualenvs/dit-pyston/lib/pyston3.8/site-packages/django/db/backends/utils.py", line 75, in _execute_with_wrappers
return executor(sql, params, many, context)
File "/home/stu/.virtualenvs/dit-pyston/lib/pyston3.8/site-packages/django/db/backends/utils.py", line 84, in _execute
return self.cursor.execute(sql, params)
File "/home/stu/.virtualenvs/dit-pyston/lib/pyston3.8/site-packages/django/db/utils.py", line 90, in __exit__
raise dj_exc_value.with_traceback(traceback) from exc_value
File "/home/stu/.virtualenvs/dit-pyston/lib/pyston3.8/site-packages/django/db/backends/utils.py", line 84, in _execute
return self.cursor.execute(sql, params)
django.db.utils.ProgrammingError: column measures_measurementunitqualifier.valid_between does not exist
LINE 1: ..._measurementunitqualifier"."trackedmodel_ptr_id", "measures_...
^
```

