### PR TITLE
Increase timeout to 120 seconds to help large upload.

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,3 @@
-web: gunicorn wsgi --bind 0.0.0.0:$PORT
+web: gunicorn wsgi --bind 0.0.0.0:$PORT --timeout 120
 worker: celery -A common.celery worker -l info
 beat: celery -A common.celery beat


### PR DESCRIPTION
Increase gunicorn timeout to 120 seconds to stop large uploads timing out.