### PR TITLE
TP-1088 Support reordering when workbasket transaction order is not contiguous

### DIFF
--- a/additional_codes/tests/test_views.py
+++ b/additional_codes/tests/test_views.py
@@ -1,16 +1,23 @@
 import pytest
 
 from additional_codes.models import AdditionalCode
-from common.tests.util import assert_model_view
-from common.tests.util import get_detail_class_based_view_urls_matching_url
+from additional_codes.views import AdditionalCodeList
+from common.tests.util import assert_model_view_renders
+from common.tests.util import get_class_based_view_urls_matching_url
+from common.tests.util import view_is_subclass
 from common.tests.util import view_urlpattern_ids
+from common.views import TamatoListView
+from common.views import TrackedModelDetailMixin
 
 pytestmark = pytest.mark.django_db
 
 
 @pytest.mark.parametrize(
     ("view", "url_pattern"),
-    get_detail_class_based_view_urls_matching_url("additional_codes/"),
+    get_class_based_view_urls_matching_url(
+        "additional_codes/",
+        view_is_subclass(TrackedModelDetailMixin),
+    ),
     ids=view_urlpattern_ids,
 )
 def test_additional_codes_detail_views(view, url_pattern, valid_user_client):
@@ -20,4 +27,19 @@ def test_additional_codes_detail_views(view, url_pattern, valid_user_client):
         "additional_codes.views.AdditionalCodeCreateDescription": AdditionalCode,
     }
 
-    assert_model_view(view, url_pattern, valid_user_client, model_overrides)
+    assert_model_view_renders(view, url_pattern, valid_user_client, model_overrides)
+
+
+@pytest.mark.parametrize(
+    ("view", "url_pattern"),
+    get_class_based_view_urls_matching_url(
+        "additional_codes/",
+        view_is_subclass(TamatoListView),
+        assert_contains_view_classes=[AdditionalCodeList],
+    ),
+    ids=view_urlpattern_ids,
+)
+def test_additional_codes_list_view(view, url_pattern, valid_user_client):
+    """Verify that additional code list view is under the url additional_codes/
+    and doesn't return an error."""
+    assert_model_view_renders(view, url_pattern, valid_user_client)

--- a/certificates/tests/test_views.py
+++ b/certificates/tests/test_views.py
@@ -1,14 +1,21 @@
 import pytest
 
 from certificates.models import Certificate
-from common.tests.util import assert_model_view
-from common.tests.util import get_detail_class_based_view_urls_matching_url
+from certificates.views import CertificatesList
+from common.tests.util import assert_model_view_renders
+from common.tests.util import get_class_based_view_urls_matching_url
+from common.tests.util import view_is_subclass
 from common.tests.util import view_urlpattern_ids
+from common.views import TamatoListView
+from common.views import TrackedModelDetailMixin
 
 
 @pytest.mark.parametrize(
     ("view", "url_pattern"),
-    get_detail_class_based_view_urls_matching_url("certificates/"),
+    get_class_based_view_urls_matching_url(
+        "certificates/",
+        view_is_subclass(TrackedModelDetailMixin),
+    ),
     ids=view_urlpattern_ids,
 )
 def test_certificate_detail_views(view, url_pattern, valid_user_client):
@@ -16,4 +23,19 @@ def test_certificate_detail_views(view, url_pattern, valid_user_client):
     don't return an error."""
     model_overrides = {"certificates.views.CertificateCreateDescription": Certificate}
 
-    assert_model_view(view, url_pattern, valid_user_client, model_overrides)
+    assert_model_view_renders(view, url_pattern, valid_user_client, model_overrides)
+
+
+@pytest.mark.parametrize(
+    ("view", "url_pattern"),
+    get_class_based_view_urls_matching_url(
+        "certificates/",
+        view_is_subclass(TamatoListView),
+        assert_contains_view_classes=[CertificatesList],
+    ),
+    ids=view_urlpattern_ids,
+)
+def test_certificate_list_view(view, url_pattern, valid_user_client):
+    """Verify that certificate list view is under the url certificates/ and
+    doesn't return an error."""
+    assert_model_view_renders(view, url_pattern, valid_user_client)

--- a/commodities/import_handlers.py
+++ b/commodities/import_handlers.py
@@ -339,6 +339,7 @@ class GoodsNomenclatureIndentHandler(BaseHandler):
             else:
                 next_parent = indent.get_parent_node(
                     parent_depth,
+                    as_of_transaction=indent.transaction,
                     start_date=start_date,
                 )
             if not next_parent:

--- a/commodities/models/orm.py
+++ b/commodities/models/orm.py
@@ -516,12 +516,11 @@ class GoodsNomenclatureIndentNode(MP_Node, ValidityMixin):
             "valid_between__startswith",
         ).last()
 
-    @property
-    def succeeding_node(
+    def get_succeeding_node(
         self,
         as_of_transaction: Optional[Transaction] = None,
     ) -> Optional[GoodsNomenclatureIndentNode]:
-        """Returns the successor to this node, if any."""
+        """Returns the successeeding node to this node, if it exists."""
         indent = self.indent.get_succeeding_indent(as_of_transaction)
 
         if not indent:

--- a/common/models/transactions.py
+++ b/common/models/transactions.py
@@ -8,7 +8,6 @@ from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.core.serializers.json import DjangoJSONEncoder
 from django.db import models
-from django.db.models import F
 from django.db.transaction import atomic
 from django_fsm import FSMIntegerField
 from django_fsm import transition
@@ -16,6 +15,7 @@ from django_fsm import transition
 from common.business_rules import BusinessRuleChecker
 from common.business_rules import BusinessRuleViolation
 from common.models.mixins import TimestampedMixin
+from common.renderers import counter_generator
 
 logger = getLogger(__name__)
 PREEMPTIVE_TRANSACTION_SEED = -100000
@@ -94,20 +94,43 @@ class TransactionQueryset(models.QuerySet):
         """
         return self.exclude(partition=TransactionPartition.DRAFT)
 
-    def preorder_negative_transactions(self) -> None:
+    @atomic
+    def apply_transaction_order(self, partition_scheme) -> None:
         """
-        Makes all order numbers negative if there is even one negative order
-        number.
+        Reorder transactions in the workbasket.
 
-        Negative order numbers happen in preemptive transactions, e.g. when we
-        import commodity code changes
+        Note that transaction orders may not be contiguous,
+        e.g. when the workbasket has preemptive transactions
+        (created by the commodity code change handler).
+
+        TODO: Enhance this method to order based on partitions also.
         """
-        if self.count() and self.order_by("order").first().order < 0:
-            order = PREEMPTIVE_TRANSACTION_SEED
-            for tx in self.order_by("order").all():
-                order += 1
-                tx.order = order
-                tx.save()
+        first_tx = self.order_by("order").first()
+
+        if self.order_by("order").first().order < 0:
+            pass
+        else:
+            first_tx.order
+
+        # Ensure order of the transactions in this query to start at the end of the existing approved partition.
+        existing_tx = self.model.objects.filter(
+            partition=partition_scheme.get_approved_partition(),
+        ).last()
+        order_start = existing_tx.order + 1 if existing_tx else 0
+
+        counter = counter_generator(start=order_start + 1)
+
+        logger.debug(
+            "Update draft transactions in query starting from %s "
+            "to start after transaction %s. order_start: %s",
+            first_tx.pk,
+            existing_tx.pk if existing_tx else None,
+            order_start,
+        )
+
+        for tx in self.order_by("order").all():
+            tx.order = counter()
+            tx.save()
 
     @atomic
     def save_drafts(self, partition_scheme):
@@ -123,6 +146,10 @@ class TransactionQueryset(models.QuerySet):
             logger.error(msg)
             raise TransactionsAlreadyApproved(msg)
 
+        if self.first() is None:
+            logger.info("Draft contains no transactions, bailing out early.")
+            return
+
         # Find the transaction in the destination approved partition with the highest order
         # get_approved_partition may raise a ValueError, e.g. when attempting to create
         # a seed transaction when revisions exist, so it is called before any of the
@@ -135,38 +162,14 @@ class TransactionQueryset(models.QuerySet):
             approved_partition,
         )
         logger.debug("Update versions_group.")
+
         for obj in self.unordered_tracked_models().order_by("pk"):
             version_group = obj.version_group
             version_group.current_version = obj
             version_group.save()
 
-        self.preorder_negative_transactions()
-
-        new_tx = self.first()
-        if new_tx is None:
-            logger.info("Draft contains no transactions, bailing out early.")
-            return
-
-        # Ensure order of the transactions in this query to start at the end of the existing approved partition.
-        existing_tx = self.model.objects.filter(
-            partition=approved_partition,
-        ).last()
-        order_start = existing_tx.order + 1 if existing_tx else 0
-        order_difference = order_start - new_tx.order if new_tx else 1
-
-        logger.debug(
-            "Update draft transactions in query starting from %s to start after transaction %s."
-            "  order_start: %s, order_difference: %s",
-            new_tx.pk if new_tx else None,
-            existing_tx.pk if existing_tx else None,
-            order_start,
-            order_difference,
-        )
-
-        self.update(
-            order=F("order") + order_difference,
-            partition=approved_partition,
-        )
+        self.apply_transaction_order(partition_scheme)
+        self.update(partition=approved_partition)
 
 
 class Transaction(TimestampedMixin):

--- a/common/models/transactions.py
+++ b/common/models/transactions.py
@@ -105,12 +105,6 @@ class TransactionQueryset(models.QuerySet):
 
         TODO: Enhance this method to order based on partitions also.
         """
-        first_tx = self.order_by("order").first()
-
-        if self.order_by("order").first().order < 0:
-            pass
-        else:
-            first_tx.order
 
         # Ensure order of the transactions in this query to start at the end of the existing approved partition.
         existing_tx = self.model.objects.filter(
@@ -118,15 +112,15 @@ class TransactionQueryset(models.QuerySet):
         ).last()
         order_start = existing_tx.order + 1 if existing_tx else 0
 
-        counter = counter_generator(start=order_start + 1)
-
         logger.debug(
             "Update draft transactions in query starting from %s "
             "to start after transaction %s. order_start: %s",
-            first_tx.pk,
+            self.order_by("order").first().pk,
             existing_tx.pk if existing_tx else None,
             order_start,
         )
+
+        counter = counter_generator(start=order_start + 1)
 
         for tx in self.order_by("order").all():
             tx.order = counter()

--- a/common/models/transactions.py
+++ b/common/models/transactions.py
@@ -125,7 +125,7 @@ class TransactionQueryset(models.QuerySet):
         existing_tx = self.model.objects.filter(
             partition=partition_scheme.get_approved_partition(),
         ).last()
-        order_start = existing_tx.order + 1 if existing_tx else 0
+        order_start = existing_tx.order + 1 if existing_tx else 1
 
         logger.debug(
             "Update draft transactions in query starting from %s "
@@ -135,7 +135,7 @@ class TransactionQueryset(models.QuerySet):
             order_start,
         )
 
-        counter = counter_generator(start=order_start + 1)
+        counter = counter_generator(start=order_start)
 
         for tx in self.order_by("order").all():
             tx.order = counter()

--- a/common/models/transactions.py
+++ b/common/models/transactions.py
@@ -94,7 +94,7 @@ class TransactionQueryset(models.QuerySet):
         """
         return self.exclude(partition=TransactionPartition.DRAFT)
 
-    def handle_negative_order_transactions(self) -> None:
+    def preorder_negative_transactions(self) -> None:
         """
         Makes all order numbers negative if there is even one negative order
         number.
@@ -140,7 +140,7 @@ class TransactionQueryset(models.QuerySet):
             version_group.current_version = obj
             version_group.save()
 
-        self.handle_negative_order_transactions()
+        self.preorder_negative_transactions()
 
         new_tx = self.first()
         if new_tx is None:

--- a/common/tests/test_transactions.py
+++ b/common/tests/test_transactions.py
@@ -98,7 +98,7 @@ def test_pre_ordering_of_querysets_with_negative_transaction_orders():
     ids = (transaction_first.id, transaction_second.id)
     qs = Transaction.objects.filter(id__in=ids)
 
-    qs.handle_negative_order_transactions()
+    qs.preorder_negative_transactions()
     assert all(tx.order < 0 for tx in qs.all())
 
 

--- a/common/tests/test_transactions.py
+++ b/common/tests/test_transactions.py
@@ -98,8 +98,9 @@ def test_pre_ordering_of_querysets_with_negative_transaction_orders():
     ids = (transaction_first.id, transaction_second.id)
     qs = Transaction.objects.filter(id__in=ids)
 
-    qs.preorder_negative_transactions()
-    assert all(tx.order < 0 for tx in qs.all())
+    qs.apply_transaction_order(partition_scheme)
+
+    assert all(tx.order > 0 for tx in qs.all())
 
 
 def test_ordering_of_querysets_with_negative_transaction_orders():
@@ -118,7 +119,7 @@ def test_ordering_of_querysets_with_negative_transaction_orders():
     ids = (transaction_first.id, transaction_second.id)
     qs = Transaction.objects.filter(id__in=ids)
 
-    qs.save_drafts(partition_scheme)
-    assert sorted(tx.order for tx in qs.all()) == [0, 1]
-    assert qs.get(pk=transaction_first.pk).order == 0
-    assert qs.get(pk=transaction_second.pk).order == 1
+    qs.apply_transaction_order(partition_scheme)
+    assert sorted(tx.order for tx in qs.all()) == [1, 2]
+    assert qs.get(pk=transaction_first.pk).order == 1
+    assert qs.get(pk=transaction_second.pk).order == 2

--- a/common/tests/test_transactions.py
+++ b/common/tests/test_transactions.py
@@ -86,3 +86,37 @@ def test_ordered_tracked_models_are_sorted_on_partition_and_order():
         )
         == list(ordered_tracked_models)
     )
+
+
+def test_pre_ordering_of_querysets_with_negative_transaction_orders():
+    """Asserts that querysets with negative tx orders assign negative orders to
+    all transactions."""
+    transaction_first = factories.TransactionFactory(order=-1)
+
+    transaction_second = factories.TransactionFactory(order=1)
+
+    ids = (transaction_first.id, transaction_second.id)
+    qs = Transaction.objects.filter(id__in=ids)
+
+    qs.handle_negative_order_transactions()
+    assert all(tx.order < 0 for tx in qs.all())
+
+
+def test_ordering_of_querysets_with_negative_transaction_orders():
+    """Asserts that querysets with negative or very large tx orders are ordered
+    correctly."""
+    transaction_first = factories.TransactionFactory(
+        partition=partition_scheme.get_partition("PROPOSED"),
+        order=-1,
+    )
+
+    transaction_second = factories.TransactionFactory(
+        partition=partition_scheme.get_partition("PROPOSED"),
+        order=99,
+    )
+
+    ids = (transaction_first.id, transaction_second.id)
+    qs = Transaction.objects.filter(id__in=ids)
+
+    qs.save_drafts(partition_scheme)
+    assert sorted(tx.order for tx in qs.all()) == [0, 1]

--- a/common/tests/test_transactions.py
+++ b/common/tests/test_transactions.py
@@ -120,3 +120,5 @@ def test_ordering_of_querysets_with_negative_transaction_orders():
 
     qs.save_drafts(partition_scheme)
     assert sorted(tx.order for tx in qs.all()) == [0, 1]
+    assert qs.get(pk=transaction_first.pk).order == 0
+    assert qs.get(pk=transaction_second.pk).order == 1

--- a/common/tests/util.py
+++ b/common/tests/util.py
@@ -20,6 +20,7 @@ from django.db.models.base import ModelBase
 from django.template.loader import render_to_string
 from django.urls import get_resolver
 from django.urls import reverse
+from django_filters.views import FilterView
 from freezegun import freeze_time
 from lxml import etree
 
@@ -31,7 +32,6 @@ from common.tests import factories
 from common.util import TaricDateRange
 from common.util import get_accessor
 from common.util import get_field_tuple
-from common.views import TrackedModelDetailMixin
 
 INTERDEPENDENT_IMPORT_IMPLEMENTED = True
 UPDATE_IMPORTER_IMPLEMENTED = True
@@ -236,32 +236,43 @@ def view_url_pattern_starts_with(url_start):
     return prefix
 
 
-def get_detail_class_based_view_urls_matching_url(url_start, must_contain_views=None):
+def get_class_based_view_urls_matching_url(
+    url_start,
+    prefix=lambda **kwargs: True,
+    assert_contains_view_classes=None,
+):
     """
-    Return class based views, and url patterns, where the url_pattern starts
-    with a supplied string.
+    Return a list of tuples of (view, url pattern), where url_pattern starts
+    with the supplied string.
 
-    Users may optionally must_contain_views to verify if certain views were found.
+    Users may pass optionally assert_contains_view_classes to verify if certain views were found.
+
+    Use prefix to filter by particular class based views:
+
+    >>> get_class_based_view_urls_matching_url("/some-url", prefix=view_is_subclass(TrackedModelDetailMixin))
 
     :param url_start: First part of URL
-    :param must_contain_views: If views are passed in here assert if they are not found,
-    :return: List of view, url_pattern
+    :param prefix: A prefix function to filter class based views with.
+    :param assert_contains_view_classes: Optional list of views, if any are not present an assertion is raise.
+    :return: List of tuples of (view, url_pattern)
     """
     valid_url = view_url_pattern_starts_with(url_start)
-    valid_view_class = view_is_subclass(TrackedModelDetailMixin)
 
-    def prefix(**kwargs):
-        return valid_url(**kwargs) and valid_view_class(**kwargs)
+    def _prefix(**kwargs):
+        return valid_url(**kwargs) and prefix(**kwargs)
 
-    view_urls = list(get_class_based_view_urls(prefix=prefix))
+    view_urls = list(get_class_based_view_urls(prefix=_prefix))
 
     # Fail if there are no matching views - it indicates the test has a bug.
     assert len(view_urls), f"Did not find any views with a url matching {url_start}"
 
-    if must_contain_views:
+    if assert_contains_view_classes:
         # Optional list of views that should be under the URL
-        views = [view for view, url in view_urls]
-        assert set(must_contain_views).issubset(views)
+        view_classes = [view.view_class for view, url in view_urls]
+        assert set(assert_contains_view_classes).issubset(view_classes), (
+            f"View classes: {assert_contains_view_classes} not "
+            f"found in urls: {view_urls} "
+        )
 
     return view_urls
 
@@ -271,9 +282,20 @@ def get_view_model(view_class, override_models):
     :return view_model from a view class, if the fully qualified classname is present inf override_models
     this is returned instead.
     """
-    return (
-        override_models.get(fully_qualified_classname(view_class)) or view_class.model
-    )
+    # User may supply their own model in the override_models dict, keyed by the view_class
+    fq_class_name = fully_qualified_classname(view_class)
+    if fq_class_name in override_models:
+        return override_models[fq_class_name]
+
+    if view_class.model:
+        # Class Based views (such as Tamato's detail views)
+        return view_class.model
+
+    if issubclass(view_class, FilterView):
+        # FilterViews (such as TamatoListView)
+        return view_class.filterset_class.Meta.model
+
+    raise NotImplemented(f"Retrieving model from {view_class} is not implemented.")
 
 
 def get_fields_dict(instance, field_names):
@@ -289,9 +311,17 @@ def get_fields_dict(instance, field_names):
 
 
 def view_urlpattern_ids(param):
-    """Function to use as ids= parameter for tests parameterized by sequences of
-    view, url_pattern, such as get_class_based_view_urls and
-    get_detail_class_based_view_urls_matching_url."""
+    """
+    Function to use as ids= parameter for tests parameterized by sequences of
+    tuples (view, url_pattern)
+
+    Parameterizer functions that generate tuples like this include:
+     - get_class_based_view_urls and
+     - get_class_based_view_urls_matching_url.
+
+    Note:  List views have no parameters, so the test ids
+           there trailing hyphens: -.
+    """
     if hasattr(param, "view_class"):
         return param.view_class.__name__
     elif isinstance(param, tuple) and len(param) == 4:
@@ -337,7 +367,7 @@ def assert_objects_resolvable(fully_qualified_names):
         )
 
 
-def assert_model_view(
+def assert_model_view_renders(
     view,
     url_pattern,
     valid_user_client,
@@ -362,7 +392,11 @@ def assert_model_view(
 
     # Before calling the models view, create data by calling the corresponding factory:
     model = get_view_model(view.view_class, override_models or {})
-    factory = getattr(factories, f"{model.__name__}Factory")
+
+    factory_class_name = f"{model.__name__}Factory"
+    factory = getattr(factories, factory_class_name, None)
+    assert factory is not None, f"Factory not found: factories.{factory_class_name}"
+
     instance = factory.create()
 
     # Build URL using fields from the model.

--- a/geo_areas/tests/test_views.py
+++ b/geo_areas/tests/test_views.py
@@ -1,16 +1,23 @@
 import pytest
 
-from common.tests.util import assert_model_view
-from common.tests.util import get_detail_class_based_view_urls_matching_url
+from common.tests.util import assert_model_view_renders
+from common.tests.util import get_class_based_view_urls_matching_url
+from common.tests.util import view_is_subclass
 from common.tests.util import view_urlpattern_ids
+from common.views import TamatoListView
+from common.views import TrackedModelDetailMixin
 from geo_areas.models import GeographicalArea
+from geo_areas.views import GeographicalAreaList
 
 pytestmark = pytest.mark.django_db
 
 
 @pytest.mark.parametrize(
     ("view", "url_pattern"),
-    get_detail_class_based_view_urls_matching_url("geographical-areas/"),
+    get_class_based_view_urls_matching_url(
+        "geographical-areas/",
+        view_is_subclass(TrackedModelDetailMixin),
+    ),
     ids=view_urlpattern_ids,
 )
 def test_geographical_area_detail_views(view, url_pattern, valid_user_client):
@@ -20,4 +27,19 @@ def test_geographical_area_detail_views(view, url_pattern, valid_user_client):
         "geo_areas.views.GeographicalAreaCreateDescription": GeographicalArea,
     }
 
-    assert_model_view(view, url_pattern, valid_user_client, model_overrides)
+    assert_model_view_renders(view, url_pattern, valid_user_client, model_overrides)
+
+
+@pytest.mark.parametrize(
+    ("view", "url_pattern"),
+    get_class_based_view_urls_matching_url(
+        "geographical-areas/",
+        view_is_subclass(TamatoListView),
+        assert_contains_view_classes=[GeographicalAreaList],
+    ),
+    ids=view_urlpattern_ids,
+)
+def test_geographical_area_list_view(view, url_pattern, valid_user_client):
+    """Verify that geographical list view is under the url geographical-areas/
+    and doesn't return an error."""
+    assert_model_view_renders(view, url_pattern, valid_user_client)

--- a/measures/tests/test_views.py
+++ b/measures/tests/test_views.py
@@ -2,10 +2,14 @@ import pytest
 from django.urls import reverse
 
 from common.tests import factories
-from common.tests.util import assert_model_view
-from common.tests.util import get_detail_class_based_view_urls_matching_url
+from common.tests.util import assert_model_view_renders
+from common.tests.util import get_class_based_view_urls_matching_url
+from common.tests.util import view_is_subclass
 from common.tests.util import view_urlpattern_ids
+from common.views import TamatoListView
+from common.views import TrackedModelDetailMixin
 from measures.views import MeasureFootnotesUpdate
+from measures.views import MeasureList
 
 pytestmark = pytest.mark.django_db
 
@@ -83,10 +87,28 @@ def test_measure_footnotes_update_post_without_remove_ignores_delete_keys(
 
 @pytest.mark.parametrize(
     ("view", "url_pattern"),
-    get_detail_class_based_view_urls_matching_url("measures/"),
+    get_class_based_view_urls_matching_url(
+        "measures/",
+        view_is_subclass(TrackedModelDetailMixin),
+    ),
     ids=view_urlpattern_ids,
 )
 def test_measure_detail_views(view, url_pattern, valid_user_client):
     """Verify that measure detail views are under the url measures/ and don't
     return an error."""
-    assert_model_view(view, url_pattern, valid_user_client)
+    assert_model_view_renders(view, url_pattern, valid_user_client)
+
+
+@pytest.mark.parametrize(
+    ("view", "url_pattern"),
+    get_class_based_view_urls_matching_url(
+        "measures/",
+        view_is_subclass(TamatoListView),
+        assert_contains_view_classes=[MeasureList],
+    ),
+    ids=view_urlpattern_ids,
+)
+def test_measure_list_view(view, url_pattern, valid_user_client):
+    """Verify that measure list view is under the url measures/ and doesn't
+    return an error."""
+    assert_model_view_renders(view, url_pattern, valid_user_client)

--- a/quotas/tests/test_views.py
+++ b/quotas/tests/test_views.py
@@ -1,18 +1,40 @@
 import pytest
 
-from common.tests.util import assert_model_view
-from common.tests.util import get_detail_class_based_view_urls_matching_url
+from common.tests.util import assert_model_view_renders
+from common.tests.util import get_class_based_view_urls_matching_url
+from common.tests.util import view_is_subclass
 from common.tests.util import view_urlpattern_ids
+from common.views import TamatoListView
+from common.views import TrackedModelDetailMixin
+from quotas.views import QuotaList
 
 pytestmark = pytest.mark.django_db
 
 
 @pytest.mark.parametrize(
     ("view", "url_pattern"),
-    get_detail_class_based_view_urls_matching_url("quotas/"),
+    get_class_based_view_urls_matching_url(
+        "quotas/",
+        view_is_subclass(TrackedModelDetailMixin),
+    ),
     ids=view_urlpattern_ids,
 )
 def test_quota_detail_views(view, url_pattern, valid_user_client):
     """Verify that quota detail views are under the url quotas and don't return
     an error."""
-    assert_model_view(view, url_pattern, valid_user_client)
+    assert_model_view_renders(view, url_pattern, valid_user_client)
+
+
+@pytest.mark.parametrize(
+    ("view", "url_pattern"),
+    get_class_based_view_urls_matching_url(
+        "quotas/",
+        view_is_subclass(TamatoListView),
+        assert_contains_view_classes=[QuotaList],
+    ),
+    ids=view_urlpattern_ids,
+)
+def test_quota_list_view(view, url_pattern, valid_user_client):
+    """Verify that quota list view is under the url quotas/ and doesn't return
+    an error."""
+    assert_model_view_renders(view, url_pattern, valid_user_client)

--- a/regulations/tests/test_views.py
+++ b/regulations/tests/test_views.py
@@ -2,10 +2,14 @@ import pytest
 from django.core.exceptions import ValidationError
 
 from common.tests import factories
-from common.tests.util import assert_model_view
-from common.tests.util import get_detail_class_based_view_urls_matching_url
+from common.tests.util import assert_model_view_renders
+from common.tests.util import get_class_based_view_urls_matching_url
 from common.tests.util import raises_if
+from common.tests.util import view_is_subclass
 from common.tests.util import view_urlpattern_ids
+from common.views import TamatoListView
+from common.views import TrackedModelDetailMixin
+from regulations.views import RegulationList
 
 pytestmark = pytest.mark.django_db
 
@@ -27,10 +31,28 @@ def test_regulation_update(new_data, expected_valid, use_update_form):
 
 @pytest.mark.parametrize(
     ("view", "url_pattern"),
-    get_detail_class_based_view_urls_matching_url("regulations/"),
+    get_class_based_view_urls_matching_url(
+        "regulations/",
+        view_is_subclass(TrackedModelDetailMixin),
+    ),
     ids=view_urlpattern_ids,
 )
 def test_regulation_detail_views(view, url_pattern, valid_user_client):
     """Verify that regulation detail views are under the url regulations/ and
     don't return an error."""
-    assert_model_view(view, url_pattern, valid_user_client)
+    assert_model_view_renders(view, url_pattern, valid_user_client)
+
+
+@pytest.mark.parametrize(
+    ("view", "url_pattern"),
+    get_class_based_view_urls_matching_url(
+        "regulations/",
+        view_is_subclass(TamatoListView),
+        assert_contains_view_classes=[RegulationList],
+    ),
+    ids=view_urlpattern_ids,
+)
+def test_regulation_list_view(view, url_pattern, valid_user_client):
+    """Verify that regulation list view is under the url regulations/ and
+    doesn't return an error."""
+    assert_model_view_renders(view, url_pattern, valid_user_client)


### PR DESCRIPTION
# TP-1088 Support reordering when workbasket transaction order is not contiguous

## Why
In some cases, e.g. we import commodity code changes, we may add preemptive transactions to the draft import workbasket, e.g. to deal with side effects on other models and avoid business rule violations.
This ticket enhances workbasket.approve(), which is also responsible for reordering workbasket transactions, to support non-contiguous transaction orders in a workbasket.

## What
Add a new method to TransactionQueryset that assumes all responsibility for reordering workbasket transactions 

