### PR TITLE
TP2000-105: Only persist changes if business rules are passed

### DIFF
--- a/additional_codes/views.py
+++ b/additional_codes/views.py
@@ -1,5 +1,6 @@
 from typing import Type
 
+from django.db import transaction
 from django.http import HttpResponseRedirect
 from rest_framework import permissions
 from rest_framework import viewsets
@@ -18,7 +19,6 @@ from additional_codes.serializers import AdditionalCodeTypeSerializer
 from common.models import TrackedModel
 from common.serializers import AutoCompleteSerializer
 from common.validators import UpdateType
-from common.views import BusinessRulesMixin
 from common.views import TamatoListView
 from common.views import TrackedModelDetailMixin
 from common.views import TrackedModelDetailView
@@ -96,6 +96,7 @@ class AdditionalCodeCreate(DraftCreateView):
     template_name = "additional_codes/create.jinja"
     form_class = AdditionalCodeCreateForm
 
+    @transaction.atomic
     def form_valid(self, form):
         transaction = self.get_transaction()
         self.object = form.save(commit=False)
@@ -126,7 +127,6 @@ class AdditionalCodeDetail(AdditionalCodeMixin, TrackedModelDetailView):
 
 class AdditionalCodeUpdate(
     AdditionalCodeMixin,
-    BusinessRulesMixin,
     TrackedModelDetailMixin,
     DraftUpdateView,
 ):

--- a/certificates/views.py
+++ b/certificates/views.py
@@ -11,7 +11,6 @@ from certificates.filters import CertificateFilterBackend
 from certificates.serializers import CertificateTypeSerializer
 from common.models import TrackedModel
 from common.serializers import AutoCompleteSerializer
-from common.views import BusinessRulesMixin
 from common.views import TamatoListView
 from common.views import TrackedModelDetailMixin
 from common.views import TrackedModelDetailView
@@ -73,7 +72,6 @@ class CertificateDetail(CertificateMixin, TrackedModelDetailView):
 
 class CertificateUpdate(
     CertificateMixin,
-    BusinessRulesMixin,
     TrackedModelDetailMixin,
     DraftUpdateView,
 ):

--- a/common/models/trackedmodel.py
+++ b/common/models/trackedmodel.py
@@ -141,20 +141,17 @@ class TrackedModel(PolymorphicModel):
         self: Cls,
         workbasket,
         transaction=None,
-        save: bool = True,
         update_type: UpdateType = UpdateType.UPDATE,
         **overrides,
     ) -> Cls:
         """
-        Return a new version of the object. Callers can override existing data
-        by passing in keyword args.
+        Create and return a new version of the object. Callers can override
+        existing data by passing in keyword args.
 
         The new version is added to a transaction which is created and added to the passed in workbasket
         (or may be supplied as a keyword arg).
 
-        update_type must be UPDATE or DELETE, with UPDATE as the default.
-
-        By default the new object is saved; this can be disabled by passing save=False.
+        `update_type` must be UPDATE or DELETE, with UPDATE as the default.
         """
         if update_type not in (
             validators.UpdateType.UPDATE,
@@ -185,25 +182,20 @@ class TrackedModel(PolymorphicModel):
         new_object_kwargs["transaction"] = transaction
 
         new_object = cls(**new_object_kwargs)
+        new_object.save()
 
-        if save:
-            new_object.save()
-
-            # TODO: make this work with save=False!
-            # Maybe the deferred values could be saved on the model
-            # and then handled with a post_save signal?
-            deferred_kwargs = {
-                field.name: field.value_from_object(self)
-                for field in get_deferred_set_fields(self)
-            }
-            deferred_overrides = {
-                name: value
-                for name, value in overrides.items()
-                if name in [f.name for f in get_deferred_set_fields(self)]
-            }
-            deferred_kwargs.update(deferred_overrides)
-            for field in deferred_kwargs:
-                getattr(new_object, field).set(deferred_kwargs[field])
+        deferred_kwargs = {
+            field.name: field.value_from_object(self)
+            for field in get_deferred_set_fields(self)
+        }
+        deferred_overrides = {
+            name: value
+            for name, value in overrides.items()
+            if name in [f.name for f in get_deferred_set_fields(self)]
+        }
+        deferred_kwargs.update(deferred_overrides)
+        for field in deferred_kwargs:
+            getattr(new_object, field).set(deferred_kwargs[field])
 
         return new_object
 

--- a/footnotes/views.py
+++ b/footnotes/views.py
@@ -1,5 +1,6 @@
 from typing import Type
 
+from django.db import transaction
 from django.http import HttpResponseRedirect
 from rest_framework import permissions
 from rest_framework import viewsets
@@ -7,7 +8,6 @@ from rest_framework import viewsets
 from common.models import TrackedModel
 from common.serializers import AutoCompleteSerializer
 from common.validators import UpdateType
-from common.views import BusinessRulesMixin
 from common.views import TamatoListView
 from common.views import TrackedModelDetailMixin
 from common.views import TrackedModelDetailView
@@ -101,6 +101,7 @@ class FootnoteCreate(DraftCreateView):
     template_name = "footnotes/create.jinja"
     form_class = forms.FootnoteCreateForm
 
+    @transaction.atomic
     def form_valid(self, form):
         transaction = self.get_transaction()
         transaction.save()
@@ -132,7 +133,6 @@ class FootnoteDetail(FootnoteMixin, TrackedModelDetailView):
 
 class FootnoteUpdate(
     FootnoteMixin,
-    BusinessRulesMixin,
     TrackedModelDetailMixin,
     DraftUpdateView,
 ):

--- a/regulations/views.py
+++ b/regulations/views.py
@@ -1,11 +1,9 @@
 from typing import Type
 
-from django.http.response import HttpResponseRedirect
 from rest_framework import viewsets
 
 from common.models import TrackedModel
 from common.serializers import AutoCompleteSerializer
-from common.views import BusinessRulesMixin
 from common.views import TamatoListView
 from common.views import TrackedModelDetailMixin
 from common.views import TrackedModelDetailView
@@ -63,14 +61,6 @@ class RegulationCreate(DraftCreateView):
     template_name = "regulations/create.jinja"
     form_class = RegulationCreateForm
 
-    def form_valid(self, form):
-        transaction = self.get_transaction()
-        self.object = form.save(commit=False)
-        self.object.update_type = self.UPDATE_TYPE
-        self.object.transaction = transaction
-        self.object.save()
-        return HttpResponseRedirect(self.get_success_url())
-
     def get_form_kwargs(self):
         kwargs = super().get_form_kwargs()
         # Make the request available to the form allowing transaction management
@@ -90,7 +80,6 @@ class RegulationConfirmCreate(TrackedModelDetailView):
 
 class RegulationUpdate(
     RegulationMixin,
-    BusinessRulesMixin,
     TrackedModelDetailMixin,
     DraftUpdateView,
 ):

--- a/workbaskets/tests/test_views.py
+++ b/workbaskets/tests/test_views.py
@@ -50,6 +50,7 @@ def test_edit_after_submit(upload, valid_user, client, date_ranges):
         footnote = factories.FootnoteFactory.create(
             update_type=UpdateType.CREATE,
         )
+    assert footnote.transaction.workbasket == workbasket
 
     response = client.get(
         reverse(
@@ -79,6 +80,7 @@ def test_edit_after_submit(upload, valid_user, client, date_ranges):
     assert tx.tracked_models.count() == 1
     new_footnote_version = tx.tracked_models.first()
     assert new_footnote_version.pk != footnote.pk
+    assert new_footnote_version.version_group == footnote.version_group
 
 
 def test_download(

--- a/workbaskets/views/generic.py
+++ b/workbaskets/views/generic.py
@@ -1,29 +1,43 @@
 from django.utils.decorators import method_decorator
+from django.views import generic
 
-from common.views import CreateView
-from common.views import UpdateView
-from workbaskets.models import WorkBasket
+from common.validators import UpdateType
+from common.views import TrackedModelChangeView
 from workbaskets.views.decorators import require_current_workbasket
-from workbaskets.views.mixins import WithCurrentWorkBasket
 
 
 @method_decorator(require_current_workbasket, name="dispatch")
-class DraftCreateView(WithCurrentWorkBasket, CreateView):
+class DraftCreateView(
+    TrackedModelChangeView,
+    generic.CreateView,
+):
     """CreateView which creates or modifies drafts of a model in the current
     workbasket."""
 
+    update_type = UpdateType.CREATE
+    permission_required = "common.add_trackedmodel"
+    success_path = "confirm-create"
+
     def get_transaction(self):
-        workbasket = WorkBasket.current(self.request)
-        transaction = workbasket.new_transaction()
-        return transaction
+        return self.workbasket.new_transaction()
+
+    def get_result_object(self, form):
+        object = form.save(commit=False)
+        object.update_type = self.update_type
+        object.transaction = self.get_transaction()
+        object.save()
+        return object
 
 
 @method_decorator(require_current_workbasket, name="dispatch")
-class DraftUpdateView(WithCurrentWorkBasket, UpdateView):
+class DraftUpdateView(
+    TrackedModelChangeView,
+    generic.UpdateView,
+):
     """UpdateView which creates or modifies drafts of a model in the current
     workbasket."""
 
-    def get_transaction(self):
-        transaction = super().get_transaction()
-        transaction.workbasket = WorkBasket.current(self.request)
-        return transaction
+    update_type = UpdateType.UPDATE
+    permission_required = "common.add_trackedmodel"
+    template_name = "common/edit.jinja"
+    success_path = "confirm-update"

--- a/workbaskets/views/mixins.py
+++ b/workbaskets/views/mixins.py
@@ -4,10 +4,14 @@ from workbaskets.models import WorkBasket
 class WithCurrentWorkBasket:
     """Add models in the current workbasket to the modelview queryset."""
 
+    @property
+    def workbasket(self) -> WorkBasket:
+        return WorkBasket.current(self.request)
+
     def get_queryset(self):
         qs = super().get_queryset()
         transaction = None
-        current = WorkBasket.current(self.request)
+        current = self.workbasket
         if current:
             transaction = current.transactions.last()
 


### PR DESCRIPTION
This commit ensures that no database changes are persisted until any business rules are passed as specified by `validate_business_rules`.

This change is necessary because calling `new_version` with `save=False` still creates a transaction, which results in lots of empty
transactions being created. The new behaviour only calls `new_version` when we are sure that the model will be saved.