### PR TITLE
Add infrastructure to test class based views render without raising a…

### DIFF
--- a/additional_codes/tests/test_views.py
+++ b/additional_codes/tests/test_views.py
@@ -1,0 +1,23 @@
+import pytest
+
+from additional_codes.models import AdditionalCode
+from common.tests.util import assert_model_view
+from common.tests.util import get_detail_class_based_view_urls_matching_url
+from common.tests.util import view_urlpattern_ids
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.mark.parametrize(
+    ("view", "url_pattern"),
+    get_detail_class_based_view_urls_matching_url("additional_codes/"),
+    ids=view_urlpattern_ids,
+)
+def test_additional_codes_detail_views(view, url_pattern, valid_user_client):
+    """Verify that additional code detail views are under the url
+    additional_codes/ and don't return an error."""
+    model_overrides = {
+        "additional_codes.views.AdditionalCodeCreateDescription": AdditionalCode,
+    }
+
+    assert_model_view(view, url_pattern, valid_user_client, model_overrides)

--- a/certificates/tests/test_views.py
+++ b/certificates/tests/test_views.py
@@ -1,0 +1,19 @@
+import pytest
+
+from certificates.models import Certificate
+from common.tests.util import assert_model_view
+from common.tests.util import get_detail_class_based_view_urls_matching_url
+from common.tests.util import view_urlpattern_ids
+
+
+@pytest.mark.parametrize(
+    ("view", "url_pattern"),
+    get_detail_class_based_view_urls_matching_url("certificates/"),
+    ids=view_urlpattern_ids,
+)
+def test_certificate_detail_views(view, url_pattern, valid_user_client):
+    """Verify that certificate detail views are under the url certificates/ and
+    don't return an error."""
+    model_overrides = {"certificates.views.CertificateCreateDescription": Certificate}
+
+    assert_model_view(view, url_pattern, valid_user_client, model_overrides)

--- a/common/util.py
+++ b/common/util.py
@@ -1,13 +1,15 @@
 """Miscellaneous utility functions."""
 from __future__ import annotations
 
-import re
 from platform import python_version_tuple
 from typing import Any
+from typing import Dict
+from typing import Tuple
 from typing import Optional
 from typing import TypeVar
 from typing import Union
 
+import re
 import wrapt
 from django.db import transaction
 from django.db.models import F
@@ -159,7 +161,7 @@ def get_field_tuple(
     model: Model,
     field_name: str,
     default: Any = None,
-) -> tuple(str, Any):
+) -> Tuple[str, Any]:
     """
     Get the value of the named field of the specified model.
 
@@ -257,7 +259,7 @@ def get_next_id(queryset: QuerySet[Model], id_field: Field, max_len: int):
     )
 
 
-def get_record_code(record: dict[str, Any]) -> str:
+def get_record_code(record: Dict[str, Any]) -> str:
     """Returns the concatenated codes for a taric record."""
     return f"{record['record_code']}{record['subrecord_code']}"
 

--- a/conftest.py
+++ b/conftest.py
@@ -881,12 +881,12 @@ def unordered_transactions():
     """
     Fixture that creates some transactions, where one is a draft.
 
-    The draft transaction is has approved transactions on either side, to allow
-    testing of save_draft and it's callers, to verify the transactions are get
+    The draft transaction has approved transactions on either side, this allows
+    testing of save_draft and it's callers to verify the transactions are getting
     sorted.
 
-    UnorderedTransactionData is returned, so the user can the DRAFT transaction as new_transaction
-    and one example of an existing_transaction.
+    UnorderedTransactionData is returned, so the user can set the new_transaction partition to DRAFT
+    and while also using an existing_transaction.
     """
     from common.tests.factories import ApprovedTransactionFactory
     from common.tests.factories import FootnoteFactory

--- a/footnotes/tests/test_views.py
+++ b/footnotes/tests/test_views.py
@@ -2,7 +2,11 @@ import pytest
 from django.core.exceptions import ValidationError
 
 from common.tests import factories
+from common.tests.util import assert_model_view
+from common.tests.util import get_detail_class_based_view_urls_matching_url
 from common.tests.util import raises_if
+from common.tests.util import view_urlpattern_ids
+from footnotes.models import Footnote
 
 pytestmark = pytest.mark.django_db
 
@@ -56,3 +60,16 @@ def test_footnote_business_rule_application(
     description = use_update_form(factories.FootnoteDescriptionFactory(), new_data)
     with raises_if(ValidationError, not workbasket_valid):
         description.transaction.workbasket.clean()
+
+
+@pytest.mark.parametrize(
+    ("view", "url_pattern"),
+    get_detail_class_based_view_urls_matching_url("footnotes/"),
+    ids=view_urlpattern_ids,
+)
+def test_footnote_detail_views(view, url_pattern, valid_user_client):
+    """Verify that measure detail views are under the url footnotes/ and don't
+    return an error."""
+    model_overrides = {"footnotes.views.FootnoteCreateDescription": Footnote}
+
+    assert_model_view(view, url_pattern, valid_user_client, model_overrides)

--- a/geo_areas/tests/test_views.py
+++ b/geo_areas/tests/test_views.py
@@ -1,0 +1,23 @@
+import pytest
+
+from common.tests.util import assert_model_view
+from common.tests.util import get_detail_class_based_view_urls_matching_url
+from common.tests.util import view_urlpattern_ids
+from geo_areas.models import GeographicalArea
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.mark.parametrize(
+    ("view", "url_pattern"),
+    get_detail_class_based_view_urls_matching_url("geographical-areas/"),
+    ids=view_urlpattern_ids,
+)
+def test_geographical_area_detail_views(view, url_pattern, valid_user_client):
+    """Verify that geographical detail views are under the url geographical-
+    areas and don't return an error."""
+    model_overrides = {
+        "geo_areas.views.GeographicalAreaCreateDescription": GeographicalArea,
+    }
+
+    assert_model_view(view, url_pattern, valid_user_client, model_overrides)

--- a/measures/jinja2/includes/measures/tabs/conditions.jinja
+++ b/measures/jinja2/includes/measures/tabs/conditions.jinja
@@ -1,16 +1,16 @@
-{% from 'macros/create_link.jinja' import create_link %} 
+{% from 'macros/create_link.jinja' import create_link %}
 
 <h2 class="govuk-heading-l">Conditions</h2>
-{% if object.get_conditions() %}
+{% if object.get_conditions(get_current_workbasket(request).last_transaction) %}
     {% set table_rows = [] %}
-    {% for condition in object.get_conditions().with_duty_sentence() -%}
+    {% for condition in object.get_conditions(get_current_workbasket(request).last_transaction).with_duty_sentence() -%}
         {{ table_rows.append([
             {"text": condition.condition_code.code ~ condition.component_sequence_number},
             {"text": condition.duty_sentence if condition.duty_sentence else '-'},
             {"text": condition.action.description},
             {"text": create_link(condition.required_certificate.get_url(), condition.required_certificate.code) if condition.required_certificate else '-'},
             {"text": condition.required_certificate.get_description().description if condition.required_certificate else '-'},
-        ]) or "" }} 
+        ]) or "" }}
     {% endfor %}
     {{ govukTable({
     "head": [

--- a/measures/tests/test_views.py
+++ b/measures/tests/test_views.py
@@ -2,6 +2,9 @@ import pytest
 from django.urls import reverse
 
 from common.tests import factories
+from common.tests.util import assert_model_view
+from common.tests.util import get_detail_class_based_view_urls_matching_url
+from common.tests.util import view_urlpattern_ids
 from measures.views import MeasureFootnotesUpdate
 
 pytestmark = pytest.mark.django_db
@@ -76,3 +79,14 @@ def test_measure_footnotes_update_post_without_remove_ignores_delete_keys(
     assert client.session[f"formset_initial_{measure.sid}"] == [
         {"footnote": str(footnote_1.pk)},
     ]
+
+
+@pytest.mark.parametrize(
+    ("view", "url_pattern"),
+    get_detail_class_based_view_urls_matching_url("measures/"),
+    ids=view_urlpattern_ids,
+)
+def test_measure_detail_views(view, url_pattern, valid_user_client):
+    """Verify that measure detail views are under the url measures/ and don't
+    return an error."""
+    assert_model_view(view, url_pattern, valid_user_client)

--- a/quotas/tests/test_views.py
+++ b/quotas/tests/test_views.py
@@ -1,0 +1,18 @@
+import pytest
+
+from common.tests.util import assert_model_view
+from common.tests.util import get_detail_class_based_view_urls_matching_url
+from common.tests.util import view_urlpattern_ids
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.mark.parametrize(
+    ("view", "url_pattern"),
+    get_detail_class_based_view_urls_matching_url("quotas/"),
+    ids=view_urlpattern_ids,
+)
+def test_quota_detail_views(view, url_pattern, valid_user_client):
+    """Verify that quota detail views are under the url quotas and don't return
+    an error."""
+    assert_model_view(view, url_pattern, valid_user_client)

--- a/regulations/tests/test_views.py
+++ b/regulations/tests/test_views.py
@@ -2,7 +2,10 @@ import pytest
 from django.core.exceptions import ValidationError
 
 from common.tests import factories
+from common.tests.util import assert_model_view
+from common.tests.util import get_detail_class_based_view_urls_matching_url
 from common.tests.util import raises_if
+from common.tests.util import view_urlpattern_ids
 
 pytestmark = pytest.mark.django_db
 
@@ -20,3 +23,14 @@ pytestmark = pytest.mark.django_db
 def test_regulation_update(new_data, expected_valid, use_update_form):
     with raises_if(ValidationError, not expected_valid):
         use_update_form(factories.UIRegulationFactory(), new_data)
+
+
+@pytest.mark.parametrize(
+    ("view", "url_pattern"),
+    get_detail_class_based_view_urls_matching_url("regulations/"),
+    ids=view_urlpattern_ids,
+)
+def test_regulation_detail_views(view, url_pattern, valid_user_client):
+    """Verify that regulation detail views are under the url regulations/ and
+    don't return an error."""
+    assert_model_view(view, url_pattern, valid_user_client)


### PR DESCRIPTION
Fix a bug in measures detail ... but also -

Adds infrastructure to test our class based views and uses it to verify all our detail views return a 200.

While this could be just one big parametrised test, I separated things out: there should be a bit of intentionality to what's in a test, and while this automates things quite a lot - automating things too much can lead to tests where it's hard to tell if it is passing because it should, or not.

This only tests detail views right now, to limit the size of the PR, testing other views should be straightforward in a follow-up PR, it'll be good to see where feedback takes this first.