### PR TITLE
TP-1096 Fix exploding db round trips in commodity tree snapshots

### DIFF
--- a/commodities/models/dc.py
+++ b/commodities/models/dc.py
@@ -24,13 +24,13 @@ from commodities.models.orm import GoodsNomenclatureIndent
 from commodities.util import clean_item_id
 from commodities.util import contained_date_range
 from commodities.util import date_ranges_overlap
-from commodities.util import get_latest_versions
 from common.business_rules import BusinessRuleViolation
 from common.models.constants import ClockType
 from common.models.dc.base import BaseModel
 from common.models.trackedmodel import TrackedModel
 from common.models.transactions import Transaction
 from common.util import TaricDateRange
+from common.util import get_latest_versions
 from common.validators import UpdateType
 from measures import business_rules as mbr
 from measures.models import FootnoteAssociationMeasure

--- a/commodities/models/dc.py
+++ b/commodities/models/dc.py
@@ -24,6 +24,7 @@ from commodities.models.orm import GoodsNomenclatureIndent
 from commodities.util import clean_item_id
 from commodities.util import contained_date_range
 from commodities.util import date_ranges_overlap
+from commodities.util import get_latest_versions
 from common.business_rules import BusinessRuleViolation
 from common.models.constants import ClockType
 from common.models.dc.base import BaseModel
@@ -197,41 +198,6 @@ class Commodity(BaseModel):
     def is_current_version(self) -> bool:
         """Returns True if this is the current version of the Taric record."""
         return self.obj == self.obj.current_version
-
-    def is_current_as_of_transaction(
-        self,
-        transaction: Optional[Transaction] = None,
-    ) -> bool:
-        """Returns True if this is the current version of the record as of a
-        given transaction."""
-        transaction_order = transaction.order if transaction else None
-        return self.is_current_as_of_transaction_order(transaction_order)
-
-    def get_current_version_as_of_transaction_order(
-        self,
-        transaction_order: Optional[int] = None,
-    ) -> int:
-        """Returns the current version of the record as of a given transaction
-        id."""
-        if transaction_order is None:
-            return self.current_version
-
-        orders = self._get_transaction_orders()
-        return len([order for order in orders if order <= transaction_order])
-
-    def is_current_as_of_transaction_order(
-        self,
-        transaction_order: Optional[int] = None,
-    ) -> bool:
-        """Returns True if this is the current version of the record as of a
-        given transaction id."""
-        if transaction_order is None:
-            return self.is_current_version
-
-        current_version = self.get_current_version_as_of_transaction_order(
-            transaction_order,
-        )
-        return self.version == current_version
 
     def _get_transaction_ids(self) -> tuple[int]:
         """Returns the id-s of all transactions in the version group of the
@@ -550,7 +516,7 @@ class CommodityTreeSnapshot(CommodityTreeBase):
             return self.moments[0]
 
     @property
-    def snapshot_transaction_id(self) -> Optional[int]:
+    def snapshot_transaction_order(self) -> Optional[int]:
         """Retruns the snapshot transaction if uses the transaction clock."""
         if self.clock_type.is_transaction_clock:
             return self.moments[1]
@@ -750,7 +716,7 @@ class CommodityCollection(CommodityTreeBase):
 
     def get_transaction_clock_snapshot(
         self,
-        transaction_id: int,
+        transaction_order: int,
     ) -> CommodityTreeSnapshot:
         """
         Return a commodity tree snapshot as of a certain transaction (based on
@@ -761,7 +727,7 @@ class CommodityCollection(CommodityTreeBase):
         will assign as the snapshot moment the highest transaction id across all
         snapshot commodities.
         """
-        return self._get_snapshot(transaction_id=transaction_id)
+        return self._get_snapshot(transaction_order=transaction_order)
 
     @property
     def current_snapshot(self) -> CommodityTreeSnapshot:
@@ -774,60 +740,78 @@ class CommodityCollection(CommodityTreeBase):
         return self._get_snapshot()
 
     @property
-    def max_transaction_id(self) -> int:
+    def max_transaction_order(self) -> int:
         return max(
-            [
-                transaction_id
-                for commodity in self.commodities
-                for transaction_id in commodity._get_transaction_ids()
-            ],
+            transaction_id
+            for commodity in self.commodities
+            for transaction_id in commodity._get_transaction_orders()
         )
 
     def _get_snapshot(
         self,
         snapshot_date: Optional[date] = None,
-        transaction_id: Optional[int] = None,
+        transaction_order: Optional[int] = None,
     ) -> CommodityTreeSnapshot:
-        if transaction_id is None == snapshot_date is None:
+        if transaction_order is None == snapshot_date is None:
             clock_type = ClockType.COMBINED
-        elif transaction_id is None:
+        elif transaction_order is None:
             clock_type = ClockType.CALENDAR
         else:
             clock_type = ClockType.TRANSACTION
 
-        if transaction_id is None:
-            transaction_id = self.max_transaction_id
+        if transaction_order is None:
+            transaction_order = self.max_transaction_order
         if snapshot_date is None:
             snapshot_date = date.today()
 
-        commodities = self._get_snapshot_commodities(snapshot_date, transaction_id)
+        commodities = self._get_snapshot_commodities(snapshot_date, transaction_order)
 
         return CommodityTreeSnapshot(
             commodities=commodities,
             clock_type=clock_type,
-            moments=(snapshot_date, transaction_id),
+            moments=(snapshot_date, transaction_order),
         )
 
     def _get_snapshot_commodities(
         self,
         snapshot_date: date,
-        transaction_id: int = None,
+        transaction_order: int = None,
     ) -> List[Commodity]:
+        """
+        Returns the list of commodities than belong to a snapshot.
+
+        This method needs to be very efficient -
+        In particular, it should make only ONE database round trip
+        regardless of the level of the root commodity in the tree.
+
+        The solution is fetch all goods matching the snapshot moment
+        (incl. potentially multiple versions of each)
+        and then call a new util method get_latest_version,
+        which efficiently yields only the latest version
+        of each good from within the returned queryset.
+
+        We then efficiently find the commodities in our collection
+        that match the latest_version goods.
+        """
         if snapshot_date is None:
             snapshot_date = date.today()
 
-        if transaction_id is None:
-            transaction_id = self.max_transaction_id
+        if transaction_order is None:
+            transaction_order = self.max_transaction_order
 
-        transaction = Transaction.objects.get(id=transaction_id)
+        item_ids = {c.get_item_id() for c in self.commodities if c.obj}
 
-        return [
-            commodity
-            for commodity in self.commodities
-            if commodity.obj is not None
-            if commodity.get_valid_between().__contains__(snapshot_date)
-            if commodity.is_current_as_of_transaction(transaction)
-        ]
+        goods = GoodsNomenclature.objects.filter(
+            item_id__in=item_ids,
+            valid_between__contains=snapshot_date,
+            transaction__order__lte=transaction_order,
+        ).order_by("item_id", "-transaction__order")
+
+        latest_versions = get_latest_versions(goods)
+        pks = {good.pk for good in latest_versions}
+
+        keyed_collection = {c.obj.pk: c for c in self.commodities if c.obj}
+        return [commodity for pk, commodity in keyed_collection.items() if pk in pks]
 
     def __copy__(self) -> "CommodityCollection":
         """Returns an independent copy of the collection."""
@@ -1266,7 +1250,11 @@ class CommodityCollectionLoader:
 
         self.prefix = prefix
 
-    def load(self, current_only: bool = False) -> CommodityCollection:
+    def load(
+        self,
+        current_only: bool = False,
+        effective_only: bool = False,
+    ) -> CommodityCollection:
         """
         Returns a CommodityCollection including all commodities that match the
         prefix.
@@ -1280,7 +1268,10 @@ class CommodityCollectionLoader:
         qs = GoodsNomenclature.objects
 
         if current_only:
-            qs = qs.latest_approved().filter(
+            qs = qs.latest_approved()
+
+        if effective_only:
+            qs = qs.filter(
                 valid_between__contains=date.today(),
             )
 

--- a/commodities/tests/test_dataclasses.py
+++ b/commodities/tests/test_dataclasses.py
@@ -254,14 +254,14 @@ def test_collection_get_calendar_clock_snapshot(collection_spanned, date_ranges,
 
 
 def test_collection_get_transaction_clock_snapshot(collection_full):
-    transaction_ids = sorted(
-        [commodity.obj.transaction.id for commodity in collection_full.commodities],
+    transaction_orders = sorted(
+        [commodity.obj.transaction.order for commodity in collection_full.commodities],
     )
     commodities = collection_full.commodities[::-1]
 
-    for i, transaction_id in enumerate(transaction_ids):
+    for i, transaction_order in enumerate(transaction_orders):
         snapshot = collection_full.get_transaction_clock_snapshot(
-            transaction_id=transaction_id,
+            transaction_order=transaction_order,
         )
 
         assert snapshot.commodities[::-1] == commodities[: i + 1]
@@ -270,9 +270,9 @@ def test_collection_get_transaction_clock_snapshot(collection_full):
 def test_collection_current_snapshot(collection_full):
     snapshot = collection_full.current_snapshot
 
-    transaction_id = collection_full.max_transaction_id
+    transaction_order = collection_full.max_transaction_order
     snapshot_date = date.today()
-    tx_snapshot = collection_full.get_transaction_clock_snapshot(transaction_id)
+    tx_snapshot = collection_full.get_transaction_clock_snapshot(transaction_order)
     cal_snapshot = collection_full.get_calendar_clock_snapshot(snapshot_date)
 
     tx_commodities = set(x.identifier for x in tx_snapshot.commodities)
@@ -281,7 +281,7 @@ def test_collection_current_snapshot(collection_full):
 
     commodities = set(x.identifier for x in snapshot.commodities)
 
-    assert snapshot.moments == (snapshot_date, transaction_id)
+    assert snapshot.moments == (snapshot_date, transaction_order)
     assert sorted(commodities) == sorted(tx_cal_commodities)
 
 
@@ -473,27 +473,27 @@ def test_snapshot_is_declarable(collection_basic):
 
 def test_snapshot_date(collection_basic):
     snapshot_date = date.today()
-    transaction_id = collection_basic.max_transaction_id
+    transaction_order = collection_basic.max_transaction_order
 
     snapshot = collection_basic.get_calendar_clock_snapshot(snapshot_date)
     assert snapshot.snapshot_date == snapshot_date
-    assert snapshot.moments == (snapshot_date, transaction_id)
+    assert snapshot.moments == (snapshot_date, transaction_order)
 
-    transaction_id = collection_basic.max_transaction_id
-    snapshot = collection_basic.get_transaction_clock_snapshot(transaction_id)
+    transaction_order = collection_basic.max_transaction_order
+    snapshot = collection_basic.get_transaction_clock_snapshot(transaction_order)
     assert snapshot.snapshot_date is None
 
 
-def test_snapshot_transaction_id(collection_basic):
+def test_snapshot_transaction_order(collection_basic):
     snapshot_date = date.today()
-    transaction_id = collection_basic.max_transaction_id
+    transaction_order = collection_basic.max_transaction_order
 
     snapshot = collection_basic.get_calendar_clock_snapshot(snapshot_date)
-    assert snapshot.snapshot_transaction_id is None
+    assert snapshot.snapshot_transaction_order is None
 
-    snapshot = collection_basic.get_transaction_clock_snapshot(transaction_id)
-    assert snapshot.snapshot_transaction_id == transaction_id
-    assert snapshot.moments == (snapshot_date, transaction_id)
+    snapshot = collection_basic.get_transaction_clock_snapshot(transaction_order)
+    assert snapshot.snapshot_transaction_order == transaction_order
+    assert snapshot.moments == (snapshot_date, transaction_order)
 
 
 def test_change_valid_create(collection_basic, commodities):

--- a/commodities/util.py
+++ b/commodities/util.py
@@ -71,3 +71,25 @@ def contained_date_range(
         start_date or a.lower,
         end_date or a.upper,
     )
+
+
+def get_latest_versions(qs):
+    """
+    Yields only the latest versions of each model within the provided queryset.
+
+    These may not be the current versions of each model,
+    e.g. because the queryset may be filtered as of a given transaction.
+
+    But if there are two versions of the same tracked model in the queryset,
+    only the one with the one with the latest transaction order
+    (which should be latest version) is yielded.
+    """
+    keys = set()
+
+    for model in qs.order_by("-transaction__order"):
+        key = tuple(model.get_identifying_fields().values())
+        if key not in keys:
+            keys.add(key)
+            yield model
+        else:
+            print(key in keys, key)

--- a/commodities/util.py
+++ b/commodities/util.py
@@ -71,23 +71,3 @@ def contained_date_range(
         start_date or a.lower,
         end_date or a.upper,
     )
-
-
-def get_latest_versions(qs):
-    """
-    Yields only the latest versions of each model within the provided queryset.
-
-    These may not be the current versions of each model,
-    e.g. because the queryset may be filtered as of a given transaction.
-
-    But if there are two versions of the same tracked model in the queryset,
-    only the one with the one with the latest transaction order
-    (which should be latest version) is yielded.
-    """
-    keys = set()
-
-    for model in qs.order_by("-transaction__order"):
-        key = tuple(model.get_identifying_fields().values())
-        if key not in keys:
-            keys.add(key)
-            yield model

--- a/commodities/util.py
+++ b/commodities/util.py
@@ -91,5 +91,3 @@ def get_latest_versions(qs):
         if key not in keys:
             keys.add(key)
             yield model
-        else:
-            print(key in keys, key)

--- a/common/util.py
+++ b/common/util.py
@@ -355,7 +355,10 @@ def get_latest_versions(qs):
     """
     keys = set()
 
-    for model in qs.order_by("-transaction__order"):
+    for model in qs.order_by(
+        "-transaction__partition",
+        "-transaction__order",
+    ):
         key = tuple(model.get_identifying_fields().values())
         if key not in keys:
             keys.add(key)

--- a/common/util.py
+++ b/common/util.py
@@ -340,3 +340,23 @@ def get_model_indefinite_article(model_instance: Model) -> Optional[str]:
     # verbose_name is initialized to None, so typing thinks it is Optional
     if name:
         return "an" if name[0] in ["a", "e", "i", "o", "u"] else "a"
+
+
+def get_latest_versions(qs):
+    """
+    Yields only the latest versions of each model within the provided queryset.
+
+    These may not be the current versions of each model,
+    e.g. because the queryset may be filtered as of a given transaction.
+
+    But if there are two versions of the same tracked model in the queryset,
+    only the one with the one with the latest transaction order
+    (which should be latest version) is yielded.
+    """
+    keys = set()
+
+    for model in qs.order_by("-transaction__order"):
+        key = tuple(model.get_identifying_fields().values())
+        if key not in keys:
+            keys.add(key)
+            yield model


### PR DESCRIPTION
# TP-1096 Fix exploding db round trips in commodity tree snapshots

## Why
At the moment, when `CommodityCollection._get_snapshot_commodities` selects the matching commodities for a given transaction or calendar moment, it makes a large number of individual select queries involving `GoodsNomenclature`, `TrackedModel`, and `VersionGroup` objects.
As a result, if we need to take a snapshot of a larger branch (e.g. when a 2-level code and all its descendants), this would become a very expensive process

## What
- Implement a more efficient algorithm in `CommodityCollection._get_snapshot_commodities` that has exactly ONE db round trip regardless of the size of the tree.
- Implement an enabling util method `get_latest_versions` that returns only the most recent version of each model within a queryset result 
- As a related necessary change, switch transaction clock in `CommodityTreeSnapshot` to be based on transaction order, not transaction ids.

<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
## Checklist
- Requires migrations?
- Requires dependency updates?
--->

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
