### PR TITLE
Updates to TP2000 199

### DIFF
--- a/common/jinja2/components/duty_help.jinja
+++ b/common/jinja2/components/duty_help.jinja
@@ -2,5 +2,6 @@
 
 {{ govukDetails({
         "summaryText": "Help with duties",
-        "text": "Enter the duty that applies to the " + component + ". This is expressed as a percentage (e.g. 4%), a specific duty (e.g. 33 GBP/100kg) or a compound duty (e.g. 3.5% + 11 GBP/LTR)."
+        "text": "Enter the duty that applies to the " + component + ". This is expressed as a percentage (e.g. 4%), a specific duty (e.g. 33 GBP/100kg) or a compound duty (e.g. 3.5% + 11 GBP / 100 kg)."
     }) }}
+    

--- a/measures/tests/conftest.py
+++ b/measures/tests/conftest.py
@@ -330,8 +330,12 @@ def irreversible_duty_sentence_data(request, get_component_data):
     return expected, [get_component_data(*args) for args in component_data]
 
 
+def erga_omnes():
+    return factories.GeographicalAreaFactory.create(area_code=1, area_id=1011)
+
+
 @pytest.fixture
-def measure_form(session_with_workbasket):
+def measure_form(session_with_workbasket, erga_omnes):
     measure = factories.MeasureFactory.create()
     data = model_to_dict(measure)
     start_date = data["valid_between"].lower
@@ -340,7 +344,6 @@ def measure_form(session_with_workbasket):
         start_date_1=start_date.month,
         start_date_2=start_date.year,
     )
-    factories.GeographicalAreaFactory.create(area_code=1, area_id=1011)
 
     return MeasureForm(
         data=data,

--- a/measures/tests/test_forms.py
+++ b/measures/tests/test_forms.py
@@ -126,7 +126,6 @@ def test_measure_forms_conditions_form_valid_data():
     action = factories.MeasureActionFactory.create()
     data = {
         "condition_code": condition_code.pk,
-        "duty_amount": 1.000,
         "action": action.pk,
     }
     form = forms.MeasureConditionsForm(data, prefix="")
@@ -137,10 +136,59 @@ def test_measure_forms_conditions_form_valid_data():
 def test_measure_forms_conditions_form_invalid_data():
     action = factories.MeasureActionFactory.create()
     data = {
-        "duty_amount": 1.000,
         "action": action.pk,
     }
     form = forms.MeasureConditionsForm(data, prefix="")
 
     assert not form.is_valid()
     assert form.errors["condition_code"][0] == "This field is required."
+
+
+def test_measure_forms_conditions_valid_duty(date_ranges, duty_sentence_parser):
+    action = factories.MeasureActionFactory.create()
+    condition_code = factories.MeasureConditionCodeFactory.create()
+    data = {
+        "condition_code": condition_code.pk,
+        "reference_price": "11 GBP / 100 kg",
+        "action": action.pk,
+    }
+    initial_data = {"measure_start_date": date_ranges.normal}
+    form = forms.MeasureConditionsForm(data, prefix="", initial=initial_data)
+    form.is_valid()
+
+    assert form.cleaned_data["duty_amount"] == 11
+    assert form.cleaned_data["monetary_unit"].code == "GBP"
+    assert (
+        form.cleaned_data["condition_measurement"].measurement_unit.abbreviation
+        == "100 kg"
+    )
+
+
+@pytest.mark.parametrize(
+    "reference_price, message",
+    [
+        ("invalid duty", "Enter a valid duty sentence."),
+        (
+            "3.5 % + 11 GBP / 100 kg",
+            "A MeasureCondition cannot be created with a compound reference price (e.g. 3.5% + 11 GBP / 100 kg)",
+        ),
+    ],
+)
+def test_measure_forms_conditions_invalid_duty(
+    reference_price,
+    message,
+    date_ranges,
+    duty_sentence_parser,
+):
+    action = factories.MeasureActionFactory.create()
+    condition_code = factories.MeasureConditionCodeFactory.create()
+    data = {
+        "condition_code": condition_code.pk,
+        "reference_price": reference_price,
+        "action": action.pk,
+    }
+    initial_data = {"measure_start_date": date_ranges.normal}
+    form = forms.MeasureConditionsForm(data, prefix="", initial=initial_data)
+
+    assert not form.is_valid()
+    assert message in form.errors["__all__"]

--- a/measures/tests/test_views.py
+++ b/measures/tests/test_views.py
@@ -299,6 +299,7 @@ def test_measure_form_wizard_finish(
     measure_type,
     regulation,
     duty_sentence_parser,
+    erga_omnes,
 ):
     commodity1, commodity2 = factories.GoodsNomenclatureFactory.create_batch(2)
 
@@ -314,6 +315,7 @@ def test_measure_form_wizard_finish(
                 "measure_create_wizard-current_step": "measure_details",
                 "measure_details-measure_type": measure_type.pk,
                 "measure_details-generating_regulation": regulation.pk,
+                "measure_details-geo_area_type": "ERGA_OMNES",
                 "measure_details-start_date_0": 2,
                 "measure_details-start_date_1": 4,
                 "measure_details-start_date_2": 2021,
@@ -326,7 +328,7 @@ def test_measure_form_wizard_finish(
                 "commodities-0-commodity": commodity1.pk,
                 "commodities-0-duties": "33 GBP/100kg",
                 "commodities-1-commodity": commodity2.pk,
-                "commodities-1-duties": "40 GBP/1kg",
+                "commodities-1-duties": "40 GBP/100kg",
             },
             "next_step": "additional_code",
         },
@@ -359,6 +361,10 @@ def test_measure_form_wizard_finish(
             "measure-ui-create",
             kwargs={"step": step_data["next_step"]},
         )
+
+    complete_response = valid_user_client.get(response.url)
+
+    assert complete_response.status_code == 200
 
 
 @unittest.mock.patch("workbaskets.models.WorkBasket.current")

--- a/measures/views.py
+++ b/measures/views.py
@@ -227,12 +227,14 @@ class MeasureCreateWizard(
                         dependent_measure=measure,
                         update_type=UpdateType.CREATE,
                         transaction=measure.transaction,
-                        duty_amount=condition_data["duty_amount"],
+                        duty_amount=condition_data.get("duty_amount"),
                         condition_code=condition_data["condition_code"],
                         action=condition_data.get("action"),
                         required_certificate=condition_data.get("required_certificate"),
-                        monetary_unit=condition_data["monetary_unit"],
-                        condition_measurement=condition_data["condition_measurement"],
+                        monetary_unit=condition_data.get("monetary_unit"),
+                        condition_measurement=condition_data.get(
+                            "condition_measurement",
+                        ),
                     )
                     condition.clean()
                     condition.save()

--- a/measures/views.py
+++ b/measures/views.py
@@ -231,6 +231,8 @@ class MeasureCreateWizard(
                         condition_code=condition_data["condition_code"],
                         action=condition_data.get("action"),
                         required_certificate=condition_data.get("required_certificate"),
+                        monetary_unit=condition_data["monetary_unit"],
+                        condition_measurement=condition_data["condition_measurement"],
                     )
                     condition.clean()
                     condition.save()

--- a/measures/views.py
+++ b/measures/views.py
@@ -8,6 +8,7 @@ from django.db.transaction import atomic
 from django.http import HttpRequest
 from django.http import HttpResponse
 from django.http import HttpResponseRedirect
+from django.shortcuts import render
 from django.utils.decorators import method_decorator
 from django.views import View
 from formtools.wizard.views import NamedUrlSessionWizardView


### PR DESCRIPTION
## Why
The reference price field on the conditions step of the MeasureCreateWizard needs to be able to handle simple duties (e.g. "3%" or "11 GBP / 100 kg").

## What
- Adds custom clean() method to MeasureConditionsForm, using DutySentenceParser to validate input and pass duty_amount, monetary_unit, and condition_measurement to the measure creation view
- Adds form tests and updates view tests
- Updates view test to handle last step of MeasureCreateWizard
- Update duty_help.jinja examples to use valid duty sentences
