### PR TITLE
Using .trackedmodel_ptr failed because TrackedModel specifies identif…

### DIFF
--- a/additional_codes/models.py
+++ b/additional_codes/models.py
@@ -32,6 +32,8 @@ class AdditionalCodeType(TrackedModel, ValidityMixin):
     description_record_code = "120"
     description_subrecord_code = "05"
 
+    identifying_fields = ("sid",)
+
     sid = models.CharField(
         max_length=1,
         validators=[validators.additional_code_type_sid_validator],
@@ -65,6 +67,8 @@ class AdditionalCode(TrackedModel, ValidityMixin, DescribedMixin):
 
     record_code = "245"
     subrecord_code = "00"
+
+    identifying_fields = ("sid",)
 
     sid = SignedIntSID(db_index=True)
     type = models.ForeignKey(AdditionalCodeType, on_delete=models.PROTECT)
@@ -110,6 +114,8 @@ class AdditionalCodeDescription(DescriptionMixin, TrackedModel):
     subrecord_code = "10"
     period_record_code = "245"
     period_subrecord_code = "05"
+
+    identifying_fields = ("sid",)
 
     # Store the additional code description period sid so that we can send it in TARIC3
     # updates to systems that expect it.

--- a/certificates/models.py
+++ b/certificates/models.py
@@ -20,6 +20,8 @@ class CertificateType(TrackedModel, ValidityMixin):
     description_record_code = "110"
     description_subrecord_code = "05"
 
+    identifying_fields = ("sid",)
+
     sid = models.CharField(
         max_length=1,
         validators=[validators.certificate_type_sid_validator],
@@ -89,6 +91,8 @@ class CertificateDescription(DescriptionMixin, TrackedModel):
 
     period_record_code = "205"
     period_subrecord_code = "05"
+
+    identifying_fields = ("sid",)
 
     sid = SignedIntSID(db_index=True)
 

--- a/commodities/models/orm.py
+++ b/commodities/models/orm.py
@@ -112,6 +112,8 @@ class GoodsNomenclature(TrackedModel, ValidityMixin, DescribedMixin):
     record_code = "400"
     subrecord_code = "00"
 
+    identifying_fields = ("sid",)
+
     sid = NumericSID()
 
     # These are character fields as they often has leading 0s
@@ -231,6 +233,8 @@ class GoodsNomenclatureIndent(TrackedModel, ValidityStartMixin):
     record_code = "400"
     subrecord_code = "05"
 
+    identifying_fields = ("sid",)
+
     objects: GoodsNomenclatureIndentQuerySet = TrackedModelManager.from_queryset(
         GoodsNomenclatureIndentQuerySet,
     )()
@@ -311,6 +315,8 @@ class GoodsNomenclatureDescription(DescriptionMixin, TrackedModel):
     subrecord_code = "15"
     period_record_code = "400"
     period_subrecord_code = "10"
+
+    identifying_fields = ("sid",)
 
     objects = PolymorphicManager.from_queryset(DescriptionQueryset)()
 

--- a/common/models/trackedmodel.py
+++ b/common/models/trackedmodel.py
@@ -125,14 +125,16 @@ class TrackedModel(PolymorphicModel):
     ones.
     """
 
-    identifying_fields: Sequence[str] = ("sid",)
+    identifying_fields: Sequence[str] = ("pk",)
     """
     The fields which together form a composite unique key for each model.
 
-    The system ID (or SID) field is normally the unique identifier of a TARIC
+    The system ID (or SID) field, 'sid' is normally the unique identifier of a TARIC
     model, but in places where this does not exist models can declare their own.
     (Note that because multiple versions of each model will exist this does not
     actually equate to a ``UNIQUE`` constraint in the database.)
+    
+    TrackedModel itself defaults to ("pk",) as it does not have an SID.
     """
 
     def new_version(

--- a/common/tests/models.py
+++ b/common/tests/models.py
@@ -17,6 +17,8 @@ class TestModel1(TrackedModel, ValidityMixin, DescribedMixin):
 
     taric_template = "test_template"
 
+    identifying_fields = ("sid",)
+
     sid = NumericSID()
     name = models.CharField(max_length=24, null=True)
 

--- a/common/tests/test_models.py
+++ b/common/tests/test_models.py
@@ -468,6 +468,21 @@ def test_trackedmodel_str(trackedmodel_factory):
     assert len(result.strip())
 
 
+@pytest.mark.django_db(transaction=True, reset_sequences=True)
+def test_trackedmodel_base_str():
+    """
+    Verify TrackedModel base class can stringify without crashing, so that.
+
+    .trackedmodel_ptr will work on TrackedModel subclasses.
+    """
+    model = factories.TestModel1Factory.create()
+    trackedmodel = model.trackedmodel_ptr
+
+    result = str(trackedmodel)
+
+    assert f"pk={trackedmodel.pk}" == result
+
+
 def test_copy(trackedmodel_factory, approved_transaction):
     """Verify that a copy of a TrackedModel is a new instance with different
     primary key and version group."""

--- a/footnotes/models.py
+++ b/footnotes/models.py
@@ -115,6 +115,8 @@ class FootnoteDescription(DescriptionMixin, TrackedModel):
     period_record_code = "200"
     period_subrecord_code = "05"
 
+    identifying_fields = ("sid",)
+
     described_footnote = models.ForeignKey(
         Footnote,
         on_delete=models.CASCADE,

--- a/geo_areas/models.py
+++ b/geo_areas/models.py
@@ -45,6 +45,8 @@ class GeographicalArea(TrackedModel, ValidityMixin, DescribedMixin):
     record_code = "250"
     subrecord_code = "00"
 
+    identifying_fields = ("sid",)
+
     url_pattern_name_prefix = "geoarea"
 
     sid = SignedIntSID(db_index=True)
@@ -183,6 +185,8 @@ class GeographicalAreaDescription(DescriptionMixin, TrackedModel):
 
     period_record_code = "250"
     period_subrecord_code = "05"
+
+    identifying_fields = ("sid",)
 
     described_geographicalarea = models.ForeignKey(
         GeographicalArea,

--- a/measures/models.py
+++ b/measures/models.py
@@ -36,6 +36,8 @@ class MeasureTypeSeries(TrackedModel, ValidityMixin):
     description_record_code = "140"
     description_subrecord_code = "05"
 
+    identifying_fields = ("sid",)
+
     sid = models.CharField(
         max_length=2,
         validators=[validators.measure_type_series_id_validator],
@@ -190,6 +192,8 @@ class DutyExpression(TrackedModel, ValidityMixin):
     description_record_code = "230"
     description_subrecord_code = "05"
 
+    identifying_fields = ("sid",)
+
     sid = models.IntegerField(
         choices=validators.DutyExpressionId.choices,
         db_index=True,
@@ -230,6 +234,8 @@ class MeasureType(TrackedModel, ValidityMixin):
 
     description_record_code = "235"
     description_subrecord_code = "05"
+
+    identifying_fields = ("sid",)
 
     sid = models.CharField(
         max_length=6,
@@ -706,6 +712,8 @@ class MeasureCondition(TrackedModel):
 
     record_code = "430"
     subrecord_code = "10"
+
+    identifying_fields = ("sid",)
 
     sid = SignedIntSID(db_index=True)
     dependent_measure = models.ForeignKey(

--- a/quotas/models.py
+++ b/quotas/models.py
@@ -27,6 +27,8 @@ class QuotaOrderNumber(TrackedModel, ValidityMixin):
     record_code = "360"
     subrecord_code = "00"
 
+    identifying_fields = ("sid",)
+
     sid = SignedIntSID(db_index=True)
     order_number = models.CharField(
         max_length=6,
@@ -91,6 +93,8 @@ class QuotaOrderNumberOrigin(TrackedModel, ValidityMixin):
 
     record_code = "360"
     subrecord_code = "10"
+
+    identifying_fields = ("sid",)
 
     sid = SignedIntSID(db_index=True)
     order_number = models.ForeignKey(QuotaOrderNumber, on_delete=models.PROTECT)
@@ -160,6 +164,8 @@ class QuotaDefinition(TrackedModel, ValidityMixin):
 
     record_code = "370"
     subrecord_code = "00"
+
+    identifying_fields = ("sid",)
 
     sid = SignedIntSID(db_index=True)
     order_number = models.ForeignKey(QuotaOrderNumber, on_delete=models.PROTECT)
@@ -286,6 +292,8 @@ class QuotaSuspension(TrackedModel, ValidityMixin):
     record_code = "370"
     subrecord_code = "15"
 
+    identifying_fields = ("sid",)
+
     sid = SignedIntSID(db_index=True)
     quota_definition = models.ForeignKey(QuotaDefinition, on_delete=models.PROTECT)
     description = ShortDescription()
@@ -298,6 +306,8 @@ class QuotaBlocking(TrackedModel, ValidityMixin):
 
     record_code = "370"
     subrecord_code = "10"
+
+    identifying_fields = ("sid",)
 
     sid = SignedIntSID(db_index=True)
     quota_definition = models.ForeignKey(QuotaDefinition, on_delete=models.PROTECT)


### PR DESCRIPTION
Fix bug in TrackedModel subclasses when using trackedmodel_ptr.

`TrackedModel.identifying_fields = ("sid"),` which throws an exception when converting it to a string.

This makes it hard to use this API in a notebook.

To fix it, set `identifying_fields` to `("pk"),` by default.
Any subclasses that need "sid" have this added manually.

A test was also added.