### PR TITLE
TP2000-181 add description-create to list of potential actions

### DIFF
--- a/additional_codes/tests/test_views.py
+++ b/additional_codes/tests/test_views.py
@@ -69,7 +69,7 @@ def test_additional_codes_detail_views(view, url_pattern, valid_user_client):
     """Verify that additional code detail views are under the url
     additional_codes/ and don't return an error."""
     model_overrides = {
-        "additional_codes.views.AdditionalCodeCreateDescription": AdditionalCode,
+        "additional_codes.views.AdditionalCodeDescriptionCreate": AdditionalCode,
     }
 
     assert_model_view_renders(view, url_pattern, valid_user_client, model_overrides)

--- a/additional_codes/views.py
+++ b/additional_codes/views.py
@@ -145,7 +145,7 @@ class AdditionalCodeUpdate(
     )
 
 
-class AdditionalCodeCreateDescription(
+class AdditionalCodeDescriptionCreate(
     AdditionalCodeCreateDescriptionMixin,
     TrackedModelDetailMixin,
     DraftCreateView,

--- a/certificates/tests/test_views.py
+++ b/certificates/tests/test_views.py
@@ -30,7 +30,7 @@ def test_certificate_delete(factory, use_delete_form):
 def test_certificate_detail_views(view, url_pattern, valid_user_client):
     """Verify that certificate detail views are under the url certificates/ and
     don't return an error."""
-    model_overrides = {"certificates.views.CertificateCreateDescription": Certificate}
+    model_overrides = {"certificates.views.CertificateDescriptionCreate": Certificate}
 
     assert_model_view_renders(view, url_pattern, valid_user_client, model_overrides)
 

--- a/certificates/views.py
+++ b/certificates/views.py
@@ -110,7 +110,7 @@ class CertificateCreateDescriptionMixin:
         return context
 
 
-class CertificateCreateDescription(
+class CertificateDescriptionCreate(
     CertificateCreateDescriptionMixin,
     TrackedModelDetailMixin,
     DraftCreateView,

--- a/common/jinja2/includes/common/tabs/descriptions.jinja
+++ b/common/jinja2/includes/common/tabs/descriptions.jinja
@@ -19,7 +19,7 @@
 {% endfor %}
 
 <h2 class="govuk-heading-l">Descriptions</h2>
-<p><a class="govuk-link" href={{object.get_url("create-description")}}>Create a new description</a></p>
+<p><a class="govuk-link" href={{object.get_url("description-create")}}>Create a new description</a></p>
 {% set head = [
 	{"text": "Start date", "classes":  "govuk-!-width-one-eighth"},
 	{"text": "Description"},

--- a/common/paths.py
+++ b/common/paths.py
@@ -18,6 +18,7 @@ OBJECT_ACTIONS = {
     "Update": "edit",
     "ConfirmUpdate": "confirm-update",
     "Delete": "delete",
+    "DescriptionCreate": "description-create",
 }
 
 

--- a/common/tests/test_models.py
+++ b/common/tests/test_models.py
@@ -398,6 +398,23 @@ def test_trackedmodel_get_url(trackedmodel_factory):
     assert not urlparse(url).netloc
 
 
+@pytest.mark.parametrize(
+    "factory",
+    [
+        factories.AdditionalCodeFactory,
+        factories.CertificateFactory,
+        factories.FootnoteFactory,
+        factories.GeographicalAreaFactory,
+    ],
+)
+def test_trackedmodel_get_description_create_url(factory):
+    """Verify get_url() returns something for creating descriptions."""
+    instance = factory.create()
+    url = instance.get_url("description-create")
+
+    assert url
+
+
 def test_trackedmodel_str(trackedmodel_factory):
     """Verify no __str__ methods of TrackedModel classes crash or return non-
     strings."""

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "tamato",
       "version": "0.1.0",
       "dependencies": {
         "accessible-autocomplete": "^2.0.3",


### PR DESCRIPTION
# TP2000-181 Add description-create to list of potential model actions

## Why
<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Use as many lines as you like.
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions or deliberately ignored edge-cases.
--->
This fixes the 'create descriptions' url for various models. This is an interim fix to allow production service to create new descriptions. 

There is more to be done to clarify the url reversal generation patterns, particularly when integrating the descriptions url lookup. In particular, we need to make sure that the 'create descriptions' url is available on the instances being described rather than on description instances themselves. This will take some work to be done in a way that is consistent with other patterns while also remaining readable. (Linked JIRA ticket https://uktrade.atlassian.net/browse/TP2000-197)

## What
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Explain like I'm 5.
 * Use pictures if you can.
--->
Returns a 'description-create' pattern to the url generation pattern list.


<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
## Checklist
- Requires migrations?
- Requires dependency updates?
--->

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
