### PR TITLE
TP2000-128: Speed up commodity code autocomplete

### DIFF
--- a/commodities/filters.py
+++ b/commodities/filters.py
@@ -5,6 +5,13 @@ from common.filters import TamatoFilterBackend
 
 class GoodsNomenclatureFilterBackend(TamatoFilterBackend):
     search_fields = (
-        StringAgg("item_id", delimiter=" "),
+        "item_id",
         StringAgg("descriptions__description", delimiter=" "),
     )  # XXX order is significant
+
+    def search_queryset(self, queryset, search_term):
+        search_term = self.get_search_term(search_term)
+        if search_term.isnumeric():
+            return queryset.filter(item_id__startswith=search_term)
+
+        return super().search_queryset(queryset, search_term)

--- a/common/models/tracked_qs.py
+++ b/common/models/tracked_qs.py
@@ -161,6 +161,20 @@ class TrackedModelQuerySet(
             ),
         )
 
+    def record_ordering(self) -> TrackedModelQuerySet:
+        """
+        Returns objects in order of their TARIC record code and subrecord code.
+
+        This is primarily useful for querysets that contain multiple types of
+        tracked model, e.g. when exporting the tracked models to XML.
+        """
+        return self.annotate_record_codes().order_by(
+            "transaction__partition",
+            "transaction__order",
+            "record_code",
+            "subrecord_code",
+        )
+
     def version_ordering(self) -> TrackedModelQuerySet:
         """
         Returns objects in canonical order, i.e. by the order in which they
@@ -229,9 +243,6 @@ class TrackedModelQuerySet(
         return self.select_related(
             "version_group", "version_group__current_version", *related_lookups
         )
-
-    def get_queryset(self):
-        return self.annotate_record_codes().order_by("record_code", "subrecord_code")
 
     @staticmethod
     def _when_model_record_codes():

--- a/exporter/serializers.py
+++ b/exporter/serializers.py
@@ -74,7 +74,7 @@ class MultiFileEnvelopeTransactionSerializer(EnvelopeSerializer):
         # Transactions written to the current output
         current_transactions = []
         for transaction in transactions.all():
-            tracked_models = transaction.tracked_models.all()
+            tracked_models = transaction.tracked_models.record_ordering()
             if not tracked_models.count():
                 # Transactions with no tracked models can occur if a workbasket
                 # is created and then populated, these are filtered as an empty

--- a/measures/filters.py
+++ b/measures/filters.py
@@ -61,6 +61,7 @@ class MeasureFilter(TamatoFilter):
         queryset=MeasureType.objects.all(),
         attrs={
             "display_class": GOV_UK_TWO_THIRDS,
+            "min_length": 3,
         },
     )
 
@@ -70,6 +71,7 @@ class MeasureFilter(TamatoFilter):
         queryset=GoodsNomenclature.objects.all(),
         attrs={
             "display_class": GOV_UK_TWO_THIRDS,
+            "min_length": 4,
         },
     )
 
@@ -79,6 +81,7 @@ class MeasureFilter(TamatoFilter):
         queryset=AdditionalCode.objects.all(),
         attrs={
             "display_class": GOV_UK_TWO_THIRDS,
+            "min_length": 3,
         },
     )
 
@@ -88,6 +91,7 @@ class MeasureFilter(TamatoFilter):
         queryset=GeographicalArea.objects.all(),
         attrs={
             "display_class": GOV_UK_TWO_THIRDS,
+            "min_length": 2,
         },
     )
 
@@ -97,6 +101,7 @@ class MeasureFilter(TamatoFilter):
         queryset=QuotaOrderNumber.objects.all(),
         attrs={
             "display_class": GOV_UK_TWO_THIRDS,
+            "min_length": 4,
         },
     )
 
@@ -106,6 +111,7 @@ class MeasureFilter(TamatoFilter):
         queryset=Regulation.objects.all(),
         attrs={
             "display_class": GOV_UK_TWO_THIRDS,
+            "min_length": 3,
         },
     )
 
@@ -115,6 +121,7 @@ class MeasureFilter(TamatoFilter):
         queryset=Footnote.objects.all(),
         attrs={
             "display_class": GOV_UK_TWO_THIRDS,
+            "min_length": 2,
         },
     )
 

--- a/regulations/filters.py
+++ b/regulations/filters.py
@@ -9,10 +9,10 @@ from regulations.models import Regulation
 
 
 class RegulationFilterMixin(TamatoFilterMixin):
-    """Filter mixin to allow custom filtering on regulation_id, role_type and
+    """Filter mixin to allow custom filtering on regulation_id and
     information_text."""
 
-    search_fields = ("regulation_id", "role_type", "information_text")
+    search_fields = ("regulation_id", "information_text")
 
 
 class RegulationFilterBackend(TamatoFilterBackend, RegulationFilterMixin):

--- a/workbaskets/views/__init__.py
+++ b/workbaskets/views/__init__.py
@@ -125,12 +125,7 @@ class WorkBasketDeleteChanges(PermissionRequiredMixin, ListView):
         # By reverse ordering on record_code + subrecord_code we're able to
         # delete child entities first, avoiding protected foreign key
         # violations.
-        object_list = (
-            self.get_queryset()
-            .annotate_record_codes()
-            .order_by("record_code", "subrecord_code")
-            .reverse()
-        )
+        object_list = self.get_queryset().record_ordering().reverse()
 
         for obj in object_list:
             # Unlike situations where TrackedModels are superceded and are


### PR DESCRIPTION
There were three main issues that made the commodity code autocomplete slow:

1. Searching on aggregated strings is slow, and we can speed this up by only searching on item ID if the search input looks like an item ID.
2. Getting the current transaction (which happens on every request) prefetches all of the tracked models, which is expensive. This basically isn't necessary at all.
3. Not having minimum lengths specified means that lots of requests get sent for the first few characters in a search, which causes a backlog as Django runs through them (aborting the req. doesn't abort the DB query, it seems). So now we have a minimum length of search which has been picked based on the individual model.