### PR TITLE
use existing util.contained_date_range

### DIFF
--- a/commodities/models/orm.py
+++ b/commodities/models/orm.py
@@ -16,6 +16,7 @@ from treebeard.mp_tree import MP_Node
 from commodities import business_rules
 from commodities import validators
 from commodities.querysets import GoodsNomenclatureIndentQuerySet
+from commodities.util import contained_date_range
 from common.business_rules import UpdateValidity
 from common.fields import LongDescription
 from common.models import NumericSID
@@ -479,23 +480,11 @@ class GoodsNomenclatureIndentNode(MP_Node, ValidityMixin):
         self,
         valid_between: TaricDateRange,
     ) -> TaricDateRange:
-        new_valid_between = self.valid_between
-        if not new_valid_between.lower or (
-            valid_between.lower and new_valid_between.lower < valid_between.lower
-        ):
-            new_valid_between = TaricDateRange(
-                valid_between.lower,
-                new_valid_between.upper,
-            )
-        if not new_valid_between.upper or (
-            valid_between.upper and new_valid_between.upper > valid_between.upper
-        ):
-            new_valid_between = TaricDateRange(
-                new_valid_between.lower,
-                valid_between.upper,
-            )
-
-        return new_valid_between
+        return contained_date_range(
+            self.valid_between,
+            valid_between,
+            fallback=valid_between,
+        )
 
     @property
     def good(self) -> GoodsNomenclature:

--- a/commodities/tests/test_util.py
+++ b/commodities/tests/test_util.py
@@ -58,7 +58,7 @@ def test_date_ranges_overlap(date_ranges, a, b, expected):
         "adjacent",
     ],
 )
-def test_trimmed_date_range(
+def test_contained_date_range(
     date_ranges,
     date_range,
     containing_range,
@@ -67,12 +67,12 @@ def test_trimmed_date_range(
 ):
     dr = getattr(date_ranges, date_range)
     dr_containing = getattr(date_ranges, containing_range)
-    dr_trimmed = util.contained_date_range(dr, dr_containing)
+    dr_contained = util.contained_date_range(dr, dr_containing)
 
     if expected_lower is None:
-        assert dr_trimmed is None
+        assert dr_contained is None
     else:
         dr_start = getattr(date_ranges, expected_lower)
         dr_end = getattr(date_ranges, expected_upper)
-        assert dr_trimmed.lower == dr_start.lower
-        assert dr_trimmed.upper == dr_end.upper
+        assert dr_contained.lower == dr_start.lower
+        assert dr_contained.upper == dr_end.upper

--- a/commodities/util.py
+++ b/commodities/util.py
@@ -1,3 +1,4 @@
+from typing import Any
 from typing import Optional
 from typing import Union
 
@@ -42,6 +43,7 @@ def date_ranges_overlap(a: TaricDateRange, b: TaricDateRange) -> bool:
 def contained_date_range(
     date_range: TaricDateRange,
     containing_date_range: TaricDateRange,
+    fallback: Optional[Any] = None,
 ) -> Optional[TaricDateRange]:
     """
     Returns a trimmed contained range that is fully contained by the container
@@ -55,8 +57,8 @@ def contained_date_range(
     a = date_range
     b = containing_date_range
 
-    if date_ranges_overlap(a, b) is False:
-        return None
+    if not date_ranges_overlap(a, b):
+        return fallback
 
     start_date = None
     end_date = None


### PR DESCRIPTION
# TP-1094 Fix _get_restricted_valid_between
<!---
 * Include the JIRA ticket number, eg TP-123, to automatically link.
 * Use 50 characters maximum.
 * Do not end with a full-stop.
--->

## Why
At the moment `GoodsNomenclatureIndentNode._get_restricted_valid_betwen` does not handle well cases with non-overlapping dates, which can legitimately occur. This has emerged as a secondary issue blocking 887.

## What
- `GoodsNomenclatureIndentNode._get_restricted_valid_betwen` now calls `commodities.util.contained_date_range` instead of trying to replicate its logic. The latter method is already well covered with tests, including cases with non-overlapping dates.
- Allow `commodities.util.contained_date_range` to return a customisable fallback value in case of non-overlapping end dates

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
