### PR TITLE
Tp2000 374 create workbasket

### DIFF
--- a/common/forms.py
+++ b/common/forms.py
@@ -156,11 +156,11 @@ class RadioNested(TypedChoiceField):
 
 class WorkbasketActionForm(forms.Form):
     class WorkbasketActions(TextChoices):
+        CREATE = "CREATE", "Create a new workbasket"
         EDIT = (
             "EDIT",
             "Edit an existing workbasket",
         )
-        CREATE = "CREATE", "Create a new workbasket"
 
     workbasket_action = forms.ChoiceField(
         label="What would you like to do?",

--- a/common/forms.py
+++ b/common/forms.py
@@ -156,7 +156,11 @@ class RadioNested(TypedChoiceField):
 
 class WorkbasketActionForm(forms.Form):
     class WorkbasketActions(TextChoices):
-        EDIT = "EDIT", "Edit an existing workbasket"
+        EDIT = (
+            "EDIT",
+            "Edit an existing workbasket",
+        )
+        CREATE = "CREATE", "Create a new workbasket"
 
     workbasket_action = forms.ChoiceField(
         label="What would you like to do?",

--- a/common/tests/test_views.py
+++ b/common/tests/test_views.py
@@ -23,19 +23,36 @@ def test_index_displays_workbasket_action_form(valid_user_client):
     page = BeautifulSoup(str(response.content), "html.parser")
     assert "What would you like to do?" in page.select("legend")[0].text
     assert "Edit an existing workbasket" in page.select("label")[0].text
+    assert "Create a new workbasket" in page.select("label")[1].text
 
 
+@pytest.mark.parametrize(
+    ("data", "response_url"),
+    (
+        (
+            {
+                "workbasket_action": "EDIT",
+            },
+            "workbaskets:select-workbasket",
+        ),
+        (
+            {
+                "workbasket_action": "CREATE",
+            },
+            "workbaskets:workbasket-ui-create",
+        ),
+    ),
+)
 def test_workbasket_action_form_response_redirects_user(
     valid_user,
     client,
+    data,
+    response_url,
 ):
-    data = {
-        "workbasket_action": "EDIT",
-    }
     client.force_login(valid_user)
     response = client.post(reverse("index"), data)
     assert response.status_code == 302
-    assert response.url == reverse("workbaskets:select-workbasket")
+    assert response.url == reverse(response_url)
 
 
 def test_dashboard_creates_workbasket_if_needed(valid_user_client, approved_workbasket):

--- a/common/views.py
+++ b/common/views.py
@@ -49,6 +49,8 @@ class WorkbasketActionView(FormView, View):
     def form_valid(self, form):
         if form.cleaned_data["workbasket_action"] == "EDIT":
             return redirect(reverse("workbaskets:select-workbasket"))
+        elif form.cleaned_data["workbasket_action"] == "CREATE":
+            return redirect(reverse("workbaskets:workbasket-ui-create"))
 
 
 @method_decorator(require_current_workbasket, name="dispatch")

--- a/workbaskets/forms.py
+++ b/workbaskets/forms.py
@@ -15,13 +15,14 @@ class WorkbasketCreateForm(forms.ModelForm):
     title = forms.CharField(
         label="Tops/Jira number",
         widget=forms.TextInput,
-        required=False,
+        required=True,
     )
 
     reason = forms.CharField(
         label="Description",
         help_text="Add your notes here. You may enter HTML formatting if required. See the guide below for more information.",
         widget=forms.Textarea,
+        required=True,
     )
 
     def __init__(self, *args, **kwargs):

--- a/workbaskets/forms.py
+++ b/workbaskets/forms.py
@@ -1,4 +1,46 @@
+from crispy_forms_gds.helper import FormHelper
+from crispy_forms_gds.layout import Field
+from crispy_forms_gds.layout import Layout
+from crispy_forms_gds.layout import Size
+from crispy_forms_gds.layout import Submit
 from django import forms
+
+from common.forms import DescriptionHelpBox
+from workbaskets import models
+
+
+class WorkbasketCreateForm(forms.ModelForm):
+    """The form for creating a new workbasket."""
+
+    title = forms.CharField(
+        label="Tops/Jira number",
+        widget=forms.TextInput,
+        required=False,
+    )
+
+    reason = forms.CharField(
+        label="Description",
+        help_text="Add your notes here. You may enter HTML formatting if required. See the guide below for more information.",
+        widget=forms.Textarea,
+    )
+
+    def __init__(self, *args, **kwargs):
+        self.request = kwargs.pop("request", None)
+        super().__init__(*args, **kwargs)
+
+        self.helper = FormHelper(self)
+        self.helper.label_size = Size.SMALL
+        self.helper.legend_size = Size.SMALL
+        self.helper.layout = Layout(
+            "title",
+            Field.textarea("reason", rows=5),
+            DescriptionHelpBox(),
+            Submit("submit", "Create"),
+        )
+
+    class Meta:
+        model = models.WorkBasket
+        fields = ("title", "reason")
 
 
 class SelectableObjectField(forms.BooleanField):

--- a/workbaskets/jinja2/workbaskets/create.jinja
+++ b/workbaskets/jinja2/workbaskets/create.jinja
@@ -1,0 +1,13 @@
+{% extends "layouts/create.jinja" %}
+{% from "components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
+
+
+{% set page_title = "Create a new workbasket" %}
+{% block breadcrumb %}
+    {{ govukBreadcrumbs({
+      "items": [
+        {"text": "Home", "href": url("index")},
+        {"text": "Create a new workbasket"}
+      ]
+    }) }}
+{% endblock %}

--- a/workbaskets/tests/test_forms.py
+++ b/workbaskets/tests/test_forms.py
@@ -1,0 +1,53 @@
+import pytest
+from django import forms
+
+from common.forms import BindNestedFormMixin
+
+pytestmark = pytest.mark.django_db
+
+
+class WorkBasketForm(BindNestedFormMixin, forms.Form):
+    title = forms.CharField()
+    reason = forms.CharField()
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.bind_nested_forms(*args, **kwargs)
+
+
+def test_workbasket_form_validation():
+    form = WorkBasketForm(
+        {
+            "title": "some title",
+            "reason": "",
+        },
+    )
+    assert not form.is_valid()
+    assert "reason" in form.errors
+
+    form = WorkBasketForm(
+        {
+            "title": "",
+            "reason": "some reason",
+        },
+    )
+    assert not form.is_valid()
+    assert "title" in form.errors
+
+    form = WorkBasketForm(
+        {
+            "title": "",
+            "reason": "",
+        },
+    )
+    assert not form.is_valid()
+    assert "title" in form.errors
+    assert "reason" in form.errors
+
+    form = WorkBasketForm(
+        {
+            "title": "some title",
+            "reason": "some reason",
+        },
+    )
+    assert form.is_valid()

--- a/workbaskets/tests/test_forms.py
+++ b/workbaskets/tests/test_forms.py
@@ -1,18 +1,15 @@
 import pytest
 from django import forms
 
-from common.forms import BindNestedFormMixin
-
 pytestmark = pytest.mark.django_db
 
 
-class WorkBasketForm(BindNestedFormMixin, forms.Form):
+class WorkBasketForm(forms.Form):
     title = forms.CharField()
     reason = forms.CharField()
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.bind_nested_forms(*args, **kwargs)
 
 
 def test_workbasket_form_validation():

--- a/workbaskets/tests/test_views.py
+++ b/workbaskets/tests/test_views.py
@@ -9,11 +9,34 @@ from common.tests import factories
 from common.tests.util import validity_period_post_data
 from common.validators import UpdateType
 from exporter.tasks import upload_workbaskets
-from workbaskets.models import WorkBasket
+from workbaskets import models
 from workbaskets.tests.util import assert_workbasket_valid
 from workbaskets.validators import WorkflowStatus
 
 pytestmark = pytest.mark.django_db
+
+
+def test_workbasket_create_form_creates_workbasket_object(
+    valid_user_api_client,
+):
+
+    # Post a form
+    create_url = reverse("workbaskets:workbasket-ui-create")
+
+    form_data = {
+        "title": "My new workbasket",
+        "reason": "Making a new workbasket",
+    }
+
+    response = valid_user_api_client.post(create_url, form_data)
+    #  get the workbasket we have made, and make sure it matches title and description
+    workbasket = models.WorkBasket.objects.filter(
+        title=form_data["title"],
+    )[0]
+
+    assert f"workbasket={workbasket.id}" in response.url
+    assert workbasket.title == form_data["title"]
+    assert workbasket.reason == form_data["reason"]
 
 
 @override_settings(CELERY_TASK_ALWAYS_EAGER=True, CELERY_TASK_EAGER_PROPOGATES=True)

--- a/workbaskets/urls.py
+++ b/workbaskets/urls.py
@@ -17,6 +17,11 @@ ui_patterns = [
         name="workbasket-ui-list",
     ),
     path(
+        "create-workbasket/",
+        ui_views.WorkBasketCreate.as_view(),
+        name="workbasket-ui-create",
+    ),
+    path(
         f"<pk>/",
         ui_views.WorkBasketDetail.as_view(),
         name="workbasket-ui-detail",

--- a/workbaskets/urls.py
+++ b/workbaskets/urls.py
@@ -17,7 +17,7 @@ ui_patterns = [
         name="workbasket-ui-list",
     ),
     path(
-        "create-workbasket/",
+        "create/",
         ui_views.WorkBasketCreate.as_view(),
         name="workbasket-ui-create",
     ),

--- a/workbaskets/views/ui.py
+++ b/workbaskets/views/ui.py
@@ -18,7 +18,6 @@ from django.views.generic.list import ListView
 
 from common.filters import TamatoFilter
 from common.pagination import build_pagination_list
-from common.validators import UpdateType
 from common.views import WithPaginationListView
 from exporter.models import Upload
 from workbaskets import forms
@@ -67,7 +66,6 @@ class WorkBasketCreate(DraftCreateView):
         user = get_user_model().objects.get(username=self.request.user.username)
         self.object = form.save(commit=False)
         self.object.author = user
-        self.object.update_type = UpdateType.CREATE
         self.object.save()
         return HttpResponseRedirect(
             f"{reverse('my-workbasket')}?workbasket={self.object.pk}&edit=1",

--- a/workbaskets/views/ui.py
+++ b/workbaskets/views/ui.py
@@ -19,10 +19,12 @@ from common.filters import TamatoFilter
 from common.pagination import build_pagination_list
 from common.views import WithPaginationListView
 from exporter.models import Upload
+from workbaskets import forms
 from workbaskets import tasks
 from workbaskets.models import WorkBasket
 from workbaskets.session_store import SessionStore
 from workbaskets.validators import WorkflowStatus
+from workbaskets.views.generic import DraftCreateView
 
 
 class WorkBasketFilter(TamatoFilter):
@@ -51,6 +53,13 @@ class WorkBasketList(WithPaginationListView):
 
     def get_queryset(self):
         return WorkBasket.objects.order_by("-updated_at")
+
+
+class WorkBasketCreate(DraftCreateView):
+    """UI endpoint for creating workbaskets."""
+
+    template_name = "workbaskets/create.jinja"
+    form_class = forms.WorkbasketCreateForm
 
 
 class SelectWorkbasketView(WorkBasketList):


### PR DESCRIPTION
# TP-2000-374 Create Workbaskets

## Why
This PR adds the following so that TM's can make their own workbaskets: 
- A new option to the landing page to create a new workbasket.
- A create a new workbasket form, that takes a title, and a description - both mandatory. 
- A redirect from the create form that takes the user to the my workbasket page for the workbasket they just made.

## Checklist
- Requires migrations? - no 
- Requires dependency updates? - no

