### PR TITLE
TP2000-371 Editing a measure changes existing condition sids

### DIFF
--- a/measures/patterns.py
+++ b/measures/patterns.py
@@ -288,7 +288,7 @@ class MeasureCreationPattern:
         measure condition components from newly created condition
         """
         condition = MeasureCondition(
-            sid=self.measure_condition_sid_counter(),
+            sid=data.get("sid") or self.measure_condition_sid_counter(),
             component_sequence_number=component_sequence_number,
             dependent_measure=measure,
             update_type=data.get("update_type") or UpdateType.CREATE,

--- a/measures/views.py
+++ b/measures/views.py
@@ -415,6 +415,7 @@ class MeasureUpdate(
                 condition_data["version_group"] = existing_conditions.get(
                     sid=f.initial["condition_sid"],
                 ).version_group
+                condition_data["sid"] = f.initial["condition_sid"]
             # If changed and condition_sid not in changed_data, then this is a newly created condition
             elif f.has_changed() and "condition_sid" not in f.changed_data:
                 update_type = UpdateType.CREATE


### PR DESCRIPTION
TP2000-371 Editing a measure changes existing condition sids
<!---
 * Include the JIRA ticket number, eg TP-123, to automatically link.
 * Use 50 characters maximum.
 * Do not end with a full-stop.
--->

## Why
<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Use as many lines as you like.
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions or deliberately ignored edge-cases.
--->
Currently when a measure with existing conditions is updated its conditions are also updated and their sids changed, which looks strange because we should never be changing the SID and causes a business rule violation on CDS because conditions with these SIDs have never been created.

We shouldn't update a condition in the first place, if the data hasn't been changed, but, due to a bug with duties, the form will always see changed data. We should create a separate ticket to fix that logic once the duties bug is resolved and get this fix for the changing sids in in the meantime.

## What
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Explain like I'm 5.
 * Use pictures if you can.
--->
- Passes in the existing SID to the create_condition_and_components method on MeasureCreationPattern.
- Updates test to check SID and update_type
- Adds commented out test for updating a measure and not changing conditions
<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
## Checklist
- Requires migrations?
- Requires dependency updates?
--->

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
