### PR TITLE
feat: serialize sqlite file for ingest into data-flow

### DIFF
--- a/exporter/sqlite/tasks.py
+++ b/exporter/sqlite/tasks.py
@@ -44,8 +44,22 @@ def export_and_upload_sqlite() -> bool:
         logger.debug("Database %s already present", export_filename)
         return False
 
+    logger.info("Deleting any S3VFS blocks from a previous partial export")
+    _, files = storage.listdir(export_filename)
+    num_files = 0
+    for file in files:
+        logger.debug("Deleting %s", file)
+        storage.delete(file)
+        num_files += 1
+    logger.info("Deleted %s files", num_files)
+
     logger.info("Generating database %s", export_filename)
     sqlite.make_export(storage.get_connection(export_filename))
+    logger.info("Generation complete")
+
+    logger.info("Serializing %s", export_filename)
+    storage.serialize(export_filename)
+    logger.info("Serializing complete")
 
     logger.info("Upload complete")
     return True

--- a/exporter/storages.py
+++ b/exporter/storages.py
@@ -40,8 +40,9 @@ class SQLiteStorage(S3Boto3Storage):
         )
         return super().generate_filename(filename)
 
-    def exists(self, filename: str) -> bool:
-        return any(self.listdir(filename))
+    def serialize(self, filename):
+        vfs_fileobj = self.vfs.serialize_fileobj(key_prefix=filename)
+        self.bucket.Object(filename).upload_fileobj(vfs_fileobj)
 
     @cached_property
     def vfs(self) -> apsw.VFS:

--- a/exporter/tests/test_sqlite.py
+++ b/exporter/tests/test_sqlite.py
@@ -145,7 +145,6 @@ def test_export_task_does_not_reupload(sqlite_storage, s3_object_names, settings
     expected_key = path.join(
         settings.SQLITE_STORAGE_DIRECTORY,
         "000000123.db",
-        "0" * 10,
     )
     sqlite_storage.save(expected_key, BytesIO(b""))
 
@@ -187,7 +186,6 @@ def test_export_task_ignores_unapproved_transactions(
     expected_key = path.join(
         settings.SQLITE_STORAGE_DIRECTORY,
         "000000123.db",
-        "0" * 10,
     )
     sqlite_storage.save(expected_key, BytesIO(b""))
 


### PR DESCRIPTION
## Why

This is to keep S3VFS a bit of an implementation detail of TaMaTo, and to make sure that that data-flow doesn't attempt to ever read a partially constructed s3vfs SQLite database: if there is a whole single file SQLite database, then it's really unlikely there was an error, or than an export is 1/2 way through.

It also essentially reverts to the same behaviour in terms of communication-via-S3 as before S3VFS was introduced: single-object "regular" SQLite databases are what are transferred via S3.

## What

It first deletes any S3VFS objects from any previous export of the same database that may have failed half way through (which is likely to be seen as a corrupt database)

After exporting the tariff to an S3VFS as it did before this PR, it then serialises this to an object which has a key which is the _same_ as the key_prefix of the VFS:

**S3VFS objects**
12345.db/0000000001
12345.db/0000000002
...

**Serialized**
12345.db

This leverages a property of S3 that doesn't exist in filesystems: that files can behave a little bit like directories have have other files "under" them (since S3 is more a key-value store than a filesystem)
