### PR TITLE
TP2000-354 Certificate descriptions created in earlier transaction than Certificate

### DIFF
--- a/certificates/tests/test_views.py
+++ b/certificates/tests/test_views.py
@@ -47,6 +47,7 @@ def test_certificate_create_form_creates_certificate_description_object(
 
     assert certificate.sid == certificate_description.described_certificate.sid
     assert certificate_description.validity_start == datetime.date(2022, 2, 2)
+    assert certificate.transaction == certificate_description.transaction
 
 
 @pytest.mark.parametrize(

--- a/certificates/views.py
+++ b/certificates/views.py
@@ -84,12 +84,17 @@ class CertificateCreate(DraftCreateView):
         self.object.transaction = transaction
         self.object.save()
 
+        return super().form_valid(form)
+
+    def get_result_object(self, form):
+        object = super().get_result_object(form)
         description = form.cleaned_data["certificate_description"]
         description.described_certificate = self.object
         description.update_type = UpdateType.CREATE
-        description.transaction = transaction
+        description.transaction = object.transaction
         description.save()
-        return super().form_valid(form)
+
+        return object
 
     def get_form_kwargs(self):
         kwargs = super().get_form_kwargs()


### PR DESCRIPTION
# TP2000-354 Certificate descriptions created in earlier transaction than Certificate
<!---
 * Include the JIRA ticket number, eg TP-123, to automatically link.
 * Use 50 characters maximum.
 * Do not end with a full-stop.
--->

## Why
<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Use as many lines as you like.
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions or deliberately ignored edge-cases.
--->
Descriptions are being created before the certificates that they describe. They should be created in the same transaction logically and CDS complain when they aren't

## What
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Explain like I'm 5.
 * Use pictures if you can.
--->
Moves logic from form_valid to get_result_object and sets the description transaction there.

<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
## Checklist
- Requires migrations?
- Requires dependency updates?
--->

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
