### PR TITLE
Tp2000 375 workbasket link update

### DIFF
--- a/commodities/jinja2/commodities/import-success.jinja
+++ b/commodities/jinja2/commodities/import-success.jinja
@@ -7,7 +7,7 @@
 {% block beforeContent %}
   {{ govukBreadcrumbs({
     "items": [
-      {"text": "Home", "href": url("dashboard")},
+      {"text": "Home", "href": url("index")},
       {"text": page_title}
     ]
   }) }}
@@ -20,7 +20,7 @@
       <h1 class="govuk-heading-xl">Your file is being imported</h1>
       <p class="govuk-body">We have confirmed that the file is valid and are processing the changes. This might take up to 20 minutes.</p>
       <p class="govuk-body">You will be able to review the changes and finish the import from the main page.</p>
-      <a href="{{ url('dashboard') }}" class="govuk-button govuk-button--secondary">Return to the main page</a>
+      <a href="{{ url('index') }}" class="govuk-button govuk-button--secondary">Return to the main page</a>
     </div>
   </div>
 {% endblock %}

--- a/commodities/jinja2/commodities/import.jinja
+++ b/commodities/jinja2/commodities/import.jinja
@@ -7,7 +7,7 @@
 {% block beforeContent %}
   {{ govukBreadcrumbs({
     "items": [
-      {"text": "Home", "href": url("dashboard")},
+      {"text": "Home", "href": url("index")},
       {"text": page_title}
     ]
   }) }}

--- a/common/jinja2/common/confirm_create.jinja
+++ b/common/jinja2/common/confirm_create.jinja
@@ -5,7 +5,7 @@
 {% block beforeContent %}
   {{ govukBreadcrumbs({
     "items": [
-      {"text": "Home", "href": url("dashboard")},
+      {"text": "Home", "href": url("index")},
       {"text": page_title}
     ]
   }) }}

--- a/common/jinja2/common/confirm_create_description.jinja
+++ b/common/jinja2/common/confirm_create_description.jinja
@@ -34,13 +34,13 @@
       <p class="govuk-body">To complete your task you must publish your change. </p>
       {{ govukButton({
         "text": "Go to your tariff changes",
-        "href": url("index"),
+        "href": url("my-workbasket"),
         "classes": "govuk-button--secondary"
       }) }}
       <ul class="govuk-list govuk-list-spaced">
         <li><a class="govuk-link" href="{{ described_object.get_url() }}">View {{ described_object._meta.verbose_name }} {{ described_object|string }}</a></li>
         <li><a class="govuk-link" href="{{ described_object.get_url("list") }}">Manage more {{ described_object._meta.verbose_name_plural }}</a></li>
-        <li><a class="govuk-link" href="{{ url("index") }}">Return to main menu</a></li>
+        <li><a class="govuk-link" href="{{ url("my-workbasket") }}">Return to main menu</a></li>
       </ul>
     </div>
   </div>

--- a/common/jinja2/common/confirm_create_description.jinja
+++ b/common/jinja2/common/confirm_create_description.jinja
@@ -10,7 +10,7 @@
 {% block beforeContent %}
   {{ govukBreadcrumbs({
     "items": [
-      {"text": "Home", "href": url("dashboard")},
+      {"text": "Home", "href": url("index")},
       {"text": "Find and edit " ~ described_object._meta.verbose_name_plural, "href": described_object.get_url("list")},
       {"text": described_object._meta.verbose_name|capitalize ~ ": " ~ described_object|string, "href": described_object.get_url()},
       {"text": page_title}
@@ -34,13 +34,13 @@
       <p class="govuk-body">To complete your task you must publish your change. </p>
       {{ govukButton({
         "text": "Go to your tariff changes",
-        "href": url("dashboard"),
+        "href": url("index"),
         "classes": "govuk-button--secondary"
       }) }}
       <ul class="govuk-list govuk-list-spaced">
         <li><a class="govuk-link" href="{{ described_object.get_url() }}">View {{ described_object._meta.verbose_name }} {{ described_object|string }}</a></li>
         <li><a class="govuk-link" href="{{ described_object.get_url("list") }}">Manage more {{ described_object._meta.verbose_name_plural }}</a></li>
-        <li><a class="govuk-link" href="{{ url("dashboard") }}">Return to main menu</a></li>
+        <li><a class="govuk-link" href="{{ url("index") }}">Return to main menu</a></li>
       </ul>
     </div>
   </div>

--- a/common/jinja2/common/confirm_update.jinja
+++ b/common/jinja2/common/confirm_update.jinja
@@ -5,7 +5,7 @@
 {% block beforeContent %}
   {{ govukBreadcrumbs({
     "items": [
-      {"text": "Home", "href": url("dashboard")},
+      {"text": "Home", "href": url("index")},
       {"text": "Find and edit " ~ object._meta.verbose_name_plural, "href": object.get_url("list")},
       {"text": object._meta.verbose_name|capitalize ~ ": " ~ object|string, "href": object.get_url()},
       {"text": page_title}

--- a/common/jinja2/common/confirm_update_description.jinja
+++ b/common/jinja2/common/confirm_update_description.jinja
@@ -10,7 +10,7 @@
 {% block beforeContent %}
   {{ govukBreadcrumbs({
     "items": [
-      {"text": "Home", "href": url("dashboard")},
+      {"text": "Home", "href": url("index")},
       {"text": "Find and edit " ~ described_object._meta.verbose_name_plural, "href": described_object.get_url("list")},
       {"text": described_object._meta.verbose_name|capitalize ~ ": " ~ described_object|string, "href": described_object.get_url()},
       {"text": page_title}
@@ -34,13 +34,13 @@
       <p class="govuk-body">To complete your task you must publish your change. </p>
       {{ govukButton({
         "text": "Go to your tariff changes",
-        "href": url("dashboard"),
+        "href": url("index"),
         "classes": "govuk-button--secondary"
       }) }}
       <ul class="govuk-list govuk-list-spaced">
         <li><a class="govuk-link" href="{{ described_object.get_url() }}">View {{ described_object._meta.verbose_name }} {{ described_object|string }}</a></li>
         <li><a class="govuk-link" href="{{ described_object.get_url("list") }}">Manage more {{ described_object._meta.verbose_name_plural }}</a></li>
-        <li><a class="govuk-link" href="{{ url("dashboard") }}">Return to main menu</a></li>
+        <li><a class="govuk-link" href="{{ url("index") }}">Return to main menu</a></li>
       </ul>
     </div>
   </div>

--- a/common/jinja2/common/create_description.jinja
+++ b/common/jinja2/common/create_description.jinja
@@ -43,7 +43,7 @@
 {% block beforeContent %}
   {{ govukBreadcrumbs({
     "items": [
-      {"text": "Home", "href": url("dashboard")},
+      {"text": "Home", "href": url("index")},
       {"text": "Find and edit " ~ described_object._meta.verbose_name_plural, "href": described_object.get_url("list")},
       {"text": described_object._meta.verbose_name|capitalize ~ ": " ~ described_object|string, "href": described_object.get_url()},
       {"text": page_title}

--- a/common/jinja2/common/delete.jinja
+++ b/common/jinja2/common/delete.jinja
@@ -7,7 +7,7 @@
 {% block beforeContent %}
   {{ govukBreadcrumbs({
     "items": [
-      {"text": "Home", "href": url("dashboard")},
+      {"text": "Home", "href": url("index")},
       {"text": "Find and edit " ~ object._meta.verbose_name_plural, "href": object.get_url("list")},
       {"text": object._meta.verbose_name|capitalize ~ ": " ~ object|string, "href": object.get_url()},
       {"text": page_title}

--- a/common/jinja2/common/edit.jinja
+++ b/common/jinja2/common/edit.jinja
@@ -5,7 +5,7 @@
 {% block beforeContent %}
   {{ govukBreadcrumbs({
     "items": [
-      {"text": "Home", "href": url("dashboard")},
+      {"text": "Home", "href": url("index")},
       {"text": "Find and edit " ~ object._meta.verbose_name_plural, "href": object.get_url("list")},
       {"text": object._meta.verbose_name|capitalize ~ ": " ~ object|string, "href": object.get_url()},
       {"text": page_title}

--- a/common/jinja2/common/edit_description.jinja
+++ b/common/jinja2/common/edit_description.jinja
@@ -45,7 +45,7 @@
 {% block beforeContent %}
   {{ govukBreadcrumbs({
     "items": [
-      {"text": "Home", "href": url("dashboard")},
+      {"text": "Home", "href": url("index")},
       {"text": "Find and edit " ~ described_object._meta.verbose_name_plural, "href": described_object.get_url("list")},
       {"text": described_object._meta.verbose_name|capitalize ~ ": " ~ described_object|string, "href": described_object.get_url()},
       {"text": page_title}

--- a/common/jinja2/common/my-workbasket.jinja
+++ b/common/jinja2/common/my-workbasket.jinja
@@ -8,7 +8,7 @@
   {% if request.GET.edit %}
     {{ govukBreadcrumbs({
       "items": [
-        {"text": "Home", "href": url("dashboard")},
+        {"text": "Home", "href": url("index")},
         {"text": "Edit an existing workbasket", "href": url("workbaskets:select-workbasket")},
         {"text": "Workbasket " ~ request.session.workbasket.id }
       ]
@@ -16,7 +16,7 @@
   {% else %}
     {{ govukBreadcrumbs({
       "items": [
-        {"text": "Home", "href": url("dashboard")},
+        {"text": "Home", "href": url("index")},
         {"text": "Workbasket " ~ request.session.workbasket.id }
       ]
     }) }}

--- a/common/jinja2/layouts/confirm.jinja
+++ b/common/jinja2/layouts/confirm.jinja
@@ -24,13 +24,13 @@
       <p class="govuk-body">To complete your task you must publish your change. </p>
       {{ govukButton({
         "text": "Go to your tariff changes",
-        "href": url("index"),
+        "href": url("my-workbasket"),
         "classes": "govuk-button--secondary"
       }) }}
       <ul class="govuk-list govuk-list-spaced">
         <li><a class="govuk-link" href="{{ object.get_url() }}">View {{ object._meta.verbose_name }} {{ object|string }}</a></li>
         <li><a href="{{ object.get_url("list") }}">Manage more {{ object._meta.verbose_name_plural }}</a></li>
-        <li><a href="{{ url("index") }}">Return to main menu</a></li>
+        <li><a href="{{ url("my-workbasket") }}">Return to main menu</a></li>
       </ul>
     </div>
   </div>

--- a/common/jinja2/layouts/confirm.jinja
+++ b/common/jinja2/layouts/confirm.jinja
@@ -6,7 +6,7 @@
 {% block beforeContent %}
   {{ govukBreadcrumbs({
     "items": [
-      {"text": "Home", "href": url("dashboard")},
+      {"text": "Home", "href": url("index")},
       {"text": "Find and edit " ~ object._meta.verbose_name_plural, "href": object.get_url("list")},
       {"text": object._meta.verbose_name|capitalize ~ ": " ~ object|string, "href": object.get_url()},
       {"text": page_title}
@@ -24,13 +24,13 @@
       <p class="govuk-body">To complete your task you must publish your change. </p>
       {{ govukButton({
         "text": "Go to your tariff changes",
-        "href": url("dashboard"),
+        "href": url("index"),
         "classes": "govuk-button--secondary"
       }) }}
       <ul class="govuk-list govuk-list-spaced">
         <li><a class="govuk-link" href="{{ object.get_url() }}">View {{ object._meta.verbose_name }} {{ object|string }}</a></li>
         <li><a href="{{ object.get_url("list") }}">Manage more {{ object._meta.verbose_name_plural }}</a></li>
-        <li><a href="{{ url("dashboard") }}">Return to main menu</a></li>
+        <li><a href="{{ url("index") }}">Return to main menu</a></li>
       </ul>
     </div>
   </div>

--- a/common/jinja2/layouts/detail.jinja
+++ b/common/jinja2/layouts/detail.jinja
@@ -3,7 +3,7 @@
 {% block breadcrumb %}
   {{ govukBreadcrumbs({
     "items": [
-      {"text": "Home", "href": url("dashboard")},
+      {"text": "Home", "href": url("index")},
       {"text": "Find and edit " ~ object._meta.verbose_name_plural, "href": object.get_url(action="list")},
       {"text": page_title}
     ]

--- a/common/jinja2/layouts/list.jinja
+++ b/common/jinja2/layouts/list.jinja
@@ -11,7 +11,7 @@
 {% block breadcrumb %}
   {{ govukBreadcrumbs({
     "items": [
-      {"text": "Home", "href": url("dashboard")},
+      {"text": "Home", "href": url("index")},
       {"text": page_title}
     ]
   }) }}

--- a/common/jinja2/layouts/list_vertical.jinja
+++ b/common/jinja2/layouts/list_vertical.jinja
@@ -11,7 +11,7 @@
 {% block breadcrumb %}
   {{ govukBreadcrumbs({
     "items": [
-      {"text": "Home", "href": url("dashboard")},
+      {"text": "Home", "href": url("index")},
       {"text": page_title}
     ]
   }) }}

--- a/common/views.py
+++ b/common/views.py
@@ -91,8 +91,8 @@ class DashboardView(TemplateResponseMixin, FormMixin, View):
     action_success_url_names = {
         "publish-all": "workbaskets:workbasket-ui-submit",
         "remove-selected": "workbaskets:workbasket-ui-delete-changes",
-        "page-prev": "dashboard",
-        "page-next": "dashboard",
+        "page-prev": "index",
+        "page-next": "index",
     }
 
     @property
@@ -159,7 +159,7 @@ class DashboardView(TemplateResponseMixin, FormMixin, View):
                 reverse(self.action_success_url_names[form_action]),
                 form_action,
             )
-        return reverse("dashboard")
+        return reverse("index")
 
     def get_initial(self):
         store = SessionStore(

--- a/footnotes/jinja2/footnotes/confirm_update_description.jinja
+++ b/footnotes/jinja2/footnotes/confirm_update_description.jinja
@@ -7,7 +7,7 @@
 {% block beforeContent %}
   {{ govukBreadcrumbs({
     "items": [
-      {"text": "Home", "href": url("dashboard")},
+      {"text": "Home", "href": url("index")},
       {"text": "Footnotes", "href": url("footnote-ui-list")},
       {"text": "Footnote " ~ object.described_footnote|string, "href": object.described_footnote.get_url()},
       {"text": page_title}
@@ -26,6 +26,6 @@
     <li><a href="{{ object.described_footnote.get_url() }}">View footnote {{ object.described_footnote|string }}</a></li>
     <li><a href="{{ url("footnote-ui-list") }}">Manage more footnotes</a></li>
     <li><a href="{{ url("workbaskets:workbasket-ui-detail", args=[request.session.workbasket.id]) }}">View content of your workbasket</a></li>
-    <li><a href="{{ url("dashboard") }}">Return to main menu</a></li>
+    <li><a href="{{ url("index") }}">Return to main menu</a></li>
   </ul>
 {% endblock %}

--- a/footnotes/jinja2/footnotes/edit_description.jinja
+++ b/footnotes/jinja2/footnotes/edit_description.jinja
@@ -9,7 +9,7 @@
 {% block beforeContent %}
   {{ govukBreadcrumbs({
     "items": [
-      {"text": "Home", "href": url("dashboard")},
+      {"text": "Home", "href": url("index")},
       {"text": "Footnotes", "href": url("footnote-ui-list")},
       {"text": "Footnote " ~ object.described_footnote|string, "href": object.described_footnote.get_url()},
       {"text": page_title}

--- a/geo_areas/jinja2/geo_areas/detail.jinja
+++ b/geo_areas/jinja2/geo_areas/detail.jinja
@@ -15,7 +15,7 @@
 {% block breadcrumb %}
   {{ govukBreadcrumbs({
     "items": [
-      {"text": "Home", "href": url("dashboard")},
+      {"text": "Home", "href": url("index")},
       {"text": "Find and edit geographical areas", "href": url("geo_area-ui-list")},
       {"text": page_title}
     ]

--- a/importer/jinja2/importer/create.jinja
+++ b/importer/jinja2/importer/create.jinja
@@ -9,7 +9,7 @@
 {% block beforeContent %}
   {{ govukBreadcrumbs({
     "items": [
-      {"text": "Home", "href": url("dashboard")},
+      {"text": "Home", "href": url("index")},
       {"text": "Find and edit import batches", "href": url("import_batch-ui-list")},
       {"text": page_title}
     ]

--- a/measures/jinja2/measures/confirm-create-multiple.jinja
+++ b/measures/jinja2/measures/confirm-create-multiple.jinja
@@ -41,13 +41,13 @@
       <p class="govuk-body">To complete your task you must publish your change. </p>
       {{ govukButton({
         "text": "Go to your tariff changes",
-        "href": url("index"),
+        "href": url("my-workbasket"),
         "classes": "govuk-button--secondary"
       }) }}
       <ul class="govuk-list govuk-list-spaced">
         <li><a class="govuk-link" href="{{ created_measures.0.get_url('create') }}">Create a new measure</a></li>
         <li><a href="{{ created_measures.0.get_url('list') }}">Manage more {{ created_measures.0._meta.verbose_name_plural }}</a></li>
-        <li><a href="{{ url('index') }}">Return to main menu</a></li>
+        <li><a href="{{ url('my-workbasket') }}">Return to main menu</a></li>
       </ul>
     </div>
   </div>

--- a/measures/jinja2/measures/confirm-create-multiple.jinja
+++ b/measures/jinja2/measures/confirm-create-multiple.jinja
@@ -21,7 +21,7 @@
 {% block beforeContent %}
   {{ govukBreadcrumbs({
     "items": [
-      {"text": "Home", "href": url("dashboard")},
+      {"text": "Home", "href": url("index")},
       {"text": page_title}
     ]
   }) }}
@@ -41,13 +41,13 @@
       <p class="govuk-body">To complete your task you must publish your change. </p>
       {{ govukButton({
         "text": "Go to your tariff changes",
-        "href": url("dashboard"),
+        "href": url("index"),
         "classes": "govuk-button--secondary"
       }) }}
       <ul class="govuk-list govuk-list-spaced">
         <li><a class="govuk-link" href="{{ created_measures.0.get_url('create') }}">Create a new measure</a></li>
         <li><a href="{{ created_measures.0.get_url('list') }}">Manage more {{ created_measures.0._meta.verbose_name_plural }}</a></li>
-        <li><a href="{{ url('dashboard') }}">Return to main menu</a></li>
+        <li><a href="{{ url('index') }}">Return to main menu</a></li>
       </ul>
     </div>
   </div>

--- a/measures/jinja2/measures/create-start.jinja
+++ b/measures/jinja2/measures/create-start.jinja
@@ -14,7 +14,7 @@
 
   <p class="govuk-body">
     You'll also need to use the 
-      <a class="govuk-link" href="{{ url("dashboard") }}">
+      <a class="govuk-link" href="{{ url("index") }}">
         manage trade tariffs service  
       </a>
     to find or create details of the following:

--- a/measures/jinja2/measures/edit.jinja
+++ b/measures/jinja2/measures/edit.jinja
@@ -14,7 +14,7 @@
 {% block beforeContent %}
   {{ govukBreadcrumbs({
     "items": [
-      {"text": "Home", "href": url("dashboard")},
+      {"text": "Home", "href": url("index")},
       {"text": "Find and edit " ~ object._meta.verbose_name_plural, "href": object.get_url("list")},
       {"text": object._meta.verbose_name|capitalize ~ ": " ~ object.sid, "href": object.get_url()},
       {"text": page_title}

--- a/regulations/jinja2/regulations/edit.jinja
+++ b/regulations/jinja2/regulations/edit.jinja
@@ -7,7 +7,7 @@
   
   {{ govukBreadcrumbs({
     "items": [
-      {"text": "Home", "href": url("dashboard")},
+      {"text": "Home", "href": url("index")},
       {"text": "Find and edit " ~ object._meta.verbose_name_plural, "href": object.get_url("list")},
       {"text": object._meta.verbose_name|capitalize ~ ": " ~ object|string, "href": object.get_url()},
       {"text": page_title}

--- a/workbaskets/jinja2/workbaskets/delete_changes.jinja
+++ b/workbaskets/jinja2/workbaskets/delete_changes.jinja
@@ -11,7 +11,7 @@
 {% block breadcrumb %}
   {{ govukBreadcrumbs({
     "items": [
-      {"text": "Home", "href": url("dashboard")},
+      {"text": "Home", "href": url("index")},
       {"text": page_title}
     ]
   }) }}

--- a/workbaskets/jinja2/workbaskets/delete_changes_confirm.jinja
+++ b/workbaskets/jinja2/workbaskets/delete_changes_confirm.jinja
@@ -9,7 +9,7 @@
 {% block breadcrumb %}
   {{ govukBreadcrumbs({
     "items": [
-      {"text": "Home", "href": url("dashboard")},
+      {"text": "Home", "href": url("index")},
       {"text": page_title}
     ]
   }) }}
@@ -35,7 +35,7 @@
     }) }}
 
     <p class="govuk-body">
-      <a href="{{ url('dashboard') }}" class="govuk-link">Return to main menu</a>
+      <a href="{{ url('index') }}" class="govuk-link">Return to main menu</a>
     </p>
   </div>
 </div>

--- a/workbaskets/jinja2/workbaskets/detail.jinja
+++ b/workbaskets/jinja2/workbaskets/detail.jinja
@@ -12,7 +12,7 @@
 {% block breadcrumb %}
   {{ govukBreadcrumbs({
     "items": [
-      {"text": "Home", "href": url("dashboard")},
+      {"text": "Home", "href": url("index")},
       {"text": "Find and edit work baskets", "href": url("workbaskets:workbasket-ui-list")},
       {"text": page_title}
     ]

--- a/workbaskets/jinja2/workbaskets/select-workbasket.jinja
+++ b/workbaskets/jinja2/workbaskets/select-workbasket.jinja
@@ -8,7 +8,7 @@
 {% block breadcrumb %}
   {{ govukBreadcrumbs({
     "items": [
-      {"text": "Home", "href": url("dashboard")},
+      {"text": "Home", "href": url("index")},
       {"text": page_title}
     ]
   }) }}


### PR DESCRIPTION
# TP-2000-375 Update links to point to the correct pages


## Why
In my last PR, I incorrectly assumed that all the links pointing to home would want to go to the dashboard still. This was dumb as we now have a workbasket page that builds upon the dashboard, so it should have linked there. This PR undoes all of the index -> dashboard link changing I did but also updates the confirm template to redirect you back to `my-workbasket`.

## What
- All links that originally pointed to index, that were changed over in the previous PR to point to dashboard, have now been reverted to index again and take you to the new landing page (new index). 
- Both the "Go to your tariff changes", and "Return to main menu" buttons / link on the Confirmation page after creating something, now take you back to the `my-workbasket` page. (This is an accessibility issue but not for long at all)


## Checklist
- Requires migrations? - no
- Requires dependency updates? - no

