### PR TITLE
rate limit to update_checks and only trigger it once per minute.

### DIFF
--- a/checks/tasks.py
+++ b/checks/tasks.py
@@ -146,9 +146,16 @@ def check_transaction_sync(transaction: Transaction):
         is_transaction_check_complete(check.pk)
 
 
-@app.task(bind=True)
+@app.task(bind=True, rate_limit="1/m")
 def update_checks(self):
-    """Triggers checking for any transaction that requires an update."""
+    """Triggers checking for any transaction that requires an update.
+
+    A rate limit is specified here to mitigate instances where this
+    task stacks up and prevents other tasks from running by monopolising
+    the worker.
+
+    TODO: Ensure this task is *not* stacking up and blocking the worker!
+    """
 
     ids_require_update = (
         Transaction.objects.exclude(

--- a/settings/common.py
+++ b/settings/common.py
@@ -357,7 +357,7 @@ CELERY_BEAT_SCHEDULE = {
     },
     "check_any_unchecked_transactions": {
         "task": "checks.tasks.update_checks",
-        "schedule": timedelta(seconds=15),
+        "schedule": timedelta(seconds=60),
     },
 }
 


### PR DESCRIPTION
update_checks seems to be monopolising the workers stopping other tasks from running.

Rate limit update_checks to only once per minute per worker and trigger it only once per minute.

rate limiting isn't anywhere near the full fix for this, but it's very trivial to add while we put through fixes that need more investigation.

This should help a little towards giving our other tasks a chance to run.