### PR TITLE
TP2000-243 Validation and rules don't show when editing or creating a footnote or footnote description

### DIFF
--- a/footnotes/views.py
+++ b/footnotes/views.py
@@ -144,7 +144,7 @@ class FootnoteUpdate(
 
     validate_business_rules = (
         business_rules.FO2,
-        # business_rules.FO4,  # XXX should it be checked here?
+        business_rules.FO4,
         business_rules.FO5,
         business_rules.FO6,
         business_rules.FO9,


### PR DESCRIPTION
TP2000-243 Validation and rules don't show when editing or creating a footnote or footnote description
<!---
 * Include the JIRA ticket number, eg TP-123, to automatically link.
 * Use 50 characters maximum.
 * Do not end with a full-stop.
--->

## Why
<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Use as many lines as you like.
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions or deliberately ignored edge-cases.
--->
We've been seeing FO4 (validity period of a footnote description must be contained by its described footnote validity period) violations when packaging. This is because it is currently possible to create a footnote and then edit its start / end date, meaning that its description validity period is no longer contained. 

## What
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Explain like I'm 5.
 * Use pictures if you can.
--->
Turns on FO4 on the footnote edit page. (We run all the other footnote business rules at this point and I don't think this one is that expensive to run as well)
<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
## Checklist
- Requires migrations?
- Requires dependency updates?
--->

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
