### PR TITLE
TP-1107  Additional code form was broken trying to get cleaned_data field not …

### DIFF
--- a/additional_codes/forms.py
+++ b/additional_codes/forms.py
@@ -127,7 +127,7 @@ class AdditionalCodeCreateForm(ValidityPeriodForm):
     def clean(self):
         cleaned_data = super().clean()
         cleaned_data["additional_code_description"] = models.AdditionalCodeDescription(
-            description=cleaned_data["description"],
+            description=cleaned_data.get("description"),
             validity_start=cleaned_data["valid_between"].lower,
         )
         return cleaned_data

--- a/additional_codes/tests/test_views.py
+++ b/additional_codes/tests/test_views.py
@@ -1,15 +1,53 @@
+import datetime
+
+import factory
 import pytest
+from dateutil.relativedelta import relativedelta
+from django.core.exceptions import ValidationError
 
 from additional_codes.models import AdditionalCode
 from additional_codes.views import AdditionalCodeList
+from common.tests.factories import AdditionalCodeFactory
+from common.tests.factories import AdditionalCodeTypeFactory
 from common.tests.util import assert_model_view_renders
+from common.tests.util import date_post_data
 from common.tests.util import get_class_based_view_urls_matching_url
+from common.tests.util import raises_if
+from common.tests.util import validity_period_post_data
 from common.tests.util import view_is_subclass
 from common.tests.util import view_urlpattern_ids
 from common.views import TamatoListView
 from common.views import TrackedModelDetailMixin
 
 pytestmark = pytest.mark.django_db
+
+
+@pytest.mark.parametrize(
+    ("new_data", "expected_valid"),
+    (
+        (lambda data: {}, False),
+        (
+            lambda data: {
+                "description": "Test description",
+                "code": "002",
+                "valid_between": validity_period_post_data(
+                    datetime.date.today(),
+                    datetime.date.today() + relativedelta(months=+1),
+                ),
+                **date_post_data("start_date", datetime.date.today()),
+                **factory.build(
+                    dict,
+                    type=AdditionalCodeTypeFactory.create().pk,
+                    FACTORY_CLASS=AdditionalCodeFactory,
+                ),
+            },
+            True,
+        ),
+    ),
+)
+def test_additional_code_create_form(use_create_form, new_data, expected_valid):
+    with raises_if(ValidationError, not expected_valid):
+        use_create_form(AdditionalCode, new_data)
 
 
 @pytest.mark.parametrize(

--- a/common/fields.py
+++ b/common/fields.py
@@ -18,7 +18,7 @@ from common.util import TaricDateTimeRange
 
 def get_next_by_max(field):
     return lambda: RawSQL(
-        sql=f'SELECT MAX("{field.column}") + 1 FROM "{field.model._meta.db_table}"',
+        sql=f'SELECT COALESCE(MAX("{field.column}"), 0) + 1 FROM "{field.model._meta.db_table}"',
         params=[],
     )
 
@@ -28,7 +28,7 @@ class NumericSID(models.PositiveIntegerField):
         kwargs["editable"] = False
         kwargs["validators"] = [validators.NumericSIDValidator()]
         kwargs["db_index"] = True
-        kwargs["default"] = get_next_by_max(self)
+        kwargs.setdefault("default", get_next_by_max(self))
         super().__init__(*args, **kwargs)
 
     def deconstruct(self):
@@ -44,7 +44,7 @@ class SignedIntSID(models.IntegerField):
     def __init__(self, *args, **kwargs):
         kwargs["editable"] = False
         kwargs["db_index"] = True
-        kwargs["default"] = get_next_by_max(self)
+        kwargs.setdefault("default", get_next_by_max(self))
         super().__init__(*args, **kwargs)
 
     def deconstruct(self):

--- a/common/models/trackedmodel.py
+++ b/common/models/trackedmodel.py
@@ -39,9 +39,7 @@ from workbaskets.validators import WorkflowStatus
 
 
 class VersionGroup(TimestampedMixin):
-    """
-    A group that contains all versions of the same TrackedModel.
-    """
+    """A group that contains all versions of the same TrackedModel."""
 
     current_version = models.OneToOneField(
         "common.TrackedModel",
@@ -208,9 +206,7 @@ class TrackedModel(PolymorphicModel):
         return new_object
 
     def get_versions(self):
-        """
-        Find all versions of this model.
-        """
+        """Find all versions of this model."""
         if hasattr(self, "version_group"):
             return self.version_group.versions.all()
         query = Q(**self.get_identifying_fields())
@@ -254,7 +250,8 @@ class TrackedModel(PolymorphicModel):
         self,
         identifying_fields: Optional[Iterable[str]] = None,
     ) -> Dict[str, Any]:
-        """Get a name/value mapping of the fields that identify this model.
+        """
+        Get a name/value mapping of the fields that identify this model.
 
         :param identifying_fields Optional[Iterable[str]]: Optionally override the
         fields to retrieve
@@ -274,10 +271,11 @@ class TrackedModel(PolymorphicModel):
         identifying_fields: Optional[Iterable[str]] = None,
     ) -> str:
         """
-        Constructs a comma separated string of the identifying fields of the model with
-        field name and value pairs delimited by "=", eg: "field1=1, field2=2"
+        Constructs a comma separated string of the identifying fields of the
+        model with field name and value pairs delimited by "=", eg: "field1=1,
+        field2=2".
 
-        :param identifying_fields Optional[Iterable[str]]: Optionally override the
+        :param identifying_fields: Optionally override the
         fields to use in the string
         :rtype str: The constructed string
         """
@@ -290,17 +288,19 @@ class TrackedModel(PolymorphicModel):
 
     @property
     def structure_code(self):
-        """A string used to describe the model instance.
+        """
+        A string used to describe the model instance.
 
-        Used as the displayed value in an AutocompleteWidget dropdown, and in the "Your
-        tariff changes" list.
+        Used as the displayed value in an AutocompleteWidget dropdown, and in
+        the "Your tariff changes" list.
         """
         return str(self)
 
     @property
     def structure_description(self) -> Optional[str]:
-        """The current description of the model, if it has related description models or a
-        description field.
+        """
+        The current description of the model, if it has related description
+        models or a description field.
 
         :rtype Optional[str]: The current description
         """
@@ -322,14 +322,15 @@ class TrackedModel(PolymorphicModel):
 
     @property
     def current_version(self: Cls) -> Cls:
-        """The current version of this model"""
+        """The current version of this model."""
         current_version = self.version_group.current_version
         if current_version is None:
             raise self.__class__.DoesNotExist("Object has no current version")
         return current_version
 
     def version_at(self: Cls, transaction) -> Cls:
-        """The latest version of this model that was approved as of the given
+        """
+        The latest version of this model that was approved as of the given
         transaction.
 
         :param transaction Transaction: Limit versions to this transaction
@@ -559,7 +560,8 @@ class TrackedModel(PolymorphicModel):
 
     @atomic
     def save(self, *args, force_write=False, **kwargs):
-        """Save the model to the database.
+        """
+        Save the model to the database.
 
         :param force_write bool: Ignore append-only restrictions and write to the
         database even if the model already exists
@@ -601,7 +603,8 @@ class TrackedModel(PolymorphicModel):
         return hash(f"{__name__}.{self.__class__.__name__}")
 
     def get_url(self, action: str = "detail") -> Optional[str]:
-        """Generate a URL to a representation of the model in the webapp.
+        """
+        Generate a URL to a representation of the model in the webapp.
 
         :param action str: The view type to generate a URL for (default "detail"),
         eg: "list" or "edit"
@@ -618,15 +621,17 @@ class TrackedModel(PolymorphicModel):
         except NoReverseMatch:
             return
 
-    def get_url_pattern_name_prefix(self):
-        """Get the prefix string for a view name for this model.
+    @classmethod
+    def get_url_pattern_name_prefix(cls):
+        """
+        Get the prefix string for a view name for this model.
 
         By default, this is the verbose name of the model with spaces replaced by
         underscores, but this method allows this to be overridden.
 
         :rtype str: The prefix
         """
-        prefix = getattr(self, "url_pattern_name_prefix", None)
+        prefix = getattr(cls, "url_pattern_name_prefix", None)
         if not prefix:
-            prefix = self._meta.verbose_name.replace(" ", "_")
+            prefix = cls._meta.verbose_name.replace(" ", "_")
         return prefix

--- a/common/tests/test_models.py
+++ b/common/tests/test_models.py
@@ -15,6 +15,7 @@ from common.tests import models
 from common.tests.factories import ApprovedTransactionFactory
 from common.tests.factories import FootnoteFactory
 from common.tests.factories import SeedFileTransactionFactory
+from common.tests.factories import TestModel1Factory
 from common.tests.factories import UnapprovedTransactionFactory
 from common.tests.models import TestModel1
 from common.tests.models import TestModel2
@@ -570,6 +571,19 @@ def test_described(description_factory):
     described = description.get_described_object()
 
     assert described.get_description() == description
+
+
+def test_get_url_pattern_name_prefix():
+    assert TestModel1.get_url_pattern_name_prefix() == "test_model1"
+
+
+@pytest.fixture(scope="session")
+def test_numeric_sid_iteration():
+    assert isinstance(TestModel1.sid.field, common.fields.NumericSID)
+
+    sids = [TestModel1Factory.create().sid for i in range(3)]
+
+    assert sids == [1, 2, 3]
 
 
 def test_copy_related_model():

--- a/common/tests/util.py
+++ b/common/tests/util.py
@@ -148,7 +148,7 @@ def get_checkable_data(model: TrackedModel, ignore=frozenset()):
         #    },
         # }
     """
-    checked_field_names = {f.name for f in model.copyable_fields} - ignore
+    checked_field_names = {f.name for f in model.copyable_fields} - set(ignore)
     data = {
         name: getattr(model, get_accessor(model._meta.get_field(name)))
         for name in checked_field_names

--- a/measures/tests/test_importer.py
+++ b/measures/tests/test_importer.py
@@ -90,6 +90,7 @@ def test_measure_action_importer(imported_fields_match):
     )
 
 
+@pytest.mark.django_db(transaction=True, reset_sequences=True)
 def test_measure_importer(
     imported_fields_match,
     approved_transaction,


### PR DESCRIPTION
AdditionCode form was broken.

This PR implements Simons suggestion on Gabes ticket TP-851 and implements use_create_form and uses it to verify the fix for additional_codes.

use_create_form is ported from use_update_form, and is just different enough I didn't combine them as use_create_form already does a lot.

Screenshot of additional_codes form before this fix:

Before:
![image](https://user-images.githubusercontent.com/179677/144126447-37c57b1e-fa68-4be5-a90b-85377523f2dd.png)
