### PR TITLE
dump_workbaskets:  add options to disable splitting, and set max size.   add benchmarking.   fix auto-envelope-id.

### DIFF
--- a/common/serializers.py
+++ b/common/serializers.py
@@ -199,12 +199,19 @@ class EnvelopeSerializer:
         self,
         output: IO,
         envelope_id: int,
-        transaction_counter: Counter = counter_generator(),
         message_counter: Counter = counter_generator(),
         max_envelope_size: Optional[int] = None,
         format: str = "xml",
         newline: bool = False,
     ) -> None:
+        """
+        :param output: The output stream to write to.
+        :param envelope_id: The id of the envelope.
+        :param message_counter: A counter for the message ids.
+        :param max_envelope_size: The maximum size of an envelope, if None then no limit.
+        :param format: Format to serialize to, defaults to xml.
+        :param newline: Whether to add a newline after the envelope.
+        """
         self.output = output
         self.message_counter = message_counter
         self.envelope_id = envelope_id
@@ -247,11 +254,13 @@ class EnvelopeSerializer:
         self.write(self.render_envelope_end())
 
     def render_file_header(self) -> str:
+        """Output the file header."""
         return render_to_string(
             template_name="common/taric/start_file.xml",
         )
 
     def render_envelope_start(self) -> str:
+        """Output the envelope start."""
         return render_to_string(
             template_name="common/taric/start_envelope.xml",
             context={"envelope_id": self.envelope_id},
@@ -278,6 +287,7 @@ class EnvelopeSerializer:
         )
 
     def render_envelope_end(self) -> str:
+        """Output the envelope end."""
         return render_to_string(template_name="common/taric/end_envelope.xml")
 
     def start_next_envelope(self) -> None:

--- a/exporter/serializers.py
+++ b/exporter/serializers.py
@@ -45,12 +45,19 @@ class MultiFileEnvelopeTransactionSerializer(EnvelopeSerializer):
         self,
         output_constructor: callable,
         envelope_id=1,
+        benchmark=False,
         *args,
         **kwargs,
     ) -> None:
+        """
+        :param output_constructor: callable that returns a file like object to write to, called each time a new envelope is started.
+        :param envelope_id: Envelope ID, to use later, when creating Envelope objects in the database.
+        :param args: Passed through to EnvelopeSerializer.
+        :param kwargs: Passed through to EnvelopeSerializer.
+        """
         self.output_constructor = output_constructor
         EnvelopeSerializer.__init__(
-            self, self.output_constructor(), envelope_id=envelope_id, *args, **kwargs
+            self, self.output_constructor(), envelope_id=envelope_id, **kwargs
         )
 
     def start_next_envelope(self):

--- a/exporter/tests/test_util.py
+++ b/exporter/tests/test_util.py
@@ -1,0 +1,34 @@
+from exporter.util import exceptions_as_messages
+from exporter.util import item_timer
+
+
+def test_exceptions_as_messages():
+    exception_list = {
+        "first_exception": [Exception("test")],
+        "second_exception": [Exception("test2")],
+    }
+
+    messages = exceptions_as_messages(exception_list)
+
+    assert messages == {
+        "first_exception": ["raised an test"],
+        "second_exception": ["raised an test2"],
+    }
+
+
+def test_item_timer():
+    """Verify that item_timer yields a tuple containing the time to retrieve
+    each item and the item itself."""
+    items = item_timer([1, 2])
+
+    time_taken, item = next(items)
+
+    assert item == 1
+    assert isinstance(time_taken, float)
+    assert time_taken > 0.0
+
+    time_taken, item = next(items)
+
+    assert item == 2
+    assert isinstance(time_taken, float)
+    assert time_taken > 0.0

--- a/exporter/util.py
+++ b/exporter/util.py
@@ -1,8 +1,13 @@
 import sys
+import time
 from itertools import count
 from pathlib import Path
+from typing import Any
 from typing import Dict
+from typing import Generator
 from typing import List
+from typing import Sequence
+from typing import Tuple
 
 
 def dit_filename_generator(start=1):
@@ -128,9 +133,22 @@ def exceptions_as_messages(
 ) -> Dict[int, List[str]]:
     """
     :param error_dict: dict of lists of exceptions.
-    :return: dict of lists of human readable strings containing the exception name.
+    :return: dict of lists of human-readable strings containing the exception name.
     """
     new_errors = {}
     for k, errors in error_dict.items():
         new_errors[k] = [f"raised an {exc}" for exc in errors]
     return new_errors
+
+
+def item_timer(items: Sequence[Any]) -> Generator[Tuple[float, Any], None, None]:
+    """
+    :param items: Sequence of items.
+
+    Iterates over the items and yield a tuple of (time_taken, item).
+    """
+    start_time = time.time()
+    for o in items:
+        time_taken = time.time() - start_time
+        yield time_taken, o
+        start_time = time.time()

--- a/pii-ner-exclude.txt
+++ b/pii-ner-exclude.txt
@@ -1138,3 +1138,4 @@ Checkers
 self.linked_model
 "Attach BusinessRules
 WorkBasketOutputFormat Enum
+param kwargs:


### PR DESCRIPTION
Output how long it takes to serialize envelopes.

- Add option to disable envelope splitting by size.
- Add option to specify the maximum envelope size.
- Add option to use the next available envelope id (not super useful yet as we don't use envelope upload)


<pre><font color="#5FD700">❯</font> <font color="#00AA00">python</font> <u style="text-decoration-style:single">manage.py</u> dump_transactions 000313 313 --disable-split-by-size
DIT000313.xml ✅  XML valid.  98 transactions, serialized in 17.21 seconds using 277202 bytes.

</pre>