### PR TITLE
Implement ME27 for regulation replacements

### DIFF
--- a/common/util.py
+++ b/common/util.py
@@ -9,6 +9,7 @@ from platform import python_version_tuple
 from typing import Any
 from typing import Dict
 from typing import Optional
+from typing import Sequence
 from typing import Tuple
 from typing import Type
 from typing import TypeVar
@@ -218,8 +219,11 @@ def validity_range_contains_range(
     return True
 
 
+RelationPath = Sequence[Tuple[Type[Model], Field]]
+
+
 @lru_cache
-def resolve_path(model: Type[Model], path: str):
+def resolve_path(model: Type[Model], path: str) -> RelationPath:
     """
     Returns an ordered sequence of types and field names of the foreign keys
     representing the passed path, starting with the passed model and following
@@ -231,7 +235,7 @@ def resolve_path(model: Type[Model], path: str):
     be returned, etc.
     """
     contained_model = model
-    relation_path = []
+    relation_path: RelationPath = []
 
     for step in path.split(LOOKUP_SEP):
         relations = {
@@ -247,6 +251,8 @@ def resolve_path(model: Type[Model], path: str):
 
         relation = relations[step]
         contained_model = relation.related_model
+        assert contained_model is not None
+
         relation_path.append((contained_model, relation.remote_field))
 
     return relation_path

--- a/measures/models.py
+++ b/measures/models.py
@@ -530,6 +530,7 @@ class Measure(TrackedModel, ValidityMixin):
         business_rules.ME12,
         business_rules.ME17,
         business_rules.ME24,
+        business_rules.ME27,
         business_rules.ME87,
         business_rules.ME33,
         business_rules.ME34,

--- a/measures/querysets.py
+++ b/measures/querysets.py
@@ -21,7 +21,6 @@ from common.models.tracked_qs import TrackedModelQuerySet
 from common.querysets import ValidityQuerySet
 from common.util import EndDate
 from common.util import StartDate
-from regulations.models import Regulation
 
 
 class DutySentenceMixin(QuerySet):
@@ -191,6 +190,10 @@ class MeasuresQuerySet(TrackedModelQuerySet, DutySentenceMixin, ValidityQuerySet
         # We also turn NULLs into "infinity" such that they sort to the top:
         # i.e. if any modification regulation is open-ended, so is the measure.
         # We then turn infinity back into NULL to be used in the date range.
+        Regulation = self.model._meta.get_field(
+            "generating_regulation",
+        ).remote_field.model
+
         end_date_from_modifications = With(
             Regulation.objects.annotate(
                 amended_end_date=NullIf(

--- a/measures/tests/test_business_rules.py
+++ b/measures/tests/test_business_rules.py
@@ -982,11 +982,19 @@ def test_ME26():
     """The entered regulation may not be completely abrogated."""
 
 
-@pytest.mark.skip(
-    reason="Abrogation, modification and replacement regulations are not used",
-)
-def test_ME27():
+def test_ME27(spanning_dates):
     """The entered regulation may not be fully replaced."""
+    replacement_dates, regulation_dates, fully_spanned = spanning_dates
+
+    measure = factories.MeasureFactory.create(
+        generating_regulation=factories.ReplacementFactory.create(
+            enacting_regulation__valid_between=replacement_dates,
+            target_regulation__valid_between=regulation_dates,
+        ).target_regulation,
+    )
+
+    with raises_if(BusinessRuleViolation, fully_spanned):
+        business_rules.ME27(measure.transaction).validate(measure)
 
 
 @pytest.mark.skip(

--- a/regulations/models.py
+++ b/regulations/models.py
@@ -4,6 +4,7 @@ from django.core.validators import RegexValidator
 from django.db import models
 from django.db.models.fields import DateField
 
+import measures.business_rules as measure_business_rules
 from common.business_rules import UpdateValidity
 from common.fields import ShortDescription
 from common.fields import TaricDateRangeField
@@ -213,6 +214,8 @@ class Regulation(TrackedModel, ValidityMixin):
         business_rules.ROIMB47,
         UpdateValidity,
     )
+
+    indirect_business_rules = (measure_business_rules.ME27,)
 
     @property
     def structure_description(self):
@@ -438,3 +441,5 @@ class Replacement(TrackedModel):
     identifying_fields = ("enacting_regulation_id", "target_regulation_id")
 
     business_rules = (UpdateValidity,)
+
+    indirect_business_rules = (measure_business_rules.ME27,)


### PR DESCRIPTION
We never implemented this rule because we thought we weren't using replacements in the UK. We're still not, but if a user  accidentally?) selects an EU regulation it's possible for the rule to be broken. Selecting EU regulations is still necessary because the UK has "retained" some EU legislation and it is still valid to choose it.
