### PR TITLE
Fix: Unordered Track Models are constrained to those linked to the TransactionQueryset

### DIFF
--- a/common/models/transactions.py
+++ b/common/models/transactions.py
@@ -70,20 +70,16 @@ class TransactionsAlreadyApproved(Exception):
 class TransactionQueryset(models.QuerySet):
     def unordered_tracked_models(self):
         """Usually 'ordered_tracked_models' is required."""
-        return self.model.tracked_models.rel.related_model.objects
+        return self.model.tracked_models.rel.related_model.objects.filter(
+            transaction__in=self,
+        )
 
     def ordered_tracked_models(self):
         """TrackedModel in order of their transactions creation order."""
 
-        tracked_models = (
-            self.unordered_tracked_models()
-            .filter(
-                transaction__in=self,
-            )
-            .order_by(
-                "transaction__partition",
-                "transaction__order",
-            )
+        tracked_models = self.unordered_tracked_models().order_by(
+            "transaction__partition",
+            "transaction__order",
         )  # order_by record_code, subrecord_code already happened in get_queryset
         return tracked_models
 

--- a/common/tests/test_transactions.py
+++ b/common/tests/test_transactions.py
@@ -1,0 +1,88 @@
+"""Includes tests for select fuctionalities in TransactionQueryset."""
+import pytest
+
+from common.models.transactions import Transaction
+from common.tests import factories
+from workbaskets.models import get_partition_scheme
+
+pytestmark = pytest.mark.django_db
+partition_scheme = get_partition_scheme()
+
+
+def test_unordered_tracked_models_are_linked_to_queryset():
+    """Asserts that all models returned by unordered_tracked_models are in the
+    workbasket."""
+    transaction_this = factories.TransactionFactory()
+    factories.MeasureFactory.create(
+        transaction=transaction_this,
+    )
+
+    transaction_other = factories.TransactionFactory()
+    factories.MeasureFactory.create(
+        transaction=transaction_other,
+    )
+
+    qs = Transaction.objects.filter(id=transaction_this.id)
+    unordered_tracked_models = qs.unordered_tracked_models()
+
+    assert (
+        unordered_tracked_models.filter(
+            transaction=transaction_this,
+        ).count()
+        == unordered_tracked_models.count()
+    )
+
+
+def test_ordered_tracked_models_are_sorted_on_order():
+    """Asserts that all models returned by ordered_tracked_models in the right
+    order."""
+    transaction_second = factories.TransactionFactory(order=2)
+    factories.MeasureFactory.create(
+        transaction=transaction_second,
+    )
+
+    transaction_first = factories.TransactionFactory(order=1)
+    factories.MeasureFactory.create(
+        transaction=transaction_first,
+    )
+
+    ids = (transaction_first.id, transaction_second.id)
+    qs = Transaction.objects.filter(id__in=ids)
+    ordered_tracked_models = qs.ordered_tracked_models().values_list(
+        "transaction__order",
+        flat=True,
+    )
+
+    assert sorted(ordered_tracked_models) == list(ordered_tracked_models)
+
+
+def test_ordered_tracked_models_are_sorted_on_partition_and_order():
+    """Asserts that all models returned by ordered_tracked_models in the right
+    order."""
+    transaction_first = factories.TransactionFactory(
+        partition=partition_scheme.get_partition("PROPOSED"),
+        order=2,
+    )
+    factories.MeasureFactory.create(
+        transaction=transaction_first,
+    )
+
+    transaction_second = factories.TransactionFactory(
+        partition=partition_scheme.get_approved_partition(),
+        order=1,
+    )
+    factories.MeasureFactory.create(
+        transaction=transaction_second,
+    )
+
+    ids = (transaction_first.id, transaction_second.id)
+    qs = Transaction.objects.filter(id__in=ids)
+    ordered_tracked_models = qs.ordered_tracked_models()
+
+    assert (
+        sorted(
+            ordered_tracked_models,
+            key=lambda x: (x.transaction.partition, x.transaction.order),
+        )
+        == list(ordered_tracked_models)
+    )


### PR DESCRIPTION
# TP-1082 Unordered Track Models are constrained to those linked to the TransactionQueryset

## Why
At the moment `common.models.transactions.TransactionQueryset.unordered_tracked_model` returns any and all models in the database. 
This is unintended and the filter condition `transaction__in=self` applied later in `ordered_tracked_model` should be moved to this method instead.

## What
Move the  filter condition `transaction__in=self` to the unordered method
