### PR TITLE
TP-2000-144 - Measure edit form still broken

### DIFF
--- a/common/views.py
+++ b/common/views.py
@@ -394,6 +394,4 @@ class TrackedModelChangeView(
             transaction.set_rollback(True)
             return self.form_invalid(form)
 
-        form.save(commit=False)
-
         return FormMixin.form_valid(self, form)

--- a/common/views.py
+++ b/common/views.py
@@ -394,4 +394,6 @@ class TrackedModelChangeView(
             transaction.set_rollback(True)
             return self.form_invalid(form)
 
+        form.save(commit=False)
+
         return FormMixin.form_valid(self, form)

--- a/measures/views.py
+++ b/measures/views.py
@@ -329,6 +329,13 @@ class MeasureUpdate(
 
         return context
 
+    def get_result_object(self, form):
+        obj = super().get_result_object(form)
+        form.instance = obj
+        form.save(commit=False)
+
+        return obj
+
 
 class MeasureConfirmUpdate(MeasureMixin, TrackedModelDetailView):
     template_name = "common/confirm_update.jinja"


### PR DESCRIPTION
## Why
MeasureUpdate view, which inherits from TrackedModelChangeView, was no longer calling MeasureForm.save(). So the ui was transitioning as normal and returning the right status codes, but the duties and footnotes weren't being updated correctly.

## What
- Overrides get_result_object on MeasureUpdate view to call form save()
- Updates measure edit view test to check that components are actually updated
- Adds view test to check that MeasureForm.save() is called
