### PR TITLE
Pin to major versions of Node and npm.

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
   "repository": "https://github.com/uktrade/tamato.git",
   "licence": "MIT",
   "engines": {
-    "node": "~16.8.0",
-    "npm": "~7.19.1"
+    "node": "^16.8.0",
+    "npm": "^7.19.1"
   },
   "dependencies": {
     "accessible-autocomplete": "^2.0.3",


### PR DESCRIPTION

TP-1160 Jenkins build failing (part 2)

## Why
* Tamato is currently pinning to a specific patch-specific version of Node.
* Cloud Foundry no longer makes the pinned version available and so builds are failing (because of the missing version of Node).
* Minor versions of Node become unavailable.

## What
* Don't pin to a minor version of Node and npm.
* Pin to a major version of Node (16.x.x) and npm (7.x.x), which (hopefully) guarantees Node and npm availability within buildpacks.

## Checklist
* Requires migrations? No
* Requires dependency updates? No

## Links to relevant material
See: [Report to SRE with suggested action](https://ditdigitalteam.slack.com/archives/C1Q2EKZK3/p1642616596104100)
