### PR TITLE
Run imports inside a single database transaction

### DIFF
--- a/importer/taric.py
+++ b/importer/taric.py
@@ -267,6 +267,7 @@ class EnvelopeParser(ElementParser):
             nursery.clear_cache()
 
 
+@atomic
 def process_taric_xml_stream(
     taric_stream,
     workbasket_status,
@@ -277,7 +278,10 @@ def process_taric_xml_stream(
     """
     Parse a TARIC XML stream through the import handlers.
 
-    This will load the data from the stream into the database.
+    This will load the data from the stream into the database. This runs inside
+    a single database transaction so that if any of the data is invalid, it will
+    not be committed and the XML can be fixed and imported again without needing
+    to remove the existing data.
     """
     xmlparser = etree.iterparse(taric_stream, ["start", "end", "start-ns"])
     handler = EnvelopeParser(


### PR DESCRIPTION
## Why
We have recently had issues that have prevented our imports from completing successfully. In these cases we've been left with the database in a inconsistent state and in order to reattempt the import we have to restore the database from a backup.

## What
As discussed, this commit changes the behaviour so that now an entire import is run inside a single database transaction. If there is an error that causes the import to bomb out, the changes are removed, and the issue can be fixed and the import reattempted more easily.

This applies to imports at the "chunk" level. Most import jobs will only generate one chunk, so that is equivalent to a single file. For imports that span across multiple independent chunks, each chunk will have to be manually restarted.
