### PR TITLE
Amend code in the MeasureSheetRowFactory to include missing argument

### DIFF
--- a/measures/tests/factories.py
+++ b/measures/tests/factories.py
@@ -31,11 +31,15 @@ class MeasureSheetRowFactory(factory.Factory):
     measure_type_description = factory.SelfAttribute("measure.measure_type.description")
     duty_sentence = factory.sequence(lambda n: f"{n}.00%")
     origin_description = factory.LazyAttribute(
-        lambda m: m.measure.geographical_area.get_description().description,
+        lambda m: m.measure.geographical_area.get_description(
+            transaction=m.measure.geographical_area.transaction,
+        ).description,
     )
     excluded_origin_descriptions = factory.LazyAttribute(
         lambda m: random.choice(MeasureSheetRow.separators).join(
-            e.excluded_geographical_area.get_description().description
+            e.excluded_geographical_area.get_description(
+                transaction=e.excluded_geographical_area.transaction,
+            ).description
             for e in m.measure.exclusions.all()
         ),
     )


### PR DESCRIPTION
# TP2000-263 Amend code in the MeasureSheetRowFactory to include missing argument

## Why
The `test_measure_sheet_importer` test has been failing recently on the CI. Gabe had included a fix on his PR, however, hir PR is not ready to merge yet. This PR is literally just taking that fix and putting it in a separate PR.

## What
The tests are failing due to the row missing a geographical area description. The MeasureSheetRowFactory which is a function that makes fake measures sheet rows for us for use in tests is not giving a description or excluded descriptions. This is because the function that goes and gets the descriptions, doesn't have the transaction argument it needs. 

This code just gives it that. 
