### PR TITLE
TP-856: Structure code links in the tariff changes view don't work for descriptions

### DIFF
--- a/common/models/mixins/description.py
+++ b/common/models/mixins/description.py
@@ -44,6 +44,9 @@ class DescriptionMixin(ValidityStartMixin):
         if action != "list":
             kwargs = self.get_identifying_fields()
             described_object = self.get_described_object()
+            if action == "detail":
+                return described_object.get_url() + "#descriptions"
+
             for field, value in described_object.get_identifying_fields().items():
                 kwargs[f"{self.described_object_field.name}__{field}"] = value
         try:


### PR DESCRIPTION
## Why
On the tariff changes table the link for a newly created description is empty ("#") and doesn't link to the described model descriptions tab as it should. This is because get_url in DescriptionMixin is looking for a url with a name of the format "'certificate_description-ui-detail", which doesn't exist.

## What
It seemed simpler to add two lines to the DescriptionMixin.get_url method than to create a redirect view and register another url for different description models (e.g. https://stackoverflow.com/questions/63467337/django-hashtags-in-url)
