### PR TITLE
Ensure ME32 always considers draft measure versions

### DIFF
--- a/commodities/models/dc.py
+++ b/commodities/models/dc.py
@@ -442,9 +442,12 @@ class CommodityTreeSnapshot(CommodityTreeBase):
 
             filter |= Q(goods_nomenclature__sid=commodity.obj.sid)
 
-        qs = Measure.objects.filter(filter).approved_up_to_transaction(
-            self.moment.transaction,
-        )
+        qs = Measure.objects.filter(filter)
+
+        if self.moment.clock_type.is_transaction_clock:
+            qs = qs.approved_up_to_transaction(self.moment.transaction)
+        else:
+            qs = qs.latest_approved()
 
         if as_at is not None and as_at is not NOT_PROVIDED:
             logger.debug("Filtering by supplied date: %s", as_at)
@@ -452,7 +455,7 @@ class CommodityTreeSnapshot(CommodityTreeBase):
                 Q(db_effective_valid_between__contains=as_at)
                 | Q(valid_between__startswith__gte=as_at),
             )
-        elif as_at is NOT_PROVIDED and self.moment.clock_type == ClockType.COMBINED:
+        elif as_at is NOT_PROVIDED and self.moment.clock_type.is_calendar_clock:
             logger.debug("Filtering by moment date: %s", self.moment.date)
             qs = qs.with_effective_valid_between().filter(
                 db_effective_valid_between__contains=self.moment.date,

--- a/commodities/models/dc.py
+++ b/commodities/models/dc.py
@@ -442,12 +442,9 @@ class CommodityTreeSnapshot(CommodityTreeBase):
 
             filter |= Q(goods_nomenclature__sid=commodity.obj.sid)
 
-        qs = Measure.objects.filter(filter)
-
-        if self.moment.clock_type == ClockType.TRANSACTION:
-            qs = qs.approved_up_to_transaction(self.moment.transaction)
-        else:
-            qs = qs.latest_approved()
+        qs = Measure.objects.filter(filter).approved_up_to_transaction(
+            self.moment.transaction,
+        )
 
         if as_at is not None and as_at is not NOT_PROVIDED:
             logger.debug("Filtering by supplied date: %s", as_at)


### PR DESCRIPTION
Previously, the measure set used by ME32 would sometimes only return measures in `latest_approved`, whereas it should always be scoped to the passed transaction.

We had no test that draft data was considered, but now do.
