### PR TITLE
TP-1059 Word change on conditions and footnotes

### DIFF
--- a/measures/forms.py
+++ b/measures/forms.py
@@ -555,10 +555,14 @@ class MeasureFootnotesForm(forms.Form):
         self.helper.form_tag = False
         self.helper.legend_size = Size.SMALL
         self.helper.layout = Layout(
-            "footnote",
-            Field("DELETE", template="includes/common/formset-delete-button.jinja")
-            if not self.prefix.endswith("__prefix__")
-            else None,
+            Fieldset(
+                "footnote",
+                Field("DELETE", template="includes/common/formset-delete-button.jinja")
+                if not self.prefix.endswith("__prefix__")
+                else None,
+                legend="Footnote",
+                legend_size=Size.SMALL,
+            ),
         )
 
 

--- a/measures/jinja2/measures/create-wizard-step.jinja
+++ b/measures/jinja2/measures/create-wizard-step.jinja
@@ -11,6 +11,10 @@
       <span class="govuk-caption-l">{{ page_subtitle|default("") }}</span>
       <h1 class="govuk-heading-xl">{{ page_title }}</h1>
 
+      {% if step_metadata[step].info %}
+      <p class="govuk-body">{{ step_metadata[step].info }}</p>
+      {% endif %}
+
       {% call django_form(action=view.get_step_url(wizard.steps.current)) %}
         {{ wizard.management_form }}
         {% block form %}{{ crispy(form) }}{% endblock %}

--- a/measures/jinja2/measures/create-wizard-step.jinja
+++ b/measures/jinja2/measures/create-wizard-step.jinja
@@ -4,6 +4,7 @@
 {% set current_step = wizard.steps.step0 + 1 %}
 {% set page_title = current_step ~ ". " ~ step_metadata[wizard.steps.current].title %}
 {% set page_subtitle = "Create a new measure" %}
+{% set info = "Create a new measure" %}
 
 {% block content %}
   <div class="govuk-grid-row">
@@ -11,8 +12,8 @@
       <span class="govuk-caption-l">{{ page_subtitle|default("") }}</span>
       <h1 class="govuk-heading-xl">{{ page_title }}</h1>
 
-      {% if step_metadata[step].info %}
-      <p class="govuk-body">{{ step_metadata[step].info }}</p>
+      {% if step_metadata[wizard.steps.current].info %}
+      <p class="govuk-body">{{ step_metadata[wizard.steps.current].info }}</p>
       {% endif %}
 
       {% call django_form(action=view.get_step_url(wizard.steps.current)) %}

--- a/measures/views.py
+++ b/measures/views.py
@@ -104,7 +104,11 @@ class MeasureCreateWizard(
             "conditions",
             {
                 "form_class": forms.MeasureConditionsFormSet,
-                "title": "Add one or more conditions",
+                "title": "Add any condition codes",
+                "info": (
+                    "This section is optional. If there are no condition "
+                    "codes, select continue."
+                ),
                 "link_text": "Conditions",
                 "template": "measures/create-formset.jinja",
             },
@@ -121,7 +125,11 @@ class MeasureCreateWizard(
             "footnotes",
             {
                 "form_class": forms.MeasureFootnotesFormSet,
-                "title": "Add one or more footnotes",
+                "title": "Add any footnotes",
+                "info": (
+                    "This section is optional. If there are no footnotes, "
+                    "select continue."
+                ),
                 "link_text": "Footnotes",
                 "template": "measures/create-formset.jinja",
             },


### PR DESCRIPTION
# TP-1059 Word change on conditions and footnotes

## Why
A recent change allowing users to enter no Condition Codes or Footnotes when creating a Measure meant that the wording on their respective steps did not describe intent accurately to the user. This change updates the wording on those Create Measure steps for Condition Codes and Footnotes and clearly describes optionality.

## What
This PR adds an `info` element to `conditions` and `footnotes` elements of the `MeasureCreateWizard.STEPS` list. The approach maintains consistency with the intent of that list to provide step-specific information that is accessible within templates. The `info` element is rendered as informational text on a step only if it is defined (currently only for Condition Codes and Footnotes).

## Checklist
- Requires migrations? No
- Requires dependency updates? No
