### PR TITLE
Bump elastic-apm version to latest.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,7 @@ django-storages==1.11.1
 django-webpack-loader==1.0.0
 djangorestframework==3.12.2
 drf-flex-fields==0.8.9
-elastic-apm==6.6.0
+elastic-apm==6.7.2
 factory-boy==3.2.0
 freezegun==1.1.0
 govuk-frontend-jinja @ git+https://github.com/alphagov/govuk-frontend-jinja.git@15845e4cca3a05df72c6e13ec6a7e35acc682f52


### PR DESCRIPTION
# TP2000-142


## Why
We're seeing APM disconnect timeouts in deployments when Django migrations run. We spotted a few issues in the currently deployed package that may be candidates for causing this issue and have since been fixed..

## What
Upgrade to latest version of `elastic-apm` within our `requirements.txt`.

## Checklist
- Requires migrations? No
- Requires dependency updates? No
