### PR TITLE
Ignore 'not reading .env' warning.

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -2,6 +2,7 @@
 """Django's command-line utility for administrative tasks."""
 import os
 import sys
+import warnings
 
 import dotenv
 
@@ -25,5 +26,7 @@ def main():
 
 
 if __name__ == "__main__":
-    dotenv.read_dotenv()
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        dotenv.read_dotenv()
     main()


### PR DESCRIPTION
# TP2000-355 Silence 'no dot env' warning
<!---
 * Include the JIRA ticket number, eg TP-123, to automatically link.
 * Use 50 characters maximum.
 * Do not end with a full-stop.
--->

## Why
<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Use as many lines as you like.
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions or deliberately ignored edge-cases.
--->
The full warning looks like this:
```
manage.py:28: UserWarning: Not reading .env - it doesn't exist.
  dotenv.read_dotenv()
```

This is useful on the first occasion a developer sets up Tamato and has forgotten to create a `.env` file (staging and production servers take their env vars from the OS environment). It clutters the command-line and pollutes our logs the rest of the time.

## What
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Explain like I'm 5.
 * Use pictures if you can.
--->
Ignore the warning via warnings filtering.

<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
--->
## Checklist
- Requires migrations? No
- Requires dependency updates? No

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
