### PR TITLE
TP-1118 Allow 9-type Certificates

### DIFF
--- a/measures/parsers.py
+++ b/measures/parsers.py
@@ -370,7 +370,7 @@ class ConditionSentenceParser:
     )
 
     CONDITION_PHRASE_PATTERN = re.compile(
-        r"^(?P<c1>[A-Z]) (?:(?P<c2>cert:) (?P<c3>[A-Z])-?(?P<c4>\d{3}) )?\((?P<c5>\d{2,3})\):\s*"
+        r"^(?P<c1>[A-Z]) (?:(?P<c2>cert:) (?P<c3>[A-Z9])-?(?P<c4>\d{3}) )?\((?P<c5>\d{2,3})\):\s*"
         f"(?:{DUTY_PHRASE_REGEX})?",
     )
 

--- a/measures/tests/conftest.py
+++ b/measures/tests/conftest.py
@@ -143,6 +143,7 @@ def condition_codes() -> Dict[str, MeasureConditionCode]:
         mcc.code: mcc
         for mcc in [
             factories.MeasureConditionCodeFactory(code="A"),
+            factories.MeasureConditionCodeFactory(code="B"),
             factories.MeasureConditionCodeFactory(code="Y"),
         ]
     }
@@ -155,6 +156,7 @@ def action_codes() -> Dict[str, MeasureAction]:
         for a in [
             factories.MeasureActionFactory(code="01"),
             factories.MeasureActionFactory(code="09"),
+            factories.MeasureActionFactory(code="24"),
             factories.MeasureActionFactory(code="299"),
         ]
     }
@@ -163,9 +165,11 @@ def action_codes() -> Dict[str, MeasureAction]:
 @pytest.fixture
 def certificates():
     d_type = factories.CertificateTypeFactory(sid="D")
+    nine_type = factories.CertificateTypeFactory(sid="9")
     return {
         "D017": factories.CertificateFactory(sid="017", certificate_type=d_type),
         "D018": factories.CertificateFactory(sid="018", certificate_type=d_type),
+        "9100": factories.CertificateFactory(sid="100", certificate_type=nine_type),
     }
 
 

--- a/measures/tests/test_parsers.py
+++ b/measures/tests/test_parsers.py
@@ -177,6 +177,12 @@ def test_seasonal_rate_parser(
                 (("A", "D017", "01"), (1, Decimal("10.0"), "XEM", None)),
             ],
         ),
+        (
+            "Cond: B cert: 9-100 (24):",
+            [
+                (("B", "9100", "24"), None),
+            ],
+        ),
     ),
 )
 def condition_sentence_data(request, get_condition_data, get_component_data):


### PR DESCRIPTION
# TP-1118 Allow 9-type Certificates

## Why
9-type certificates do exist (national certificates)we need to fix the CONDITION_PHRASE_PATTERN in the ConditionSentenceParser to accommodate this

## What
Modify the condition phrase  pattern to allow for 9-type certs and add a test case
