### PR TITLE
TP 1122: Add NIG12 to direct BR-s on GoodsNomenclature

### DIFF
--- a/commodities/models/orm.py
+++ b/commodities/models/orm.py
@@ -175,6 +175,7 @@ class GoodsNomenclature(TrackedModel, ValidityMixin, DescribedMixin):
     business_rules = (
         business_rules.NIG1,
         business_rules.NIG5,
+        business_rules.NIG12,
         business_rules.NIG30,
         business_rules.NIG31,
         business_rules.NIG34,

--- a/commodities/tests/test_business_rules.py
+++ b/commodities/tests/test_business_rules.py
@@ -1,4 +1,5 @@
 import pytest
+from django.core.exceptions import ValidationError
 from django.db import DataError
 
 from commodities import business_rules
@@ -276,6 +277,16 @@ def test_NIG12_description_start_before_nomenclature_end(
 
     with pytest.raises(BusinessRuleViolation):
         business_rules.NIG12(early_description.transaction).validate(goods_nomenclature)
+
+
+def test_NIG12_direct_rule_called_for_goods():
+    good = factories.GoodsNomenclatureFactory.create(description=None)
+
+    with pytest.raises(
+        ValidationError,
+        match="At least one description record is mandatory.",
+    ):
+        good.transaction.clean()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Why
"NIG12 is not included in GoodsNomenclature model's direct BR, while it should be (it's only included as an indirect on GoodsNomenclatureDescription model, but that's not enough)."

## What
Adds direct rule to GoodsNomenclature and tests that this is being called