### PR TITLE
TP2000-217 duplicate footnotes displaying in measure edit form

### DIFF
--- a/measures/forms.py
+++ b/measures/forms.py
@@ -128,8 +128,16 @@ class MeasureForm(ValidityPeriodForm):
         # If no footnote keys are stored in the session for a measure,
         # store all the pks of a measure's footnotes on the session, using the measure sid as key
         if f"instance_footnotes_{self.instance.sid}" not in self.request.session.keys():
+            tx = WorkBasket.get_current_transaction(self.request)
+            associations = (
+                models.FootnoteAssociationMeasure.objects.approved_up_to_transaction(
+                    tx,
+                ).filter(
+                    footnoted_measure=self.instance,
+                )
+            )
             self.request.session[f"instance_footnotes_{self.instance.sid}"] = [
-                footnote.pk for footnote in self.instance.footnotes.all()
+                a.associated_footnote.pk for a in associations
             ]
 
     def clean_duty_sentence(self):

--- a/measures/jinja2/measures/create-footnotes-formset.jinja
+++ b/measures/jinja2/measures/create-footnotes-formset.jinja
@@ -1,7 +1,7 @@
 {% with form_footnotes = form.request.session["instance_footnotes_" ~ form.instance.sid] %}
     {% if form_footnotes %}
         {% set table_rows = [] %}
-        {% for footnote in form.instance.footnotes.all() %}
+        {% for footnote in footnotes %}
             {% if footnote.pk in form.request.session["instance_footnotes_"~form.instance.sid]%}
                 {% set footnote_link -%}
                 <a class="govuk-link govuk-!-font-weight-bold" href="{{ footnote.get_url() }}">{{ footnote|string }}</a>

--- a/measures/tests/test_views.py
+++ b/measures/tests/test_views.py
@@ -14,6 +14,7 @@ from common.tests.util import get_class_based_view_urls_matching_url
 from common.tests.util import raises_if
 from common.tests.util import view_is_subclass
 from common.tests.util import view_urlpattern_ids
+from common.validators import UpdateType
 from common.views import TamatoListView
 from common.views import TrackedModelDetailMixin
 from measures.models import Measure
@@ -23,6 +24,8 @@ from measures.validators import validate_duties
 from measures.views import MeasureCreateWizard
 from measures.views import MeasureFootnotesUpdate
 from measures.views import MeasureList
+from measures.views import MeasureUpdate
+from workbaskets.models import WorkBasket
 
 pytestmark = pytest.mark.django_db
 
@@ -265,6 +268,23 @@ def test_measure_form_save_called_on_measure_update(
     client.post(url, data=post_data)
 
     save.assert_called_with(commit=False)
+
+
+def test_measure_update_get_footnotes(session_with_workbasket):
+    association = factories.FootnoteAssociationMeasureFactory.create()
+    view = MeasureUpdate(request=session_with_workbasket)
+    footnotes = view.get_footnotes(association.footnoted_measure)
+
+    assert len(footnotes) == 1
+
+    association.new_version(
+        WorkBasket.current(session_with_workbasket),
+        update_type=UpdateType.DELETE,
+    )
+
+    footnotes = view.get_footnotes(association.footnoted_measure)
+
+    assert len(footnotes) == 0
 
 
 @pytest.mark.django_db

--- a/measures/views.py
+++ b/measures/views.py
@@ -24,6 +24,7 @@ from common.views import TrackedModelDetailView
 from measures import forms
 from measures.filters import MeasureFilter
 from measures.filters import MeasureTypeFilterBackend
+from measures.models import FootnoteAssociationMeasure
 from measures.models import Measure
 from measures.models import MeasureCondition
 from measures.models import MeasureConditionComponent
@@ -344,6 +345,12 @@ class MeasureUpdate(
 
         return form
 
+    def get_footnotes(self, measure):
+        associations = FootnoteAssociationMeasure.objects.current().filter(
+            footnoted_measure=measure,
+        )
+        return [a.associated_footnote for a in associations]
+
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         initial = self.request.session.get(
@@ -356,6 +363,7 @@ class MeasureUpdate(
         context["formset"] = formset
         context["no_form_tags"] = FormHelper()
         context["no_form_tags"].form_tag = False
+        context["footnotes"] = self.get_footnotes(context["measure"])
 
         return context
 

--- a/measures/views.py
+++ b/measures/views.py
@@ -346,9 +346,13 @@ class MeasureUpdate(
         return form
 
     def get_footnotes(self, measure):
-        associations = FootnoteAssociationMeasure.objects.current().filter(
+        tx = WorkBasket.get_current_transaction(self.request)
+        associations = FootnoteAssociationMeasure.objects.approved_up_to_transaction(
+            tx,
+        ).filter(
             footnoted_measure=measure,
         )
+
         return [a.associated_footnote for a in associations]
 
     def get_context_data(self, **kwargs):


### PR DESCRIPTION
## Why
Currently the MeasureUpdate view and MeasureForm both use the reverse relationship when getting footnotes, but really they should be using the FootnoteAssociationMeasure model. Otherwise we get duplicated footnotes and footnotes associated with a deleted FootnoteAssociationMeasure displaying on the edit form.

## What
- Updates view and form to filter using FootnoteAssociationMeasure
- Adds test to check this

[Original teams chat](https://teams.microsoft.com/l/message/19:MU-0VlKdDiGxdC3Iv8oKQbAlshz1N3ZhH3f6qrOoW7g1@thread.tacv2/1647511203316?tenantId=8fa217ec-33aa-46fb-ad96-dfe68006bb86&groupId=16ae1baa-31cc-4fda-8ea7-cfcd00d254ed&parentMessageId=1647511203316&teamName=Tariff%20Team&channelName=General&createdTime=1647511203316)
