### PR TITLE
geo-area-error-on-measure-create-summary

### DIFF
--- a/measures/jinja2/measures/create-review.jinja
+++ b/measures/jinja2/measures/create-review.jinja
@@ -56,10 +56,15 @@
     {{ rows.extend([
       ("Measure type", data["measure_type"] ~ " - " ~ data["measure_type"].description),
       ("Regulation ID", data["generating_regulation"]),
-      ("Geographical area", data["geographical_area"].get_description().description|safe),
       ("Quota order number", data["order_number"]),
       ("Measure start date", "{:%d/%m/%Y}".format(data["valid_between"].lower) if data["valid_between"] and data["valid_between"].lower else "-"),
       ("Measure end date", "{:%d/%m/%Y}".format(data["valid_between"].upper) if data["valid_between"] and data["valid_between"].upper else "-"),
+    ]) }}
+  {% endcall %}
+  
+  {% call(rows, data) review_step("geographical_area") %}
+    {{ rows.extend([
+      ("Geographical area", data["geographical_area"].get_description().description|safe),
     ]) }}
   {% endcall %}
 


### PR DESCRIPTION
<!---
 * Include the JIRA ticket number, eg TP-123, to automatically link.
 * Use 50 characters maximum.
 * Do not end with a full-stop.
--->
## Why
<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Use as many lines as you like.
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions or deliberately ignored edge-cases.
--->
We're seeing a 500 on measure create summary page because the measure details section of the page still expects to find a geographical_area field, even though this has now been moved to a separate page

## What
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Explain like I'm 5.
 * Use pictures if you can.
--->
Updates jinja to include geographical_area as part of a separate step

<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
## Checklist
- Requires migrations? No
- Requires dependency updates? No
--->

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
