### PR TITLE
Transition stalled imports to ERRORED.

### DIFF
--- a/data_patches/TP2000_338_set_chunks_status.py
+++ b/data_patches/TP2000_338_set_chunks_status.py
@@ -1,10 +1,10 @@
 """
-This is a "run once" script to transition imports out of their RUNNING status
-that can be correctly manipulated via existing Django management commands.
+This is a "run once" script to transition imports out of their RUNNING status so
+that they may be correctly manipulated via existing Django management commands
+or re-imported.
 
-In order to run this script, from a Tamato virtualenv:
-
-    python manage.py runscript data_patches.TP2000_338_set_chunks_status
+Run this script from a Tamato virtualenv:     python manage.py runscript
+data_patches.TP2000_338_set_chunks_status
 """
 
 
@@ -20,11 +20,11 @@ from importer.models import ImporterXMLChunk
 @atomic
 def set_chunks_status(batch, status):
     """
-    Transition chunks of a batch import to status.
+    Transition chunks of a batch import to the given status.
 
-    If any chunks for a batch are in DONE status then more sophisticated remaial
-    effor is required than this function offers and so an exception will be
-    raised.
+    If any chunks for a batch are in DONE status then more sophisticated
+    remedial effort is required than this function offers and so an exception
+    will be raised.
     """
     batch_chunks = ImporterXMLChunk.objects.filter(batch=batch)
     print(f"'{batch}' has {batch_chunks.count()} chunk(s).")

--- a/data_patches/TP2000_338_set_chunks_status.py
+++ b/data_patches/TP2000_338_set_chunks_status.py
@@ -1,0 +1,60 @@
+"""
+This is a "run once" script to transition imports out of their RUNNING status
+that can be correctly manipulated via existing Django management commands.
+
+In order to run this script, from a Tamato virtualenv:
+
+    python manage.py runscript data_patches.TP2000_338_set_chunks_status
+"""
+
+
+from datetime import datetime
+
+from django.db.transaction import atomic
+
+from importer.models import ImportBatch
+from importer.models import ImporterChunkStatus
+from importer.models import ImporterXMLChunk
+
+
+@atomic
+def set_chunks_status(batch, status):
+    """
+    Transition chunks of a batch import to status.
+
+    If any chunks for a batch are in DONE status then more sophisticated remaial
+    effor is required than this function offers and so an exception will be
+    raised.
+    """
+    batch_chunks = ImporterXMLChunk.objects.filter(batch=batch)
+    print(f"'{batch}' has {batch_chunks.count()} chunk(s).")
+
+    if batch_chunks.filter(status=ImporterChunkStatus.DONE):
+        raise Exception(f"ERROR: '{batch}' already has chunks in DONE status.")
+
+    for chunk in batch_chunks:
+        old_status = ImporterChunkStatus(chunk.status)
+        print(
+            f"Transitioning '{chunk}' from {old_status.name} to {status.name}",
+        )
+        chunk.status = status
+        chunk.save()
+
+
+def run():
+    """
+    Function called by django_extentions runscript management command:
+
+    https://django-extensions.readthedocs.io/en/latest/runscript.html
+    """
+    print(f"{datetime.now()} starting batch status transitions...")
+
+    # Transition to ERRORED in preparation for a second import attempt.
+    batch_220039 = ImportBatch.objects.get(name="Batch 220039")
+    set_chunks_status(batch_220039, ImporterChunkStatus.ERRORED)
+
+    # Transition to ERRORED in preparation for a second import attempt.
+    batch_j_and_g = ImportBatch.objects.get(name="Jersey_Guernsey Test File")
+    set_chunks_status(batch_j_and_g, ImporterChunkStatus.ERRORED)
+
+    print(f"{datetime.now()} completed transitions.")


### PR DESCRIPTION
# TP2000-338 Fix stalled importer tasks
<!---
 * Include the JIRA ticket number, eg TP-123, to automatically link.
 * Use 50 characters maximum.
 * Do not end with a full-stop.
--->

## Why
<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Use as many lines as you like.
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions or deliberately ignored edge-cases.
--->
Two imports were created with associated Celery tasks, and import set to `RUNNING`. Those tasks went unserviced before a queue purge, leaving the imports in limbo.


## What
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Explain like I'm 5.
 * Use pictures if you can.
--->
This PR provides a run-once script to transition the stalled tasks to `ERRORED` preparing for a clean re-import.

<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
--->
## Checklist
- Requires migrations? No
- Requires dependency updates? No

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
