### PR TITLE
Geo areas form and measure edit form very slow 

### DIFF
--- a/geo_areas/tests/test_util.py
+++ b/geo_areas/tests/test_util.py
@@ -1,0 +1,25 @@
+import pytest
+
+from common.tests import factories
+from geo_areas import models
+from geo_areas import util
+
+pytestmark = pytest.mark.django_db
+
+
+def test_with_description_returns_empty_string():
+    factories.GeographicalAreaDescriptionFactory.create(description=None)
+    geo_area = util.with_description_string(
+        models.GeographicalArea.objects.all(),
+    ).first()
+
+    assert geo_area.description == ""
+
+
+def test_with_description_returns_description_string():
+    factories.GeographicalAreaDescriptionFactory.create(description="Guernsey")
+    geo_area = util.with_description_string(
+        models.GeographicalArea.objects.all(),
+    ).first()
+
+    assert geo_area.description == "Guernsey"

--- a/geo_areas/util.py
+++ b/geo_areas/util.py
@@ -1,0 +1,17 @@
+from django.db import models
+
+
+def with_description_string(qs):
+    """If a description object has no description value, return an empty string,
+    else return description value."""
+    return qs.annotate(
+        description=models.Case(
+            models.When(
+                descriptions__description__isnull=True,
+                then=models.Value(""),
+            ),
+            default=models.F(
+                "descriptions__description",
+            ),
+        ),
+    )

--- a/measures/forms.py
+++ b/measures/forms.py
@@ -27,6 +27,7 @@ from footnotes.models import Footnote
 from geo_areas.forms import GeographicalAreaFormMixin
 from geo_areas.forms import GeographicalAreaSelect
 from geo_areas.models import GeographicalArea
+from geo_areas.util import with_description_string
 from measures import models
 from measures.parsers import DutySentenceParser
 from measures.patterns import MeasureCreationPattern
@@ -289,16 +290,20 @@ class MeasureForm(ValidityPeriodForm):
         required=False,
     )
     geographical_area_group = forms.ModelChoiceField(
-        queryset=GeographicalArea.objects.filter(
-            area_code=1,
+        queryset=with_description_string(
+            GeographicalArea.objects.filter(
+                area_code=1,
+            ),
         ),
         required=False,
         widget=forms.Select(attrs={"class": "govuk-select"}),
         empty_label=None,
     )
     geographical_area_country_or_region = forms.ModelChoiceField(
-        queryset=GeographicalArea.objects.exclude(
-            area_code=1,
+        queryset=with_description_string(
+            GeographicalArea.objects.exclude(
+                area_code=1,
+            ),
         ),
         widget=forms.Select(attrs={"class": "govuk-select"}),
         required=False,
@@ -324,9 +329,7 @@ class MeasureForm(ValidityPeriodForm):
         self.initial_geographical_area = self.instance.geographical_area
 
         for field in ["geographical_area_group", "geographical_area_country_or_region"]:
-            self.fields[
-                field
-            ].label_from_instance = lambda obj: obj.structure_description
+            self.fields[field].label_from_instance = lambda obj: obj.description
 
         if self.instance.geographical_area.is_group():
             self.fields[


### PR DESCRIPTION
# TP2000-299 Geo areas form and measure edit form very slow 
<!---
 * Include the JIRA ticket number, eg TP-123, to automatically link.
 * Use 50 characters maximum.
 * Do not end with a full-stop.
--->

## Why
<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Use as many lines as you like.
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions or deliberately ignored edge-cases.
--->
Loading the geo areas step of the wizard or the measure edit form currently takes ~8 seconds. With this change it takes about 1 or 2 secs

## What
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Explain like I'm 5.
 * Use pictures if you can.
--->
Adds annotation to geo area queries, so that we no longer have to use the `structure_description` property, which runs over 300 queries when calling `descriptions.last()`

<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
## Checklist
- Requires migrations? No
- Requires dependency updates? No
--->

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
