### PR TITLE
TP-1125: Make ME58 consider volumes and units as well

### DIFF
--- a/common/tests/factories.py
+++ b/common/tests/factories.py
@@ -6,6 +6,7 @@ from itertools import product
 
 import factory
 from factory.fuzzy import FuzzyChoice
+from faker import Faker
 
 from common.models import TrackedModel
 from common.models.transactions import TransactionPartition
@@ -41,6 +42,12 @@ def string_sequence(length=1, characters=string.ascii_uppercase + string.digits)
 
 def numeric_sid():
     return factory.Sequence(lambda x: x + 1)
+
+
+def duty_amount():
+    return factory.LazyFunction(
+        lambda: Faker().pydecimal(left_digits=7, right_digits=3, positive=True),
+    )
 
 
 def date_ranges(name):
@@ -1067,7 +1074,7 @@ class MeasureConditionFactory(TrackedModelMixin):
     )
     condition_code = factory.SubFactory(MeasureConditionCodeFactory)
     component_sequence_number = factory.Faker("random_int", min=1, max=999)
-    duty_amount = factory.Faker("pydecimal", left_digits=7, right_digits=3)
+    duty_amount = duty_amount()
     monetary_unit = factory.SubFactory(MonetaryUnitFactory)
     condition_measurement = None
     action = factory.SubFactory(MeasureActionFactory)
@@ -1091,7 +1098,7 @@ class MeasureConditionComponentFactory(TrackedModelMixin):
         transaction=factory.SelfAttribute("..transaction"),
     )
     duty_expression = factory.SubFactory(DutyExpressionFactory)
-    duty_amount = factory.Faker("pydecimal", left_digits=7, right_digits=3)
+    duty_amount = duty_amount()
     monetary_unit = factory.SubFactory(MonetaryUnitFactory)
     component_measurement = None
 

--- a/measures/business_rules.py
+++ b/measures/business_rules.py
@@ -882,10 +882,22 @@ class ME58(BusinessRule):
                 },
             )
 
+        if measure_condition.condition_measurement is None:
+            kwargs.update({"condition_measurement": None})
+        else:
+            kwargs.update(
+                {
+                    "condition_measurement__version_group": measure_condition.condition_measurement.version_group,
+                },
+            )
+
+        kwargs.update({"duty_amount": measure_condition.duty_amount})
+
         if (
             type(measure_condition)
-            .objects.exclude(pk=measure_condition.pk or None)
-            .excluding_versions_of(version_group=measure_condition.version_group)
+            .objects.excluding_versions_of(
+                version_group=measure_condition.version_group,
+            )
             .filter(**kwargs)
             .approved_up_to_transaction(self.transaction)
             .exists()

--- a/measures/business_rules.py
+++ b/measures/business_rules.py
@@ -865,33 +865,26 @@ class ME57(MeasureValidityPeriodContained):
 
 
 class ME58(BusinessRule):
-    """The same certificate can only be referenced once by the same measure and
-    the same condition type."""
+    """The same certificate, volume or price can only be referenced once by the
+    same measure and the same condition type."""
+
+    @staticmethod
+    def match_related_model(model, key):
+        obj = getattr(model, key)
+        if obj is None:
+            return {key: None}
+        else:
+            return {f"{key}__version_group": obj.version_group}
 
     def validate(self, measure_condition):
         kwargs = {
             "condition_code__code": measure_condition.condition_code.code,
             "dependent_measure__sid": measure_condition.dependent_measure.sid,
+            "duty_amount": measure_condition.duty_amount,
+            **self.match_related_model(measure_condition, "required_certificate"),
+            **self.match_related_model(measure_condition, "condition_measurement"),
+            **self.match_related_model(measure_condition, "monetary_unit"),
         }
-        if measure_condition.required_certificate is None:
-            kwargs.update({"required_certificate": None})
-        else:
-            kwargs.update(
-                {
-                    "required_certificate__version_group": measure_condition.required_certificate.version_group,
-                },
-            )
-
-        if measure_condition.condition_measurement is None:
-            kwargs.update({"condition_measurement": None})
-        else:
-            kwargs.update(
-                {
-                    "condition_measurement__version_group": measure_condition.condition_measurement.version_group,
-                },
-            )
-
-        kwargs.update({"duty_amount": measure_condition.duty_amount})
 
         if (
             type(measure_condition)

--- a/measures/tests/test_business_rules.py
+++ b/measures/tests/test_business_rules.py
@@ -1363,16 +1363,20 @@ def test_ME57(date_ranges):
 @pytest.mark.parametrize("existing_cert", (True, False))
 @pytest.mark.parametrize("existing_volume", (True, False))
 @pytest.mark.parametrize("existing_unit", (True, False))
+@pytest.mark.parametrize("existing_currency", (True, False))
 @pytest.mark.parametrize("duplicate_cert", (True, False))
 @pytest.mark.parametrize("duplicate_volume", (True, False))
 @pytest.mark.parametrize("duplicate_unit", (True, False))
+@pytest.mark.parametrize("duplicate_currency", (True, False))
 def test_ME58(
     existing_cert: bool,
     existing_volume: bool,
     existing_unit: bool,
+    existing_currency: bool,
     duplicate_cert: bool,
     duplicate_volume: bool,
     duplicate_unit: bool,
+    duplicate_currency: bool,
 ):
     """
     The same certificate can only be referenced once by the same measure and the
@@ -1393,16 +1397,19 @@ def test_ME58(
         (existing_cert == duplicate_cert)
         and (existing_volume == duplicate_volume)
         and (existing_unit == duplicate_unit)
+        and (existing_currency == duplicate_currency)
     )
 
     cert = factories.CertificateFactory.create()
     volume = factories.duty_amount().function()
     unit = factories.MeasurementFactory.create()
+    currency = factories.MonetaryUnitFactory.create()
 
     existing = factories.MeasureConditionFactory.create(
         required_certificate=(cert if existing_cert else None),
         duty_amount=(volume if existing_volume else None),
         condition_measurement=(unit if existing_unit else None),
+        monetary_unit=(currency if existing_currency else None),
     )
     duplicate = factories.MeasureConditionFactory.create(
         condition_code=existing.condition_code,
@@ -1410,6 +1417,7 @@ def test_ME58(
         required_certificate=(cert if duplicate_cert else None),
         duty_amount=(volume if duplicate_volume else None),
         condition_measurement=(unit if duplicate_unit else None),
+        monetary_unit=(currency if duplicate_currency else None),
     )
 
     with raises_if(BusinessRuleViolation, expect_error):

--- a/measures/tests/test_business_rules.py
+++ b/measures/tests/test_business_rules.py
@@ -1360,27 +1360,56 @@ def test_ME57(date_ranges):
         business_rules.ME57(condition.transaction).validate(condition)
 
 
-@pytest.mark.parametrize(
-    "required_certificate, expect_error",
-    [
-        (factories.CertificateFactory.create, True),
-        (lambda: None, True),
-        (factories.CertificateFactory.create, False),
-    ],
-)
-def test_ME58(required_certificate, expect_error):
-    """The same certificate can only be referenced once by the same measure and
-    the same condition type."""
+@pytest.mark.parametrize("existing_cert", (True, False))
+@pytest.mark.parametrize("existing_volume", (True, False))
+@pytest.mark.parametrize("existing_unit", (True, False))
+@pytest.mark.parametrize("duplicate_cert", (True, False))
+@pytest.mark.parametrize("duplicate_volume", (True, False))
+@pytest.mark.parametrize("duplicate_unit", (True, False))
+def test_ME58(
+    existing_cert: bool,
+    existing_volume: bool,
+    existing_unit: bool,
+    duplicate_cert: bool,
+    duplicate_volume: bool,
+    duplicate_unit: bool,
+):
+    """
+    The same certificate can only be referenced once by the same measure and the
+    same condition type.
+
+    Although the rule only mentions certificates, we have extended it to cover
+    volumes and units as well. Thus, it now checks that each combination of
+    certificate, volume and unit is unique, including where all are missing.
+
+    Volume and unit should always come together, and the same volume under a
+    different unit is allowed. So e.g. 20.000 KGM and 20.000 TNE is valid.
+
+    Note that it is not really meant to be possible to have a certificate and a
+    volume and unit, but that should be enforced elsewhere so this test checks
+    for it anyway.
+    """
+    expect_error = (
+        (existing_cert == duplicate_cert)
+        and (existing_volume == duplicate_volume)
+        and (existing_unit == duplicate_unit)
+    )
+
+    cert = factories.CertificateFactory.create()
+    volume = factories.duty_amount().function()
+    unit = factories.MeasurementFactory.create()
 
     existing = factories.MeasureConditionFactory.create(
-        required_certificate=required_certificate(),
+        required_certificate=(cert if existing_cert else None),
+        duty_amount=(volume if existing_volume else None),
+        condition_measurement=(unit if existing_unit else None),
     )
     duplicate = factories.MeasureConditionFactory.create(
         condition_code=existing.condition_code,
         dependent_measure=existing.dependent_measure,
-        required_certificate=existing.required_certificate
-        if expect_error
-        else factories.CertificateFactory.create(),
+        required_certificate=(cert if duplicate_cert else None),
+        duty_amount=(volume if duplicate_volume else None),
+        condition_measurement=(unit if duplicate_unit else None),
     )
 
     with raises_if(BusinessRuleViolation, expect_error):


### PR DESCRIPTION
## Why
In TP-1020 we made it so that users could not add more than one condition with the same certificate. This works for all certificate-based conditions, but it is not correct for conditions with volumes (under e.g. condition code E).

ME58 will now stop users from adding conditions that use volume amounts, because these conditions don’t have certificates and the rule thinks this is a duplicate of the base case where nothing is supplied. 

## What
So this commit fixes the rule to only enforce that the combination of certificate + volume + unit is unique.