### PR TITLE
TP2000-377 Add footnotes tab to measure detail page

### DIFF
--- a/measures/jinja2/includes/measures/tabs/conditions.jinja
+++ b/measures/jinja2/includes/measures/tabs/conditions.jinja
@@ -16,30 +16,28 @@
 
 <h2 class="govuk-heading-l">Conditions</h2>
 
-{% set has_conditions = false %}
-{% for condition_code, conditions in condition_groups %}
-    <h3 class="govuk-heading-m">{{ condition_code.code }}: {{ condition_code.description }}</h3>
-    {% set has_conditions = true %}
-    {% set table_rows = [] %}
-    {% for condition in conditions -%}
-        {{ table_rows.append([
-            {"text": condition.sid },
-            {"text": requirement(condition) },
-            {"text": condition.action.description},
-            {"text": condition.duty_sentence if condition.duty_sentence else '-'},
-        ]) or "" }}
-    {% endfor %}
-    {{ govukTable({
-    "head": [
-        {"text": "SID"},
-        {"text": "Required certificate or amount", "classes": "govuk-!-width-two-thirds"},
-        {"text": "Action"},
-        {"text": "Applicable duties"},
-    ],
-    "rows": table_rows
-    }) }}
-{% endfor %}
-
 {% if has_conditions %}
-    <p class="govuk-body">This measure has no conditions.</p>
+  {% for condition_code, conditions in condition_groups %}
+      <h3 class="govuk-heading-m">{{ condition_code.code }}: {{ condition_code.description }}</h3>
+      {% set table_rows = [] %}
+      {% for condition in conditions -%}
+          {{ table_rows.append([
+              {"text": condition.sid },
+              {"text": requirement(condition) },
+              {"text": condition.action.description},
+              {"text": condition.duty_sentence if condition.duty_sentence else '-'},
+          ]) or "" }}
+      {% endfor %}
+      {{ govukTable({
+      "head": [
+          {"text": "SID"},
+          {"text": "Required certificate or amount", "classes": "govuk-!-width-two-thirds"},
+          {"text": "Action"},
+          {"text": "Applicable duties"},
+      ],
+      "rows": table_rows
+      }) }}
+  {% endfor %}
+{% else %}
+  <p class="govuk-body">This measure has no conditions.</p>
 {% endif %}

--- a/measures/jinja2/includes/measures/tabs/footnotes.jinja
+++ b/measures/jinja2/includes/measures/tabs/footnotes.jinja
@@ -2,23 +2,21 @@
 
 <h2 class="govuk-heading-l">Footnotes</h2>
 
-{% set has_footnotes = false %}
-{% set table_rows = [] %}
-{% for footnote in object.footnotes.all() %}
-  {% set has_footnotes = true %}
-  {{ table_rows.append([
-      {"text": create_link(footnote.get_url(), footnote|string) },
-      {"text": footnote.descriptions.first().description },
-    ]) or "" }}
-{% endfor %}
-  {{ govukTable({
-  "head": [
-      {"text": "SID"},
-      {"text": "Description"},
-  ],
-  "rows": table_rows
-  }) }}
-
-{% if has_footnotes %}
+{% if object.footnotes.all() %}
+  {% set table_rows = [] %}
+  {% for footnote in object.footnotes.all() %}
+    {{ table_rows.append([
+        {"text": create_link(footnote.get_url(), footnote|string) },
+        {"text": footnote.descriptions.first().description },
+      ]) or "" }}
+  {% endfor %}
+    {{ govukTable({
+    "head": [
+        {"text": "SID"},
+        {"text": "Description"},
+    ],
+    "rows": table_rows
+    }) }}
+{% else %}
     <p class="govuk-body">This measure has no footnotes.</p>
 {% endif %}

--- a/measures/jinja2/includes/measures/tabs/footnotes.jinja
+++ b/measures/jinja2/includes/measures/tabs/footnotes.jinja
@@ -1,0 +1,24 @@
+{% from 'macros/create_link.jinja' import create_link %}
+
+<h2 class="govuk-heading-l">Footnotes</h2>
+
+{% set has_footnotes = false %}
+{% set table_rows = [] %}
+{% for footnote in object.footnotes.all() %}
+  {% set has_footnotes = true %}
+  {{ table_rows.append([
+      {"text": create_link(footnote.get_url(), footnote|string) },
+      {"text": footnote.descriptions.first().description },
+    ]) or "" }}
+{% endfor %}
+  {{ govukTable({
+  "head": [
+      {"text": "SID"},
+      {"text": "Description"},
+  ],
+  "rows": table_rows
+  }) }}
+
+{% if has_footnotes %}
+    <p class="govuk-body">This measure has no footnotes.</p>
+{% endif %}

--- a/measures/jinja2/measures/detail.jinja
+++ b/measures/jinja2/measures/detail.jinja
@@ -7,6 +7,7 @@
 
 {% set core_data_tab_html %}{% include "includes/measures/tabs/core_data.jinja" %}{% endset %}
 {% set conditions_tab_html %}{% include "includes/measures/tabs/conditions.jinja" %}{% endset %}
+{% set footnotes_tab_html %}{% include "includes/measures/tabs/footnotes.jinja" %}{% endset %}
 
 {% set tabs = {
     "items": [
@@ -22,6 +23,13 @@
         "id": "conditions",
         "panel": {
           "html": conditions_tab_html
+        }
+      },
+      {
+        "label": "Footnotes",
+        "id": "footnotes",
+        "panel": {
+          "html": footnotes_tab_html
         }
       }
     ]

--- a/measures/tests/test_views.py
+++ b/measures/tests/test_views.py
@@ -227,6 +227,22 @@ def test_measure_detail_footnotes(client, valid_user):
     }
 
 
+def test_measure_detail_no_footnotes(client, valid_user):
+    measure = factories.MeasureFactory.create()
+    url = reverse("measure-ui-detail", kwargs={"sid": measure.sid}) + "#footnotes"
+    client.force_login(valid_user)
+    response = client.get(url)
+    page = BeautifulSoup(
+        response.content.decode(response.charset),
+        "html.parser",
+    )
+
+    assert (
+        page.select("#footnotes .govuk-body")[0].text
+        == "This measure has no footnotes."
+    )
+
+
 @pytest.mark.parametrize(
     ("view", "url_pattern"),
     get_class_based_view_urls_matching_url(

--- a/measures/tests/test_views.py
+++ b/measures/tests/test_views.py
@@ -173,6 +173,22 @@ def test_measure_detail_conditions(client, valid_user):
     assert len(rows) == 2
 
 
+def test_measure_detail_no_conditions(client, valid_user):
+    measure = factories.MeasureFactory.create()
+    url = reverse("measure-ui-detail", kwargs={"sid": measure.sid}) + "#conditions"
+    client.force_login(valid_user)
+    response = client.get(url)
+    page = BeautifulSoup(
+        response.content.decode(response.charset),
+        "html.parser",
+    )
+
+    assert (
+        page.select("#conditions .govuk-body")[0].text
+        == "This measure has no conditions."
+    )
+
+
 def test_measure_detail_footnotes(client, valid_user):
     measure = factories.MeasureFactory.create()
     footnote1 = factories.FootnoteAssociationMeasureFactory.create(

--- a/measures/views.py
+++ b/measures/views.py
@@ -90,6 +90,7 @@ class MeasureDetail(MeasureMixin, TrackedModelDetailView):
 
         context = super().get_context_data(**kwargs)
         context["condition_groups"] = condition_groups
+        context["has_conditions"] = bool(len(conditions))
         return context
 
 


### PR DESCRIPTION
# TP2000-377 Add footnotes tab to measure detail page
<!---
 * Include the JIRA ticket number, eg TP-123, to automatically link.
 * Use 50 characters maximum.
 * Do not end with a full-stop.
--->

## Why
<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Use as many lines as you like.
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions or deliberately ignored edge-cases.
--->
* Users need to be able to see measures' associated footnotes on the measue detail page

## What
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Explain like I'm 5.
 * Use pictures if you can.
--->
* Adds an extra tab to display a measure's footnotes

<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
## Checklist
- Requires migrations?
- Requires dependency updates?
--->

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
