### PR TITLE
Return ME67 to active service

### DIFF
--- a/measures/tests/test_business_rules.py
+++ b/measures/tests/test_business_rules.py
@@ -1640,21 +1640,21 @@ def test_ME66():
         business_rules.ME66(exclusion.transaction).validate(exclusion)
 
 
-@pytest.mark.xfail(reason="ME67 disabled")
-def test_ME67(date_ranges):
+def test_ME67(spanning_dates):
     """The membership period of the excluded geographical area must span the
     validity period of the measure."""
+    membership_period, measure_period, fully_spans = spanning_dates
 
     membership = factories.GeographicalMembershipFactory.create(
-        valid_between=date_ranges.normal,
+        valid_between=membership_period,
     )
     exclusion = factories.MeasureExcludedGeographicalAreaFactory.create(
         excluded_geographical_area=membership.member,
         modified_measure__geographical_area=membership.geo_group,
-        modified_measure__valid_between=date_ranges.overlap_normal,
+        modified_measure__valid_between=measure_period,
     )
-    with pytest.raises(BusinessRuleViolation):
-        business_rules.ME67(exclusion.transaction).validate(exclusion.modified_measure)
+    with raises_if(BusinessRuleViolation, not fully_spans):
+        business_rules.ME67(exclusion.transaction).validate(exclusion)
 
 
 def test_ME68():


### PR DESCRIPTION
## Why
At some point in the past, ME67 has been disabled, probably due to a faulty implementation that was firing on seed data erroneously.

However, our data does need to abide by ME67 and we have had a number of recent cases where we've failed to do so because this rule is disabled.

## What
This commit restores ME67 and adds to its tests to ensure that it behaves correctly.


<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
## Checklist
- Requires migrations?
- Requires dependency updates?
--->

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
