### PR TITLE
TP2000-225 Users cannot find some countries from geo area autocomplete or search

### DIFF
--- a/common/tests/test_models.py
+++ b/common/tests/test_models.py
@@ -277,6 +277,13 @@ def test_new_version_retains_related_objects(sample_model):
         sample_model.transaction.workbasket,
     )
     assert new_model.descriptions.get() == description
+    assert sample_model.descriptions.get() == description
+    assert type(sample_model).objects.filter(descriptions__isnull=False).exists()
+    assert (
+        type(sample_model).objects.filter(descriptions__isnull=False).first()
+        == new_model
+    )
+    assert not type(sample_model).objects.filter(descriptions__isnull=True).exists()
 
 
 def test_current_as_of(sample_model):


### PR DESCRIPTION
# TP2000-225 Users cannot find some countries from geo area autocomplete or search
<!---
 * Include the JIRA ticket number, eg TP-123, to automatically link.
 * Use 50 characters maximum.
 * Do not end with a full-stop.
--->

## Why
<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Use as many lines as you like.
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions or deliberately ignored edge-cases.
--->
Countries that have been updated (i.e. where more than one version exists) aren't showing when searching by description. The countries that aren't displaying in search appear in the queryset generated by`GeographicalArea.objects.filter(descriptions__isnull=True)`, even though calling `.descriptions` on the model clearly shows that descriptions are attached. The query includes the SQL `INNER JOIN "geo_areas_geographicalareadescription" ON ("geo_areas_geographicalarea"."trackedmodel_ptr_id" = "geo_areas_geographicalareadescription"."described_geographicalarea_id")`. Where a country doesn't display in search the description's described_geographicalarea_id does not match the geo area trackedmodel_ptr_id.

## What
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Explain like I'm 5.
 * Use pictures if you can.
--->
I've created a draft adding assertions to a test Simon wrote as part of his work to fix reverse relations. The last two are failing but I think all of them should be passing and wanted to get some opinions before going further with it.
<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
## Checklist
- Requires migrations?
- Requires dependency updates?
--->

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
