### PR TITLE
New content to be added to the start page of the Create Measures journey

### DIFF
--- a/measures/jinja2/measures/create-start.jinja
+++ b/measures/jinja2/measures/create-start.jinja
@@ -4,7 +4,29 @@
 
 {% block form %}
   <p class="govuk-body">
-    It is essential to plan your activities in advance of using this measure creation functionality.
+    Before you start, you'll need:
+    <ul class="govuk-list govuk-list--bullet">
+      <li>the measure type</li>
+      <li>the measure start date</li>
+      <li>the measure end date (if there is one)</li>
+    </ul>
+  </p>
+
+  <p class="govuk-body">
+    You'll also need to use the 
+      <a class="govuk-link" href="{{ url("index") }}">
+        manage trade tariffs service  
+      </a>
+    to find or create details of the following:
+    <ul class="govuk-list govuk-list--bullet">
+      <li>the geographical area the measure applies to</li>
+      <li>the regulation ID</li>
+      <li>the 10-digit commodity code or codes the measure applies to</li>
+      <li>the duty which applies to the measure</li>
+      <li>any additional code</li>
+      <li>any condition codes</li>
+      <li>any footnotes</li>
+    </ul>
   </p>
   {{ govukButton({"text": "Start now", "isStartButton": True}) }}
 {% endblock %}


### PR DESCRIPTION
# TP2000-256 New content to be added to the start page of the Create Measures journey

## Why
This PR adds additional text to the create measures start page in order to inform a user of the information they need in order to create a measure. 

This will prevent users from partially completing the form, only to find that they have to go back and lose all their work as they've missed an important piece of data, or didn't create something they needed for this process first. 

Due to the nature of the tool not having drafts, or versioning for creating a measure, the next most appropriate measure is to ensure that the user is adequately prepared to complete this process in one sitting. 

## What
This PR adds text to the page to highlight what information is needed to create a measure. It goes from looking like this: 

<img width="1246" alt="Screenshot 2022-04-21 at 11 55 09" src="https://user-images.githubusercontent.com/46787754/164465632-a6ea7868-1661-472c-9d81-e13f97a8958d.png">

...To looking like this: 

<img width="1246" alt="Screenshot 2022-04-21 at 11 55 09" src="https://user-images.githubusercontent.com/46787754/164465709-7e9292da-4931-4409-8013-2a9b4b020d97.png">


