### PR TITLE
Use naming conventions to auto-generate routes

### DIFF
--- a/additional_codes/urls.py
+++ b/additional_codes/urls.py
@@ -3,6 +3,7 @@ from django.urls import path
 from rest_framework import routers
 
 from additional_codes import views
+from common.paths import get_ui_paths
 
 api_router = routers.DefaultRouter()
 api_router.register(
@@ -14,59 +15,7 @@ api_router.register(r"additional_code_types", views.AdditionalCodeTypeViewSet)
 
 detail = "<sid:sid>"
 description_detail = "<sid:described_additionalcode__sid>/description/<sid:sid>"
-
-ui_patterns = [
-    path(
-        "",
-        views.AdditionalCodeList.as_view(),
-        name="additional_code-ui-list",
-    ),
-    path(
-        "create/",
-        views.AdditionalCodeCreate.as_view(),
-        name="additional_code-ui-create",
-    ),
-    path(
-        f"{detail}/confirm-create/",
-        views.AdditionalCodeConfirmCreate.as_view(),
-        name="additional_code-ui-confirm-create",
-    ),
-    path(
-        f"{detail}/",
-        views.AdditionalCodeDetail.as_view(),
-        name="additional_code-ui-detail",
-    ),
-    path(
-        f"{detail}/edit/",
-        views.AdditionalCodeUpdate.as_view(),
-        name="additional_code-ui-edit",
-    ),
-    path(
-        f"{detail}/confirm-update/",
-        views.AdditionalCodeConfirmUpdate.as_view(),
-        name="additional_code-ui-confirm-update",
-    ),
-    path(
-        f"{detail}/create-description/",
-        views.AdditionalCodeCreateDescription.as_view(),
-        name="additional_code-ui-create-description",
-    ),
-    path(
-        f"{description_detail}/edit/",
-        views.AdditionalCodeUpdateDescription.as_view(),
-        name="additional_code_description-ui-edit",
-    ),
-    path(
-        f"{description_detail}/confirm-create/",
-        views.AdditionalCodeDescriptionConfirmCreate.as_view(),
-        name="additional_code_description-ui-confirm-create",
-    ),
-    path(
-        f"{description_detail}/confirm-update/",
-        views.AdditionalCodeDescriptionConfirmUpdate.as_view(),
-        name="additional_code_description-ui-confirm-update",
-    ),
-]
+ui_patterns = get_ui_paths(views, detail, description=description_detail)
 
 
 urlpatterns = [

--- a/additional_codes/views.py
+++ b/additional_codes/views.py
@@ -158,7 +158,7 @@ class AdditionalCodeCreateDescription(
     template_name = "common/create_description.jinja"
 
 
-class AdditionalCodeUpdateDescription(
+class AdditionalCodeDescriptionUpdate(
     AdditionalCodeDescriptionMixin,
     TrackedModelDetailMixin,
     DraftUpdateView,

--- a/certificates/tests/test_views.py
+++ b/certificates/tests/test_views.py
@@ -1,7 +1,7 @@
 import pytest
 
 from certificates.models import Certificate
-from certificates.views import CertificatesList
+from certificates.views import CertificateList
 from common.tests.util import assert_model_view_renders
 from common.tests.util import get_class_based_view_urls_matching_url
 from common.tests.util import view_is_subclass
@@ -31,7 +31,7 @@ def test_certificate_detail_views(view, url_pattern, valid_user_client):
     get_class_based_view_urls_matching_url(
         "certificates/",
         view_is_subclass(TamatoListView),
-        assert_contains_view_classes=[CertificatesList],
+        assert_contains_view_classes=[CertificateList],
     ),
     ids=view_urlpattern_ids,
 )

--- a/certificates/urls.py
+++ b/certificates/urls.py
@@ -6,6 +6,7 @@ from rest_framework import routers
 from certificates import views
 from certificates.path_converters import CertificateSIDConverter
 from certificates.path_converters import CertificateTypeSIDConverter
+from common.paths import get_ui_paths
 
 register_converter(CertificateSIDConverter, "cert_sid")
 register_converter(CertificateTypeSIDConverter, "ctype_sid")
@@ -20,49 +21,7 @@ api_router.register(r"certificate_types", views.CertificateTypeViewSet)
 
 detail = "<ctype_sid:certificate_type__sid><cert_sid:sid>"
 description_detail = "<ctype_sid:described_certificate__certificate_type__sid><cert_sid:described_certificate__sid>/description/<sid:sid>"
-
-ui_patterns = [
-    path(
-        "",
-        views.CertificatesList.as_view(),
-        name="certificate-ui-list",
-    ),
-    path(
-        f"{detail}/",
-        views.CertificateDetail.as_view(),
-        name="certificate-ui-detail",
-    ),
-    path(
-        f"{detail}/create-description/",
-        views.CertificateCreateDescription.as_view(),
-        name="certificate-ui-create-description",
-    ),
-    path(
-        f"{description_detail}/edit/",
-        views.CertificateUpdateDescription.as_view(),
-        name="certificate_description-ui-edit",
-    ),
-    path(
-        f"{description_detail}/confirm-create/",
-        views.CertificateDescriptionConfirmCreate.as_view(),
-        name="certificate_description-ui-confirm-create",
-    ),
-    path(
-        f"{description_detail}/confirm-update/",
-        views.CertificateDescriptionConfirmUpdate.as_view(),
-        name="certificate_description-ui-confirm-update",
-    ),
-    path(
-        f"{detail}/edit/",
-        views.CertificateUpdate.as_view(),
-        name="certificate-ui-edit",
-    ),
-    path(
-        f"{detail}/confirm-update/",
-        views.CertificateConfirmUpdate.as_view(),
-        name="certificate-ui-confirm-update",
-    ),
-]
+ui_patterns = get_ui_paths(views, detail, description=description_detail)
 
 urlpatterns = [
     path("certificates/", include(ui_patterns)),

--- a/certificates/views.py
+++ b/certificates/views.py
@@ -54,7 +54,7 @@ class CertificateMixin:
         )
 
 
-class CertificatesList(CertificateMixin, TamatoListView):
+class CertificateList(CertificateMixin, TamatoListView):
     """UI endpoint for viewing and filtering Certificates."""
 
     template_name = "certificates/list.jinja"

--- a/common/jinja2/common/index.jinja
+++ b/common/jinja2/common/index.jinja
@@ -67,7 +67,7 @@
       <h2 class="govuk-heading-m">Geographical areas</h2>
       <ul class="govuk-list">
         <li>
-          <a class="govuk-link" href="{{ url('geoarea-ui-list') }}">
+          <a class="govuk-link" href="{{ url('geo_area-ui-list') }}">
             Find and edit geographical areas
           </a>
         </li>

--- a/common/paths.py
+++ b/common/paths.py
@@ -1,0 +1,87 @@
+import logging
+from types import ModuleType
+from typing import Collection
+
+from django.urls import URLPattern
+from django.urls import path
+
+logger = logging.getLogger(__name__)
+
+BULK_ACTIONS = {
+    "List": "",
+    "Create": "create",
+}
+
+OBJECT_ACTIONS = {
+    "ConfirmCreate": "confirm-create",
+    "Detail": "",
+    "Update": "edit",
+    "ConfirmUpdate": "confirm-update",
+    "Delete": "delete",
+}
+
+
+def get_ui_paths(
+    views: ModuleType,
+    pattern: str,
+    **subrecords: str,
+) -> Collection[URLPattern]:
+    """
+    Return a set of routes auto-generated from the passed views module, based on
+    a set of conventions for TrackedModels.
+
+    This will attempt to create routes for the paths listed in BULK_ACTIONS and
+    OBJECT_ACTIONS, for both a root record and a description record if the
+    `description_detail` is passed. Any views that aren't implemented for the
+    passed views module are ignored.
+
+    The conventions are:
+
+    * View classes in the views module begin with the singular of the app name
+      (additional_codes -> AdditionalCode)
+    * View classes in the views module end with one of the keys of BULK_ACTIONS
+      or OBJECT_ACTIONS
+    * The view class should be mapped to a URL that is the corresponding value
+      of BULK_ACTIONS or OBJECT_ACTIONS
+    * OBJECT_ACTIONS have URLs that are prefixed with a `pattern`
+    * Subrecords have URLs that are prefixed with both `subrecord` patterns
+    * The name of the path is the same as the URL, apart from if the URL is
+      blank, in which case it is the lowercase of the action key.
+
+    E.g. when passed `additional_codes.views` with the pattern `<sid:sid>`, will
+    return routes for:
+
+    * Name "additional_code-ui-list" mapped to URL "" using view
+      `AdditionalCodeList`
+    * Name "additional_code-ui-detail" mapped to URL "<sid:sid>/" using view
+      `AdditionalCodeDetail`
+    * Name "additional_code-ui-update" mapped to URL "<sid:sid>/edit/" using
+      view `AdditionalCodeUpdate`
+
+    etc.
+    """
+    app_name = views.__name__.split(".")[0]
+
+    combinations = [
+        (app_name[:-1], BULK_ACTIONS, ""),
+        (app_name[:-1], OBJECT_ACTIONS, pattern),
+    ]
+
+    for name, pattern in subrecords.items():
+        combinations.append((f"{app_name[:-1]}_{name}", OBJECT_ACTIONS, pattern))
+
+    paths = []
+    for prefix, actions, pattern in combinations:
+        for class_suffix, pathname in actions.items():
+            class_prefix = "".join(word.title() for word in prefix.split("_"))
+            classname = class_prefix + class_suffix
+            if hasattr(views, classname):
+                view = getattr(views, classname)
+                name = f"{prefix}-ui-{pathname if pathname else class_suffix.lower()}"
+                url = pattern + ("/" if pattern else "") + pathname
+
+                paths.append(path(url, view.as_view(), name=name))
+            else:
+                logger.debug("No action %s for %s", classname, app_name)
+
+    return paths

--- a/footnotes/tests/test_views.py
+++ b/footnotes/tests/test_views.py
@@ -78,7 +78,7 @@ def test_footnote_business_rule_application(
 def test_footnote_detail_views(view, url_pattern, valid_user_client):
     """Verify that measure detail views are under the url footnotes/ and don't
     return an error."""
-    model_overrides = {"footnotes.views.FootnoteCreateDescription": Footnote}
+    model_overrides = {"footnotes.views.FootnoteDescriptionCreate": Footnote}
 
     assert_model_view_renders(view, url_pattern, valid_user_client, model_overrides)
 

--- a/footnotes/urls.py
+++ b/footnotes/urls.py
@@ -3,6 +3,7 @@ from django.urls import path
 from django.urls import register_converter
 from rest_framework import routers
 
+from common.paths import get_ui_paths
 from footnotes import views
 from footnotes.path_converters import FootnoteIdConverter
 from footnotes.path_converters import FootnoteTypeIdConverter
@@ -20,60 +21,7 @@ api_router.register(r"footnote_types", views.FootnoteTypeViewSet)
 
 detail = "<footnote_type_id:footnote_type__footnote_type_id><footnote_id:footnote_id>"
 description_detail = "<footnote_type_id:described_footnote__footnote_type__footnote_type_id><footnote_id:described_footnote__footnote_id>/description/<sid:sid>"
-
-ui_patterns = [
-    path(
-        "",
-        views.FootnoteList.as_view(),
-        name="footnote-ui-list",
-    ),
-    path(
-        "create",
-        views.FootnoteCreate.as_view(),
-        name="footnote-ui-create",
-    ),
-    path(
-        f"{detail}/confirm-create",
-        views.FootnoteConfirmCreate.as_view(),
-        name="footnote-ui-confirm-create",
-    ),
-    path(
-        f"{detail}/",
-        views.FootnoteDetail.as_view(),
-        name="footnote-ui-detail",
-    ),
-    path(
-        f"{detail}/edit/",
-        views.FootnoteUpdate.as_view(),
-        name="footnote-ui-edit",
-    ),
-    path(
-        f"{detail}/confirm-update/",
-        views.FootnoteConfirmUpdate.as_view(),
-        name="footnote-ui-confirm-update",
-    ),
-    path(
-        f"{detail}/create_description/",
-        views.FootnoteCreateDescription.as_view(),
-        name="footnote-ui-create-description",
-    ),
-    path(
-        f"{description_detail}/edit/",
-        views.FootnoteUpdateDescription.as_view(),
-        name="footnote_description-ui-edit",
-    ),
-    path(
-        f"{description_detail}/confirm-create/",
-        views.FootnoteDescriptionConfirmCreate.as_view(),
-        name="footnote_description-ui-confirm-create",
-    ),
-    path(
-        f"{description_detail}/confirm-update/",
-        views.FootnoteDescriptionConfirmUpdate.as_view(),
-        name="footnote_description-ui-confirm-update",
-    ),
-    path("api/", include(api_router.urls)),
-]
+ui_patterns = get_ui_paths(views, detail, description=description_detail)
 
 urlpatterns = [
     path("footnotes/", include(ui_patterns)),

--- a/footnotes/views.py
+++ b/footnotes/views.py
@@ -152,7 +152,7 @@ class FootnoteConfirmUpdate(FootnoteMixin, TrackedModelDetailView):
     template_name = "common/confirm_update.jinja"
 
 
-class FootnoteCreateDescription(
+class FootnoteDescriptionCreate(
     FootnoteCreateDescriptionMixin,
     TrackedModelDetailMixin,
     DraftCreateView,
@@ -171,7 +171,7 @@ class FootnoteCreateDescription(
     template_name = "common/create_description.jinja"
 
 
-class FootnoteUpdateDescription(
+class FootnoteDescriptionUpdate(
     FootnoteDescriptionMixin,
     TrackedModelDetailMixin,
     DraftUpdateView,

--- a/geo_areas/filters.py
+++ b/geo_areas/filters.py
@@ -43,7 +43,7 @@ class GeographicalAreaFilter(
         required=False,
     )
 
-    clear_url = reverse_lazy("geoarea-ui-list")
+    clear_url = reverse_lazy("geo_area-ui-list")
 
     class Meta:
         model = GeographicalArea

--- a/geo_areas/jinja2/geo_areas/detail.jinja
+++ b/geo_areas/jinja2/geo_areas/detail.jinja
@@ -16,7 +16,7 @@
   {{ govukBreadcrumbs({
     "items": [
       {"text": "Home", "href": url("index")},
-      {"text": "Find and edit geographical areas", "href": url("geoarea-ui-list")},
+      {"text": "Find and edit geographical areas", "href": url("geo_area-ui-list")},
       {"text": page_title}
     ]
   }) }}

--- a/geo_areas/jinja2/geo_areas/list.jinja
+++ b/geo_areas/jinja2/geo_areas/list.jinja
@@ -1,4 +1,4 @@
-{% set form_url = "geoarea-ui-list" %}
+{% set form_url = "geo_area-ui-list" %}
 {% set list_include = "includes/geo_areas/list.jinja" %}
 
 {%- include "layouts/list.jinja" -%}

--- a/geo_areas/jinja2/includes/geo_areas/list.jinja
+++ b/geo_areas/jinja2/includes/geo_areas/list.jinja
@@ -1,7 +1,7 @@
 {% set table_rows = [] %}
 {% for geo_area in object_list %}
   {% set geo_area_link -%}
-    <a class="govuk-link govuk-!-font-weight-bold" href="{{ url("geoarea-ui-detail", kwargs={"sid": geo_area.sid}) }}">{{ geo_area.area_id }}</a>
+    <a class="govuk-link govuk-!-font-weight-bold" href="{{ url("geo_area-ui-detail", kwargs={"sid": geo_area.sid}) }}">{{ geo_area.area_id }}</a>
   {%- endset %}
   {{ table_rows.append([
     {"html": geo_area_link},

--- a/geo_areas/models.py
+++ b/geo_areas/models.py
@@ -47,7 +47,7 @@ class GeographicalArea(TrackedModel, ValidityMixin, DescribedMixin):
 
     identifying_fields = ("sid",)
 
-    url_pattern_name_prefix = "geoarea"
+    url_pattern_name_prefix = "geo_area"
 
     sid = SignedIntSID(db_index=True)
     area_id = models.CharField(max_length=4, validators=[area_id_validator])
@@ -204,6 +204,8 @@ class GeographicalAreaDescription(DescriptionMixin, TrackedModel):
             self.sid = highest_sid + 1
 
         return super().save(*args, **kwargs)
+
+    url_pattern_name_prefix = "geo_area_description"
 
     class Meta:
         ordering = ("validity_start",)

--- a/geo_areas/tests/bdd/test_browse_geo_areas.py
+++ b/geo_areas/tests/bdd/test_browse_geo_areas.py
@@ -14,7 +14,7 @@ scenarios("features/browse_geo_areas.feature")
 @pytest.fixture
 @when("I search for a geographical_area using a <search_term>")
 def geo_area_search(search_term, client):
-    return client.get(reverse("geoarea-list"), {"search": search_term})
+    return client.get(reverse("geo_area-list"), {"search": search_term})
 
 
 @then("the search result should contain the geographical_area searched for")

--- a/geo_areas/tests/test_views.py
+++ b/geo_areas/tests/test_views.py
@@ -7,7 +7,7 @@ from common.tests.util import view_urlpattern_ids
 from common.views import TamatoListView
 from common.views import TrackedModelDetailMixin
 from geo_areas.models import GeographicalArea
-from geo_areas.views import GeographicalAreaList
+from geo_areas.views import GeoAreaList
 
 pytestmark = pytest.mark.django_db
 
@@ -24,7 +24,7 @@ def test_geographical_area_detail_views(view, url_pattern, valid_user_client):
     """Verify that geographical detail views are under the url geographical-
     areas and don't return an error."""
     model_overrides = {
-        "geo_areas.views.GeographicalAreaCreateDescription": GeographicalArea,
+        "geo_areas.views.GeoAreaDescriptionCreate": GeographicalArea,
     }
 
     assert_model_view_renders(view, url_pattern, valid_user_client, model_overrides)
@@ -35,7 +35,7 @@ def test_geographical_area_detail_views(view, url_pattern, valid_user_client):
     get_class_based_view_urls_matching_url(
         "geographical-areas/",
         view_is_subclass(TamatoListView),
-        assert_contains_view_classes=[GeographicalAreaList],
+        assert_contains_view_classes=[GeoAreaList],
     ),
     ids=view_urlpattern_ids,
 )

--- a/geo_areas/urls.py
+++ b/geo_areas/urls.py
@@ -2,33 +2,15 @@ from django.urls import include
 from django.urls import path
 from rest_framework import routers
 
+from common.paths import get_ui_paths
 from geo_areas import views
 
 api_router = routers.DefaultRouter()
-api_router.register(r"geographical_areas", views.GeoAreaViewSet, basename="geoarea")
+api_router.register(r"geographical_areas", views.GeoAreaViewSet, basename="geo_area")
 
-ui_patterns = [
-    path(
-        "",
-        views.GeographicalAreaList.as_view(),
-        name="geoarea-ui-list",
-    ),
-    path(
-        "<sid:sid>/",
-        views.GeographicalAreaDetail.as_view(),
-        name="geoarea-ui-detail",
-    ),
-    path(
-        "<sid:sid>/create-description/",
-        views.GeographicalAreaCreateDescription.as_view(),
-        name="geoarea-ui-create-description",
-    ),
-    path(
-        "<sid:described_geographicalarea__sid>/description/<sid:sid>/confirm-create/",
-        views.GeographicalAreaDescriptionConfirmCreate.as_view(),
-        name="geographical_area_description-ui-confirm-create",
-    ),
-]
+detail = "<sid:sid>"
+description_detail = "<sid:described_geographicalarea__sid>/description/<sid:sid>"
+ui_patterns = get_ui_paths(views, detail, description=description_detail)
 
 
 urlpatterns = [

--- a/geo_areas/views.py
+++ b/geo_areas/views.py
@@ -28,7 +28,15 @@ class GeoAreaViewSet(viewsets.ReadOnlyModelViewSet):
     search_fields = ["sid", "area_code"]
 
 
-class GeographicalAreaDescriptionMixin:
+class GeoAreaMixin:
+    model: Type[TrackedModel] = GeographicalArea
+
+    def get_queryset(self):
+        tx = WorkBasket.get_current_transaction(self.request)
+        return GeographicalArea.objects.approved_up_to_transaction(tx)
+
+
+class GeoAreaDescriptionMixin:
     model: Type[TrackedModel] = GeographicalAreaDescription
 
     def get_queryset(self):
@@ -36,7 +44,7 @@ class GeographicalAreaDescriptionMixin:
         return GeographicalAreaDescription.objects.approved_up_to_transaction(tx)
 
 
-class GeographicalAreaCreateDescriptionMixin:
+class GeoAreaCreateDescriptionMixin:
     model: Type[TrackedModel] = GeographicalAreaDescription
 
     def get_context_data(self, **kwargs):
@@ -47,21 +55,18 @@ class GeographicalAreaCreateDescriptionMixin:
         return context
 
 
-class GeographicalAreaList(TamatoListView):
-    queryset = GeographicalArea.objects.latest_approved()
+class GeoAreaList(GeoAreaMixin, TamatoListView):
     template_name = "geo_areas/list.jinja"
     filterset_class = GeographicalAreaFilter
     search_fields = ["sid", "descriptions__description"]
 
 
-class GeographicalAreaDetail(TrackedModelDetailView):
-    model = GeographicalArea
+class GeoAreaDetail(GeoAreaMixin, TrackedModelDetailView):
     template_name = "geo_areas/detail.jinja"
-    queryset = GeographicalArea.objects.latest_approved()
 
 
-class GeographicalAreaCreateDescription(
-    GeographicalAreaCreateDescriptionMixin,
+class GeoAreaDescriptionCreate(
+    GeoAreaCreateDescriptionMixin,
     TrackedModelDetailMixin,
     DraftCreateView,
 ):
@@ -76,8 +81,8 @@ class GeographicalAreaCreateDescription(
     template_name = "common/create_description.jinja"
 
 
-class GeographicalAreaDescriptionConfirmCreate(
-    GeographicalAreaDescriptionMixin,
+class GeoAreaDescriptionConfirmCreate(
+    GeoAreaDescriptionMixin,
     TrackedModelDetailView,
 ):
     template_name = "common/confirm_create_description.jinja"

--- a/measures/jinja2/includes/measures/list.jinja
+++ b/measures/jinja2/includes/measures/list.jinja
@@ -17,7 +17,7 @@
     {"text": measure.goods_nomenclature.item_id|wordwrap(2)|replace("\n", " ") if measure.goods_nomenclature else '-', "classes": "govuk-!-width-one-eighth"},
     {"text": measure.duty_sentence if measure.duty_sentence else '-'},
     {"html": create_link(url("additional_code-ui-detail", kwargs={"sid": measure.additional_code.sid}), measure.additional_code.type.sid ~ measure.additional_code.code) if measure.additional_code else '-'},
-    {"html": create_link(url("geoarea-ui-detail", kwargs={"sid": measure.geographical_area.sid}), measure.geographical_area.area_id ~ " - " ~ measure.geographical_area.get_description().description) if measure.geographical_area else '-'},
+    {"html": create_link(url("geo_area-ui-detail", kwargs={"sid": measure.geographical_area.sid}), measure.geographical_area.area_id ~ " - " ~ measure.geographical_area.get_description().description) if measure.geographical_area else '-'},
     {"text": create_link(measure.order_number.get_url(), measure.order_number.order_number) if measure.order_number else '-'},
     {"text": footnotes if measure.footnotes.all() else '-'},
     {"text": conditions_list(measure) if measure.conditions.latest_approved() else "-", "classes": "govuk-!-width-one-quarter"},

--- a/measures/urls.py
+++ b/measures/urls.py
@@ -2,22 +2,15 @@ from django.urls import include
 from django.urls import path
 from rest_framework import routers
 
+from common.paths import get_ui_paths
 from measures import views
 
 api_router = routers.DefaultRouter()
 api_router.register(r"measure_types", views.MeasureTypeViewSet, basename="measuretype")
 
+detail = "<sid:sid>"
 ui_patterns = [
-    path(
-        "",
-        views.MeasureList.as_view(),
-        name="measure-ui-list",
-    ),
-    path(
-        "create/<sid:sid>/confirm/",
-        views.MeasureConfirmCreate.as_view(),
-        name="measure-ui-confirm-create",
-    ),
+    *get_ui_paths(views, detail),
     path(
         "create/",
         views.MeasureCreateWizard.as_view(),
@@ -29,22 +22,7 @@ ui_patterns = [
         name="measure-ui-create",
     ),
     path(
-        "<sid:sid>/",
-        views.MeasureDetail.as_view(),
-        name="measure-ui-detail",
-    ),
-    path(
-        "<sid:sid>/edit/",
-        views.MeasureUpdate.as_view(),
-        name="measure-ui-edit",
-    ),
-    path(
-        "<sid:sid>/confirm-update/",
-        views.MeasureConfirmUpdate.as_view(),
-        name="measure-ui-confirm-update",
-    ),
-    path(
-        "<sid:sid>/edit-footnotes/",
+        f"{detail}/edit-footnotes/",
         views.MeasureFootnotesUpdate.as_view(),
         name="measure-ui-edit-footnotes",
     ),

--- a/quotas/jinja2/includes/quotas/list.jinja
+++ b/quotas/jinja2/includes/quotas/list.jinja
@@ -8,7 +8,7 @@
     {% set origins %}
         <ul class="govuk-table-list">
         {% for origin in quota.origins.distinct().all() %}
-            <li>{{create_link(url("geoarea-ui-detail", kwargs={"sid": origin.sid}), origin.area_id ~ " - " ~ origin.get_description().description)}}</li>
+            <li>{{create_link(url("geo_area-ui-detail", kwargs={"sid": origin.sid}), origin.area_id ~ " - " ~ origin.get_description().description)}}</li>
         {% endfor %}
         </ul>
     {% endset %}

--- a/quotas/urls.py
+++ b/quotas/urls.py
@@ -2,6 +2,7 @@ from django.urls import include
 from django.urls import path
 from rest_framework import routers
 
+from common.paths import get_ui_paths
 from quotas import views
 
 api_router = routers.DefaultRouter()
@@ -21,18 +22,8 @@ api_router.register(r"quota_suspensions", views.QuotaSuspensionViewset)
 api_router.register(r"quota_blocking_periods", views.QuotaBlockingViewset)
 api_router.register(r"quota_events", views.QuotaEventViewset)
 
-ui_patterns = [
-    path(
-        "",
-        views.QuotaList.as_view(),
-        name="quota-ui-list",
-    ),
-    path(
-        "<sid:sid>/",
-        views.QuotaDetail.as_view(),
-        name="quota-ui-detail",
-    ),
-]
+ui_patterns = get_ui_paths(views, "<sid:sid>")
+
 urlpatterns = [
     path("quotas/", include(ui_patterns)),
     path("api/", include(api_router.urls)),

--- a/quotas/views.py
+++ b/quotas/views.py
@@ -2,7 +2,7 @@ from rest_framework import permissions
 from rest_framework import viewsets
 
 from common.serializers import AutoCompleteSerializer
-from common.views import TamatoListView
+from common.views import TamatoListView, TrackedModelDetailMixin
 from common.views import TrackedModelDetailView
 from quotas import models
 from quotas import serializers
@@ -66,13 +66,18 @@ class QuotaEventViewset(viewsets.ReadOnlyModelViewSet):
     permission_classes = [permissions.IsAuthenticated]
 
 
-class QuotaList(TamatoListView):
-    queryset = models.QuotaOrderNumber.objects.latest_approved()
+class QuotaMixin:
+    model = models.QuotaOrderNumber
+
+    def get_queryset(self):
+        tx = WorkBasket.get_current_transaction(self.request)
+        return models.QuotaOrderNumber.objects.approved_up_to_transaction(tx)
+
+
+class QuotaList(QuotaMixin, TamatoListView):
     template_name = "quotas/list.jinja"
     filterset_class = QuotaFilter
 
 
-class QuotaDetail(TrackedModelDetailView):
-    model = models.QuotaOrderNumber
+class QuotaDetail(QuotaMixin, TrackedModelDetailView):
     template_name = "quotas/detail.jinja"
-    queryset = models.QuotaOrderNumber.objects.latest_approved()

--- a/regulations/urls.py
+++ b/regulations/urls.py
@@ -3,6 +3,7 @@ from django.urls import path
 from django.urls import register_converter
 from rest_framework import routers
 
+from common.paths import get_ui_paths
 from regulations import views
 from regulations.path_converters import RegulationIdConverter
 from regulations.path_converters import RegulationRoleTypeConverter
@@ -14,39 +15,7 @@ api_router = routers.DefaultRouter()
 api_router.register(r"regulations", views.RegulationViewSet, basename="regulation")
 
 detail = "<reg_type:role_type>/<reg_id:regulation_id>"
-
-ui_patterns = [
-    path(
-        "",
-        views.RegulationList.as_view(),
-        name="regulation-ui-list",
-    ),
-    path(
-        "create/",
-        views.RegulationCreate.as_view(),
-        name="regulation-ui-create",
-    ),
-    path(
-        f"{detail}/confirm-create/",
-        views.RegulationConfirmCreate.as_view(),
-        name="regulation-ui-confirm-create",
-    ),
-    path(
-        f"{detail}/",
-        views.RegulationDetail.as_view(),
-        name="regulation-ui-detail",
-    ),
-    path(
-        f"{detail}/edit/",
-        views.RegulationUpdate.as_view(),
-        name="regulation-ui-edit",
-    ),
-    path(
-        f"{detail}/confirm-update/",
-        views.RegulationConfirmUpdate.as_view(),
-        name="regulation-ui-confirm-update",
-    ),
-]
+ui_patterns = get_ui_paths(views, detail)
 
 urlpatterns = [
     path("regulations/", include(ui_patterns)),


### PR DESCRIPTION
## Why
<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Use as many lines as you like.
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions or deliberately ignored edge-cases.
--->

We already have a set of naming conventions that we are using the UI for views, e.g. "list" is the page that shows all the things, "edit" is the page that updates a thing, etc. We use these conventions already to name our routes and views, but we also have to list them manually in every url module.

This increases the surface area that needs to be touched every time we need to add new features. If we are about to implement a lot of new views for deletions, this will save needing to update the URLs manually every time.

## What
This commit removes the need to endlessly hardcode our routes by auto-generating the routes based on what views are present. It will silently ignore views we don't have yet, so when we add a new view to do a certain job (e.g. deleting a certificate) no more configuration is required beyond just naming the view class correctly.


<!---
 * Include the JIRA ticket number, eg TP-123, to automatically link.
 * Use 50 characters maximum.
 * Do not end with a full-stop.
--->



<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Explain like I'm 5.
 * Use pictures if you can.
--->

<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
## Checklist
- Requires migrations?
- Requires dependency updates?
--->

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
