### PR TITLE
Optimisations around moving transactions.

### DIFF
--- a/pii-ner-exclude.txt
+++ b/pii-ner-exclude.txt
@@ -1137,5 +1137,6 @@ CheckResult
 Checkers
 self.linked_model
 "Attach BusinessRules
-WorkBasketOutputFormat Enum
+WorkBasketOutputFormat
 param kwargs:
+Enum


### PR DESCRIPTION
Optimise apply_transaction_order and rename to move_to_end_of_partiton:

- Make it use bulk_update to massively reduce query count
- Make this a generalised "move transactions to end of any partition".
- Make it take a partition, instead of partition scheme, since at this point the partition is frozen.
In future this may allow us to remove the hack of using negative "pre-emptive" transactions.

Optimise preorder_negative_transactions by using bulk_update.

(Slightly) future proof  Transaction.approved by instead of checking != DRAFT, checking ! partition <= REVISION

Update tests for apply_transaction_order to work with move_to_end_of_partiton and work with partitions not partition schemes.


These fixes were extracted from the "archived transactions" PR - this are all the optimisations and cleanups that do not involve adding archived transactions.


Generalising and speeding up "moving transactions to the end of a partition" is a win, apart from the speed up on saving - it opens the way to a cleaner implementation of "pre-emptive partitions" - that doesn't involve negative transaction ids.