### PR TITLE
update celery to >=5.2.2 in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ api-client==1.3.0
 apsw-wheels==3.36.0.post1
 black==21.12b0
 boto3==1.18.51
-celery[redis]==5.0.5
+celery[redis]>=5.2.2
 coverage[toml]==5.4
 crispy-forms-gds @ git+https://github.com/uktrade/crispy-forms-gds.git@b50168d0e23ffacbdd30e7819ec8f9a08e055c8e
 dj-database-url==0.5.0


### PR DESCRIPTION
## Why
A vulnerability "affects the package celery before 5.2.2. It by default trusts the messages and metadata stored in backends (result stores). When reading task metadata from the backend, the data is deserialized. Given that an attacker can gain access to, or somehow manipulate the metadata within a celery backend, they could trigger a stored command injection vulnerability and potentially gain further access to the system."

## What
Updates celery[redis] to >=5.2.2 in requirements.txt

## Checklist
Requires you to run 'pip install -r requirements.txt'

https://uktrade.atlassian.net/browse/TP-1156
