### PR TITLE
Add task information to logs from celery task by using celerys logger.

### DIFF
--- a/checks/tasks.py
+++ b/checks/tasks.py
@@ -1,7 +1,7 @@
-import logging
 from itertools import cycle
 
 from celery import group
+from celery.utils.log import get_task_logger
 
 from checks.checks import applicable_to
 from checks.models import TransactionCheck
@@ -10,9 +10,9 @@ from common.models.trackedmodel import TrackedModel
 from common.models.transactions import Transaction
 from common.models.transactions import TransactionPartition
 from common.models.utils import override_current_transaction
-from workbaskets.validators import WorkflowStatus
 
-logger = logging.getLogger(__name__)
+# Celery logger adds the task id and status and outputs via the worker.
+logger = get_task_logger(__name__)
 
 
 @app.task(time_limit=60)

--- a/workbaskets/tasks.py
+++ b/workbaskets/tasks.py
@@ -1,11 +1,15 @@
 from celery import group
 from celery import shared_task
+from celery.utils.log import get_task_logger
 from django.db.transaction import atomic
 
 from checks.tasks import check_transaction
 from checks.tasks import check_transaction_sync
 from common.celery import app
 from workbaskets.models import WorkBasket
+
+# Celery logger adds the task id and status and outputs via the worker.
+logger = get_task_logger(__name__)
 
 
 @shared_task
@@ -18,19 +22,21 @@ def transition(instance_id: int, state: str, *args):
     transition will not be applied. Any extra arguments passed to the task will
     be passed along to the transition function.
     """
-
     instance = WorkBasket.objects.get(pk=instance_id)
     getattr(instance, state)(*args)
     instance.save()
+    logger.info("Transitioned workbasket %s to state %s", instance_id, instance.status)
 
 
 @app.task(bind=True)
 def check_workbasket(self, workbasket_id: int):
     """Run and record transaction checks for the passed workbasket ID,
     asynchronously."""
+
     workbasket: WorkBasket = WorkBasket.objects.get(pk=workbasket_id)
     transactions = workbasket.transactions.values_list("pk", flat=True)
 
+    logger.debug("Setup task to check workbasket %s", workbasket_id)
     return self.replace(group(check_transaction.si(id) for id in transactions))
 
 
@@ -44,5 +50,10 @@ def check_workbasket_sync(workbasket: WorkBasket):
     """
     transactions = workbasket.transactions.all()
 
+    logger.debug(
+        "Start synchronous check of workbasket %s with % transactions",
+        workbasket.pk,
+        transactions.count(),
+    )
     for transaction in transactions:
         check_transaction_sync(transaction)


### PR DESCRIPTION
Use the celery logger in celery tasks, adding task information to the log messages.

This adds useful information, such as the task status, which is handy for debugging.
Celery itself also provides some functionality to output these.

During local development celery logs output in the terminal the celery worker is in, and the log level is controllable from the commandline.