### PR TITLE
fix: sqlite export

### DIFF
--- a/exporter/sqlite/tasks.py
+++ b/exporter/sqlite/tasks.py
@@ -44,15 +44,6 @@ def export_and_upload_sqlite() -> bool:
         logger.debug("Database %s already present", export_filename)
         return False
 
-    logger.info("Deleting any S3VFS blocks from a previous partial export")
-    _, files = storage.listdir(export_filename)
-    num_files = 0
-    for file in files:
-        logger.debug("Deleting %s", file)
-        storage.delete(file)
-        num_files += 1
-    logger.info("Deleted %s files", num_files)
-
     logger.info("Generating database %s", export_filename)
     sqlite.make_export(storage.get_connection(export_filename))
     logger.info("Generation complete")

--- a/exporter/storages.py
+++ b/exporter/storages.py
@@ -40,6 +40,9 @@ class SQLiteStorage(S3Boto3Storage):
         )
         return super().generate_filename(filename)
 
+    def exists(self, filename: str) -> bool:
+        return any(self.listdir(filename))
+
     def serialize(self, filename):
         vfs_fileobj = self.vfs.serialize_fileobj(key_prefix=filename)
         self.bucket.Object(filename).upload_fileobj(vfs_fileobj)

--- a/exporter/tests/test_sqlite.py
+++ b/exporter/tests/test_sqlite.py
@@ -145,6 +145,7 @@ def test_export_task_does_not_reupload(sqlite_storage, s3_object_names, settings
     expected_key = path.join(
         settings.SQLITE_STORAGE_DIRECTORY,
         "000000123.db",
+        "0" * 10,
     )
     sqlite_storage.save(expected_key, BytesIO(b""))
 
@@ -186,6 +187,7 @@ def test_export_task_ignores_unapproved_transactions(
     expected_key = path.join(
         settings.SQLITE_STORAGE_DIRECTORY,
         "000000123.db",
+        "0" * 10,
     )
     sqlite_storage.save(expected_key, BytesIO(b""))
 


### PR DESCRIPTION
## Why

The change in https://github.com/uktrade/tamato/pull/430 resulted in what seems to be multiple SQLite exports happening at the same time on the same S3VFS database, which caused corruption. The export is triggered every 30 minutes, and there were assumptions that each export would take < 30 minutes and/or multiple export tasks cannot run at the same time. These seemed incorrect.

## What

This fixes the corruption issue by aborting the SQLite export if at least one block has been written to S3, which happens very soon after the start of the export, rather than aborting if the serialized SQLite file has been written, which happens right at the end of the export.

The consequence of this is that exports that fail after the 1st block is written are not automatically recovered from. However, once new data is pushed using another filename, that export will be attempted automatically. This apparently happens frequently.