### PR TITLE
TP2000-195 Users can get a 500 error if they fail to select a geographical area

### DIFF
--- a/geo_areas/forms.py
+++ b/geo_areas/forms.py
@@ -138,6 +138,9 @@ class GeographicalAreaFormMixin(forms.Form):
         self.fields["geo_group"].initial = geo_group.pk if geo_group else None
         self.fields["geo_area"].initial = geo_area.pk if geo_area else None
 
+        if not cleaned_data["geographical_area"]:
+            raise ValidationError("A Geographical area must be selected")
+
         return cleaned_data
 
 

--- a/measures/tests/test_forms.py
+++ b/measures/tests/test_forms.py
@@ -38,7 +38,7 @@ def test_error_raised_if_no_duty_sentence(session_with_workbasket):
         MeasureForm(data={}, instance=measure, request=session_with_workbasket)
 
 
-def test_measure_forms_details_valid_data(measure_type, regulation):
+def test_measure_forms_details_valid_data(measure_type, regulation, erga_omnes):
     data = {
         "measure_type": measure_type.pk,
         "generating_regulation": regulation.pk,
@@ -46,6 +46,7 @@ def test_measure_forms_details_valid_data(measure_type, regulation):
         "start_date_0": 2,
         "start_date_1": 4,
         "start_date_2": 2021,
+        "geographical_area": erga_omnes.pk,
     }
     form = forms.MeasureDetailsForm(data, prefix="")
     assert form.is_valid()
@@ -69,7 +70,7 @@ def test_measure_forms_details_invalid_data():
     assert not form.is_valid()
 
 
-def test_measure_forms_details_invalid_date_range(measure_type, regulation):
+def test_measure_forms_details_invalid_date_range(measure_type, regulation, erga_omnes):
     data = {
         "measure_type": measure_type.pk,
         "generating_regulation": regulation.pk,
@@ -77,6 +78,7 @@ def test_measure_forms_details_invalid_date_range(measure_type, regulation):
         "start_date_0": 1,
         "start_date_1": 1,
         "start_date_2": 2000,
+        "geographical_area": erga_omnes.pk,
     }
     form = forms.MeasureDetailsForm(data, prefix="")
     # In the real wizard view the prefix will be populated with the name of the form. It's left blank here to make the mock form data simpler


### PR DESCRIPTION
# TP2000-195 Users can get a 500 error if they fail to select a geographical area

## Why
Currently users can go through the create measure journey without selecting a geographical area in the measure details form. This causes a 500 on the summary page when trying to render the geographical area's description.

## What
- Add a validation error on the measure details form when a user hasn't selected a geographical area
- Updates tests to include a default erga omnes value


## Checklist
- Requires migrations? No
- Requires dependency updates? No


