### PR TITLE
TP2000-238 Duties field is required on Measure create wizard commodities / duties step

### DIFF
--- a/measures/forms.py
+++ b/measures/forms.py
@@ -512,6 +512,7 @@ class MeasureCommodityAndDutiesForm(forms.Form):
 
     duties = forms.CharField(
         label="Duties",
+        required=False,
     )
 
     def __init__(self, *args, **kwargs):

--- a/measures/views.py
+++ b/measures/views.py
@@ -283,8 +283,9 @@ class MeasureCreateWizard(
     def get_form_initial(self, step):
         current_step = self.storage.current_step
         initial_data = super().get_form_initial(step)
+        duty_steps = ["commodities", "conditions"]
 
-        if (current_step, step) == ("duties", "duties"):
+        if current_step in duty_steps and step in duty_steps:
             # At each step get_form_initial is called for every step, avoid a loop
             details_data = self.get_cleaned_data_for_step("measure_details")
 


### PR DESCRIPTION
## Why
The duties field on the commodities / duties step of the wizard should not be required because it should be possible to create a measure without a duty amount.

The wizard get_form_initial method also should be update because there is no longer a step called "duties", which means that duty validation is not being called and we are seeing 500 parse errors. This validation should also be called for the "conditions" step.

## What
- Make duties field required on form and update get_form_initial method

<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
## Checklist
- Requires migrations? No
- Requires dependency updates? No
--->

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
https://uktrade.atlassian.net/browse/TP2000-238