### PR TITLE
Optionally omit the 'name' attr of dummy autocomplete fields.

### DIFF
--- a/common/static/common/js/application.js
+++ b/common/static/common/js/application.js
@@ -8,6 +8,9 @@ import initStepNav from './step-by-step-nav';
 import { initAll } from 'govuk-frontend';
 import initCheckAllCheckboxes from './checkAllCheckboxes';
 showHideCheckboxes();
+// Initialise accessible-autocomplete components without a `name` attr in order
+// to avoid the "dummy" autocomplete field being submitted as part of the form
+// to the server.
 initAutocomplete(false);
 initStepNav();
 initAll();

--- a/common/static/common/js/application.js
+++ b/common/static/common/js/application.js
@@ -8,7 +8,7 @@ import initStepNav from './step-by-step-nav';
 import { initAll } from 'govuk-frontend';
 import initCheckAllCheckboxes from './checkAllCheckboxes';
 showHideCheckboxes();
-initAutocomplete();
+initAutocomplete(false);
 initStepNav();
 initAll();
 initCheckAllCheckboxes();

--- a/common/static/common/js/autocomplete.js
+++ b/common/static/common/js/autocomplete.js
@@ -3,10 +3,10 @@ import accessibleAutocomplete from 'accessible-autocomplete'
 const template = (result) => result && result.label
 
 let aborter = null;
-const initAutocomplete = () => { 
+const initAutocomplete = (includeNameAttr=true) => { 
   for (let element of document.querySelectorAll(".autocomplete")) {
     const hiddenInput = element.querySelector("input[type=hidden]");
-    accessibleAutocomplete({
+    const params = {
       element: element.querySelector(".autocomplete-container"),
       id: hiddenInput.id + "_autocomplete",
       source: (query, populateResults) => {
@@ -26,7 +26,7 @@ const initAutocomplete = () => {
       },
       minLength: element.dataset.minLength ? element.dataset.minLength : 0,
       defaultValue: element.dataset.originalValue,
-      name: `${hiddenInput.name}_autocomplete`,
+      name: "",
       templates: {
         inputValue: template,
         suggestion: template
@@ -39,7 +39,13 @@ const initAutocomplete = () => {
           hiddenInput.value = "";
         }
       }
-    });
+    };
+
+    if (includeNameAttr) {
+      params.name = `${hiddenInput.name}_autocomplete`;
+    }
+
+    accessibleAutocomplete(params);
   }
 }
 


### PR DESCRIPTION
# TP2000-229 Don't submit '_autocomplete' fields
<!---
 * Include the JIRA ticket number, eg TP-123, to automatically link.
 * Use 50 characters maximum.
 * Do not end with a full-stop.
--->

## Why
Autocomplete fields are only used in the client and have no purpose on the server, but current behaviour submits their contents to the server (as URL encoded params on many of Tamato's forms). This can cause undesirable side-effects.

## What
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Explain like I'm 5.
 * Use pictures if you can.
--->
 [the auto](https://github.com/alphagov/accessible-autocomplete) allows setting the name attribute of the autocomplete field. This PR allows setting it to an empty value and thereby avoids submitting its value to the server.

<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
## Checklist
- Requires migrations?
- Requires dependency updates?
--->

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
