### PR TITLE
pytest - pyproject.toml - Ignore more directories to speed up startup for testing.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,8 +78,17 @@ force_single_line = true
 [tool.pytest.ini_options]
 DJANGO_SETTINGS_MODULE = "settings.test"
 norecursedirs = [
-    "venv",
-    "node_modules",
+    "allure-results",
+    "csv",
+    "dist",
+    "docs",
+    "*.egg-info",
+    ".git",
     ".local",
+    "node_modules",
+    "prof",
+    "__pycache__",
+    "run",
+    "venv",
 ]
 addopts = "-n=auto"


### PR DESCRIPTION
Ignore more directories to speed up startup for testing.

Saves about .5 second when collecting tests locally (these add up when running just one test).