### PR TITLE
Fix commodity import from import_taric commandline.

### DIFF
--- a/importer/management/commands/import_taric.py
+++ b/importer/management/commands/import_taric.py
@@ -26,7 +26,7 @@ def import_taric(
         split_on_code=split_codes,
     )
     with open(taric3_file, "rb") as seed_file:
-        batch = chunk_taric(seed_file, batch)
+        batch = chunk_taric(seed_file, batch, record_group=record_group)
 
     run_batch(
         batch.name,

--- a/importer/taric.py
+++ b/importer/taric.py
@@ -85,6 +85,7 @@ class MessageParser(ElementParser):
         :param data: A dict of parsed element, mapping field names to values
         :param transaction_id: The primary key of the transaction to add records to
         """
+        logger.debug("Saving message id: %s", data.get("id"))
         for record_data in data.get("record", []):
             self.record.save(record_data, transaction_id)
 


### PR DESCRIPTION
Filtering for only commodity codes wasn't happening everywhere making import_taric -c misbehave.