### PR TITLE
TP2000-179 Add quota order number to measure detail page

### DIFF
--- a/measures/jinja2/includes/measures/tabs/core_data.jinja
+++ b/measures/jinja2/includes/measures/tabs/core_data.jinja
@@ -58,7 +58,7 @@
         },
         {
             "key": {"text": "Quota order number"},
-            "value": {"text":  object.order_number.sid if object.order_number else '-'},
+            "value": {"text":  object.order_number if object.order_number else '-'},
             "actions": {"items": []}
         },
         {

--- a/measures/tests/test_views.py
+++ b/measures/tests/test_views.py
@@ -242,6 +242,20 @@ def test_measure_detail_no_footnotes(client, valid_user):
     )
 
 
+def test_measure_detail_quota_order_number(client, valid_user):
+    quota_order_number = factories.QuotaOrderNumberFactory.create()
+    measure = factories.MeasureFactory.create(order_number=quota_order_number)
+    url = reverse("measure-ui-detail", kwargs={"sid": measure.sid})
+    client.force_login(valid_user)
+    response = client.get(url)
+    page = BeautifulSoup(
+        response.content.decode(response.charset),
+        "html.parser",
+    )
+    items = [element.text.strip() for element in page.select("#core-data dl dd")]
+    assert str(quota_order_number) in items
+
+
 def test_measure_detail_version_control(client, valid_user):
     measure = factories.MeasureFactory.create()
     measure.new_version(measure.transaction.workbasket)


### PR DESCRIPTION
# TP2000-179 Add quota order number to measure detail page
<!---
 * Include the JIRA ticket number, eg TP-123, to automatically link.
 * Use 50 characters maximum.
 * Do not end with a full-stop.
--->

## Why
<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Use as many lines as you like.
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions or deliberately ignored edge-cases.
--->
* Users could only see the quota order number SID which wasn't helpful

## What
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Explain like I'm 5.
 * Use pictures if you can.
--->
* Displays the measure's order_number instead of order_number.sid on the details page

<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
## Checklist
- Requires migrations?
- Requires dependency updates?
--->

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
