### PR TITLE
Fix measure effective validity calculation

### DIFF
--- a/common/filters.py
+++ b/common/filters.py
@@ -18,10 +18,8 @@ from crispy_forms_gds.layout import Size
 from django import forms
 from django.contrib.postgres.aggregates import StringAgg
 from django.contrib.postgres.search import SearchVector
-from django.db.models import DateField
 from django.db.models import Q
 from django.db.models.functions import Extract
-from django.db.models.functions import Lower
 from django.utils.safestring import mark_safe
 from django_filters import CharFilter
 from django_filters import FilterSet
@@ -33,6 +31,7 @@ from rest_framework.settings import api_settings
 from common.fields import AutoCompleteField
 from common.jinja2 import break_words
 from common.models.tracked_qs import TrackedModelQuerySet
+from common.util import StartDate
 from common.util import TaricDateRange
 
 ACTIVE_STATE_CHOICES = [Choice("active", "Active"), Choice("terminated", "Terminated")]
@@ -260,7 +259,7 @@ class StartYearMixin(FilterSet):
         if value:
             queryset = queryset.annotate(
                 start_year=Extract(
-                    Lower("valid_between", output_field=DateField()),
+                    StartDate("valid_between"),
                     "year",
                 ),
             ).filter(start_year__in=value)

--- a/measures/business_rules.py
+++ b/measures/business_rules.py
@@ -5,6 +5,7 @@ from typing import Optional
 
 from dateutil.relativedelta import relativedelta
 from django.db.models import Q
+from django.db.utils import DataError
 
 from common.business_rules import BusinessRule
 from common.business_rules import FootnoteApplicability
@@ -289,12 +290,17 @@ class ME25(BusinessRule):
     the start date of the measure must be less than or equal to the end date."""
 
     def validate(self, measure):
-        effective_end_date = measure.effective_end_date
+        try:
+            effective_end_date = measure.effective_end_date
 
-        if effective_end_date is None:
-            return
+            if effective_end_date is None:
+                return
 
-        if measure.valid_between.lower > effective_end_date:
+            if measure.valid_between.lower > effective_end_date:
+                raise self.violation(measure)
+        except DataError:
+            # ``effective_end_date`` will raise a database error if it tries to
+            # compute the date and it breaks this rule
             raise self.violation(measure)
 
 

--- a/measures/filters.py
+++ b/measures/filters.py
@@ -1,9 +1,6 @@
 from django import forms
 from django.contrib.postgres.aggregates import StringAgg
-from django.db.models import DateField
 from django.db.models import Q
-from django.db.models.functions import Lower
-from django.db.models.functions import Upper
 from django.urls import reverse_lazy
 from django_filters import CharFilter
 from django_filters import ChoiceFilter
@@ -15,6 +12,8 @@ from common.filters import AutoCompleteFilter
 from common.filters import TamatoFilter
 from common.filters import TamatoFilterBackend
 from common.forms import DateInputFieldFixed
+from common.util import EndDate
+from common.util import StartDate
 from footnotes.models import Footnote
 from geo_areas.models import GeographicalArea
 from measures.forms import MeasureFilterForm
@@ -160,7 +159,7 @@ class MeasureFilter(TamatoFilter):
             else:
                 filter_query = Q(start_date=value)
             queryset = queryset.annotate(
-                start_date=Lower("valid_between", output_field=DateField()),
+                start_date=StartDate("valid_between"),
             ).filter(filter_query)
         return queryset
 
@@ -175,12 +174,7 @@ class MeasureFilter(TamatoFilter):
                 filter_query = Q(end_date=value)
             queryset = (
                 queryset.with_effective_valid_between()
-                .annotate(
-                    end_date=Upper(
-                        "db_effective_valid_between",
-                        output_field=DateField(),
-                    ),
-                )
+                .annotate(end_date=EndDate("db_effective_valid_between"))
                 .filter(filter_query)
             )
         return queryset

--- a/measures/models.py
+++ b/measures/models.py
@@ -544,42 +544,28 @@ class Measure(TrackedModel, ValidityMixin):
     validity_field_name = "db_effective_valid_between"
 
     @property
-    def effective_end_date(self):
+    def effective_end_date(self) -> date:
         """Measure end dates may be overridden by regulations."""
-
-        # UK measures will have explicit end dates only
-        # if self.national:
-        #     return self.valid_between.upper
-
-        reg = self.generating_regulation
-        effective_end_date = (
-            date(
-                reg.effective_end_date.year,
-                reg.effective_end_date.month,
-                reg.effective_end_date.day,
+        if not hasattr(self, self.validity_field_name):
+            effective_valid_between = (
+                type(self)
+                .objects_with_validity_field()
+                .filter(pk=self.pk)
+                .get()
+                .db_effective_valid_between
             )
-            if reg.effective_end_date
-            else None
-        )
+            setattr(self, self.validity_field_name, effective_valid_between)
 
-        if self.valid_between.upper and reg and effective_end_date:
-            if self.valid_between.upper > effective_end_date:
-                return effective_end_date
-            return self.valid_between.upper
-
-        if self.valid_between.upper and self.terminating_regulation:
-            return self.valid_between.upper
-
-        if reg:
-            return effective_end_date
-
-        return self.valid_between.upper
+        return getattr(self, self.validity_field_name).upper
 
     def __str__(self):
         return str(self.sid)
 
     @property
-    def effective_valid_between(self):
+    def effective_valid_between(self) -> TaricDateRange:
+        if hasattr(self, self.validity_field_name):
+            return getattr(self, self.validity_field_name)
+
         return TaricDateRange(self.valid_between.lower, self.effective_end_date)
 
     @classmethod

--- a/measures/querysets.py
+++ b/measures/querysets.py
@@ -7,11 +7,20 @@ from django.db.models import Q
 from django.db.models import QuerySet
 from django.db.models import Value
 from django.db.models import When
+from django.db.models.aggregates import Max
+from django.db.models.fields import DateField
+from django.db.models.functions import Coalesce
 from django.db.models.functions import Concat
+from django.db.models.functions.comparison import Cast
+from django.db.models.functions.comparison import NullIf
 from django.db.models.functions.text import Trim
+from django_cte.cte import With
 
 from common.fields import TaricDateRangeField
 from common.models.tracked_qs import TrackedModelQuerySet
+from common.util import EndDate
+from common.util import StartDate
+from regulations.models import Regulation
 
 
 class DutySentenceMixin(QuerySet):
@@ -151,76 +160,79 @@ class DutySentenceMixin(QuerySet):
 class MeasuresQuerySet(TrackedModelQuerySet, DutySentenceMixin):
     def with_effective_valid_between(self):
         """
-        In many cases the measures regulation effective_end_date overrides the
-        measures validity range.
+        There are five ways in which measures can get end dated:
 
-        Annotate the queryset with the db_effective_valid_between based on the regulations and measure.
+        1. Where the measure is given an explicit end date on the measure record
+           itself
+        2. Where the measure's generating regulation is a base regulation, and
+           the base regulation itself is end-dated
+        3. Where the measure's generating regulation is a modification
+           regulation, and the modification regulation itself is end-dated
+        4. Where the measure's generating regulation is a base regulation,
+           and any of the modification regulations that modify it are end-dated
+        5. Where the measure's generating regulation is a modification
+           regulation, and the base regulation that it modifies is end-dated
 
-        Generates the following SQL:
-
-        .. code:: SQL
-
-            SELECT *,
-                   CASE
-                     WHEN (
-                       "regulations_regulation"."effective_end_date" IS NOT NULL AND
-                       "measures_measure"."valid_between" @> "regulations_regulation"."effective_end_date"::timestamp WITH time zone AND
-                       NOT Upper_inf("measures_measure"."valid_between")
-                     ) THEN Daterange(Lower("measures_measure"."valid_between"), "regulations_regulation"."effective_end_date", [])
-                     WHEN (
-                       "regulations_regulation"."effective_end_date" IS NOT NULL AND
-                       Upper_inf("measures_measure"."valid_between")
-                     ) THEN "measures_measure"."valid_between"
-                     WHEN (
-                       "measures_measure"."terminating_regulation_id" IS NOT NULL AND
-                       NOT Upper_inf("measures_measure"."valid_between")
-                     ) THEN "measures_measure"."valid_between"
-                     WHEN "measures_measure"."generating_regulation_id" IS NOT NULL THEN Daterange(Lower("measures_measure"."valid_between"), "regulations_regulation"."effective_end_date", [])
-                     ELSE "measures_measure"."valid_between"
-                   END AS "db_effective_valid_between"
-              FROM "measures_measure"
-             INNER JOIN "regulations_regulation"
-                ON "measures_measure"."generating_regulation_id" = "regulations_regulation"."trackedmodel_ptr_id"
-             INNER JOIN "common_trackedmodel"
-                ON "measures_measure"."trackedmodel_ptr_id" = "common_trackedmodel"."id"
+        Numbers 2–5 also have to take account of the "effective end date" which
+        if set should be used over any explicit date. The effective end date is
+        set when other types of regulations are used (abrogation, prorogation,
+        etc).
         """
-        return self.annotate(
-            db_effective_valid_between=Case(
-                When(
-                    valid_between__upper_inf=False,
-                    generating_regulation__effective_end_date__isnull=False,
-                    valid_between__contains=F(
-                        "generating_regulation__effective_end_date",
+
+        # Computing the end date for case 4 is expensive because it involves
+        # aggregating over all of the modifications to the base regulation,
+        # where there is one. So we pull this out into a CTE to let Postgres
+        # know that none of this caluclation depends on the queryset filters.
+        #
+        # We also turn NULLs into "infinity" such that they sort to the top:
+        # i.e. if any modification regulation is open-ended, so is the measure.
+        # We then turn infinity back into NULL to be used in the date range.
+        end_date_from_modifications = With(
+            Regulation.objects.annotate(
+                amended_end_date=NullIf(
+                    Max(
+                        Coalesce(
+                            F("amendments__enacting_regulation__effective_end_date"),
+                            EndDate("amendments__enacting_regulation__valid_between"),
+                            Cast(Value("infinity"), DateField()),
+                        ),
                     ),
-                    then=Func(
-                        Func(F("valid_between"), function="LOWER"),
-                        F("generating_regulation__effective_end_date"),
-                        Value("[]"),
-                        function="DATERANGE",
-                    ),
+                    Cast(Value("infinity"), DateField()),
                 ),
-                When(
-                    valid_between__upper_inf=False,
-                    generating_regulation__effective_end_date__isnull=False,
-                    then=F("valid_between"),
-                ),
-                When(
-                    valid_between__upper_inf=False,
-                    terminating_regulation__isnull=False,
-                    then=F("valid_between"),
-                ),
-                When(
-                    generating_regulation__isnull=False,
-                    then=Func(
-                        Func(F("valid_between"), function="LOWER"),
-                        F("generating_regulation__effective_end_date"),
-                        Value("[]"),
-                        function="DATERANGE",
-                    ),
-                ),
-                default=F("valid_between"),
-                output_field=TaricDateRangeField(),
             ),
+            "end_date_from_modifications",
+        )
+
+        return (
+            end_date_from_modifications.join(
+                self,
+                generating_regulation_id=end_date_from_modifications.col.id,
+            )
+            .with_cte(end_date_from_modifications)
+            .annotate(
+                db_effective_end_date=Coalesce(
+                    # Case 1 – explicit end date, which is always used if present
+                    EndDate("valid_between"),
+                    # Case 2 and 3 – end date of regulation
+                    F("generating_regulation__effective_end_date"),
+                    EndDate("generating_regulation__valid_between"),
+                    # Case 4 – generating regulation is a base regulation, and
+                    # the modification regulation is end-dated
+                    end_date_from_modifications.col.amended_end_date,
+                    # Case 5 – generating regulation is a modification regulation,
+                    # and the base it modifies is end-dated. Note that the above
+                    # means that this only applies if the modification has no end date.
+                    F("generating_regulation__amends__effective_end_date"),
+                    EndDate("generating_regulation__amends__valid_between"),
+                ),
+                db_effective_valid_between=Func(
+                    StartDate("valid_between"),
+                    F("db_effective_end_date"),
+                    Value("[]"),
+                    function="DATERANGE",
+                    output_field=TaricDateRangeField(),
+                ),
+            )
         )
 
 


### PR DESCRIPTION
## Why
A measure can have either an explicit or implicit end date, where the implicit version is specified by the regulation. Our previous algorithm for finding the implicit end date was not correct, because it reported lots of EU measures as still being in force when clearly (as enforced by ME32) they could not be.

## What
This commit fixes the algorithm, and also ensures that when the value is requested from a measure for which it was not pre-loaded, it is calculated in the same way.

The new algorithm has been found through examination of the existing data and comparison with the Online Tariff service as a known good source. E.g. I found EU measures that the system considers still active using:

```python
Measure.objects
.with_effective_valid_between()
.filter(
    sid__lt=20000000, # exclude UK measures
    db_effective_valid_between__contains=date.today(),
)
```

With this new algorithm, the above query returns a small number of measures which it would make sense if still active e.g. measures on Meursing codes. There are still some anomalies, but the situation is much improved.

<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
## Checklist
- Requires migrations?
- Requires dependency updates?
--->

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
