### PR TITLE
TP-1123: MeasureSnapshot.overlaps() should check commodity exists before calling get_branch_measures(commodity)

### DIFF
--- a/measures/snapshots.py
+++ b/measures/snapshots.py
@@ -56,6 +56,10 @@ class MeasureSnapshot:
             measure.goods_nomenclature.item_id,
             measure.goods_nomenclature.suffix,
         )
+
+        if not commodity:
+            return Measure.objects.none()
+
         valid_between = measure.effective_valid_between
         return (
             self.get_branch_measures(commodity)


### PR DESCRIPTION
## Why
This is to avoid an AttributeError when self.ancestors[commodity.identifier] is called in commodities/models/dc.

## What
MeasureSnapshot.overlaps returns an empty queryset, if no commodity is found

