### PR TITLE
TP2000-309 GeographicalArea.MultipleObjectsReturned error on measure edit form

### DIFF
--- a/geo_areas/forms.py
+++ b/geo_areas/forms.py
@@ -7,7 +7,7 @@ from common.forms import CreateDescriptionForm
 from common.forms import delete_form_for
 from geo_areas.models import GeographicalArea
 from geo_areas.models import GeographicalAreaDescription
-from geo_areas.util import with_description_string
+from geo_areas.util import with_latest_description_string
 from geo_areas.validators import AreaCode
 
 
@@ -75,7 +75,7 @@ class GeographicalAreaFormMixin(forms.Form):
         self.transaction = tx
         super().__init__(*args, **kwargs)
 
-        self.fields["geo_group"].queryset = with_description_string(
+        self.fields["geo_group"].queryset = with_latest_description_string(
             GeographicalArea.objects.filter(
                 area_code=AreaCode.GROUP,
             )
@@ -90,7 +90,7 @@ class GeographicalAreaFormMixin(forms.Form):
         # self.fields[
         #     "geo_group_exclusions"
         # ].queryset = GeographicalArea.objects.approved_up_to_transaction(tx)
-        self.fields["geo_area"].queryset = with_description_string(
+        self.fields["geo_area"].queryset = with_latest_description_string(
             GeographicalArea.objects.exclude(
                 area_code=AreaCode.GROUP,
                 descriptions__description__isnull=True,

--- a/geo_areas/tests/test_util.py
+++ b/geo_areas/tests/test_util.py
@@ -1,3 +1,6 @@
+from datetime import datetime
+from datetime import timedelta
+
 import pytest
 
 from common.tests import factories
@@ -7,10 +10,29 @@ from geo_areas import util
 pytestmark = pytest.mark.django_db
 
 
-def test_with_description_returns_description_string():
+def test_with_latest_description_returns_description_string():
     factories.GeographicalAreaDescriptionFactory.create(description="Guernsey")
-    geo_area = util.with_description_string(
+    geo_area = util.with_latest_description_string(
         models.GeographicalArea.objects.all(),
     ).first()
 
     assert geo_area.description == "Guernsey"
+
+
+def test_with_latest_description_multiple_descriptions():
+    """Tests that when a GeographicalArea has more than one description, the
+    description with a later validity_start date is used to generate the
+    description string."""
+    area = factories.GeographicalAreaFactory.create()
+    earlier_description = factories.GeographicalAreaDescriptionFactory.create(
+        validity_start=datetime.today(),
+        described_geographicalarea=area,
+    )
+    later_description = factories.GeographicalAreaDescriptionFactory.create(
+        validity_start=datetime.today() + timedelta(days=1),
+        described_geographicalarea=area,
+    )
+    qs = util.with_latest_description_string(models.GeographicalArea.objects.all())
+
+    assert qs.count() == 1
+    assert later_description.description == qs.first().description

--- a/geo_areas/util.py
+++ b/geo_areas/util.py
@@ -1,11 +1,15 @@
 from django.db import models
 
 
-def with_description_string(qs):
+def with_latest_description_string(qs):
     """Returns a queryset annotated with description object's description field
     value."""
-    return qs.annotate(
-        description=models.F(
-            "descriptions__description",
-        ),
+    return (
+        qs.annotate(latest_date=models.Max("descriptions__validity_start"))
+        .filter(descriptions__validity_start=models.F("latest_date"))
+        .annotate(
+            description=models.F(
+                "descriptions__description",
+            ),
+        )
     )

--- a/geo_areas/util.py
+++ b/geo_areas/util.py
@@ -2,11 +2,12 @@ from django.db import models
 
 
 def with_latest_description_string(qs):
-    """Returns a queryset annotated with description object's description field
-    value."""
+    """Returns a queryset annotate with its latest description's validity_start
+    date, filtered by this date and then annotated with that latest description
+    object's description field value."""
     return (
-        qs.annotate(latest_date=models.Max("descriptions__validity_start"))
-        .filter(descriptions__validity_start=models.F("latest_date"))
+        qs.annotate(latest_description_date=models.Max("descriptions__validity_start"))
+        .filter(descriptions__validity_start=models.F("latest_description_date"))
         .annotate(
             description=models.F(
                 "descriptions__description",

--- a/manage.py
+++ b/manage.py
@@ -13,8 +13,6 @@ def main():
         "DJANGO_SETTINGS_MODULE",
         "settings.test" if in_test else "settings.dev" if in_dev else "settings",
     )
-    print(in_test, in_dev)
-    print(os.environ.get("DJANGO_SETTINGS_MODULE"))
     try:
         from django.core.management import execute_from_command_line
     except ImportError as exc:

--- a/measures/forms.py
+++ b/measures/forms.py
@@ -27,7 +27,7 @@ from footnotes.models import Footnote
 from geo_areas.forms import GeographicalAreaFormMixin
 from geo_areas.forms import GeographicalAreaSelect
 from geo_areas.models import GeographicalArea
-from geo_areas.util import with_description_string
+from geo_areas.util import with_latest_description_string
 from measures import models
 from measures.parsers import DutySentenceParser
 from measures.patterns import MeasureCreationPattern
@@ -290,20 +290,19 @@ class MeasureForm(ValidityPeriodForm):
         required=False,
     )
     geographical_area_group = forms.ModelChoiceField(
-        queryset=with_description_string(
+        queryset=with_latest_description_string(
             GeographicalArea.objects.filter(
                 area_code=1,
-            ).exclude(descriptions__description__isnull=True),
+            ),
         ),
         required=False,
         widget=forms.Select(attrs={"class": "govuk-select"}),
         empty_label=None,
     )
     geographical_area_country_or_region = forms.ModelChoiceField(
-        queryset=with_description_string(
+        queryset=with_latest_description_string(
             GeographicalArea.objects.exclude(
                 area_code=1,
-                descriptions__description__isnull=True,
             ),
         ),
         widget=forms.Select(attrs={"class": "govuk-select"}),
@@ -336,7 +335,7 @@ class MeasureForm(ValidityPeriodForm):
                 .approved_up_to_transaction(tx)
                 .with_latest_links("descriptions")
                 .prefetch_related("descriptions")
-                .order_by("description")
+                .order_by("descriptions__description")
             )
             self.fields[field].label_from_instance = lambda obj: obj.description
 


### PR DESCRIPTION
# TP2000-309 GeographicalArea.MultipleObjectsReturned error on measure edit form
<!---
 * Include the JIRA ticket number, eg TP-123, to automatically link.
 * Use 50 characters maximum.
 * Do not end with a full-stop.
--->

## Why
<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Use as many lines as you like.
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions or deliberately ignored edge-cases.
--->
Currently `with_description_string` returns a queryset with duplicate geographical areas where a geographical area has more than one associated description. The old logic which used `structure_description` and was [replaced in this PR](https://github.com/uktrade/tamato/pull/548) accounted for this by calling `descriptions.last()` but this was really expensive in terms of SQL queries and made the page too slow. 

## What
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Explain like I'm 5.
 * Use pictures if you can.
--->
- Renames `with_description_string` to `with_latest_description_string` and adds filtering logic to return only the latest descriptions by `validity_start_date`. (I know we don't normally annotate and filter in `with` methods, but I think the annotation by itself isn't something we want anywhere)
- Adds test for this multiple description scenario
- Updates edit form geo area querysets to match create wizard querysets

<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
## Checklist
- Requires migrations? No
- Requires dependency updates? No
--->

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
