### PR TITLE
ActionRequiresDuty business rule doesn't handle 0% duty

### DIFF
--- a/measures/business_rules.py
+++ b/measures/business_rules.py
@@ -1026,7 +1026,7 @@ class ActionRequiresDuty(BusinessRule):
 
     def validate(self, condition):
         components = condition.components.approved_up_to_transaction(self.transaction)
-        components_have_duty = any([c.duty_amount for c in components])
+        components_have_duty = any([c.duty_amount is not None for c in components])
         if condition.action.requires_duty and not components_have_duty:
             raise self.violation(
                 message=f"Condition with action code {condition.action.code} must have at least one component with a duty amount",

--- a/measures/tests/test_business_rules.py
+++ b/measures/tests/test_business_rules.py
@@ -1700,6 +1700,18 @@ def test_ActionRequiresDuty_ignores_outdated_components():
         business_rules.ActionRequiresDuty(condition.transaction).validate(condition)
 
 
+# https://uktrade.atlassian.net/browse/TP2000-369  /PS-IGNORE
+def test_ActionRequiresDuty_accepts_0_percent_duty():
+    condition = factories.MeasureConditionFactory.create(action__requires_duty=True)
+    factories.MeasureConditionComponentFactory.create(
+        condition=condition,
+        duty_amount=0.000,
+        transaction=condition.transaction,
+    )
+
+    business_rules.ActionRequiresDuty(condition.transaction).validate(condition)
+
+
 @pytest.mark.parametrize(
     ("applicability_code", "amount", "error_expected"),
     [


### PR DESCRIPTION
# TP2000-369 ActionRequiresDuty business rule doesn't handle 0% duty
<!---
 * Include the JIRA ticket number, eg TP-123, to automatically link.
 * Use 50 characters maximum.
 * Do not end with a full-stop.
--->

## Why
<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Use as many lines as you like.
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions or deliberately ignored edge-cases.
--->
The ActionRequiresDuty rule currently sees an applicable duty of 0% as equivalent to a Null duty_amount. This has led to the rule firing on workbasket 332 (TOPS 536 New Exporter Review China). 

## What
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Explain like I'm 5.
 * Use pictures if you can.
--->
Update the rule to look for non Null values and add a test for this scenario
<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
## Checklist
- Requires migrations?
- Requires dependency updates?
--->

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
