### PR TITLE
TP-1087 Find a version group created in the same draft workbasket

### DIFF
--- a/common/models/trackedmodel.py
+++ b/common/models/trackedmodel.py
@@ -210,7 +210,30 @@ class TrackedModel(PolymorphicModel):
     def _get_version_group(self) -> VersionGroup:
         if self.update_type == validators.UpdateType.CREATE:
             return VersionGroup.objects.create()
-        return self.get_versions().latest_approved().last().version_group
+
+        latest_version = self.get_versions().latest_approved().last()
+
+        if not latest_version:
+            # An object may be created and deleted/updated in the same workbasket.
+            # If the workbasket status is not WorkflowStatus.PUBLISHED,
+            # then latest_approved() in the above line of code will return None.
+            # Trying to get the version group off that will throw an exception.
+            # The extra bit of logic below deals with such cases
+            # It will attempt to find the corresponding CREATE record
+            # in the current workbasket and return that as the latest_version.
+            try:
+                latest_version = [
+                    record
+                    for transaction in self.transaction.workbasket.transactions.all()
+                    for record in transaction.tracked_models.all()
+                    if type(record) == type(self)
+                    if record.update_type == UpdateType.CREATE
+                    if record.get_identifying_fields() == self.get_identifying_fields()
+                ][0]
+            except IndexError:
+                return
+
+        return latest_version.version_group
 
     def _can_write(self):
         return not (


### PR DESCRIPTION
# TP-1087 Find a version group created in the same draft workbasket

## Why
Historically, `TrackedModel._get_version_group()` has only looked at `latest_approved()` versions of a model when looking for a version group.
However, when importing a large taric envelope, it is possible to have the same model created and then updated in the same workbasket.
This ticket is to enable that.

## What
Enhance `TrackedModel._get_version_group()` to support the extra lookup functionality

<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
## Checklist
- Requires migrations?
- Requires dependency updates?
--->

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
