### PR TITLE
TP-1020: ME58 should cover conditions without certificates as well

### DIFF
--- a/common/models/mixins/description.py
+++ b/common/models/mixins/description.py
@@ -44,6 +44,9 @@ class DescriptionMixin(ValidityStartMixin):
         if action != "list":
             kwargs = self.get_identifying_fields()
             described_object = self.get_described_object()
+            if action == "detail":
+                return described_object.get_url() + "#descriptions"
+
             for field, value in described_object.get_identifying_fields().items():
                 kwargs[f"{self.described_object_field.name}__{field}"] = value
         try:

--- a/measures/business_rules.py
+++ b/measures/business_rules.py
@@ -929,8 +929,7 @@ class ME58(BusinessRule):
         else:
             kwargs.update(
                 {
-                    "required_certificate__sid": measure_condition.required_certificate.sid,
-                    "required_certificate__certificate_type__sid": measure_condition.required_certificate.certificate_type.sid,
+                    "required_certificate__version_group": measure_condition.required_certificate.version_group,
                 },
             )
 

--- a/measures/tests/test_business_rules.py
+++ b/measures/tests/test_business_rules.py
@@ -1369,6 +1369,16 @@ def test_ME58():
     with pytest.raises(BusinessRuleViolation):
         business_rules.ME58(duplicate.transaction).validate(existing)
 
+    not_required = factories.MeasureConditionFactory.create(required_certificate=None)
+    duplicate = factories.MeasureConditionFactory.create(
+        condition_code=not_required.condition_code,
+        dependent_measure=not_required.dependent_measure,
+        required_certificate=None,
+    )
+
+    with pytest.raises(BusinessRuleViolation):
+        business_rules.ME58(duplicate.transaction).validate(not_required)
+
 
 def test_ME59(reference_nonexistent_record):
     """The referenced action code must exist."""


### PR DESCRIPTION
## Why
"Our current implementation doesn't run the rule if there is no certificate, but actually, this rule should still apply. I.e. there should only be one measure condition with "no required certificate" per measure condition code."

## What
- Update ME58 to filter by kwargs set conditionally on whether a measure_condition has a required_certificate
- Add case to business rule test