### PR TITLE
TP-758: ME32 without the materialized tree

### DIFF
--- a/commodities/tests/test_importer.py
+++ b/commodities/tests/test_importer.py
@@ -10,6 +10,7 @@ from common.util import TaricDateRange
 from common.validators import UpdateType
 from importer.namespaces import TARIC_RECORD_GROUPS
 from measures.models import Measure
+from workbaskets.validators import WorkflowStatus
 
 pytestmark = pytest.mark.django_db
 
@@ -802,6 +803,9 @@ def test_correct_affected_measures_are_selected(
         ),
         serializers.GoodsNomenclatureSerializer,
         TARIC_RECORD_GROUPS["commodities"],
+        # Need a draft workbasket status so that the measure generated
+        # as a side effect is ordered *after* the commodity it is on.
+        WorkflowStatus.PROPOSED,
     )
 
     workbasket = imported_good.transaction.workbasket

--- a/commodities/tests/test_scenarios.py
+++ b/commodities/tests/test_scenarios.py
@@ -58,7 +58,7 @@ def test_scenario1_add_node_diff(scenario_1: TScenario):
     assert diff == [node]
 
 
-def test_scenario2_delete_node(scenario_2: TScenario, date_ranges):
+def test_scenario2_delete_node(scenario_2: TScenario):
     """Asserts correct handling of ADR 13, scenario 2."""
     collection, changes = scenario_2
 

--- a/common/models/trackedmodel.py
+++ b/common/models/trackedmodel.py
@@ -46,6 +46,8 @@ class VersionGroup(TimestampedMixin):
         related_query_name="is_current",
     )
 
+    versions: QuerySet[TrackedModel]
+
 
 Cls = TypeVar("Cls", bound="TrackedModel")
 
@@ -73,7 +75,7 @@ class TrackedModel(PolymorphicModel):
     :attr:`version_group` created.
     """
 
-    version_group = models.ForeignKey(
+    version_group: VersionGroup = models.ForeignKey(
         VersionGroup,
         on_delete=models.PROTECT,
         related_name="versions",

--- a/measures/business_rules.py
+++ b/measures/business_rules.py
@@ -336,74 +336,23 @@ class ME32(BusinessRule):
 
         return query
 
-    def matching_measures(self, measure, query):
-        return (
-            type(measure)
-            .objects.filter(query)
-            .approved_up_to_transaction(measure.transaction)
-            .exclude(version_group=measure.version_group)
-        )
-
     def validate(self, measure):
         if measure.goods_nomenclature is None:
             return
 
         # build the query for measures matching the given measure
+        from measures.snapshots import MeasureSnapshot
+
         query = self.compile_query(measure)
-        matching_measures = self.matching_measures(measure, query)
-
-        # get all goods nomenclature versions associated with this measure
-        GoodsNomenclature = type(measure.goods_nomenclature)
-        goods = GoodsNomenclature.objects.approved_up_to_transaction(
-            measure.transaction,
-        ).filter(
-            sid=measure.goods_nomenclature.sid,
-            valid_between__overlap=measure.effective_valid_between,
-        )
-
-        # hack to avoid circular import
-        Indent = GoodsNomenclature.indents.rel.related_model
-        Node = Indent.nodes.rel.related_model
-
-        # for each goods nomenclature version, get all indents
-        for good in goods:
-            indents = (
-                Indent.objects.with_end_date()
-                .approved_up_to_transaction(
-                    measure.transaction,
-                )
-                .filter(
-                    valid_between__overlap=measure.effective_valid_between,
-                    indented_goods_nomenclature=good,
-                )
+        clashing_measures = type(measure).objects.none()
+        for snapshot in MeasureSnapshot.get_snapshots(measure, self.transaction):
+            clashing_measures = clashing_measures.union(
+                snapshot.overlaps(measure).filter(query),
+                all=True,
             )
 
-            nodes = Node.objects.filter(
-                valid_between__overlap=measure.effective_valid_between,
-                indent__in=indents,
-            )
-
-            # for each indent, get the goods tree
-            for node in nodes:
-                tree = (
-                    node.get_ancestors()
-                    | node.get_descendants()
-                    | Node.objects.filter(pk=node.pk)
-                ).filter(
-                    valid_between__overlap=measure.effective_valid_between,
-                )
-
-                # check for any measures associated to commodity codes in the tree which
-                # clash with the specified measure
-                clashing_measures = matching_measures.with_effective_valid_between().filter(
-                    goods_nomenclature__indents__nodes__in=tree.values_list(
-                        "pk",
-                        flat=True,
-                    ),
-                    db_effective_valid_between__overlap=measure.effective_valid_between,
-                )
-                if clashing_measures.exists():
-                    raise self.violation(measure)
+        if clashing_measures.exists():
+            raise self.violation(measure)
 
 
 # -- Ceiling/quota definition existence
@@ -658,7 +607,7 @@ class ME33(BusinessRule):
 
     def validate(self, measure):
         if (
-            measure.effective_valid_between.upper is None
+            measure.valid_between.upper is None
             and measure.terminating_regulation is not None
         ):
             raise self.violation(measure)

--- a/measures/models.py
+++ b/measures/models.py
@@ -624,9 +624,12 @@ class Measure(TrackedModel, ValidityMixin):
             and self.get_versions().order_by("transaction__order").last()
         ):
             previous = self.get_versions().order_by("transaction__order").last()
-            nomenclature_removed = not (
-                previous.goods_nomenclature and self.goods_nomenclature
-            )
+            try:
+                nomenclature_removed = not (
+                    previous.goods_nomenclature and self.goods_nomenclature
+                )
+            except type(previous.goods_nomenclature).DoesNotExist:
+                return super().save(*args, force_write=force_write, **kwargs)
             nomenclature_changed = (
                 True
                 if nomenclature_removed

--- a/measures/snapshots.py
+++ b/measures/snapshots.py
@@ -1,0 +1,108 @@
+from dataclasses import dataclass
+from datetime import date
+from datetime import timedelta
+
+from commodities.models.dc import Commodity
+from commodities.models.dc import CommodityCollection
+from commodities.models.dc import CommodityCollectionLoader
+from commodities.models.dc import CommodityTreeSnapshot
+from commodities.models.dc import SnapshotMoment
+from common.models.transactions import Transaction
+from measures.models import Measure
+from measures.querysets import MeasuresQuerySet
+
+
+@dataclass
+class MeasureSnapshot:
+    """Represents a set of measures that apply to a part of the commodity tree
+    at a given date and transaction."""
+
+    moment: SnapshotMoment
+    tree: CommodityTreeSnapshot
+
+    @property
+    def extent(self):
+        """Returns the date range for which the snapshot is correct."""
+        return self.tree.extent
+
+    def get_measures(self, *commodities: Commodity) -> MeasuresQuerySet:
+        """Returns the measures attached to the given commodities."""
+        return self.tree.get_dependent_measures(*commodities, as_at=self.moment.date)
+
+    def get_applicable_measures(self, commodity: Commodity) -> MeasuresQuerySet:
+        """Returns the mesures that apply to the commodity (i.e. any defined on
+        it or one of its ancestors)."""
+        return self.get_measures(commodity, *self.tree.get_ancestors(commodity))
+
+    def get_branch_measures(self, commodity: Commodity) -> MeasuresQuerySet:
+        """Returns the measures that are within the same tree branch as the
+        commodity (i.e. any defined on it, its ancestors or any of its
+        descendants)."""
+        return self.get_measures(
+            commodity,
+            *self.tree.get_ancestors(commodity),
+            *self.tree.get_descendants(commodity),
+        )
+
+    def overlaps(self, measure: Measure) -> MeasuresQuerySet:
+        """
+        Returns the measures that overlap with the passed measure.
+
+        The MeasureSnapshot must have been created with a commodity tree that
+        contains the goods nomenclature on the measure, otherwise this method
+        will return an empty set.
+        """
+        commodity = self.tree.get_commodity(
+            measure.goods_nomenclature.item_id,
+            measure.goods_nomenclature.suffix,
+        )
+        valid_between = measure.effective_valid_between
+        return (
+            self.get_branch_measures(commodity)
+            .with_effective_valid_between()
+            .excluding_versions_of(measure.version_group)
+            .filter(db_effective_valid_between__overlap=valid_between)
+        )
+
+    @classmethod
+    def _get_snapshot_from_tree(
+        cls,
+        collection: CommodityCollection,
+        as_at: date,
+        transaction: Transaction,
+    ):
+        tree = collection._get_snapshot(transaction, as_at)
+        # `None` is not a bug! We want the commodity code tree to be
+        # linked to a specific date, but the measure date actually
+        # represents a range of dates, and not a specific one.
+        return cls(SnapshotMoment(transaction, None), tree)
+
+    @classmethod
+    def get_snapshots(cls, measure: Measure, transaction: Transaction):
+        """
+        Yield a MeasureSnapshot for each commodity tree that contains the goods
+        nomenclature on the measure.
+
+        It is possible for the commodity tree to change over the lifetime of the
+        measure, so this method will yield a snapshot for each of the commodity
+        trees that existed over that lifetime.
+        """
+        loader = CommodityCollectionLoader(
+            prefix=measure.goods_nomenclature.code.chapter,
+        )
+        collection = loader.load()
+
+        snapshot = cls._get_snapshot_from_tree(
+            collection,
+            measure.effective_valid_between.lower,
+            transaction,
+        )
+        yield snapshot
+
+        while measure.effective_valid_between.upper_is_greater(snapshot.extent):
+            snapshot = cls._get_snapshot_from_tree(
+                collection,
+                snapshot.extent.upper + timedelta(days=1),
+                transaction,
+            )
+            yield snapshot

--- a/measures/tests/test_models.py
+++ b/measures/tests/test_models.py
@@ -158,8 +158,8 @@ def test_measure_action_in_use(in_use_check_respects_deletes):
     assert in_use_check_respects_deletes(
         factories.MeasureActionFactory,
         "in_use",
-        factories.MeasureConditionComponentFactory,
-        "condition__action",
+        factories.MeasureConditionFactory,
+        "action",
     )
 
 


### PR DESCRIPTION
## Why
Our previous implementation of ME32 used the Nodes contained in the Goods Nomenclature tree to check for overlaps between commodities. We have found these Nodes difficult to maintain (it's a 3D-cube of commodity trees!) and subsequently the data structure is wrong in many places.

This leads to false positives and (presumably) false negatives from ME32.

## What
This commit introduces a new implementation of ME32 that does not use the tree and insteadmakes use of the in-memory tree used for the commodity code importer.

## Checklist
- Requires migrations? No.
- Requires dependency updates? No.


<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
