### PR TITLE
Add ADR 15 around formalising immutability in our data.

### DIFF
--- a/docs/source/adr/0015-make-transaction-immutable-by-default.rst
+++ b/docs/source/adr/0015-make-transaction-immutable-by-default.rst
@@ -1,0 +1,49 @@
+.. _15-record-architecture-decisions:
+
+15. Make Transactions Immutable by Default
+==========================================
+
+Date: 2021-11-19
+
+Status
+------
+
+Proposed
+
+Context
+-------
+
+Data in Tamato is written as an set of "changes to things", stored in the "Tracked Model" model grouped by the Transaction model.
+The exception to this rule are Tracked Models with Transactions in the DRAFT partition, which may be modified.
+
+Currently immutability is a convention, but unenforced.
+This ADR attempts to make the places where writing happens more visible and default to being read-only elsewhere.
+
+
+Decision
+--------
+
+1. Use typing to make read-only transactions the default:
+
+i.   MutableTransaction will be added as a proxy to the Transaction class.
+
+MutableTransaction will be used in places where we need to modify transactions, i.e. save_drafts.
+
+This will be a proxy to the existing Transaction class, so will work in the same way as Transaction does today.
+
+
+ii.  Transaction to become read-only by default.
+
+Transaction will gain logic to prevent save() and update() and a mechanism to get it's mutable equivilent.
+
+
+iii. Update TrackedModel disallow writing non-draft data.
+
+Update TrackedModel will be updated to the new API.
+
+
+
+Consequences
+------------
+
+Code that writes data will have a slight overhead while being more explicit.


### PR DESCRIPTION
This ADR is about making our Transactions read-only, by default, and adding MutableTransaction as a proxy for the times we need to `.save` and `objects.update`.

## Why
Conventions are great, but what happens after we have all gone ?
This helps formalise the convention behind an API, while we can't control what future developers will do, we can make people stop for thought.

Separating reading from writing makes it very explicit that we are trying to be immutable.

https://github.com/uktrade/tamato/blob/ADR-15-make-transaction-immutable-by-default/docs/source/adr/0015-make-transaction-immutable-by-default.rst