### PR TITLE
TP2000-339 - Log transaction summaries including partiton, workbasket, workbasket status.

### DIFF
--- a/checks/tasks.py
+++ b/checks/tasks.py
@@ -108,7 +108,7 @@ def check_transaction(self, transaction_id: int):
     check, model_ids = setup_or_resume_transaction_check(transaction)
     if check.completed and not any(model_ids):
         logger.debug(
-            "Skipping check of %s " "because an up-to-date check already exists",
+            "Skipping check of %s because an up-to-date check already exists",
             transaction.summary,
         )
         return

--- a/common/models/transactions.py
+++ b/common/models/transactions.py
@@ -262,9 +262,8 @@ class Transaction(TimestampedMixin):
         Stringification is lazily evaluated, so this property can be passed to loggers.
         """
         return (
-            f"transaction {self.partition}, {self.pk} "
-            f"in workbasket {self.workbasket.pk} "
-            f"with status {self.workbasket.status}"
+            f"transaction: {self.partition}, {self.pk} "
+            f"in workbasket: {self.workbasket.status}, {self.workbasket.pk}"
         )
 
     @property
@@ -273,9 +272,11 @@ class Transaction(TimestampedMixin):
         Return a short summary of the transaction.
 
         Attempts a balance between readability and enough information to debug
-        issues, so contains the pk and status of the transaction and workbasket.
+        issues, so contains the partion, order for transactions and pk, status
+        for workbaskets.
 
-        Stringification is lazily evaluated, so this property can be passed to loggers.
+        Stringification happens lazily so this property is suitable for use
+        when logging.
         """
         # This is not decorated with lazy_string because it doesn't work with properties
         return self._get_summary()

--- a/common/models/utils.py
+++ b/common/models/utils.py
@@ -2,6 +2,7 @@ import contextlib
 import threading
 from typing import FrozenSet
 
+import wrapt
 from django.db.models import Value
 
 _thread_locals = threading.local()
@@ -51,6 +52,25 @@ class LazyTransaction(LazyValue):
     """Proxy to support lazily evaluated Transaction instances."""
 
     allow_list = frozenset({"order", "partition", "workbasket_id"})
+
+
+class LazyString:
+    """
+    Wrapper around a function that returns a string.
+
+    Useful for logging messages that are expensive to construct.
+    """
+
+    def __init__(self, func):
+        self.func = func
+
+    def __str__(self):
+        return self.func()
+
+
+@wrapt.decorator
+def lazy_string(wrapped, instance, *args, **kwargs):
+    return LazyString(wrapped)
 
 
 def get_current_transaction():

--- a/common/tests/test_models.py
+++ b/common/tests/test_models.py
@@ -11,6 +11,7 @@ from common.exceptions import NoIdentifyingValuesGivenError
 from common.models import TrackedModel
 from common.models.transactions import Transaction
 from common.models.transactions import TransactionPartition
+from common.models.utils import LazyString
 from common.tests import factories
 from common.tests import models
 from common.tests.factories import TestModel1Factory
@@ -680,3 +681,18 @@ def test_copy_nested_field_two_levels_deep():
     )
 
     assert copied_measure.conditions.first().components.first().duty_amount == 0
+
+
+def test_transaction_summary(approved_transaction):
+    """Verify that transaction.summary returns a LazyString which evaluates to a
+    string with the expected fields."""
+    # It's tricky to test lazy evaluation here, verifying an instance of LazyString works as a stand-in.
+    assert isinstance(approved_transaction.summary, LazyString)
+
+    expected_summary = (
+        f"transaction {approved_transaction.partition}, {approved_transaction.pk} "
+        f"in workbasket {approved_transaction.workbasket.pk} "
+        f"with status {approved_transaction.workbasket.status}"
+    )
+
+    assert str(approved_transaction.summary) == expected_summary

--- a/common/tests/test_models.py
+++ b/common/tests/test_models.py
@@ -690,9 +690,8 @@ def test_transaction_summary(approved_transaction):
     assert isinstance(approved_transaction.summary, LazyString)
 
     expected_summary = (
-        f"transaction {approved_transaction.partition}, {approved_transaction.pk} "
-        f"in workbasket {approved_transaction.workbasket.pk} "
-        f"with status {approved_transaction.workbasket.status}"
+        f"transaction: {approved_transaction.partition}, {approved_transaction.pk} "
+        f"in workbasket: {approved_transaction.workbasket.status}, {approved_transaction.workbasket.pk}"
     )
 
     assert str(approved_transaction.summary) == expected_summary

--- a/common/tests/test_models_utils.py
+++ b/common/tests/test_models_utils.py
@@ -2,8 +2,10 @@ from unittest import mock
 
 import pytest
 
+from common.models.utils import LazyString
 from common.models.utils import LazyValue
 from common.models.utils import get_current_transaction
+from common.models.utils import lazy_string
 from common.models.utils import override_current_transaction
 from common.models.utils import set_current_transaction
 from common.tests import factories
@@ -19,6 +21,18 @@ def test_lazy_value():
     assert val.value == 0
     assert val.value == 1
     assert val.value == 2
+
+
+def test_lazy_string():
+    """Verify the lazy_string decorator returns a LazyString, and evaluates to
+    the expected string."""
+
+    @lazy_string
+    def hello():
+        return "hello world"
+
+    assert isinstance(hello(), LazyString)
+    assert str(hello()) == "hello world"
 
 
 def test_get_current_transaction_from_thread_locals():

--- a/pii-ner-exclude.txt
+++ b/pii-ner-exclude.txt
@@ -1123,6 +1123,7 @@ OAuth2
 Quotas
 0009_add_abbrev_to_unit_qualifier_with_code_n
 0.0.0.34
+LazyString
 TrackedModelCheck
 f"Error
 TransactionCheck


### PR DESCRIPTION
Improve logging for transactions outputting a summary transaction and workbasket pk and status.
    
Info is fetched only during stringification so cost is only incurred if logging is enabled.

In the example below it is easy to see that transactions in archived workbaskets are being checked..
![image](https://user-images.githubusercontent.com/179677/170132345-ab20ac28-16a2-4d6a-988f-ba41e4183a7a.png)