### PR TITLE
Remove pinning to an exact minor version of Node.

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
   "repository": "https://github.com/uktrade/tamato.git",
   "licence": "MIT",
   "engines": {
-    "node": "^16.8.0",
-    "npm": "7.19.1"
+    "node": "~16.8.0",
+    "npm": "~7.19.1"
   },
   "dependencies": {
     "accessible-autocomplete": "^2.0.3",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "repository": "https://github.com/uktrade/tamato.git",
   "licence": "MIT",
   "engines": {
-    "node": "16.8.0",
+    "node": "^16.8.0",
     "npm": "7.19.1"
   },
   "dependencies": {


### PR DESCRIPTION
# TP-1160 Jenkins build failing

## Why
* Tamato is currently pinning to a specific patch-specific version of Node.
* Cloud Foundry no longer makes the pinned version available and so builds are failing (because of the missing version of Node).

## What
* Don't pin to a patch version of Node and npm.
* Pin to a more general version of Node and npm, which (hopefully) guarantees Node and npm availability within buildpacks.

## Checklist
- Requires migrations? No
- Requires dependency updates? No

Links to relevant material
See: [Report to SRE with suggested action](https://ditdigitalteam.slack.com/archives/C1Q2EKZK3/p1642616596104100)
