### PR TITLE
Only `EDITING` workbaskets should be used for editing

### DIFF
--- a/workbaskets/models.py
+++ b/workbaskets/models.py
@@ -250,6 +250,11 @@ class WorkBasketQueryset(QuerySet):
             approver__isnull=False,
         )
 
+    def editable(self):
+        return self.filter(
+            status=WorkflowStatus.EDITING,
+        )
+
 
 class WorkBasket(TimestampedMixin):
     """
@@ -259,7 +264,7 @@ class WorkBasket(TimestampedMixin):
     See https://uktrade.atlassian.net/wiki/spaces/TARIFFSALPHA/pages/953581609/a.+Workbasket+workflow
     """
 
-    objects = WorkBasketQueryset.as_manager()
+    objects: WorkBasketQueryset = WorkBasketQueryset.as_manager()
 
     title = models.CharField(
         max_length=255,
@@ -426,7 +431,7 @@ class WorkBasket(TimestampedMixin):
         if "workbasket" in request.session:
             workbasket = cls.load_from_session(request.session)
 
-            if workbasket.status in WorkflowStatus.approved_statuses():
+            if workbasket.status != WorkflowStatus.EDITING:
                 del request.session["workbasket"]
                 return None
 

--- a/workbaskets/views/decorators.py
+++ b/workbaskets/views/decorators.py
@@ -10,7 +10,7 @@ def require_current_workbasket(view_func):
     @wraps(view_func)
     def check_for_current_workbasket(request, *args, **kwargs):
         if WorkBasket.current(request) is None:
-            workbasket = WorkBasket.objects.is_not_approved().last()
+            workbasket = WorkBasket.objects.editable().last()
             if not workbasket:
                 workbasket = WorkBasket.objects.create(
                     author=request.user,


### PR DESCRIPTION

## Why
<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Use as many lines as you like.
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions or deliberately ignored edge-cases.
--->
At the moment, any workbasket in a non-approved state can be selected as the currently active workbasket. This isn't right because users shouldn't be editing baskets once they are `PROPOSED` and shouldn't be stuck editing a basket that is `ARCHIVED`. Essentially, they should only be editing baskets in the `EDITING` state.

## What
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Explain like I'm 5.
 * Use pictures if you can.
--->


This commit makes sure that the current workbasket is in `EDITING` and if not, picks the next available `EDITING` workbasket. If there is none, it creates one as before.

<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
## Checklist
- Requires migrations?
- Requires dependency updates?
--->

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
