### PR TITLE
Fix reverse relations on all TrackedModels

### DIFF
--- a/commodities/models/orm.py
+++ b/commodities/models/orm.py
@@ -15,6 +15,7 @@ from common.business_rules import UpdateValidity
 from common.fields import LongDescription
 from common.models import NumericSID
 from common.models import TrackedModel
+from common.models.managers import TrackedModelManager
 from common.models.mixins.description import DescribedMixin
 from common.models.mixins.description import DescriptionMixin
 from common.models.mixins.description import DescriptionQueryset
@@ -230,7 +231,7 @@ class GoodsNomenclatureIndent(TrackedModel, ValidityStartMixin):
     record_code = "400"
     subrecord_code = "05"
 
-    objects: GoodsNomenclatureIndentQuerySet = PolymorphicManager.from_queryset(
+    objects: GoodsNomenclatureIndentQuerySet = TrackedModelManager.from_queryset(
         GoodsNomenclatureIndentQuerySet,
     )()
 

--- a/common/business_rules.py
+++ b/common/business_rules.py
@@ -122,8 +122,8 @@ class BusinessRule(metaclass=BusinessRuleBase):
         ``business_rules`` attribute.
 
         :param model TrackedModel: Get models linked to this model instance
-        :param transaction Transaction: Get latest approved versions of linked models as of this
-        transaction
+        :param transaction Transaction: Get latest approved versions of linked
+            models as of this transaction
         :rtype Iterator[TrackedModel]: The linked models
         """
         for field, related_model in get_relations(type(model)).items():
@@ -185,7 +185,7 @@ class BusinessRuleChecker:
         transaction.
 
         :raises ValidationError: All rule violations are raised in a single
-        ValidationError
+            ValidationError
         """
         violations = []
 
@@ -212,8 +212,8 @@ def only_applicable_after(cutoff: Union[date, datetime, str]):
     """
     Decorate BusinessRules to make them only applicable after a given date.
 
-    :param cutoff Union[date, datetime, str]: The date, datetime or isoformat date
-    string of the time before which the rule should not apply
+    :param cutoff Union[date, datetime, str]: The date, datetime or isoformat
+        date string of the time before which the rule should not apply
     """
 
     if isinstance(cutoff, str):
@@ -385,10 +385,10 @@ class ValidityPeriodContained(BusinessRule):
         Raise a violation unless the contained model validity period falls
         entirely within the validity period of the container model.
 
-        :param container TrackedModel: The model whose validity should contain that of
-        the contained model
-        :param contained TrackedModel: The model whose validity should be contained by
-        that of the container model
+        :param container TrackedModel: The model whose validity should contain
+            that of the contained model
+        :param contained TrackedModel: The model whose validity should be
+            contained by that of the container model
         :param model TrackedModel: The model to associate with the violation
         :raises self.violation: A business violation exception
         """

--- a/common/models/managers.py
+++ b/common/models/managers.py
@@ -1,0 +1,85 @@
+from typing import Any
+from typing import Dict
+from typing import Tuple
+
+from django.db.models import Model
+from django.db.models.fields import Field
+from polymorphic.managers import PolymorphicManager
+
+
+class TrackedModelManager(PolymorphicManager):
+    """
+    Fixes reverse relations so that always return correct results for versioned
+    models.
+
+    For why, see ADR `15. Make reverse relations aware of versions`_.
+
+    This mixin swaps out the foreign keys used by the RelatedManager for
+    querying and replaces them with the version group of the instance. The
+    apporach is to take over control of the `core_filters` attribute used in
+    django/db/models/fields/related_descriptors.py.
+
+    The attribute is only set in two places – either once for a RelatedManager
+    or (in the case of a many-to-many relation) updated in a loop, but the loop
+    is only dependent on context provided by the relation itself. Hence it is
+    possible to define a property override for `core_filters` that will always
+    return the correct result, and ignore anything that it set to the property.
+    """
+
+    instance: Model
+    """This is the model we are trying to find related objects to – e.g. the
+    `parent` that we are calling `descriptions` on in the example in the ADR."""
+
+    field: Field
+    """
+    This is the foreign key field on the remote model – e.g. the
+    `described_object` field of the `Description` model that links back to
+    `Parent` objects in the above example.
+
+    This will be set if this is a one-to-many relationship and this Manager is
+    being used as a RelatedManager. If this is a many-to-many relationship this
+    Manager is a ManyRelatedManager and this attribute is not present.
+    """
+
+    def get_filter_for_relationship(self, model) -> Tuple[str, Any]:
+        """Use the passed object's version group for querying if it has one,
+        otherwise resolve the foreign key normally."""
+        if hasattr(model, "version_group"):
+            return "__version_group", model.version_group
+        else:
+            return "", model
+
+    def get_core_filters(self) -> Dict[str, Any]:
+        """
+        Returns a dictionary of filters used to find related objects.
+
+        The logic duplicates RelatedManager and ManyRelatedManager, but for the
+        former uses version groups instead of foreign keys.
+        """
+
+        if hasattr(self, "field"):
+            # RelatedManager: find all of the remote objects that refer to this
+            # instance by querying on the field name on the remote objects.
+            suffix, object = self.get_filter_for_relationship(self.instance)
+            return {f"{self.field.name}{suffix}": object}
+        else:
+            # ManyRelatedManager: this is a many-to-many relationship with an
+            # auto-generated through model. The auto-generated model does not
+            # take part in the TrackedModel system – hence each version of the
+            # many-to-many models needs an independent set of links, otherwise
+            # it wouldn't be possible for the links to be updated. The
+            # implementation is the same as the default and it is up to the code
+            # that creates new versions to duplicate the many-to-many links.
+            return {
+                f"{self.query_field_name}__{rh_field.attname}": getattr(
+                    self.instance,
+                    rh_field.attname,
+                )
+                for _, rh_field in self.source_field.related_fields
+            }
+
+    def set_core_filters(self, value: Dict[str, Model]) -> None:
+        """Used by Django internal code – we are ignoring what it sets and
+        instead using our own filters."""
+
+    core_filters = property(get_core_filters, set_core_filters)

--- a/common/models/mixins/description.py
+++ b/common/models/mixins/description.py
@@ -1,11 +1,11 @@
 from django.db.models.fields import Field
 from django.urls import NoReverseMatch
 from django.urls import reverse
-from polymorphic.managers import PolymorphicManager
 
 from common.business_rules import NoBlankDescription
 from common.business_rules import UpdateValidity
 from common.exceptions import NoDescriptionError
+from common.models.managers import TrackedModelManager
 from common.models.mixins.validity import ValidityStartMixin
 from common.models.mixins.validity import ValidityStartQueryset
 from common.models.tracked_qs import TrackedModelQuerySet
@@ -18,7 +18,7 @@ class DescriptionQueryset(ValidityStartQueryset, TrackedModelQuerySet):
 
 
 class DescriptionMixin(ValidityStartMixin):
-    objects = PolymorphicManager.from_queryset(DescriptionQueryset)()
+    objects = TrackedModelManager.from_queryset(DescriptionQueryset)()
 
     business_rules = (
         NoBlankDescription,

--- a/common/models/trackedmodel.py
+++ b/common/models/trackedmodel.py
@@ -253,8 +253,8 @@ class TrackedModel(PolymorphicModel):
         """
         Get a name/value mapping of the fields that identify this model.
 
-        :param identifying_fields Optional[Iterable[str]]: Optionally override the
-        fields to retrieve
+        :param identifying_fields Optional[Iterable[str]]: Optionally override
+            the fields to retrieve
         :rtype dict[str, Any]: A dict of field names to values
         """
 
@@ -275,8 +275,8 @@ class TrackedModel(PolymorphicModel):
         model with field name and value pairs delimited by "=", eg: "field1=1,
         field2=2".
 
-        :param identifying_fields: Optionally override the
-        fields to use in the string
+        :param identifying_fields: Optionally override the fields to use in the
+            string
         :rtype str: The constructed string
         """
         field_list = [
@@ -563,8 +563,8 @@ class TrackedModel(PolymorphicModel):
         """
         Save the model to the database.
 
-        :param force_write bool: Ignore append-only restrictions and write to the
-        database even if the model already exists
+        :param force_write bool: Ignore append-only restrictions and write to
+            the database even if the model already exists
         """
         if not force_write and not self._can_write():
             raise IllegalSaveError(
@@ -606,8 +606,8 @@ class TrackedModel(PolymorphicModel):
         """
         Generate a URL to a representation of the model in the webapp.
 
-        :param action str: The view type to generate a URL for (default "detail"),
-        eg: "list" or "edit"
+        :param action str: The view type to generate a URL for (default
+            "detail"), eg: "list" or "edit"
         :rtype Optional[str]: The generated URL
         """
         kwargs = {}

--- a/common/models/trackedmodel.py
+++ b/common/models/trackedmodel.py
@@ -18,7 +18,6 @@ from django.db.models.query import QuerySet
 from django.db.transaction import atomic
 from django.urls import NoReverseMatch
 from django.urls import reverse
-from polymorphic.managers import PolymorphicManager
 from polymorphic.models import PolymorphicModel
 
 from common import validators
@@ -26,6 +25,7 @@ from common.exceptions import IllegalSaveError
 from common.fields import NumericSID
 from common.fields import SignedIntSID
 from common.models import TimestampedMixin
+from common.models.managers import TrackedModelManager
 from common.models.tracked_qs import TrackedModelQuerySet
 from common.models.tracked_utils import get_deferred_set_fields
 from common.models.tracked_utils import get_models_linked_to
@@ -94,7 +94,7 @@ class TrackedModel(PolymorphicModel):
     these fields.
     """
 
-    objects: TrackedModelQuerySet = PolymorphicManager.from_queryset(
+    objects: TrackedModelQuerySet = TrackedModelManager.from_queryset(
         TrackedModelQuerySet,
     )()
 

--- a/common/tests/test_models.py
+++ b/common/tests/test_models.py
@@ -336,6 +336,18 @@ def test_new_version_works_for_all_models(trackedmodel_factory):
     model.new_version(model.transaction.workbasket)
 
 
+def test_new_version_retains_related_objects(sample_model):
+    description = factories.TestModelDescription1Factory(
+        described_record=sample_model,
+    )
+    assert sample_model.descriptions.get() == description
+
+    new_model = sample_model.new_version(
+        sample_model.transaction.workbasket,
+    )
+    assert new_model.descriptions.get() == description
+
+
 def test_current_as_of(sample_model):
     transaction = factories.UnapprovedTransactionFactory.create()
 

--- a/docs/source/api/index.rst
+++ b/docs/source/api/index.rst
@@ -9,3 +9,4 @@ This page gives an overview of all TaMaTo objects, functions and methods.
 .. toctree::
 
     common/common.rst
+    common/common.models.rst

--- a/docs/source/architecture/index.rst
+++ b/docs/source/architecture/index.rst
@@ -89,7 +89,7 @@ done to them.
 
 Each model will exist multiple times in the database, with each row representing
 a new version of that model. This is implemented using the
-:class:`~common.models.tracked.TrackedModel` system.
+:class:`~common.models.trackedmodel.TrackedModel` system.
 
 Note that which version of a model is the "current" one depends in general on
 what transactions have been applied. Each row is pinned to a specific
@@ -103,7 +103,7 @@ that is not draft is considered to be "current".
 
 There are a number of convenience methods for finding "current" models.
 
-.. autoclass:: common.models.tracked.TrackedModelQuerySet
+.. autoclass:: common.models.trackedmodel.TrackedModelQuerySet
   :members: latest_approved, approved_up_to_transaction
 
 Domain Modules
@@ -158,7 +158,7 @@ either as modules themselves or single files.
 
 Classes representing domain models. With again a few exceptions, most models
 correspond directly to an element in the TARIC specification. Most of these will
-inherit from :class:`~common.models.tracked.TrackedModel` which represents a
+inherit from :class:`~common.models.trackedmodel.TrackedModel` which represents a
 model for whom history is being tracked.
 
 The most notable places where the database schema has diverged from the TARIC
@@ -237,7 +237,7 @@ database queries. In some places it is desirable to more tightly control how the
 system fetches it's data – for example, to efficiently generate a new field using
 aggregates.
 
-The :class:`~common.models.tracked.TrackedModelQuerySet` is one of the most used
+The :class:`~common.models.trackedmodel.TrackedModelQuerySet` is one of the most used
 as it implements selecting the correct versions from the version control system.
 
 ``parsers``

--- a/measures/models.py
+++ b/measures/models.py
@@ -2,13 +2,13 @@ from datetime import date
 from typing import Set
 
 from django.db import models
-from polymorphic.managers import PolymorphicManager
 
 from common.business_rules import UpdateValidity
 from common.fields import ApplicabilityCode
 from common.fields import ShortDescription
 from common.fields import SignedIntSID
 from common.models import TrackedModel
+from common.models.managers import TrackedModelManager
 from common.models.mixins.validity import ValidityMixin
 from common.util import TaricDateRange
 from common.util import classproperty
@@ -530,7 +530,7 @@ class Measure(TrackedModel, ValidityMixin):
         UpdateValidity,
     )
 
-    objects = PolymorphicManager.from_queryset(MeasuresQuerySet)()
+    objects = TrackedModelManager.from_queryset(MeasuresQuerySet)()
 
     @property
     def footnote_application_codes(self) -> Set[footnote_validators.ApplicationCode]:
@@ -752,7 +752,7 @@ class MeasureCondition(TrackedModel):
         blank=True,
     )
 
-    objects = PolymorphicManager.from_queryset(MeasureConditionQuerySet)()
+    objects = TrackedModelManager.from_queryset(MeasureConditionQuerySet)()
 
     indirect_business_rules = (
         business_rules.MA2,

--- a/quotas/models.py
+++ b/quotas/models.py
@@ -2,12 +2,12 @@ from decimal import Decimal
 
 from django.core.serializers.json import DjangoJSONEncoder
 from django.db import models
-from polymorphic.managers import PolymorphicManager
 
 from common.business_rules import UpdateValidity
 from common.fields import ShortDescription
 from common.fields import SignedIntSID
 from common.models import TrackedModel
+from common.models.managers import TrackedModelManager
 from common.models.mixins.validity import ValidityMixin
 from quotas import business_rules
 from quotas import querysets
@@ -68,7 +68,7 @@ class QuotaOrderNumber(TrackedModel, ValidityMixin):
         UpdateValidity,
     )
 
-    objects = PolymorphicManager.from_queryset(querysets.QuotaOrderNumberQuerySet)()
+    objects = TrackedModelManager.from_queryset(querysets.QuotaOrderNumberQuerySet)()
 
     def __str__(self):
         return self.order_number


### PR DESCRIPTION
Implements ADR-15.

When tracked models exist in a one-to-many
relationship (such as how one parent object can
have many descriptions) each description object
will hold a foreign key back to the parent object
that specifically links to the version it was
created against.

    Parent X (primary key = 1)
    Description X (primary key = 2, parent = 1)

Calling the reverse relation on the parent will
correctly discover the descriptions:

    parent.descriptions
    # => [<Description: pk=2>]

If that parent object is updated, it receives a
new row in the database, but the descriptions are
not updated. This means that the reverse
relationship now no longer returns any objects,
because the reverse relationship by default tries
to find descriptions that have the primary key of
the *new* parent object:

    parent_v2 = parent.new_version(...)
    parent_v2.descriptions # => []

What needs to be done instead is not use the
database primary key of the parent object but
instead refer to that object's version group,
which will stay constant between versions.

    Parent.objects = TrackedModelManager.from_queryset(...)
    parent_v2.descriptions # => [<Description: pk=2>]

This commit therefore creates a new Manager class
(that will be inherited by RelatedManager) and
that replaces PKs with the version group of the
instance. For more information on why this works
see django/db/models/fields/related_descriptors.py.