### PR TITLE
TP-1089 fix get parent node call arguments

### DIFF
--- a/commodities/import_handlers.py
+++ b/commodities/import_handlers.py
@@ -339,6 +339,7 @@ class GoodsNomenclatureIndentHandler(BaseHandler):
             else:
                 next_parent = indent.get_parent_node(
                     parent_depth,
+                    as_of_transaction=indent.transaction,
                     start_date=start_date,
                 )
             if not next_parent:

--- a/commodities/models/orm.py
+++ b/commodities/models/orm.py
@@ -520,7 +520,7 @@ class GoodsNomenclatureIndentNode(MP_Node, ValidityMixin):
         self,
         as_of_transaction: Optional[Transaction] = None,
     ) -> Optional[GoodsNomenclatureIndentNode]:
-        """Returns the successor to this node, if any."""
+        """Returns the successeeding node to this node, if it exists."""
         indent = self.indent.get_succeeding_indent(as_of_transaction)
 
         if not indent:

--- a/commodities/models/orm.py
+++ b/commodities/models/orm.py
@@ -516,8 +516,7 @@ class GoodsNomenclatureIndentNode(MP_Node, ValidityMixin):
             "valid_between__startswith",
         ).last()
 
-    @property
-    def succeeding_node(
+    def get_succeeding_node(
         self,
         as_of_transaction: Optional[Transaction] = None,
     ) -> Optional[GoodsNomenclatureIndentNode]:


### PR DESCRIPTION
# TP-1089 fix get parent node call arguments

## Why
As part of the TP-1037, we fixed goods nomenclature node end dating issues.
One of the new methods attached to `GoodsNomenclatureIndentNode` (`get_parent_node`) exposes an as_of_transaction argument, which should be used when the method is called from within the date span loop in commodities import handler.
This bug fix addresses that issue as well as a method name issue in the same model.

## What
- call to `get_parent_node` in commodities.import_handler date span loop passes an `as_of_transaction` arg
- the name of the `get_succeeding_node` method is fixed and the property decorator is removed

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
