### PR TITLE
TP2000-206: Automatically select terminating regulations

### DIFF
--- a/common/models/mixins/validity.py
+++ b/common/models/mixins/validity.py
@@ -43,7 +43,7 @@ class ValidityMixin(models.Model):
     validity_field_name: str = "valid_between"
     """The name of the field that should be used for validity date checking."""
 
-    def terminate(self: Self, workbasket, when: date, **params) -> Self:
+    def terminate(self: Self, workbasket, when: date) -> Self:
         """
         Returns a new version of the object updated to end on the specified
         date.
@@ -74,7 +74,6 @@ class ValidityMixin(models.Model):
                 lower=self.valid_between.lower,
                 upper=when,
             )
-            update_params.update(params)
 
         return self.new_version(workbasket, **update_params)
 

--- a/measures/apps.py
+++ b/measures/apps.py
@@ -3,3 +3,8 @@ from common.app_config import CommonConfig
 
 class MeasuresConfig(CommonConfig):
     name = "measures"
+
+    def ready(self):
+        from measures import signals  # connect receivers
+
+        return super().ready()

--- a/measures/patterns.py
+++ b/measures/patterns.py
@@ -335,11 +335,6 @@ class MeasureCreationPattern:
             **data,
         }
 
-        if actual_end is not None:
-            measure_data["terminating_regulation"] = measure_data[
-                "generating_regulation"
-            ]
-
         new_measure = Measure.objects.create(**measure_data)
         yield new_measure
 

--- a/measures/signals.py
+++ b/measures/signals.py
@@ -1,0 +1,54 @@
+from typing import Type
+
+from django.db.models.signals import pre_save
+from django.dispatch import receiver
+
+from common.validators import UpdateType
+from measures import models
+
+
+@receiver(pre_save, sender=models.Measure, dispatch_uid="update_terminating_regulation")
+def update_terminating_regulation(sender: Type, **kwargs):
+    """
+    Update the terminating regulation on the measure to not be present if the
+    measure has no explicit end date or to be equal to the generating regulation
+    if the measure has an explicit end date and the termination regulation is
+    not already set.
+
+    This automatically avoids issues with ~`measures.business_rules.ME33` and
+    ~`measures.business_rules.ME34`.
+    """
+    instance: models.Measure = kwargs["instance"]
+    should_have_reg = not instance.valid_between.upper_inf
+    if should_have_reg and instance.terminating_regulation is None:
+        instance.terminating_regulation = instance.generating_regulation
+    elif not should_have_reg:
+        instance.terminating_regulation = None
+
+
+@receiver(pre_save, sender=models.Measure, dispatch_uid="handle_changed_commodity_code")
+def handle_changed_commodity_code(sender: Type, **kwargs):
+    """If the commodity code is being changed on an existing measure, the
+    measure is deleted instead of doing an `UPDATE` and a new measure created
+    with the updated commodity code."""
+    instance: models.Measure = kwargs["instance"]
+    is_update = instance.update_type == UpdateType.UPDATE
+    previous: models.Measure = instance.get_versions().version_ordering().last()
+
+    if is_update and previous is not None:
+        try:
+            nomenclature_removed = not (
+                previous.goods_nomenclature and instance.goods_nomenclature
+            )
+        except type(previous.goods_nomenclature).DoesNotExist:
+            return
+
+        nomenclature_changed = (
+            True
+            if nomenclature_removed
+            else instance.goods_nomenclature.sid != previous.goods_nomenclature.sid
+        )
+        if nomenclature_changed:
+            instance.copy(instance.transaction.workbasket.new_transaction())
+            instance.goods_nomenclature = previous.goods_nomenclature
+            instance.update_type = UpdateType.DELETE

--- a/measures/tests/test_business_rules.py
+++ b/measures/tests/test_business_rules.py
@@ -1,8 +1,10 @@
 from decimal import Decimal
 
+import factory
 import pytest
 from dateutil.relativedelta import relativedelta
 from django.db import DataError
+from django.db.models import signals
 
 from common.business_rules import BusinessRuleViolation
 from common.business_rules import UniqueIdentifyingFields
@@ -1021,6 +1023,7 @@ def test_ME29():
         (True, True),
     ),
 )
+@factory.django.mute_signals(signals.pre_save)
 def test_ME33(terminating_regulation, date_ranges, error_expected):
     """
     A justification regulation may not be entered if the measure end date is not
@@ -1050,6 +1053,7 @@ def test_ME33(terminating_regulation, date_ranges, error_expected):
         (False, True),
     ),
 )
+@factory.django.mute_signals(signals.pre_save)
 def test_ME34(terminating_regulation, date_ranges, error_expected):
     """
     A justification regulation must be entered if the measure end date is filled
@@ -1099,9 +1103,8 @@ def test_ME40(applicability_code, component, condition_component, error_expected
     specified.  If the flag is set "not permitted" then no measure component or
     measure condition component must exist.  Measure components and measure
     condition components are mutually exclusive. A measure can have either
-    components or condition components (if the ‘duty expression’ flag is.
-
-    ‘mandatory’ or ‘optional’) but not both.
+    components or condition components (if the "duty expression" flag is
+    "mandatory" or "optional") but not both.
 
     This describes the fact that measures of certain types MUST have components
     (duties) assigned to them, whereas others must not. Note the sub-clause also

--- a/measures/tests/test_signals.py
+++ b/measures/tests/test_signals.py
@@ -1,0 +1,36 @@
+import pytest
+
+from common.tests import factories
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.mark.parametrize(
+    ("old_dates", "old_terminating_reg", "new_dates", "expect_any", "expect_same"),
+    (
+        ("no_end", lambda: None, "normal", True, False),
+        ("normal", factories.RegulationFactory, "no_end", False, False),
+        ("normal", factories.RegulationFactory, "normal", True, True),
+    ),
+)
+def test_terminating_regulation_update(
+    old_dates,
+    old_terminating_reg,
+    new_dates,
+    expect_any,
+    expect_same,
+):
+    """Tests that when the validity dates on a measure are changed, a
+    terminating regulation is automatically added or removed, and that any
+    existing terminating regulation is used."""
+    regulation = old_terminating_reg()
+    instance = factories.MeasureFactory.create(
+        valid_between=factories.date_ranges(old_dates),
+        terminating_regulation=regulation,
+    )
+    new_version = instance.new_version(
+        instance.transaction.workbasket,
+        valid_between=factories.date_ranges(new_dates).function(),
+    )
+    assert (new_version.terminating_regulation is not None) == expect_any
+    assert (new_version.terminating_regulation == regulation) == expect_same

--- a/regulations/tests/test_business_rules.py
+++ b/regulations/tests/test_business_rules.py
@@ -4,6 +4,7 @@ from django.db import DataError
 from common.business_rules import BusinessRuleViolation
 from common.tests import factories
 from common.tests.util import only_applicable_after
+from common.tests.util import raises_if
 from regulations import business_rules
 from regulations.validators import RoleType
 
@@ -139,7 +140,15 @@ def test_ROIMB44(id, approved, change_flag, expect_error):
         business_rules.ROIMB44(regulation.transaction).validate(regulation)
 
 
-def test_ROIMB46(delete_record):
+@pytest.mark.parametrize(
+    ("regulation_id", "role_type", "expect_error"),
+    (
+        (factories.BaseRegulationFactory.regulation_id, RoleType.BASE, True),
+        ("C2000000", RoleType.BASE, False),
+        (factories.BaseRegulationFactory.regulation_id, RoleType.MODIFICATION, False),
+    ),
+)
+def test_ROIMB46(regulation_id, role_type, expect_error, delete_record):
     """A base regulation cannot be deleted if it is used as a justification
     regulation, except for ‘C’ regulations used only in measures as both
     measure-generating regulation and justification regulation."""
@@ -147,29 +156,20 @@ def test_ROIMB46(delete_record):
     # justification regulation field, though there will be a lot of EU regulations where
     # the justification regulation field is set.
 
-    regulation = factories.BaseRegulationFactory.create()
-    factories.MeasureFactory.create(terminating_regulation=regulation)
+    regulation = factories.RegulationFactory.create(
+        regulation_id=regulation_id,
+        role_type=role_type,
+    )
+    measure = factories.MeasureFactory.create(
+        valid_between=factories.date_ranges("normal"),
+        generating_regulation=regulation,
+        terminating_regulation=regulation,
+    )
+    assert measure.terminating_regulation == regulation
+
     deleted = delete_record(regulation)
-
-    with pytest.raises(BusinessRuleViolation):
+    with raises_if(BusinessRuleViolation, expect_error):
         business_rules.ROIMB46(deleted.transaction).validate(deleted)
-
-    draft_regulation = factories.BaseRegulationFactory.create(regulation_id="C2000000")
-    factories.MeasureFactory.create(
-        generating_regulation=draft_regulation,
-        terminating_regulation=draft_regulation,
-    )
-
-    deleted = delete_record(draft_regulation)
-    business_rules.ROIMB46(deleted.transaction).validate(deleted)
-
-    not_base_regulation = factories.RegulationFactory.create(
-        role_type=RoleType.MODIFICATION,
-    )
-    factories.MeasureFactory.create(terminating_regulation=not_base_regulation)
-
-    deleted = delete_record(not_base_regulation)
-    business_rules.ROIMB46(deleted.transaction).validate(deleted)
 
 
 def test_ROIMB47(assert_spanning_enforced):


### PR DESCRIPTION
## Why
At the moment it's not possible for users to add or remove end dates to measures because they aren't able to make a corresponding edit to the terminating regulation. This behaviour is also handled in a number of bespoke places in the code base.

## What
This commit unifies that logic into a signal that is fired pre-save, so no matter where the edit to the measure is happening the logic will be applied. This also lets us remove some redundant code.

We also take the changed commodity code handling logic out into a signal.

The ``mute_signals`` decorator is necessary for ME33 and ME34 so that it _is_ possible to create test data that ignore this logic.

