### PR TITLE
TP-1106: Don't display `None` above form errors.

### DIFF
--- a/common/jinja2/layouts/form.jinja
+++ b/common/jinja2/layouts/form.jinja
@@ -42,7 +42,7 @@
       {% set formset_errors = [] %}
       {% for form in forms %}
         {% if form.errors %}
-          {{ formset_errors.append(true) }}
+          {{ formset_errors.append(true) or "" }}
         {% endif %}
       {% endfor %}
     {% if formset_errors %}


### PR DESCRIPTION
At the moment the system prints "None" when displaying errors on forms. It shouldn't!