### PR TITLE
Exclude checks app models from sqlite dump.

### DIFF
--- a/exporter/sqlite/__init__.py
+++ b/exporter/sqlite/__init__.py
@@ -42,7 +42,11 @@ SKIPPED_MODELS = {
 
 
 def make_export_plan(sqlite: runner.Runner) -> plan.Plan:
-    names = (name.split(".")[0] for name in settings.DOMAIN_APPS)
+    names = (
+        name.split(".")[0]
+        for name in settings.DOMAIN_APPS
+        if name not in settings.SQLITE_EXCLUDED_APPS
+    )
     all_models = chain(*[apps.get_app_config(name).get_models() for name in names])
     models_by_table = {model._meta.db_table: model for model in all_models}
 

--- a/settings/common.py
+++ b/settings/common.py
@@ -357,6 +357,10 @@ CELERY_BEAT_SCHEDULE = {
     },
 }
 
+SQLITE_EXCLUDED_APPS = [
+    "checks",
+]
+
 # -- Google Tag Manager
 GOOGLE_ANALYTICS_ID = os.environ.get("GOOGLE_ANALYTICS_ID")
 


### PR DESCRIPTION
# TP2000-349 Sqlite failing to upload to S3
<!---
 * Include the JIRA ticket number, eg TP-123, to automatically link.
 * Use 50 characters maximum.
 * Do not end with a full-stop.
--->

## Why
<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Use as many lines as you like.
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions or deliberately ignored edge-cases.
--->
Attempts to include models in the checks app is causing a check constraint violation. `checks` model instances shouldn't be included in the Sqlite dump since it isn't part of the public data set and they can reference transactions that are not in a published state.

## What
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Explain like I'm 5.
 * Use pictures if you can.
--->
Provide a new settings list attribute, `SQLITE_EXCLUDED_APPS`, that makes provision for excluding domain apps and models from the Sqlite export. Include the `checks` app in this new list attribute.

<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
--->
## Checklist
- Requires migrations? No
- Requires dependency updates? No

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
