### PR TITLE
Tools to filter and renumber TARIC XML files.

### DIFF
--- a/common/tests/test_xml_util.py
+++ b/common/tests/test_xml_util.py
@@ -1,0 +1,89 @@
+import pytest
+from django.db import transaction
+
+from common.models.transactions import Transaction
+from common.tests import factories
+from common.tests.util import serialize_xml
+from common.xml.util import remove_transactions
+from common.xml.util import renumber_records
+from common.xml.util import renumber_transactions
+
+pytestmark = pytest.mark.django_db
+
+
+def test_record_renumbering_produces_valid_import_data(import_xml, export_xml):
+    """Tests that when the renumbering function is used, the XML file it
+    produces is valid and when imported produces records in the database that
+    are correctly renumbered."""
+    code_type = factories.AdditionalCodeTypeFactory.create()
+    workbasket = factories.ApprovedWorkBasketFactory()
+    first = factories.AdditionalCodeFactory.create(
+        type=code_type,
+        transaction__workbasket=workbasket,
+    )
+    second = factories.AdditionalCodeFactory.create(
+        type=code_type,
+        transaction__workbasket=workbasket,
+    )
+
+    for instance in (first, second):
+        assert not type(instance).objects.filter(sid=instance.sid + 2).exists()
+
+    xml = export_xml(workbasket=workbasket)
+    renumber_records(xml, second.sid + 1, "oub:additional.code.sid")
+    import_xml(serialize_xml(xml))
+
+    for instance in (first, second):
+        new_instance = type(instance).objects.get(sid=instance.sid + 2)
+        assert new_instance.type == instance.type
+        assert new_instance.code == instance.code
+        assert new_instance.version_group != instance.version_group
+
+
+def test_transaction_renumbering_produces_valid_import_data(import_xml, export_xml):
+    """Tests that when the transaction renumbering function is used, the XML
+    file it produces is valid and when imported produces transactions in the
+    database that are correctly renumbered."""
+    with transaction.atomic():
+        model = factories.AdditionalCodeTypeFactory.create()
+        xml = export_xml(workbasket=model.transaction.workbasket)
+        original_order = model.transaction.order
+        transaction.set_rollback(True)
+
+    assert not Transaction.objects.filter(order=original_order).exists()
+    assert not Transaction.objects.filter(order=original_order + 1).exists()
+    renumber_transactions(xml, original_order + 1)
+    import_xml(serialize_xml(xml))
+
+    txn = Transaction.objects.get(order=original_order + 1)
+    assert txn.tracked_models.get().sid == model.sid
+
+
+def test_transaction_removing_produces_valid_import_data(import_xml, export_xml):
+    """Tests that when the transaction filtering function is used, the XML file
+    it produces is valid and when imported does not contain the removed
+    transactions."""
+    code_type = factories.AdditionalCodeTypeFactory.create()
+    with transaction.atomic():
+        workbasket = factories.ApprovedWorkBasketFactory()
+        first = factories.AdditionalCodeFactory.create(
+            type=code_type,
+            transaction__workbasket=workbasket,
+        )
+        second = factories.AdditionalCodeFactory.create(
+            type=code_type,
+            transaction__workbasket=workbasket,
+        )
+        xml = export_xml(workbasket=workbasket)
+        transaction.set_rollback(True)
+
+    assert not Transaction.objects.filter(order=first.transaction.order).exists()
+    assert not Transaction.objects.filter(order=second.transaction.order).exists()
+
+    remove_transactions(xml, "oub:additional.code.sid", [str(first.sid)])
+    import_xml(serialize_xml(xml))
+
+    assert not Transaction.objects.filter(order=first.transaction.order).exists()
+    assert Transaction.objects.filter(order=second.transaction.order).exists()
+    assert not type(first).objects.filter(sid=first.sid).exists()
+    assert type(second).objects.filter(sid=second.sid).exists()

--- a/common/xml/namespaces.py
+++ b/common/xml/namespaces.py
@@ -11,3 +11,11 @@ nsmap = {
     TARIC_MESSAGE: "urn:publicid:-:DGTAXUD:TARIC:MESSAGE:1.0",
     XML_SCHEMA: "http://www.w3.org/2001/XMLSchema",
 }
+
+
+def register():
+    # Necessary to get ElementTree to output XML with the familiar prefixes.
+    from xml.etree import ElementTree
+
+    for prefix in (ENVELOPE, TARIC_MESSAGE):
+        ElementTree.register_namespace(prefix, nsmap[prefix])

--- a/common/xml/util.py
+++ b/common/xml/util.py
@@ -1,0 +1,166 @@
+import contextlib
+import logging
+import re
+from typing import Collection
+from xml.etree import ElementTree
+
+from common.validators import UpdateType
+from common.xml.namespaces import nsmap
+
+
+@contextlib.contextmanager
+def rewrite(filename: str):
+    """Opens the passed XML file and yields the parsed XML tree for
+    modification, and then overwrite the original file with the modified tree
+    afterwards."""
+
+    with open(filename, "rb") as file:
+        tree = ElementTree.parse(file)
+        root = tree.getroot()
+        yield root
+
+    tree.write(filename, "utf-8", True)
+
+
+ATTRIBUTE_XPATH = re.compile(r"\[@([a-z]+)\]")
+
+
+def renumber_paths(element: ElementTree.Element, start_from: int, *paths: str):
+    """
+    Re-numbers the integer values contained in XML attributes or text values to
+    start from a new value.
+
+    Differences between values are retained, so that if an XML tree contains a
+    sequence of values the sequence will still exist but will just have been
+    shifted to start at the new starting value. The values are expected to be in
+    order within the file, i.e. the smallest value should appear first.
+
+    Attributes or tags are identified using XPath strings. If the XPath string
+    contains an attribute declaration, that attribute is what will be updated.
+    Otherwise, the XML tag's text content will be updated. In both cases, there
+    is expected to be an original value.
+
+    Multiple paths can be used, allowing multiple text values and attributes to
+    be updated at once.
+
+    Example input:
+
+        <root>
+            <element id="123"/>
+            <something>124</something>
+        </root>
+
+    Calling ``renumber(input, 456, "element[@id]", "something")`` results in:
+
+        <root>
+            <element id="456"/>
+            <sometihng>457</something>
+        </root>
+    """
+    add_value = None
+    for path in paths:
+        result = ATTRIBUTE_XPATH.search(path)
+        if result:
+            # We are updating an XML attribute.
+            attribute = result.groups()[0]
+            getter = lambda e: int(e.get(attribute))
+            setter = lambda e, v: e.set(attribute, str(v))
+        else:
+            # We are updating the body of an XML element.
+            getter = lambda e: int(getattr(e, "text"))
+            setter = lambda e, v: setattr(e, "text", str(v))
+
+        if not add_value:
+            first_tag = element.find(path, nsmap)
+            first_value = int(getter(first_tag))
+            add_value = start_from - first_value
+
+        for tag in element.findall(path, nsmap):
+            value = int(getter(tag))
+            setter(tag, str(value + add_value))
+
+
+def renumber_transactions(envelope: ElementTree.Element, start_from: int):
+    """Renumbers transactions in the passed TARIC XML file to start from the
+    specified value."""
+    renumber_paths(
+        envelope,
+        start_from,
+        ".//oub:transaction.id",
+        ".//env:transaction[@id]",
+    )
+
+
+def renumber_records(envelope: ElementTree.Element, start_from: int, record_name: str):
+    """
+    Renumbers the integer values found in TARIC XML records matching paths with
+    numbers that start from the passed integer.
+
+    Any records that are CREATEd will receive a new value. Any values that are
+    UPDATEd or DELETEd will only receive a new value if they were CREATEd in
+    this file.
+    """
+    logger = logging.getLogger(__name__)
+    add_value = None
+    remaps = dict()
+
+    def get(element: ElementTree.Element) -> int:
+        return int(element.text)
+
+    def set(element: ElementTree.Element, value: int):
+        element.text = str(value)
+
+    for transaction in envelope.findall(".//env:transaction", nsmap):
+        for record in transaction.findall(".//oub:record", nsmap):
+            update_type = get(record.find(".//oub:update.type", namespaces=nsmap))
+
+            for tag in record.findall(f".//{record_name}", nsmap):
+                current_value = get(tag)
+
+                if update_type == UpdateType.CREATE:
+                    if not add_value:
+                        add_value = start_from - current_value
+
+                    remaps[current_value] = current_value + add_value
+
+                if current_value in remaps:
+                    set(tag, remaps[current_value])
+
+    logger.debug("Renumbered %d distinct values of %s", len(remaps), record_name)
+
+
+def element_contains(
+    haystack: ElementTree.Element,
+    needle_name: str,
+    needle_values: Collection[str],
+) -> bool:
+    """Returns whether the passed element contains a descendent element matching
+    the passed tag name which has any of passed text values."""
+
+    for tag in haystack.findall(f".//{needle_name}", nsmap):
+        if tag.text in needle_values:
+            return True
+
+    return False
+
+
+def remove_transactions(
+    envelope: ElementTree.Element,
+    element_name: str,
+    element_values: Collection[str],
+):
+    """
+    Removes transactions from the passed TARIC XML tree where the passed tag
+    name is present and has the passed value.
+
+    For example, calling ``filter_taric(root, "oub:measure.sid", "12345678",
+    "23456789")`` will remove any transaction containing any reference to a
+    measure SID 12345678 or 23456789. This might be the measure itself or it
+    might also include any conditions or components that reference the measure.
+    """
+    logger = logging.getLogger(__name__)
+
+    for transaction in envelope.findall("./env:transaction", nsmap):
+        if element_contains(transaction, element_name, element_values):
+            logger.debug("Removing transaction", transaction.attrib["id"])
+            envelope.remove(transaction)

--- a/exporter/apps.py
+++ b/exporter/apps.py
@@ -30,3 +30,9 @@ class ExporterConfig(CommonConfig):
 
     def ready(self):
         apsw.config(apsw.SQLITE_CONFIG_LOG, handle_sqlite_log)
+
+        from common.xml import namespaces
+
+        namespaces.register()
+
+        return super().ready()

--- a/importer/apps.py
+++ b/importer/apps.py
@@ -3,3 +3,10 @@ from common.app_config import CommonConfig
 
 class ImporterConfig(CommonConfig):
     name = "importer"
+
+    def ready(self):
+        from common.xml import namespaces
+
+        namespaces.register()
+
+        return super().ready()

--- a/importer/management/commands/filter_taric.py
+++ b/importer/management/commands/filter_taric.py
@@ -1,0 +1,23 @@
+from django.core.management import BaseCommand
+
+from common.xml.util import remove_transactions
+from common.xml.util import rewrite
+
+
+class Command(BaseCommand):
+    help = str(remove_transactions.__doc__)
+
+    def add_arguments(self, parser) -> None:
+        parser.add_argument("file", type=str, help="The XML file to filter, in place")
+        parser.add_argument("name", type=str, help="The XML tag name to look for")
+        parser.add_argument(
+            "values",
+            type=str,
+            nargs="*",
+            help="String value that the XML tag should have to be removed",
+        )
+        return super().add_arguments(parser)
+
+    def handle(self, *args, **options):
+        with rewrite(options["file"]) as root:
+            remove_transactions(root, options["name"], options["values"])

--- a/importer/management/commands/renumber_taric.py
+++ b/importer/management/commands/renumber_taric.py
@@ -1,0 +1,22 @@
+from django.core.management import BaseCommand
+
+from common.xml.util import renumber_records
+from common.xml.util import rewrite
+
+
+class Command(BaseCommand):
+    help = str(renumber_records.__doc__)
+
+    def add_arguments(self, parser) -> None:
+        parser.add_argument("file", type=str, help="The XML file to renumber, in place")
+        parser.add_argument("number", type=int, help="The number to start from")
+        parser.add_argument(
+            "tag",
+            type=str,
+            help="TARIC tag name to renumber, with XML namespace",
+        )
+        return super().add_arguments(parser)
+
+    def handle(self, *args, **options):
+        with rewrite(options["file"]) as root:
+            renumber_records(root, options["number"], options["tag"])

--- a/importer/management/commands/renumber_transactions.py
+++ b/importer/management/commands/renumber_transactions.py
@@ -1,0 +1,17 @@
+from django.core.management import BaseCommand
+
+from common.xml.util import renumber_transactions
+from common.xml.util import rewrite
+
+
+class Command(BaseCommand):
+    help = str(renumber_transactions.__doc__)
+
+    def add_arguments(self, parser) -> None:
+        parser.add_argument("file", type=str, help="The XML file to renumber, in place")
+        parser.add_argument("number", type=int, help="The number to start from")
+        return super().add_arguments(parser)
+
+    def handle(self, *args, **options):
+        with rewrite(options["file"]) as root:
+            renumber_transactions(root, options["number"])

--- a/importer/taric.py
+++ b/importer/taric.py
@@ -85,7 +85,7 @@ class MessageParser(ElementParser):
         :param data: A dict of parsed element, mapping field names to values
         :param transaction_id: The primary key of the transaction to add records to
         """
-        for record_data in data["record"]:
+        for record_data in data.get("record", []):
             self.record.save(record_data, transaction_id)
 
 
@@ -133,7 +133,7 @@ class TransactionParser(ElementParser):
             order=int(self.data["id"]),
         )
 
-        for message_data in data["message"]:
+        for message_data in data.get("message", []):
             self.message.save(message_data, transaction.id)
 
         is_commodity_import = (
@@ -202,8 +202,8 @@ class TransactionParser(ElementParser):
 
         codes = [
             get_record_code(record)
-            for transmission in data["message"]
-            for record in transmission["record"]
+            for transmission in data.get("message", [])
+            for record in transmission.get("record", [])
         ]
 
         matching_codes = [

--- a/quotas/tests/test_xml.py
+++ b/quotas/tests/test_xml.py
@@ -70,10 +70,9 @@ def test_quota_blocking_xml(xml):
     zip(QuotaEventType.values, QuotaEventType.names),
 )
 def test_quota_event_xml(
-    api_client,
+    valid_user_api_client,
     taric_schema,
     approved_transaction,
-    valid_user,
     subrecord_code,
     event_type_name,
 ):
@@ -86,7 +85,7 @@ def test_quota_event_xml(
     event_type_name = event_type_name.lower()
     if event_type_name == "closed":
         event_type_name = "closed.and.transferred"
-    tag = f"quota.{event_type_name}.event"
+    tag = f"oub:quota.{event_type_name}.event"
 
     @validate_taric_xml(
         instance=factories.QuotaEventFactory.create(
@@ -95,7 +94,7 @@ def test_quota_event_xml(
         ),
     )
     def test_event_type(xml):
-        element = xml.find(f".//{tag}", xml.nsmap)
+        element = xml.find(f".//{tag}", nsmap)
         assert element is not None
 
-    test_event_type(api_client, taric_schema, approved_transaction, valid_user)
+    test_event_type(valid_user_api_client, taric_schema, approved_transaction)

--- a/settings/common.py
+++ b/settings/common.py
@@ -392,6 +392,10 @@ LOGGING = {
             "level": os.environ.get("LOG_LEVEL", "DEBUG"),
             "propagate": False,
         },
+        "common.paths": {
+            "handlers": [],
+            "propagate": DEBUG is True,
+        },
         "footnotes": {
             "handlers": ["console"],
             "level": os.environ.get("LOG_LEVEL", "DEBUG"),


### PR DESCRIPTION
## Why
<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Use as many lines as you like.
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions or deliberately ignored edge-cases.
--->
As part of our operational process to keep Production in line with data changes made on engineer machines, it is sometimes necessary to manually renumber or filter TARIC XML files to avoid data created on Production clashing on auto-picked ID numbers.

## What
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Explain like I'm 5.
 * Use pictures if you can.
--->
This PR adds three new tools (`renumber_records`, `renumber_transactions` and `filter_transactions`) that can be run against XML files, and tests for them.

<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
## Checklist
- Requires migrations?
- Requires dependency updates?
--->

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
