### PR TITLE
Make sure geo exclusion business rules don't consider deleted memberships

### DIFF
--- a/measures/business_rules.py
+++ b/measures/business_rules.py
@@ -8,6 +8,7 @@ from django.db.models import Q
 from django.db.utils import DataError
 
 from common.business_rules import BusinessRule
+from common.business_rules import ExclusionMembership
 from common.business_rules import FootnoteApplicability
 from common.business_rules import MustExist
 from common.business_rules import PreventDeleteIfInUse
@@ -1055,17 +1056,11 @@ class ME65(BusinessRule):
             raise self.violation(exclusion)
 
 
-class ME66(BusinessRule):
+class ME66(ExclusionMembership):
     """The excluded geographical area must be a member of the geographical area
     group."""
 
-    def validate(self, exclusion):
-        geo_group = exclusion.modified_measure.geographical_area
-
-        if not geo_group.memberships.filter(
-            sid=exclusion.excluded_geographical_area.sid,
-        ).exists():
-            raise self.violation(exclusion)
+    excluded_from = "modified_measure"
 
 
 class ME67(BusinessRule):

--- a/measures/tests/test_business_rules.py
+++ b/measures/tests/test_business_rules.py
@@ -1718,6 +1718,16 @@ def test_ME66():
 
     business_rules.ME66(exclusion.transaction).validate(exclusion)
 
+    deleted = factories.GeographicalMembershipFactory.create(
+        geo_group=membership.geo_group,
+        member=membership.member,
+        version_group=membership.version_group,
+        update_type=UpdateType.DELETE,
+    )
+
+    with pytest.raises(BusinessRuleViolation):
+        business_rules.ME66(deleted.transaction).validate(exclusion)
+
     exclusion = factories.MeasureExcludedGeographicalAreaFactory.create(
         modified_measure=measure,
         excluded_geographical_area=factories.GeographicalAreaFactory.create(),

--- a/quotas/business_rules.py
+++ b/quotas/business_rules.py
@@ -3,6 +3,7 @@ from datetime import date
 from decimal import Decimal
 
 from common.business_rules import BusinessRule
+from common.business_rules import ExclusionMembership
 from common.business_rules import MustExist
 from common.business_rules import PreventDeleteIfInUse
 from common.business_rules import UniqueIdentifyingFields
@@ -149,16 +150,11 @@ class ON13(BusinessRule):
             raise self.violation(exclusion)
 
 
-class ON14(BusinessRule):
+class ON14(ExclusionMembership):
     """The excluded geographical area must be a member of the geographical area
     group."""
 
-    def validate(self, exclusion):
-        if not exclusion.excluded_geographical_area.groups.filter(
-            member__sid=exclusion.excluded_geographical_area.sid,
-            geo_group__sid=exclusion.origin.geographical_area.sid,
-        ).exists():
-            raise self.violation(exclusion)
+    excluded_from = "origin"
 
 
 class CertificatesMustExist(MustExist):

--- a/quotas/tests/test_business_rules.py
+++ b/quotas/tests/test_business_rules.py
@@ -252,6 +252,16 @@ def test_ON14():
 
     business_rules.ON14(exclusion.transaction).validate(exclusion)
 
+    deleted = factories.GeographicalMembershipFactory.create(
+        geo_group=membership.geo_group,
+        member=membership.member,
+        version_group=membership.version_group,
+        update_type=UpdateType.DELETE,
+    )
+
+    with pytest.raises(BusinessRuleViolation):
+        business_rules.ON14(deleted.transaction).validate(exclusion)
+
 
 def test_CertificatesMustExist():
     """The referenced certificates must exist."""


### PR DESCRIPTION

## Why
<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Use as many lines as you like.
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions or deliberately ignored edge-cases.
--->

In the previous implementations of ME66 and ON14, even memberships that had been deleted would be considered as valid memberships that prevented the business rule from triggering.
## What
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Explain like I'm 5.
 * Use pictures if you can.
--->
This implementation abstracts out the common logic in these rules and adds tests that neither will consider a membership that has been deleted.
