### PR TITLE
Make XML record renumbering be aware of records.

### DIFF
--- a/importer/management/commands/renumber_taric.py
+++ b/importer/management/commands/renumber_taric.py
@@ -11,12 +11,22 @@ class Command(BaseCommand):
         parser.add_argument("file", type=str, help="The XML file to renumber, in place")
         parser.add_argument("number", type=int, help="The number to start from")
         parser.add_argument(
-            "tag",
+            "record",
             type=str,
-            help="TARIC tag name to renumber, with XML namespace",
+            help="TARIC record name to renumber, with XML namespace",
+        )
+        parser.add_argument(
+            "attribute",
+            type=str,
+            help="TARIC record attribute to renumber, with XML namespace",
         )
         return super().add_arguments(parser)
 
     def handle(self, *args, **options):
         with rewrite(options["file"]) as root:
-            renumber_records(root, options["number"], options["tag"])
+            renumber_records(
+                root,
+                options["number"],
+                options["record"],
+                options["attribute"],
+            )


### PR DESCRIPTION
## Why
There is a bug in the XML renumbering tools that incorrectly renumbers IDs in records that are CREATEs but that don't actually use the given ID as an identifier and instead use it a foreign key.

For example, if a file updates a measure by CREATEing a `MeasureComponent`, the script will interpret the creation of the component as a new measure and renubmer the SID. Instead, it should ignore it.

## What
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Explain like I'm 5.
 * Use pictures if you can.
--->
This commit adds a parameter to the renumbering function that is the name of the TARIC record that the ID refers to. Only records of that type that are CREATED will cause renumbering to happen.

<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
## Checklist
- Requires migrations?
- Requires dependency updates?
--->

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
