### PR TITLE
TP2000-386 get_current_memberships uses latest_approved instead of approved_up_to_transaction

### DIFF
--- a/geo_areas/models.py
+++ b/geo_areas/models.py
@@ -94,7 +94,7 @@ class GeographicalArea(TrackedModel, ValidityMixin, DescribedMixin):
             GeographicalMembership.objects.filter(
                 Q(geo_group__sid=self.sid) | Q(member__sid=self.sid),
             )
-            .latest_approved()
+            .current()
             .select_related("member", "geo_group")
         )
 

--- a/geo_areas/tests/test_models.py
+++ b/geo_areas/tests/test_models.py
@@ -1,5 +1,7 @@
 import pytest
 
+from common.models.transactions import Transaction
+from common.models.utils import set_current_transaction
 from common.tests import factories
 
 pytestmark = pytest.mark.django_db
@@ -24,6 +26,7 @@ def test_get_current_memberships_on_groups(membership_data, expected):
     group = factories.GeoGroupFactory()
     for data in membership_data(group):
         factories.GeographicalMembershipFactory(**data)
+    set_current_transaction(Transaction.objects.last())
 
     assert len(group.get_current_memberships()) == expected
 
@@ -47,6 +50,7 @@ def test_get_current_memberships_on_areas(membership_data, expected):
     area = factories.CountryFactory()
     for data in membership_data(area):
         factories.GeographicalMembershipFactory(**data)
+    set_current_transaction(Transaction.objects.last())
 
     assert len(area.get_current_memberships()) == expected
 
@@ -56,6 +60,7 @@ def test_get_current_memberships_when_region_and_country_share_sid():
     region = factories.RegionFactory.create(sid=country.sid)
     country_membership = factories.GeographicalMembershipFactory.create(member=country)
     region_membership = factories.GeographicalMembershipFactory.create(member=region)
+    set_current_transaction(Transaction.objects.last())
     country_memberships = country.get_current_memberships()
     region_memberships = region.get_current_memberships()
 

--- a/measures/forms.py
+++ b/measures/forms.py
@@ -221,6 +221,7 @@ class CountryRegionForm(forms.Form):
     )
 
     def __init__(self, *args, **kwargs):
+        # Depending on whether it is used a part of a formset or independently, transaction will be passed directly into kwargs or as part of form_kwargs
         tx = kwargs.pop("transaction", None)
         form_kwargs = kwargs.pop("form_kwargs", None)
         if form_kwargs and not tx:

--- a/measures/forms.py
+++ b/measures/forms.py
@@ -90,7 +90,8 @@ class GeoGroupForm(forms.Form):
     )
 
     def __init__(self, *args, **kwargs):
-        tx = kwargs.pop("transaction", None)
+        form_kwargs = kwargs.pop("form_kwargs", None)
+        tx = form_kwargs.get("transaction")
         self.transaction = tx
         super().__init__(*args, **kwargs)
         self.fields[
@@ -126,7 +127,6 @@ class ErgaOmnesExclusionsForm(forms.Form):
 
     def __init__(self, *args, **kwargs):
         tx = kwargs.pop("transaction", None)
-        self.transaction = tx
         super().__init__(*args, **kwargs)
         self.fields["erga_omnes_exclusion"].queryset = with_latest_description_string(
             GeographicalArea.objects.exclude(
@@ -156,7 +156,6 @@ class GeoGroupExclusionsForm(forms.Form):
 
     def __init__(self, *args, **kwargs):
         tx = kwargs.pop("transaction", None)
-        self.transaction = tx
         super().__init__(*args, **kwargs)
         self.fields["geo_group_exclusion"].queryset = with_latest_description_string(
             GeographicalArea.objects.exclude(
@@ -223,7 +222,9 @@ class CountryRegionForm(forms.Form):
 
     def __init__(self, *args, **kwargs):
         tx = kwargs.pop("transaction", None)
-        self.transaction = tx
+        form_kwargs = kwargs.pop("form_kwargs", None)
+        if form_kwargs and not tx:
+            tx = form_kwargs.get("transaction")
         super().__init__(*args, **kwargs)
         self.fields["geographical_area_country_or_region"].queryset = (
             self.fields["geographical_area_country_or_region"]
@@ -572,6 +573,7 @@ class MeasureForm(ValidityPeriodForm, BindNestedFormMixin, forms.ModelForm):
         nested_forms_initial = {**self.initial}
         nested_forms_initial["geographical_area"] = self.instance.geographical_area
         kwargs.pop("initial")
+        kwargs["form_kwargs"] = {"transaction": tx}
         self.bind_nested_forms(*args, initial=nested_forms_initial, **kwargs)
 
     def clean_duty_sentence(self):
@@ -877,7 +879,7 @@ class MeasureGeographicalAreaForm(BindNestedFormMixin, forms.Form):
             nested_forms_initial["geographical_area"] = geographical_area_fields[
                 self.fields["geo_area"].initial
             ]
-
+        kwargs["form_kwargs"] = {"transaction": self.transaction}
         self.bind_nested_forms(*args, initial=nested_forms_initial, **kwargs)
 
         self.helper = FormHelper(self)

--- a/measures/forms.py
+++ b/measures/forms.py
@@ -90,9 +90,6 @@ class GeoGroupForm(forms.Form):
     )
 
     def __init__(self, *args, **kwargs):
-        form_kwargs = kwargs.pop("form_kwargs", None)
-        tx = form_kwargs.get("transaction")
-        self.transaction = tx
         super().__init__(*args, **kwargs)
         self.fields[
             "geographical_area_group"
@@ -101,7 +98,7 @@ class GeoGroupForm(forms.Form):
                 descriptions__description__isnull=True,
             )
             .as_at_today()
-            .approved_up_to_transaction(tx)
+            .current()
             .with_latest_links("descriptions")
             .prefetch_related("descriptions")
             .order_by("descriptions__description"),
@@ -126,14 +123,13 @@ class ErgaOmnesExclusionsForm(forms.Form):
     )
 
     def __init__(self, *args, **kwargs):
-        tx = kwargs.pop("transaction", None)
         super().__init__(*args, **kwargs)
         self.fields["erga_omnes_exclusion"].queryset = with_latest_description_string(
             GeographicalArea.objects.exclude(
                 descriptions__description__isnull=True,
             )
             .as_at_today()
-            .approved_up_to_transaction(tx)
+            .current()
             .with_latest_links("descriptions")
             .prefetch_related("descriptions")
             .order_by("descriptions__description"),
@@ -155,14 +151,13 @@ class GeoGroupExclusionsForm(forms.Form):
     )
 
     def __init__(self, *args, **kwargs):
-        tx = kwargs.pop("transaction", None)
         super().__init__(*args, **kwargs)
         self.fields["geo_group_exclusion"].queryset = with_latest_description_string(
             GeographicalArea.objects.exclude(
                 descriptions__description__isnull=True,
             )
             .as_at_today()
-            .approved_up_to_transaction(tx)
+            .current()
             .with_latest_links("descriptions")
             .prefetch_related("descriptions")
             .order_by("descriptions__description"),
@@ -221,16 +216,11 @@ class CountryRegionForm(forms.Form):
     )
 
     def __init__(self, *args, **kwargs):
-        # Depending on whether it is used a part of a formset or independently, transaction will be passed directly into kwargs or as part of form_kwargs
-        tx = kwargs.pop("transaction", None)
-        form_kwargs = kwargs.pop("form_kwargs", None)
-        if form_kwargs and not tx:
-            tx = form_kwargs.get("transaction")
         super().__init__(*args, **kwargs)
         self.fields["geographical_area_country_or_region"].queryset = (
             self.fields["geographical_area_country_or_region"]
             .queryset.as_at_today()
-            .approved_up_to_transaction(tx)
+            .current()
             .with_latest_links("descriptions")
             .prefetch_related("descriptions")
             .order_by("descriptions__description")
@@ -574,7 +564,6 @@ class MeasureForm(ValidityPeriodForm, BindNestedFormMixin, forms.ModelForm):
         nested_forms_initial = {**self.initial}
         nested_forms_initial["geographical_area"] = self.instance.geographical_area
         kwargs.pop("initial")
-        kwargs["form_kwargs"] = {"transaction": tx}
         self.bind_nested_forms(*args, initial=nested_forms_initial, **kwargs)
 
     def clean_duty_sentence(self):
@@ -858,8 +847,6 @@ class MeasureGeographicalAreaForm(BindNestedFormMixin, forms.Form):
     )
 
     def __init__(self, *args, **kwargs):
-        tx = kwargs.pop("transaction", None)
-        self.transaction = tx
         super().__init__(*args, **kwargs)
 
         kwargs.pop("initial")
@@ -880,7 +867,7 @@ class MeasureGeographicalAreaForm(BindNestedFormMixin, forms.Form):
             nested_forms_initial["geographical_area"] = geographical_area_fields[
                 self.fields["geo_area"].initial
             ]
-        kwargs["form_kwargs"] = {"transaction": self.transaction}
+
         self.bind_nested_forms(*args, initial=nested_forms_initial, **kwargs)
 
         self.helper = FormHelper(self)
@@ -901,11 +888,7 @@ class MeasureGeographicalAreaForm(BindNestedFormMixin, forms.Form):
 
     @property
     def erga_omnes_instance(self):
-        return (
-            GeographicalArea.objects.approved_up_to_transaction(self.transaction)
-            .erga_omnes()
-            .get()
-        )
+        return GeographicalArea.objects.current().erga_omnes().get()
 
     def clean(self):
         cleaned_data = super().clean()

--- a/measures/tests/conftest.py
+++ b/measures/tests/conftest.py
@@ -10,6 +10,8 @@ import requests
 from django.core.exceptions import ValidationError
 from django.forms.models import model_to_dict
 
+from common.models.transactions import Transaction
+from common.models.utils import set_current_transaction
 from common.tests import factories
 from common.util import TaricDateRange
 from common.validators import ApplicabilityCode
@@ -380,6 +382,7 @@ def measure_edit_conditions_data(measure_form_data):
 
 @pytest.fixture
 def measure_form(measure_form_data, session_with_workbasket, erga_omnes):
+    set_current_transaction(Transaction.objects.last())
     return MeasureForm(
         data=measure_form_data,
         instance=Measure.objects.with_duty_sentence().first(),

--- a/measures/tests/test_forms.py
+++ b/measures/tests/test_forms.py
@@ -3,6 +3,8 @@ from unittest.mock import patch
 import pytest
 from django.forms.models import model_to_dict
 
+from common.models.transactions import Transaction
+from common.models.utils import set_current_transaction
 from common.tests import factories
 from geo_areas.validators import AreaCode
 from measures import forms
@@ -86,6 +88,7 @@ def test_measure_forms_geo_area_valid_data_erga_omnes(erga_omnes):
     data = {
         f"{GEO_AREA_FORM_PREFIX}-geo_area": forms.GeoAreaType.ERGA_OMNES,
     }
+    set_current_transaction(Transaction.objects.last())
     form = forms.MeasureGeographicalAreaForm(
         data,
         initial={},
@@ -102,6 +105,7 @@ def test_measure_forms_geo_area_valid_data_erga_omnes_exclusions(erga_omnes):
         "erga_omnes_exclusions_formset-0-erga_omnes_exclusion": geo_area1.pk,
         "erga_omnes_exclusions_formset-1-erga_omnes_exclusion": geo_area2.pk,
     }
+    set_current_transaction(Transaction.objects.last())
     form = forms.MeasureGeographicalAreaForm(
         data,
         initial={},
@@ -117,6 +121,7 @@ def test_measure_forms_geo_area_valid_data_erga_omnes_exclusions_delete(erga_omn
         "erga_omnes_exclusions_formset-0-erga_omnes_exclusion": geo_area1.pk,
         "erga_omnes_exclusions_formset-0-DELETE": "1",
     }
+    set_current_transaction(Transaction.objects.last())
     form = forms.MeasureGeographicalAreaForm(
         data,
         initial={},
@@ -133,6 +138,7 @@ def test_measure_forms_geo_area_valid_data_geo_group_exclusions(erga_omnes):
         f"{GEO_AREA_FORM_PREFIX}-geographical_area_group": geo_group.pk,
         "geo_group_exclusions_formset-0-geo_group_exclusion": geo_area1.pk,
     }
+    set_current_transaction(Transaction.objects.last())
     form = forms.MeasureGeographicalAreaForm(
         data,
         initial={},
@@ -150,6 +156,7 @@ def test_measure_forms_geo_area_valid_data_geo_group_exclusions_delete(erga_omne
         "geo_group_exclusions_formset-0-geo_group_exclusion": geo_area1.pk,
         "geo_group_exclusions_formset-0-DELETE": "1",
     }
+    set_current_transaction(Transaction.objects.last())
     form = forms.MeasureGeographicalAreaForm(
         data,
         initial={},
@@ -165,6 +172,7 @@ def test_measure_forms_geo_area_valid_data_erga_omnes_exclusions_add(erga_omnes)
         "erga_omnes_exclusions_formset-0-erga_omnes_exclusion": geo_area1.pk,
         "erga_omnes_exclusions_formset-ADD": "1",
     }
+    set_current_transaction(Transaction.objects.last())
     form = forms.MeasureGeographicalAreaForm(
         data,
         initial={},
@@ -179,6 +187,7 @@ def test_measure_forms_geo_area_valid_data_geo_group(erga_omnes):
         f"{GEO_AREA_FORM_PREFIX}-geo_area": forms.GeoAreaType.GROUP,
         f"{GEO_AREA_FORM_PREFIX}-geographical_area_group": geo_group.pk,
     }
+    set_current_transaction(Transaction.objects.last())
     form = forms.MeasureGeographicalAreaForm(
         data,
         initial={},
@@ -195,6 +204,7 @@ def test_measure_forms_geo_area_valid_data_countries(erga_omnes):
         "country_region_formset-0-geographical_area_country_or_region": geo_area1.pk,
         "country_region_formset-1-geographical_area_country_or_region": geo_area2.pk,
     }
+    set_current_transaction(Transaction.objects.last())
     form = forms.MeasureGeographicalAreaForm(
         data,
         initial={},
@@ -212,6 +222,7 @@ def test_measure_forms_geo_area_valid_data_countries_delete(erga_omnes):
         "country_region_formset-1-geographical_area_country_or_region": geo_area2.pk,
         "country_region_formset-1-DELETE": "on",
     }
+    set_current_transaction(Transaction.objects.last())
     form = forms.MeasureGeographicalAreaForm(
         data,
         initial={},
@@ -227,6 +238,7 @@ def test_measure_forms_geo_area_valid_data_countries_add(erga_omnes):
         "country_region_formset-0-geographical_area_country_or_region": geo_area1.pk,
         "country_region_formset-ADD": "1",
     }
+    set_current_transaction(Transaction.objects.last())
     form = forms.MeasureGeographicalAreaForm(
         data,
         initial={},
@@ -241,6 +253,7 @@ def test_measure_forms_geo_area_invalid_data_geo_group(erga_omnes):
         f"{GEO_AREA_FORM_PREFIX}-geo_area": forms.GeoAreaType.GROUP,
         "geographical_area_group-geographical_area_group": geo_area1.pk,
     }
+    set_current_transaction(Transaction.objects.last())
     form = forms.MeasureGeographicalAreaForm(
         data,
         initial={},
@@ -270,6 +283,7 @@ def test_measure_forms_geo_area_invalid_data_geo_group(erga_omnes):
     ],
 )
 def test_measure_forms_geo_area_invalid_data_error_messages(data, error, erga_omnes):
+    set_current_transaction(Transaction.objects.last())
     form = forms.MeasureGeographicalAreaForm(
         data,
         initial={},
@@ -684,6 +698,7 @@ def test_measure_form_valid_data(erga_omnes, session_with_workbasket):
         start_date_1=start_date.month,
         start_date_2=start_date.year,
     )
+    set_current_transaction(Transaction.objects.last())
     form = forms.MeasureForm(
         data=data,
         initial={},
@@ -748,6 +763,7 @@ def test_measure_form_cleaned_data_geo_exclusions_group(
         "geo_group_exclusions_formset-1-geo_group_exclusion": excluded_country2.pk,
     }
     data.update(exclusions_data)
+    set_current_transaction(Transaction.objects.last())
     form = forms.MeasureForm(
         data=data,
         initial={},
@@ -784,6 +800,7 @@ def test_measure_form_cleaned_data_geo_exclusions_erga_omnes(
         "erga_omnes_exclusions_formset-1-erga_omnes_exclusion": excluded_country2.pk,
     }
     data.update(exclusions_data)
+    set_current_transaction(Transaction.objects.last())
     form = forms.MeasureForm(
         data=data,
         initial={},

--- a/measures/views.py
+++ b/measures/views.py
@@ -278,9 +278,6 @@ class MeasureCreateWizard(
             # commodities/duties step is a formset which expects form_kwargs to pass kwargs to its child forms
             kwargs["form_kwargs"] = {"measure_start_date": valid_between.lower}
 
-        if step == self.GEOGRAPHICAL_AREA:
-            kwargs["transaction"] = WorkBasket.get_current_transaction(self.request)
-
         return kwargs
 
     def get_form(self, step=None, data=None, files=None):

--- a/measures/views.py
+++ b/measures/views.py
@@ -277,6 +277,10 @@ class MeasureCreateWizard(
             )
             # commodities/duties step is a formset which expects form_kwargs to pass kwargs to its child forms
             kwargs["form_kwargs"] = {"measure_start_date": valid_between.lower}
+
+        if step == self.GEOGRAPHICAL_AREA:
+            kwargs["transaction"] = WorkBasket.get_current_transaction(self.request)
+
         return kwargs
 
     def get_form(self, step=None, data=None, files=None):

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,4 +2,3 @@
 
 django_debug_toolbar
 pre-commit
-pytest-celery


### PR DESCRIPTION


# TP2000-386 get_current_memberships uses latest_approved instead of approved_up_to_transaction
<!---
 * Include the JIRA ticket number, eg TP-123, to automatically link.
 * Use 50 characters maximum.
 * Do not end with a full-stop.
--->

## Why
<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Use as many lines as you like.
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions or deliberately ignored edge-cases.
--->
At present newly created memberships don't display in the memberships tab when viewing a geo area. Separately we also don't see new geo areas in dropdown menus on the measure create or edit forms.

## What
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Explain like I'm 5.
 * Use pictures if you can.
--->
- Have `get_current_memberships` use the `current` queryset method
- Pass in current transaction to geo area forms, so that latest editing workbasket changes are visible to the user

<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
## Checklist
- Requires migrations?
- Requires dependency updates?
--->

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
