### PR TITLE
TP2000 242 Build and deploy the create certificates design (pt.2)

### DIFF
--- a/pii-ner-exclude.txt
+++ b/pii-ner-exclude.txt
@@ -1129,3 +1129,4 @@ f"Error
 TransactionCheck
 Restart
 MeasureFootnoteAssociation
+sid A01


### PR DESCRIPTION
# TP2000 242 Build and deploy the create certificates design 
<!---
 * Include the JIRA ticket number, eg TP-123, to automatically link.
 * Use 50 characters maximum.
 * Do not end with a full-stop.
--->

## Why
<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Use as many lines as you like.
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions or deliberately ignored edge-cases.
--->
User testing revealed a bug where auto-generation of sid failed because some certificates have a non-numeric sid (e.g. "A01") where our logic expected only integers.

## What
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Explain like I'm 5.
 * Use pictures if you can.
--->
This PR adds an sid field to the form ui and checks that this sid isn't already in use. When a user doesn't input an sid (which we think will be most of the time) we autogenerate the sid, ignoring any non-numeric sids.

<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
## Checklist
- Requires migrations?
- Requires dependency updates?
--->

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
