### PR TITLE
Fix view tests that fail around month end.

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -288,7 +288,7 @@ def use_update_form(valid_user_api_client: APIClient):
     that the passed data contains errors.
     """
 
-    def use(object: TrackedModel, new_data: dict[str, Callable[[Any], Any]]):
+    def use(object: TrackedModel, new_data: Callable[[TrackedModel], dict[str, Any]]):
         model = type(object)
         versions = set(
             model.objects.filter(**object.get_identifying_fields()).values_list(
@@ -306,10 +306,10 @@ def use_update_form(valid_user_api_client: APIClient):
         # Get the data out of the edit page
         # and override it with any data that has been passed in
         data = get_form_data(response.context_data["form"])
-        assert set(new_data.keys()).issubset(data.keys())
 
         # Submit the edited data and if we expect success ensure we are redirected
-        realised_data = {key: new_data[key](data[key]) for key in new_data}
+        realised_data = new_data(object)
+        assert set(realised_data.keys()).issubset(data.keys())
         data.update(realised_data)
         response = valid_user_api_client.post(edit_url, data)
 

--- a/regulations/tests/test_views.py
+++ b/regulations/tests/test_views.py
@@ -5,6 +5,7 @@ from common.tests import factories
 from common.tests.util import assert_model_view_renders
 from common.tests.util import get_class_based_view_urls_matching_url
 from common.tests.util import raises_if
+from common.tests.util import valid_between_start_delta
 from common.tests.util import view_is_subclass
 from common.tests.util import view_urlpattern_ids
 from common.views import TamatoListView
@@ -17,11 +18,11 @@ pytestmark = pytest.mark.django_db
 @pytest.mark.parametrize(
     ("new_data", "expected_valid"),
     (
-        ({}, True),
-        ({"start_date_0": lambda d: d + 1}, True),
-        ({"start_date_0": lambda d: d - 1}, False),
-        ({"start_date_1": lambda m: m + 1}, True),
-        ({"start_date_2": lambda y: y + 1}, True),
+        (lambda r: {}, True),
+        (valid_between_start_delta(days=+1), True),
+        (valid_between_start_delta(days=-1), False),
+        (valid_between_start_delta(months=1), True),
+        (valid_between_start_delta(years=1), True),
     ),
 )
 def test_regulation_update(new_data, expected_valid, use_update_form):


### PR DESCRIPTION
## Why
We have some view tests that try to test update forms. These often based on the date because they try to naively add 1 to a date or month counter, and this often results in invalid dates (e.g. the 32nd March).

## What
This commit changes the system to add amounts to the date using a relative delta. To do this, the model needed to change from being based on a lambda for each field, to a single lambda that returns all of the new form data.

## Checklist
- Requires migrations? No
- Requires dependency updates? No