### PR TITLE
Iterate docstring in as_at_transaction_filter.

### DIFF
--- a/common/models/transactions.py
+++ b/common/models/transactions.py
@@ -27,6 +27,10 @@ class TransactionPartition(models.IntegerChoices):
 
     Within a partition, a transactions order applies, to obtain a global
     ordering a order_by("partition", "order") must be used.
+
+    The numbers chosen increment by "era" of transaction, starting
+    from approved transactions SEED_FILE and REVISION
+    then ending with DRAFT.
     """
 
     SEED_FILE = 1, "Seed"


### PR DESCRIPTION
Little docstring update...

This thing *really* confused me, even though I added the infrastructure on which it sits and it just uses it.

Not an indictment on this code: it makes sense, but I think I'd forgotten a bunch of context.
I hadn't thought about the fact that `partitions` are in fact temporal themselves, so `earlier` partition threw me a bit.

I had a bit of a go at condensing some bits of the docstring and splitting others + added context for the temporal bit.