### PR TITLE
TP2000-214 Add conditional rendering to MeasureCondition form

### DIFF
--- a/.github/actions/setup-python/action.yml
+++ b/.github/actions/setup-python/action.yml
@@ -25,7 +25,6 @@ runs:
           ${{ runner.os }}-pip-
 
     - name: Install dependencies
-      if: steps.cache.outputs.cache-hit != 'true'
       shell: bash
       run: |
         python -m pip install --upgrade pip

--- a/common/jinja2/components/measure_condition_action_code/template.jinja
+++ b/common/jinja2/components/measure_condition_action_code/template.jinja
@@ -1,0 +1,18 @@
+<div id="div_id_{{ field.html_name }}" class="govuk-form-group">
+    {% set selected_action = field.initial | int %}
+    <label for="id_{{ field.html_name }}" class="govuk-label">
+        Action code
+    </label>
+    <select name="{{ field.html_name }}" class="govuk-select" id="id_{{ field.html_name }}"> 
+        <option value="">-- Please select an action code --</option>
+        {% for action in form.fields.action.queryset %}
+            <option 
+                value={{ action.id }}
+                data-duty={{ action.requires_duty }}
+                {% if action.id == selected_action %}selected{% endif %}
+            >
+                {{ action }}
+            </option>
+        {% endfor %}
+    </select> 
+</div>

--- a/common/jinja2/components/measure_condition_code/template.jinja
+++ b/common/jinja2/components/measure_condition_code/template.jinja
@@ -1,0 +1,16 @@
+<div id="div_id_{{ field.html_name }}" class="govuk-form-group">
+    {% set selected_code = field.initial | int %}
+    <select name="{{ field.html_name }}" class="govuk-select" id="id_{{ field.html_name }}"> 
+        <option value="">-- Please select a condition code --</option>
+        {% for condition in form.fields.condition_code.queryset %}
+            <option 
+                value={{ condition.id }}
+                data-certificate={{ condition.accepts_certificate }}
+                data-price={{ condition.accepts_price }}
+                {% if condition.id == selected_code %}selected{% endif %}
+            >
+                {{ condition }}
+            </option>
+        {% endfor %}
+    </select> 
+</div>

--- a/common/jinja2/components/measure_condition_component_duty/template.jinja
+++ b/common/jinja2/components/measure_condition_component_duty/template.jinja
@@ -1,7 +1,7 @@
 <div class="govuk-radios__conditional" id="div_id_{{ field.html_name }}">
     <label class="govuk-label" for="id_{{ field.html_name}}">Duty</label>
     <div id="condition-duty-hint" class="govuk-hint">
-        If a different duty applies to each certificate, licence or document on this measure, enter it here.
+        If this condition should apply a different duty, enter it here.
         {% with component="condition" %}
             {% include "components/duty_help.jinja" %}
         {% endwith %}

--- a/common/static/common/js/application.js
+++ b/common/static/common/js/application.js
@@ -7,6 +7,7 @@ import initAutocomplete from './autocomplete';
 import initStepNav from './step-by-step-nav';
 import { initAll } from 'govuk-frontend';
 import initCheckAllCheckboxes from './checkAllCheckboxes';
+import initConditionalMeasureConditions from './conditionalMeasureConditions';
 showHideCheckboxes();
 // Initialise accessible-autocomplete components without a `name` attr in order
 // to avoid the "dummy" autocomplete field being submitted as part of the form
@@ -15,3 +16,4 @@ initAutocomplete(false);
 initStepNav();
 initAll();
 initCheckAllCheckboxes();
+initConditionalMeasureConditions();

--- a/common/static/common/js/conditionalMeasureConditions.js
+++ b/common/static/common/js/conditionalMeasureConditions.js
@@ -1,0 +1,51 @@
+// Sets up conditional rendering for all MeasureCondition fieldsets
+
+import { nodeListForEach } from './util.js'
+
+// Generic visibility change function
+const changeElementVisibility = (triggerElement, displayElement, triggerProperty) => {
+    displayElement.style.display = 
+        (triggerElement.selectedOptions[0].dataset[triggerProperty] == 'True') 
+        ? 'block' 
+        : 'none'
+}
+
+// Sets up conditional rendering for an individual MeasureCondition fieldset
+const applyConditionalRendering = (parent, id) => {
+    // Gets reference elements
+    let conditionCodeElement = parent.querySelector(`#id_conditions-${id}-condition_code`)
+    let actionCodeElement = parent.querySelector(`#id_conditions-${id}-action`)
+
+    // Gets changeable elements
+    let certificateElement = parent.querySelector(`#div_id_conditions-${id}-required_certificate`)
+    let referencePriceElement = parent.querySelector(`#div_id_conditions-${id}-reference_price`)
+    let dutyElement = parent.querySelector(`#div_id_conditions-${id}-applicable_duty`)
+    
+    // Functions to set element visibility based on specific triggers
+    let changeConditionCodeDependencies = () => {
+        changeElementVisibility(conditionCodeElement, certificateElement, 'certificate')
+        changeElementVisibility(conditionCodeElement, referencePriceElement, 'price')
+    }
+    let changeActionCodeDependency = () => {
+        changeElementVisibility(actionCodeElement, dutyElement, 'duty')
+    }
+
+    // Sets initial display choices
+    changeConditionCodeDependencies()
+    changeActionCodeDependency()
+
+    // Activates change visibilty on select
+    conditionCodeElement.addEventListener("change", () => changeConditionCodeDependencies())
+    actionCodeElement.addEventListener("change", () => changeActionCodeDependency())
+}
+
+// Applies conditional rendering for all MeasureConditions in a form
+const initConditionalMeasureConditions = () => {
+    let conditionalMeasureFieldsets = document.querySelectorAll('[data-field="condition_code"]')
+
+    nodeListForEach(conditionalMeasureFieldsets, (conditionalMeasureForm, i) => {
+        applyConditionalRendering(conditionalMeasureForm, i)
+    });
+}
+
+export default initConditionalMeasureConditions;

--- a/common/static/common/js/conditionalMeasureConditions.js
+++ b/common/static/common/js/conditionalMeasureConditions.js
@@ -3,11 +3,14 @@
 import { nodeListForEach } from './util.js'
 
 // Generic visibility change function
-const changeElementVisibility = (triggerElement, displayElement, triggerProperty) => {
-    displayElement.style.display = 
-        (triggerElement.selectedOptions[0].dataset[triggerProperty] == 'True') 
-        ? 'block' 
-        : 'none'
+const changeElementVisibility = (triggerElement, displayElement, triggerProperty) => {    
+    if(triggerElement.selectedOptions[0].dataset[triggerProperty] == 'True') {
+        displayElement.style.display = 'block'
+    } else {
+        displayElement.style.display = 'none'
+        // TODO: handle data set in autocomplete
+        displayElement.querySelector('input').value = null
+    }
 }
 
 // Sets up conditional rendering for an individual MeasureCondition fieldset

--- a/common/static/common/js/showHideCheckboxes.js
+++ b/common/static/common/js/showHideCheckboxes.js
@@ -1,13 +1,6 @@
-let showMoreClicked = {};
+import { nodeListForEach } from './util.js'
 
-const nodeListForEach = (nodes, callback) => {
-    if (window.NodeList.prototype.forEach) {
-      return nodes.forEach(callback)
-    }
-    for (let i = 0; i < nodes.length; i++) {
-      callback.call(window, nodes[i], i, nodes)
-    }
-}
+let showMoreClicked = {};
 
 class FilterShowMore {
     constructor(module) {

--- a/common/static/common/js/util.js
+++ b/common/static/common/js/util.js
@@ -1,0 +1,10 @@
+const nodeListForEach = (nodes, callback) => {
+    if (window.NodeList.prototype.forEach) {
+        return nodes.forEach(callback)
+    }
+    for (let i = 0; i < nodes.length; i++) {
+        callback.call(window, nodes[i], i, nodes)
+    }
+}
+
+export { nodeListForEach }

--- a/measures/forms.py
+++ b/measures/forms.py
@@ -576,7 +576,7 @@ class MeasureConditionsForm(forms.ModelForm):
     # reference_price expects a non-compound duty string (e.g. "11 GBP / 100 kg".
     # Using DutySentenceParser we validate this string and get the decimal value to pass to the model field, duty_amount)
     reference_price = forms.CharField(
-        label="Reference price (where applicable).",
+        label="Reference price or quantity",
         required=False,
     )
     required_certificate = AutoCompleteField(

--- a/measures/forms.py
+++ b/measures/forms.py
@@ -609,12 +609,14 @@ class MeasureConditionsForm(forms.ModelForm):
                 Div(
                     Field("reference_price", css_class="govuk-input"),
                     "required_certificate",
-                    Field(
-                        "action",
-                        template="components/measure_condition_action_code/template.jinja",
-                    ),
-                    MeasureConditionComponentDuty("applicable_duty"),
                     css_class="govuk-radios__conditional",
+                ),
+                Field(
+                    "action",
+                    template="components/measure_condition_action_code/template.jinja",
+                ),
+                Div(
+                    MeasureConditionComponentDuty("applicable_duty"),
                 ),
                 Field("DELETE", template="includes/common/formset-delete-button.jinja")
                 if not self.prefix.endswith("__prefix__")

--- a/measures/forms.py
+++ b/measures/forms.py
@@ -659,6 +659,12 @@ class MeasureConditionsForm(forms.ModelForm):
             cleaned_data["monetary_unit"] = components[0].monetary_unit
             cleaned_data["condition_measurement"] = components[0].component_measurement
 
+        # The JS autocomplete does not allow for clearing unnecessary certificates
+        # In case of a user changing data, the information is cleared here.
+        condition_code = cleaned_data.get("condition_code")
+        if condition_code and not condition_code.accepts_certificate:
+            cleaned_data["required_certificate"] = None
+
         return cleaned_data
 
 

--- a/measures/forms.py
+++ b/measures/forms.py
@@ -599,13 +599,20 @@ class MeasureConditionsForm(forms.ModelForm):
 
         self.helper = FormHelper(self)
         self.helper.form_tag = False
+
         self.helper.layout = Layout(
             Fieldset(
-                Field("condition_code"),
+                Field(
+                    "condition_code",
+                    template="components/measure_condition_code/template.jinja",
+                ),
                 Div(
                     Field("reference_price", css_class="govuk-input"),
                     "required_certificate",
-                    "action",
+                    Field(
+                        "action",
+                        template="components/measure_condition_action_code/template.jinja",
+                    ),
                     MeasureConditionComponentDuty("applicable_duty"),
                     css_class="govuk-radios__conditional",
                 ),
@@ -614,6 +621,7 @@ class MeasureConditionsForm(forms.ModelForm):
                 else None,
                 legend="Condition code",
                 legend_size=Size.SMALL,
+                data_field="condition_code",
             ),
         )
 

--- a/measures/forms.py
+++ b/measures/forms.py
@@ -580,7 +580,7 @@ class MeasureConditionsForm(forms.ModelForm):
         required=False,
     )
     required_certificate = AutoCompleteField(
-        label="Certificate, license or document",
+        label="Certificate, licence or document",
         queryset=Certificate.objects.all(),
         required=False,
     )


### PR DESCRIPTION
# TP2000-214 Add conditional rendering to `MeasureCondition` form

## Why
As different measure conditions expect different supporting data, to make data entry easier, this hides any measure condition form fields that are not relevant for a particular `MeasureConditionCode` or `MeasureAction`. _For more information, see: https://uktrade.github.io/tariff-data-manual/documentation/data-structures/measure-conditions.html#condition-codes_

## What
This adds a new JavaScript file that allows for conditional rendering of individual fields in the measure conditions form. (The form will still work without JavaScript, but will not have the option of hiding fields for clarity, so there is some progressive enhancement).

New Jinja templates have been added so that the triggers for hiding particular fields are generated from the `MeasureConditionCode` and `MeasureAction` instances rather than a hardcoded list of ids. `data-*` attributes have been used to pass this information to the JS frontend.

### Before
All fields visible
<img width="799" alt="Before" src="https://user-images.githubusercontent.com/23265724/160598347-a5e2f1a9-3b7d-4406-b272-28667a4ca3b7.png">

### After
Only relevant fields visible
<img width="605" alt="After" src="https://user-images.githubusercontent.com/23265724/160598409-786f955b-7ee5-41e9-a909-64ef9d46ee3f.png">


## Checklist
Will require a rebuilding of static files to view locally