### PR TITLE
Bugfix - described objects with no url should not break the homepage.

### DIFF
--- a/common/models/mixins/description.py
+++ b/common/models/mixins/description.py
@@ -45,7 +45,10 @@ class DescriptionMixin(ValidityStartMixin):
             kwargs = self.get_identifying_fields()
             described_object = self.get_described_object()
             if action == "detail":
-                return described_object.get_url() + "#descriptions"
+                url = described_object.get_url()
+                if url:
+                    return url + "#descriptions"
+                return
 
             for field, value in described_object.get_identifying_fields().items():
                 kwargs[f"{self.described_object_field.name}__{field}"] = value

--- a/common/models/trackedmodel.py
+++ b/common/models/trackedmodel.py
@@ -606,6 +606,8 @@ class TrackedModel(PolymorphicModel):
         """
         Generate a URL to a representation of the model in the webapp.
 
+        Callers should handle the case where no URL is returned.
+
         :param action str: The view type to generate a URL for (default
             "detail"), eg: "list" or "edit"
         :rtype Optional[str]: The generated URL
@@ -619,7 +621,7 @@ class TrackedModel(PolymorphicModel):
                 kwargs=kwargs,
             )
         except NoReverseMatch:
-            return
+            return None
 
     @classmethod
     def get_url_pattern_name_prefix(cls):


### PR DESCRIPTION
If a described_object get_url() returned None an error occured on the index page.