### PR TITLE
TP2000-156 - Component sequence number start at 1, fixing the importer.

### DIFF
--- a/geo_areas/forms.py
+++ b/geo_areas/forms.py
@@ -108,7 +108,7 @@ class GeographicalAreaFormMixin(forms.Form):
     def clean(self):
         cleaned_data = super().clean()
 
-        geo_area_type = cleaned_data.pop("geo_area_type")
+        geo_area_type = cleaned_data.pop("geo_area_type", None)
         erga_omnes_exclusions = cleaned_data.pop("erga_omnes_exclusions", None)
         geo_group = cleaned_data.pop("geo_group", None)
         geo_group_exclusions = cleaned_data.pop("geo_group_exclusions", None)

--- a/measures/patterns.py
+++ b/measures/patterns.py
@@ -375,11 +375,12 @@ class MeasureCreationPattern:
         if condition_sentence:
             yield from self.create_measure_conditions(new_measure, condition_sentence)
 
-        # Now generate the duty components for the passed duty rate.
-        yield from self.create_measure_components_from_duty_rate(
-            new_measure,
-            duty_sentence,
-        )
+        # If there is a duty_sentence parse it and generate the duty components from the duty rate.
+        if duty_sentence:
+            yield from self.create_measure_components_from_duty_rate(
+                new_measure,
+                duty_sentence,
+            )
 
     def create(self, *args, **kwargs) -> Measure:
         """

--- a/measures/tests/conftest.py
+++ b/measures/tests/conftest.py
@@ -362,6 +362,11 @@ def measure_type():
 
 
 @pytest.fixture()
+def erga_omnes():
+    return factories.GeoGroupFactory(area_id=1011)
+
+
+@pytest.fixture()
 def regulation():
     return factories.RegulationFactory.create()
 

--- a/measures/tests/conftest.py
+++ b/measures/tests/conftest.py
@@ -362,11 +362,6 @@ def measure_type():
 
 
 @pytest.fixture()
-def erga_omnes():
-    return factories.GeoGroupFactory(area_id=1011)
-
-
-@pytest.fixture()
 def regulation():
     return factories.RegulationFactory.create()
 

--- a/measures/tests/test_views.py
+++ b/measures/tests/test_views.py
@@ -7,6 +7,7 @@ from bs4 import BeautifulSoup
 from django.core.exceptions import ValidationError
 from django.urls import reverse
 
+from common.models import TrackedModel
 from common.models.transactions import Transaction
 from common.tests import factories
 from common.tests.util import assert_model_view_renders
@@ -283,8 +284,7 @@ def test_measure_form_wizard_finish(
     regulation,
     duty_sentence_parser,
 ):
-    commodity1 = factories.GoodsNomenclatureFactory.create()
-    commodity2 = factories.GoodsNomenclatureFactory.create()
+    commodity1, commodity2 = factories.GoodsNomenclatureFactory.create_batch(2)
 
     mock_duty_sentence_parser.return_value = duty_sentence_parser
 
@@ -357,18 +357,18 @@ def test_measure_form_wizard_create_measures(
     commodity1,
     commodity2,
 ):
+    """Pass data to the MeasureWizard and verify that the created Measures contain the expected data."""
     mock_workbasket.return_value = factories.WorkBasketFactory.create()
 
     commodity3 = factories.GoodsNomenclatureFactory.create()
-    footnote1 = factories.FootnoteFactory.create()
-    footnote2 = factories.FootnoteFactory.create()
+    footnote1, footnote2 = factories.FootnoteFactory.create_batch(2)
     geo_area = factories.GeographicalAreaFactory.create()
-    condition_code1 = factories.MeasureConditionCodeFactory()
-    condition_code2 = factories.MeasureConditionCodeFactory()
-    condition_code3 = factories.MeasureConditionCodeFactory()
-    action1 = factories.MeasureActionFactory()
-    action2 = factories.MeasureActionFactory()
-    action3 = factories.MeasureActionFactory()
+    (
+        condition_code1,
+        condition_code2,
+        condition_code3,
+    ) = factories.MeasureConditionCodeFactory.create_batch(3)
+    action1, action2, action3 = factories.MeasureActionFactory.create_batch(3)
 
     form_data = {
         "measure_type": measure_type,
@@ -414,64 +414,60 @@ def test_measure_form_wizard_create_measures(
 
     wizard = MeasureCreateWizard(request=mock_request)
 
-    measures = wizard.create_measures(form_data)
+    # Create measures returns a list of created measures
+    measure_data = wizard.create_measures(form_data)
+    measures = Measure.objects.filter(goods_nomenclature__in=[commodity1, commodity2])
 
-    assert len(measures) == 2
+    """
+    In this implementation goods_nomenclature is a FK of Measure, so there is one measure
+    for each commodity specified in formset-commodities.
+    
+    Verify that the expected measures were created.
+    """
+    assert len(measure_data) == 2
+    assert set(measures.values_list("pk", "goods_nomenclature_id")) == {
+        (measure_data[0].pk, commodity1.pk),
+        (measure_data[1].pk, commodity2.pk),
+    }
 
-    assert Measure.objects.get(goods_nomenclature=commodity1)
-    assert Measure.objects.get(goods_nomenclature=commodity2)
-    with pytest.raises(Measure.DoesNotExist):
-        Measure.objects.get(goods_nomenclature=commodity3)
+    assert set(
+        measures.values_list("goods_nomenclature_id", "components__duty_amount")
+    ) == {
+        (commodity1.pk, Decimal("33.000")),
+        (commodity2.pk, Decimal("40.000")),
+    }
 
-    assert (
-        Measure.objects.get(
-            goods_nomenclature=commodity1,
+    assert set(measures.values_list("pk", "footnotes")) == {
+        (measure_data[0].pk, footnote1.pk),
+        (measure_data[1].pk, footnote1.pk),
+    }
+
+    # Each created measure contains the supplied condition codes where DELETE=False
+    # Each component should have a 1 based 'component_sequence_number' that iterates for each condition in
+    # a measure.
+    assert set(
+        measures.values_list(
+            "pk", "conditions__component_sequence_number", "conditions__condition_code"
         )
-        .components.get()
-        .duty_amount
-        == Decimal("33.000")
-    )
-    assert (
-        Measure.objects.get(
-            goods_nomenclature=commodity2,
+    ) == {
+        (measure_data[0].pk, 1, condition_code1.pk),
+        (measure_data[0].pk, 2, condition_code2.pk),
+        (measure_data[1].pk, 1, condition_code1.pk),
+        (measure_data[1].pk, 2, condition_code2.pk),
+    }
+
+    # Verify that MeasureComponents were created for each formset-condition containing an applicable-duty
+    assert set(
+        measures.values_list(
+            "pk",
+            "conditions__components__duty_amount",
+            "conditions__components__monetary_unit__code",
         )
-        .components.get()
-        .duty_amount
-        == Decimal("40.000")
-    )
-
-    assert measures[0].footnotes.get() == footnote1
-    assert measures[1].footnotes.get() == footnote1
-
-    assert len(measures[0].footnotes.all()) == 1
-    assert len(measures[1].footnotes.all()) == 1
-
-    assert len(measures[0].conditions.all()) == 2
-    assert len(measures[1].conditions.all()) == 2
-
-    created_conditions = MeasureCondition.objects.filter(
-        dependent_measure__in=[m.id for m in measures],
-    )
-
-    created_condition_codes = MeasureConditionCode.objects.filter(
-        conditions__in=[c.id for c in created_conditions],
-    )
-
-    assert condition_code1 in created_condition_codes
-    assert condition_code2 in created_condition_codes
-    assert condition_code3 not in created_condition_codes
-
-    created_condition_components = (
-        created_conditions.last().components.approved_up_to_transaction(
-            created_conditions.last().transaction,
-        )
-    )
-
-    assert created_condition_components.count() == 2
-    assert created_condition_components.first().duty_amount == Decimal("8.800")
-    assert created_condition_components.last().duty_amount == Decimal("1.700")
-    assert created_condition_components.last().monetary_unit.code == "EUR"
-    assert (
-        created_condition_components.last().component_measurement.measurement_unit.abbreviation
-        == "100 kg"
-    )
+    ) == {
+        (measure_data[0].pk, None, None),
+        (measure_data[0].pk, Decimal("8.800"), None),
+        (measure_data[0].pk, Decimal("1.700"), "EUR"),
+        (measure_data[1].pk, None, None),
+        (measure_data[1].pk, Decimal("8.800"), None),
+        (measure_data[1].pk, Decimal("1.700"), "EUR"),
+    }

--- a/measures/tests/test_views.py
+++ b/measures/tests/test_views.py
@@ -16,6 +16,7 @@ from common.tests.util import view_is_subclass
 from common.tests.util import view_urlpattern_ids
 from common.views import TamatoListView
 from common.views import TrackedModelDetailMixin
+from geo_areas.forms import GeographicalAreaFormMixin
 from measures.models import Measure
 from measures.models import MeasureCondition
 from measures.models import MeasureConditionCode

--- a/measures/views.py
+++ b/measures/views.py
@@ -8,7 +8,6 @@ from django.db.transaction import atomic
 from django.http import HttpRequest
 from django.http import HttpResponse
 from django.http import HttpResponseRedirect
-from django.shortcuts import render
 from django.utils.decorators import method_decorator
 from django.views import View
 from formtools.wizard.views import NamedUrlSessionWizardView
@@ -218,6 +217,7 @@ class MeasureCreateWizard(
             )
             for i, condition_data in enumerate(
                 data.get("formset-conditions", []),
+                start=1,
             ):
                 if not condition_data["DELETE"]:
 

--- a/measures/views.py
+++ b/measures/views.py
@@ -215,7 +215,7 @@ class MeasureCreateWizard(
                 measure.valid_between.lower,
                 component_output=MeasureConditionComponent,
             )
-            for i, condition_data in enumerate(
+            for component_sequence_number, condition_data in enumerate(
                 data.get("formset-conditions", []),
                 start=1,
             ):
@@ -223,7 +223,7 @@ class MeasureCreateWizard(
 
                     condition = MeasureCondition(
                         sid=measure_creation_pattern.measure_condition_sid_counter(),
-                        component_sequence_number=i,
+                        component_sequence_number=component_sequence_number,
                         dependent_measure=measure,
                         update_type=UpdateType.CREATE,
                         transaction=measure.transaction,


### PR DESCRIPTION
Component sequence numbers start at 1 not 0, fixing the importer.
Make `test_measure_form_wizard_create_measures` a little more batch oriented making it easier to test this, should save some queries too.