### PR TITLE
Tp 1162 edit duties

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -17,6 +17,7 @@ from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Group
 from django.contrib.auth.models import Permission
 from django.core.exceptions import ValidationError
+from django.test.client import RequestFactory
 from django.test.html import parse_html
 from django.urls import reverse
 from factory.django import DjangoModelFactory
@@ -982,3 +983,14 @@ def unordered_transactions():
     assert existing_transaction.order > 1
 
     return UnorderedTransactionData(existing_transaction, new_transaction)
+
+
+@pytest.fixture
+def session_request(client, workbasket):
+    session = client.session
+    session.save()
+    request = RequestFactory()
+    request.session = session
+    request.session.update({"workbasket": {"id": workbasket.pk}})
+
+    return request

--- a/footnotes/tests/test_forms.py
+++ b/footnotes/tests/test_forms.py
@@ -4,7 +4,6 @@ import factory
 import pytest
 from dateutil.relativedelta import relativedelta
 from django.core.exceptions import ValidationError
-from django.test.client import RequestFactory
 
 from common.tests import factories
 from common.tests.util import date_post_data
@@ -17,17 +16,10 @@ from footnotes import models
 pytestmark = pytest.mark.django_db
 
 # https://uktrade.atlassian.net/browse/TP-851
-def test_form_save_creates_new_footnote_id_and_footnote_type_id_combo(client):
+def test_form_save_creates_new_footnote_id_and_footnote_type_id_combo(session_request):
     """Tests that when two non-overlapping footnotes of the same type are
     created that these are created with a different footnote_id, to avoid
     duplication of footnote_id and footnote_type_id combination e.g. TN001."""
-    workbasket = factories.ApprovedWorkBasketFactory.create()
-    session = client.session
-    session.update({"workbasket": {"id": workbasket.pk}})
-    session.save()
-    request = RequestFactory()
-    request.session = session
-
     footnote_type = factories.FootnoteTypeFactory.create()
     valid_between = TaricDateRange(
         datetime.date(2021, 1, 1),
@@ -46,7 +38,7 @@ def test_form_save_creates_new_footnote_id_and_footnote_type_id_combo(client):
         "start_date_2": 2022,
         "description": "A note on feet",
     }
-    form = forms.FootnoteCreateForm(data=data, request=request)
+    form = forms.FootnoteCreateForm(data=data, request=session_request)
     new_footnote = form.save(commit=False)
 
     assert earlier.footnote_id != new_footnote.footnote_id

--- a/measures/jinja2/measures/edit.jinja
+++ b/measures/jinja2/measures/edit.jinja
@@ -37,6 +37,21 @@
 
 {% endset %}
 
+{% set duties_html %}
+    {{ govukInput({
+        "id": "duty_sentence",
+        "name": "duty_sentence",
+        "label": {
+            "text": form.duty_sentence.label,
+        },
+        "value": form.initial.duty_sentence|default("")
+    }) }}
+    {{ govukDetails({
+        "summaryText": "Help with duties",
+        "text": "Enter the duty that applies to the measure. This is expressed as a percentage (e.g. 4%), a specific duty (e.g. 33 GBP/100kg) or a compound duty (e.g. 3.5% + 11 GBP/LTR)."
+    }) }}
+{% endset %}
+
 {% set geographical_area_html %}
     {{ govukRadios({
         "idPrefix": "geographical_area_choice",
@@ -101,6 +116,13 @@
                         "heading": {"text": "Commodity code"},
                         "content": {
                             "html": form.goods_nomenclature
+                        },
+                        "summary": {}
+                    },
+                    {
+                        "heading": {"text": "Duties"},
+                        "content": {
+                            "html": duties_html
                         },
                         "summary": {}
                     },

--- a/measures/parsers.py
+++ b/measures/parsers.py
@@ -16,7 +16,6 @@ from typing import Union
 
 from parsec import Parser
 from parsec import Value
-from parsec import choice
 from parsec import joint
 from parsec import optional
 from parsec import regex
@@ -144,7 +143,7 @@ class DutySentenceParser:
         # For monetary units, the expression just contains the same code as is
         # present in the sentence. Percentage values correspond to no unit.
         self._monetary_unit = (
-            reduce(choice, map(code, monetary_units)) if monetary_units else fail
+            reduce(try_choice, map(code, monetary_units)) if monetary_units else fail
         )
         percentage_unit = token("%").result(None)
 

--- a/measures/tests/conftest.py
+++ b/measures/tests/conftest.py
@@ -9,6 +9,7 @@ from django.core.exceptions import ValidationError
 
 from common.tests import factories
 from common.validators import ApplicabilityCode
+from measures.forms import MeasureForm
 from measures.models import DutyExpression
 from measures.models import MeasureAction
 from measures.models import MeasureConditionCode
@@ -307,3 +308,9 @@ def irreversible_duty_sentence_data(request, get_component_data):
     places."""
     expected, component_data = request.param
     return expected, [get_component_data(*args) for args in component_data]
+
+
+@pytest.fixture
+def measure_form(session_request):
+    measure = factories.MeasureFactory.create()
+    return MeasureForm(data={}, instance=measure, request=session_request)

--- a/measures/tests/conftest.py
+++ b/measures/tests/conftest.py
@@ -6,11 +6,13 @@ from typing import Tuple
 
 import pytest
 from django.core.exceptions import ValidationError
+from django.forms.models import model_to_dict
 
 from common.tests import factories
 from common.validators import ApplicabilityCode
 from measures.forms import MeasureForm
 from measures.models import DutyExpression
+from measures.models import Measure
 from measures.models import MeasureAction
 from measures.models import MeasureConditionCode
 from measures.models import Measurement
@@ -313,4 +315,17 @@ def irreversible_duty_sentence_data(request, get_component_data):
 @pytest.fixture
 def measure_form(session_request):
     measure = factories.MeasureFactory.create()
-    return MeasureForm(data={}, instance=measure, request=session_request)
+    data = model_to_dict(measure)
+    start_date = data["valid_between"].lower
+    data.update(
+        start_date_0=start_date.day,
+        start_date_1=start_date.month,
+        start_date_2=start_date.year,
+    )
+    factories.GeographicalAreaFactory.create(area_code=1, area_id=1011)
+
+    return MeasureForm(
+        data=data,
+        instance=Measure.objects.with_duty_sentence().first(),
+        request=session_request,
+    )

--- a/measures/tests/test_forms.py
+++ b/measures/tests/test_forms.py
@@ -1,87 +1,37 @@
+from unittest.mock import patch
+
 import pytest
 
 from common.tests import factories
-from common.validators import UpdateType
-from workbaskets.models import WorkBasket
+from measures.forms import MeasureForm
 
 pytestmark = pytest.mark.django_db
 
 
-def test_diff_components_update(
-    session_request,
-    duty_sentence_parser,
-    percent_or_amount,
+@patch("measures.models.Measure.diff_components")
+def test_diff_components_not_called(
+    diff_components,
     measure_form,
-):
-    original_component = factories.MeasureComponentFactory.create(
-        component_measure=measure_form.instance,
-        duty_amount=9.000,
-        duty_expression=percent_or_amount,
-    )
-    measure_form.diff_components(
-        "8.000%",
-        measure_form.instance,
-        measure_form.instance.valid_between.lower,
-    )
-    components = measure_form.instance.components.approved_up_to_transaction(
-        WorkBasket.objects.get(
-            id=session_request.session["workbasket"].get("id"),
-        ).current_transaction,
-    )
-
-    assert components.count() == 1
-
-    new_component = components.last()
-
-    assert new_component.update_type == UpdateType.UPDATE
-    assert new_component.version_group == original_component.version_group
-    assert new_component.component_measure == measure_form.instance
-    assert new_component.transaction == measure_form.instance.transaction
-    assert new_component.duty_amount == 8.000
-
-
-def test_diff_components_create(session_request, duty_sentence_parser, measure_form):
-    measure_form.diff_components(
-        "8.000%",
-        measure_form.instance,
-        measure_form.instance.valid_between.lower,
-    )
-    components = measure_form.instance.components.approved_up_to_transaction(
-        WorkBasket.objects.get(
-            id=session_request.session["workbasket"].get("id"),
-        ).current_transaction,
-    )
-
-    assert components.count() == 1
-
-    new_component = components.last()
-
-    assert new_component.update_type == UpdateType.CREATE
-    assert new_component.component_measure == measure_form.instance
-    assert new_component.transaction == measure_form.instance.transaction
-    assert new_component.duty_amount == 8.000
-
-
-def test_diff_components_delete(
-    session_request,
     duty_sentence_parser,
-    percent_or_amount,
-    measure_form,
 ):
-    factories.MeasureComponentFactory.create(
-        component_measure=measure_form.instance,
-        duty_amount=9.000,
-        duty_expression=percent_or_amount,
-    )
-    measure_form.diff_components(
-        "",
-        measure_form.instance,
-        measure_form.instance.valid_between.lower,
-    )
-    components = measure_form.instance.components.approved_up_to_transaction(
-        WorkBasket.objects.get(
-            id=session_request.session["workbasket"].get("id"),
-        ).current_transaction,
-    )
+    measure_form.save(commit=False)
 
-    assert components.count() == 0
+    assert diff_components.called == False
+
+
+@patch("measures.models.Measure.diff_components")
+def test_diff_components_called(diff_components, measure_form, duty_sentence_parser):
+    measure_form.data.update(duty_sentence="6.000%")
+    measure_form.save(commit=False)
+
+    assert diff_components.called == True
+
+
+def test_error_raised_if_no_duty_sentence(session_request):
+    measure = factories.MeasureFactory.create()
+
+    with pytest.raises(
+        AttributeError,
+        match="Measure instance is missing `duty_sentence` attribute. Try calling `with_duty_sentence` queryset method",
+    ):
+        MeasureForm(data={}, instance=measure, request=session_request)

--- a/measures/tests/test_forms.py
+++ b/measures/tests/test_forms.py
@@ -1,0 +1,87 @@
+import pytest
+
+from common.tests import factories
+from common.validators import UpdateType
+from workbaskets.models import WorkBasket
+
+pytestmark = pytest.mark.django_db
+
+
+def test_diff_components_update(
+    session_request,
+    duty_sentence_parser,
+    percent_or_amount,
+    measure_form,
+):
+    original_component = factories.MeasureComponentFactory.create(
+        component_measure=measure_form.instance,
+        duty_amount=9.000,
+        duty_expression=percent_or_amount,
+    )
+    measure_form.diff_components(
+        "8.000%",
+        measure_form.instance,
+        measure_form.instance.valid_between.lower,
+    )
+    components = measure_form.instance.components.approved_up_to_transaction(
+        WorkBasket.objects.get(
+            id=session_request.session["workbasket"].get("id"),
+        ).current_transaction,
+    )
+
+    assert components.count() == 1
+
+    new_component = components.last()
+
+    assert new_component.update_type == UpdateType.UPDATE
+    assert new_component.version_group == original_component.version_group
+    assert new_component.component_measure == measure_form.instance
+    assert new_component.transaction == measure_form.instance.transaction
+    assert new_component.duty_amount == 8.000
+
+
+def test_diff_components_create(session_request, duty_sentence_parser, measure_form):
+    measure_form.diff_components(
+        "8.000%",
+        measure_form.instance,
+        measure_form.instance.valid_between.lower,
+    )
+    components = measure_form.instance.components.approved_up_to_transaction(
+        WorkBasket.objects.get(
+            id=session_request.session["workbasket"].get("id"),
+        ).current_transaction,
+    )
+
+    assert components.count() == 1
+
+    new_component = components.last()
+
+    assert new_component.update_type == UpdateType.CREATE
+    assert new_component.component_measure == measure_form.instance
+    assert new_component.transaction == measure_form.instance.transaction
+    assert new_component.duty_amount == 8.000
+
+
+def test_diff_components_delete(
+    session_request,
+    duty_sentence_parser,
+    percent_or_amount,
+    measure_form,
+):
+    factories.MeasureComponentFactory.create(
+        component_measure=measure_form.instance,
+        duty_amount=9.000,
+        duty_expression=percent_or_amount,
+    )
+    measure_form.diff_components(
+        "",
+        measure_form.instance,
+        measure_form.instance.valid_between.lower,
+    )
+    components = measure_form.instance.components.approved_up_to_transaction(
+        WorkBasket.objects.get(
+            id=session_request.session["workbasket"].get("id"),
+        ).current_transaction,
+    )
+
+    assert components.count() == 0

--- a/measures/tests/test_util.py
+++ b/measures/tests/test_util.py
@@ -4,22 +4,6 @@ from measures import util
 
 
 @pytest.mark.parametrize(
-    "value, expected",
-    [
-        ("6.00 %", "6.00 %"),
-        ("1.23 GBP/kg", "1.23 GBP/kg"),
-        (0, "0.000%"),
-        (1, "100.000%"),
-        (0.12, "12.000%"),
-        (0.12345, "12.345%"),
-        (0.123456789, "12.345%"),
-    ],
-)
-def test_clean_duty_sentence(value, expected):
-    assert util.clean_duty_sentence(value) == expected
-
-
-@pytest.mark.parametrize(
     "value, conversion, expected",
     [
         ("20.000", 2, "40.000"),

--- a/measures/util.py
+++ b/measures/util.py
@@ -1,21 +1,5 @@
 import decimal
 from math import floor
-from typing import Union
-
-
-def clean_duty_sentence(value: Union[str, int, float]) -> str:
-    """Given a value, return a string representing a duty sentence taking into
-    account that the value may be storing simple percentages as a number
-    value."""
-    if isinstance(value, float) or isinstance(value, int):
-        # This is a percentage value that Excel has
-        # represented as a number.
-        decimal.getcontext().prec = 3
-        decimal.getcontext().rounding = decimal.ROUND_DOWN
-        return f"{decimal.Decimal(str(value)):.3%}"
-    else:
-        # All other values will appear as text.
-        return str(value)
 
 
 def convert_eur_to_gbp(amount: str, eur_gbp_conversion_rate: float) -> str:


### PR DESCRIPTION
## Why
The ability to edit duties is in the original designs, but currently missing from editor functionality

## What
- Adds a diff_components method to `Measure` to determine whether to create, update, or delete components 
- Adds logic to `MeasureForm` to ensure that this method is only called when user has changed or added a duty value
- Adds unit tests for three `diff_components` scenarios and form logic
- Adds conftest fixtures to make it easier to create an instance of `MeasureForm`
- Deletes unused measure util, `clean_duty_sentence`

This [bug](https://uktrade.atlassian.net/browse/TP2000-100) was discovered while doing this ticket and so we should let the tariff managers know that until it's fixed the displayed value will look like it's duplicated (see screenshot below)

<img width="522" alt="Screenshot 2022-02-04 at 16 05 56" src="https://user-images.githubusercontent.com/46938749/152562097-c6515e97-20d8-4013-91d2-f52b996e8dcd.png">

