### PR TITLE
TP2000 242 build create certificate form

### DIFF
--- a/certificates/forms.py
+++ b/certificates/forms.py
@@ -68,15 +68,11 @@ class CertificateCreateForm(ValidityPeriodForm):
     def save(self, commit=True):
         instance = super(CertificateCreateForm, self).save(commit=False)
 
-        workbasket = WorkBasket.current(self.request)
-        tx = None
-        if workbasket:
-            tx = workbasket.transactions.order_by("order").last()
-
+        current_transaction = WorkBasket.get_current_transaction(self.request)
         instance.sid = get_next_id(
             models.Certificate.objects.filter(
                 certificate_type__sid=instance.certificate_type.sid,
-            ).approved_up_to_transaction(tx),
+            ).approved_up_to_transaction(current_transaction),
             instance._meta.get_field("sid"),
             max_len=3,
         )

--- a/certificates/forms.py
+++ b/certificates/forms.py
@@ -52,21 +52,13 @@ class CertificateCreateForm(ValidityPeriodForm):
             Submit("submit", "Save"),
         )
 
-    def clean(self):
-        cleaned_data = super().clean()
-
-        if self.errors:
-            return cleaned_data
-
-        cleaned_data["certificate_description"] = models.CertificateDescription(
-            description=cleaned_data["description"],
-            validity_start=cleaned_data["valid_between"].lower,
-        )
-
-        return cleaned_data
-
     def save(self, commit=True):
         instance = super(CertificateCreateForm, self).save(commit=False)
+
+        self.cleaned_data["certificate_description"] = models.CertificateDescription(
+            description=self.cleaned_data["description"],
+            validity_start=self.cleaned_data["valid_between"].lower,
+        )
 
         current_transaction = WorkBasket.get_current_transaction(self.request)
         instance.sid = get_next_id(

--- a/certificates/forms.py
+++ b/certificates/forms.py
@@ -22,14 +22,14 @@ class CertificateCreateForm(ValidityPeriodForm):
 
     certificate_type = forms.ModelChoiceField(
         label="Certificate type",
-        help_text="Some sort of help text will go here",
+        help_text="Selecting the right certificate type will determine whether it can be associated with measures, commodity codes, or both",
         queryset=models.CertificateType.objects.latest_approved(),
         empty_label="Select a certificate type",
     )
 
     description = forms.CharField(
         label="Certificate description",
-        help_text="Some sort of help text will go here.",
+        help_text="You may enter HTML formatting if required. See the guide below for more information.",
         widget=forms.Textarea,
     )
 

--- a/certificates/forms.py
+++ b/certificates/forms.py
@@ -10,11 +10,88 @@ from django.core.exceptions import ValidationError
 from certificates import models
 from common.forms import CreateDescriptionForm
 from common.forms import DescriptionForm
+from common.forms import DescriptionHelpBox
 from common.forms import ValidityPeriodForm
 from common.forms import delete_form_for
+from common.util import get_next_id
+from workbaskets.models import WorkBasket
+
+
+class CertificateCreateForm(ValidityPeriodForm):
+    """The form for creating a new certificate."""
+
+    certificate_type = forms.ModelChoiceField(
+        label="Certificate type",
+        help_text="Some sort of help text will go here",
+        queryset=models.CertificateType.objects.latest_approved(),
+        empty_label="Select a certificate type",
+    )
+
+    description = forms.CharField(
+        label="Certificate description",
+        help_text="Some sort of help text will go here.",
+        widget=forms.Textarea,
+    )
+
+    def __init__(self, *args, **kwargs):
+        self.request = kwargs.pop("request", None)
+        super().__init__(*args, **kwargs)
+
+        self.fields[
+            "certificate_type"
+        ].label_from_instance = lambda obj: f"{obj.sid} - {obj.description}"
+
+        self.helper = FormHelper(self)
+        self.helper.label_size = Size.SMALL
+        self.helper.legend_size = Size.SMALL
+        self.helper.layout = Layout(
+            "certificate_type",
+            "start_date",
+            Field.textarea("description", rows=5),
+            DescriptionHelpBox(),
+            Submit("submit", "Save"),
+        )
+
+    def clean(self):
+        cleaned_data = super().clean()
+
+        if self.errors:
+            return cleaned_data
+
+        cleaned_data["certificate_description"] = models.CertificateDescription(
+            description=cleaned_data["description"],
+            validity_start=cleaned_data["valid_between"].lower,
+        )
+
+        return cleaned_data
+
+    def save(self, commit=True):
+        instance = super(CertificateCreateForm, self).save(commit=False)
+
+        workbasket = WorkBasket.current(self.request)
+        tx = None
+        if workbasket:
+            tx = workbasket.transactions.order_by("order").last()
+
+        instance.sid = get_next_id(
+            models.Certificate.objects.filter(
+                certificate_type__sid=instance.certificate_type.sid,
+            ).approved_up_to_transaction(tx),
+            instance._meta.get_field("sid"),
+            max_len=3,
+        )
+        if commit:
+            instance.save()
+        return instance
+
+    class Meta:
+        model = models.Certificate
+        fields = ("certificate_type", "valid_between")
 
 
 class CertificateForm(ValidityPeriodForm):
+    """The form for editing a certificate."""
+
     code = forms.CharField(
         label="Certificate ID",
         required=False,

--- a/certificates/jinja2/certificates/create.jinja
+++ b/certificates/jinja2/certificates/create.jinja
@@ -1,0 +1,3 @@
+{% extends "layouts/create.jinja" %}
+
+{% set page_title = "Create a new certificate" %}

--- a/certificates/tests/test_forms.py
+++ b/certificates/tests/test_forms.py
@@ -1,0 +1,76 @@
+import datetime
+
+import factory
+import pytest
+from dateutil.relativedelta import relativedelta
+from django.core.exceptions import ValidationError
+
+from certificates import forms
+from certificates import models
+from common.tests import factories
+from common.tests.util import date_post_data
+from common.tests.util import raises_if
+from common.tests.util import validity_period_post_data
+from common.util import TaricDateRange
+
+pytestmark = pytest.mark.django_db
+
+
+def test_form_save_creates_new_certificate_sid_and_certificate_type_sid_combo(
+    session_with_workbasket,
+):
+    """Tests that two certificates of the same type are created with different
+    sid's."""
+
+    certificate_type = factories.CertificateTypeFactory.create()
+    valid_between = TaricDateRange(
+        datetime.date(2021, 1, 1),
+        datetime.date(2021, 12, 1),
+    )
+    certificate_a = factories.CertificateFactory.create(
+        certificate_type=certificate_type,
+        valid_between=valid_between,
+        sid="001",
+    )
+
+    data = {
+        "certificate_type": certificate_type.pk,
+        "start_date_0": 2,
+        "start_date_1": 2,
+        "start_date_2": 2022,
+        "description": "A participation certificate",
+    }
+    form = forms.CertificateCreateForm(data=data, request=session_with_workbasket)
+    certificate_b = form.save(commit=False)
+
+    assert certificate_a.sid != certificate_b.sid
+
+
+@pytest.mark.parametrize(
+    ("new_data", "expected_valid"),
+    (
+        (lambda data: {}, False),
+        (
+            lambda data: {
+                "description": "Test description",
+                "certificate_type": "Z",
+                "valid_between": validity_period_post_data(
+                    datetime.date.today(),
+                    datetime.date.today() + relativedelta(months=+1),
+                ),
+                **date_post_data("start_date", datetime.date.today()),
+                **factory.build(
+                    dict,
+                    sid="001",
+                    certificate_type=factories.CertificateTypeFactory.create().pk,
+                    description=factories.CertificateDescriptionFactory.create().pk,
+                    FACTORY_CLASS=factories.CertificateFactory,
+                ),
+            },
+            True,
+        ),
+    ),
+)
+def test_certificate_create_form(use_create_form, new_data, expected_valid):
+    with raises_if(ValidationError, not expected_valid):
+        use_create_form(models.Certificate, new_data)

--- a/certificates/tests/test_forms.py
+++ b/certificates/tests/test_forms.py
@@ -1,16 +1,9 @@
 import datetime
 
-import factory
 import pytest
-from dateutil.relativedelta import relativedelta
-from django.core.exceptions import ValidationError
 
 from certificates import forms
-from certificates import models
 from common.tests import factories
-from common.tests.util import date_post_data
-from common.tests.util import raises_if
-from common.tests.util import validity_period_post_data
 from common.util import TaricDateRange
 
 pytestmark = pytest.mark.django_db
@@ -51,39 +44,27 @@ def test_form_save_creates_new_certificate(
     assert certificate_b.sid == "002"
 
 
-@pytest.mark.parametrize(
-    ("new_data", "expected_valid"),
-    (
-        (lambda data: {}, False),
-        (
-            lambda data: {
-                "description": "Test description",
-                "certificate_type": "Z",
-                "valid_between": validity_period_post_data(
-                    datetime.date.today(),
-                    datetime.date.today() + relativedelta(months=+1),
-                ),
-                **date_post_data("start_date", datetime.date.today()),
-                **factory.build(
-                    dict,
-                    sid="001",
-                    certificate_type=factories.CertificateTypeFactory.create().pk,
-                    description=factories.CertificateDescriptionFactory.create().pk,
-                    FACTORY_CLASS=factories.CertificateFactory,
-                ),
-            },
-            True,
-        ),
-    ),
-)
-def test_certificate_create_form(use_create_form, new_data, expected_valid):
-    """
-    Tests that if invalid data is passed to the create certificate form, a
-    validation error is raised.
+def test_certificate_create_form_validates_data(session_with_workbasket):
+    """A test to check that the create form validates data and ciphers out
+    incorrect submissions."""
 
-    In this particular test, the first test case is empty, and we assign
-    "expected_valid" to be false. The second test case passes in valid data, and
-    we assign "expected_valid" to be true.
-    """
-    with raises_if(ValidationError, not expected_valid):
-        use_create_form(models.Certificate, new_data)
+    certificate_data = {
+        "certificate_type": "I am not right",
+        "start_date_0": 2,
+        "start_date_1": 13,
+        "start_date_2": 2022,
+        "description": "A participation certificate",
+    }
+    form = forms.CertificateCreateForm(
+        data=certificate_data,
+        request=session_with_workbasket,
+    )
+    error_string = [
+        "Select a valid choice. That choice is not one of the available choices.",
+    ]
+    date_error_string = [
+        "Month must be in 1..12",
+    ]
+    assert form.errors["certificate_type"] == error_string
+    assert form.errors["start_date"] == date_error_string
+    assert not form.is_valid()

--- a/certificates/tests/test_forms.py
+++ b/certificates/tests/test_forms.py
@@ -44,6 +44,49 @@ def test_form_save_creates_new_certificate(
     assert certificate_b.sid == "002"
 
 
+def test_certificate_type_does_not_increment_id(
+    session_with_workbasket,
+):
+    """Tests that when two certificates are made with different types, the sids
+    are not incremented."""
+
+    certificate_type_a = factories.CertificateTypeFactory.create()
+    certificate_type_b = factories.CertificateTypeFactory.create()
+
+    certificates = [
+        {
+            "certificate_type": certificate_type_a.pk,
+            "start_date_0": 2,
+            "start_date_1": 2,
+            "start_date_2": 2022,
+            "description": "certificate 1",
+        },
+        {
+            "certificate_type": certificate_type_b.pk,
+            "start_date_0": 2,
+            "start_date_1": 2,
+            "start_date_2": 2022,
+            "description": "certificate 2",
+        },
+    ]
+    completed_certificates = []
+
+    for certificate in certificates:
+        form = forms.CertificateCreateForm(
+            data=certificate,
+            request=session_with_workbasket,
+        )
+        saved_certificate = form.save(commit=False)
+        completed_certificates.append(saved_certificate)
+
+    assert (
+        completed_certificates[0].certificate_type
+        != completed_certificates[1].certificate_type
+    )
+    assert completed_certificates[0].sid == "001"
+    assert completed_certificates[1].sid == "001"
+
+
 def test_certificate_create_form_validates_data(session_with_workbasket):
     """A test to check that the create form validates data and ciphers out
     incorrect submissions."""

--- a/certificates/tests/test_views.py
+++ b/certificates/tests/test_views.py
@@ -1,6 +1,9 @@
-import pytest
+import datetime
 
-from certificates.models import Certificate
+import pytest
+from django.urls import reverse
+
+from certificates import models
 from certificates.views import CertificateList
 from common.tests import factories
 from common.tests.util import assert_model_view_renders
@@ -19,6 +22,33 @@ def test_certificate_delete(factory, use_delete_form):
     use_delete_form(factory())
 
 
+def test_certificate_create_form_creates_certificate_description_object(
+    valid_user_api_client,
+):
+
+    # Post a form
+    create_url = reverse("certificate-ui-create")
+
+    certificate_type = factories.CertificateTypeFactory.create()
+    form_data = {
+        "certificate_type": certificate_type.pk,
+        "start_date_0": 2,
+        "start_date_1": 2,
+        "start_date_2": 2022,
+        "description": "A participation certificate",
+    }
+
+    valid_user_api_client.post(create_url, form_data)
+    #  get the certificate we have made, and the certificate description matching our description on the form
+    certificate = models.Certificate.objects.all()[0]
+    certificate_description = models.CertificateDescription.objects.filter(
+        description=form_data["description"],
+    )[0]
+
+    assert certificate.sid == certificate_description.described_certificate.sid
+    assert certificate_description.validity_start == datetime.date(2022, 2, 2)
+
+
 @pytest.mark.parametrize(
     ("view", "url_pattern"),
     get_class_based_view_urls_matching_url(
@@ -30,7 +60,9 @@ def test_certificate_delete(factory, use_delete_form):
 def test_certificate_detail_views(view, url_pattern, valid_user_client):
     """Verify that certificate detail views are under the url certificates/ and
     don't return an error."""
-    model_overrides = {"certificates.views.CertificateDescriptionCreate": Certificate}
+    model_overrides = {
+        "certificates.views.CertificateDescriptionCreate": models.Certificate,
+    }
 
     assert_model_view_renders(view, url_pattern, valid_user_client, model_overrides)
 

--- a/certificates/views.py
+++ b/certificates/views.py
@@ -71,6 +71,7 @@ class CertificateList(CertificateMixin, TamatoListView):
 
 
 class CertificateCreate(DraftCreateView):
+    """UI endpoint for creating Certificates."""  # /PS-IGNORE
 
     template_name = "certificates/create.jinja"
     form_class = forms.CertificateCreateForm

--- a/certificates/views.py
+++ b/certificates/views.py
@@ -1,5 +1,7 @@
 from typing import Type
 
+from django.db import transaction
+from django.http import HttpResponseRedirect
 from rest_framework import permissions
 from rest_framework import viewsets
 
@@ -11,6 +13,7 @@ from certificates.filters import CertificateFilterBackend
 from certificates.serializers import CertificateTypeSerializer
 from common.models import TrackedModel
 from common.serializers import AutoCompleteSerializer
+from common.validators import UpdateType
 from common.views import TamatoListView
 from common.views import TrackedModelDetailMixin
 from common.views import TrackedModelDetailView
@@ -65,6 +68,37 @@ class CertificateList(CertificateMixin, TamatoListView):
         "sid",
         "descriptions__description",
     ]
+
+
+class CertificateCreate(DraftCreateView):
+
+    template_name = "certificates/create.jinja"
+    form_class = forms.CertificateCreateForm
+
+    @transaction.atomic
+    def form_valid(self, form):
+        transaction = self.get_transaction()
+        transaction.save()
+        self.object = form.save(commit=False)
+        self.object.update_type = UpdateType.CREATE
+        self.object.transaction = transaction
+        self.object.save()
+
+        description = form.cleaned_data["certificate_description"]
+        description.described_certificate = self.object
+        description.update_type = UpdateType.CREATE
+        description.transaction = transaction
+        description.save()
+        return HttpResponseRedirect(self.get_success_url())
+
+    def get_form_kwargs(self):
+        kwargs = super().get_form_kwargs()
+        kwargs["request"] = self.request
+        return kwargs
+
+
+class CertificateConfirmCreate(CertificateMixin, TrackedModelDetailView):
+    template_name = "common/confirm_create.jinja"
 
 
 class CertificateDetail(CertificateMixin, TrackedModelDetailView):

--- a/certificates/views.py
+++ b/certificates/views.py
@@ -1,7 +1,6 @@
 from typing import Type
 
 from django.db import transaction
-from django.http import HttpResponseRedirect
 from rest_framework import permissions
 from rest_framework import viewsets
 
@@ -90,7 +89,7 @@ class CertificateCreate(DraftCreateView):
         description.update_type = UpdateType.CREATE
         description.transaction = transaction
         description.save()
-        return HttpResponseRedirect(self.get_success_url())
+        return super().form_valid(form)
 
     def get_form_kwargs(self):
         kwargs = super().get_form_kwargs()

--- a/common/jinja2/common/index.jinja
+++ b/common/jinja2/common/index.jinja
@@ -41,6 +41,11 @@
     <div class="govuk-grid-column-one-quarter">
       <h2 class="govuk-heading-m">Certificates</h2>
       <ul class="govuk-list">
+      <li>
+          <a class="govuk-link" href="{{ url('certificate-ui-create') }}">
+            Create a new certificate
+          </a>
+        </li>
         <li>
           <a class="govuk-link" href="{{ url("certificate-ui-list") }}">
             Find and edit certificates


### PR DESCRIPTION
# TP2000-242 Build create certificate form

## Why
Currently, the Tariff Managers don't have the ability to make new certificates, however we think that's a bit silly. This PR adds a Create Certificates form, and a link on the home page, to allow TM's to make new certificates. 


## What
A new form has been added to the tool, that allows TM's to create their own certificates. It's a very similar process to footnotes, just with certificates instead. Once a certificate has been created, you get a nice looking success message like you do with footnotes, but beyond that nothing else has changed. 

here's a photo for you to enjoy: 

<img width="1297" alt="Screenshot 2022-05-20 at 13 49 08" src="https://user-images.githubusercontent.com/46787754/169531398-3289aa6d-a8c4-4766-b6b8-f0d051857c42.png">

<img width="912" alt="Screenshot 2022-05-20 at 13 49 33" src="https://user-images.githubusercontent.com/46787754/169531457-0a42d5f3-de8d-4c3b-baec-9a1d3b5f0ff8.png">


!! psa to anyone reviewing this - please let me know if I've missed out on any tests. I've copied the setup for footnotes, but it feels a bit little. If there's any other tests I could add, or any types of tests I've missed, please let me know!!


## Checklist
- Requires migrations? - no
- Requires dependency updates? - no


