### PR TITLE
Make copy accept saved related models

### DIFF
--- a/common/tests/test_models.py
+++ b/common/tests/test_models.py
@@ -714,12 +714,26 @@ def test_copy_saved_related_models():
 
     assert measure.exclusions.count() == 3
     assert copied_measure.exclusions.count() == 2
-    # assert exclusion_1 in measure.exclusions.all()
-    # assert exclusion_1 not in copied_measure.exclusions.all()
-    # assert exclusion_2 in measure.exclusions.all()
-    # assert exclusion_2 in copied_measure.exclusions.all()
-    # assert exclusion_3 in measure.exclusions.all() /PS-IGNORE
-    # assert exclusion_3 in copied_measure.exclusions.all() /PS-IGNORE
+    assert exclusion_1 in measure.exclusions.all()
+    assert not copied_measure.exclusions.filter(
+        modified_measure__sid=exclusion_1.modified_measure.sid,
+    ).exists()
+    assert exclusion_2 in measure.exclusions.all()
+    assert copied_measure.exclusions.filter(
+        modified_measure__sid=copied_measure.sid,
+        excluded_geographical_area=exclusion_2.excluded_geographical_area,
+    ).exists()
+    assert not copied_measure.exclusions.filter(
+        modified_measure__sid=exclusion_2.modified_measure.sid,
+    ).exists()
+    assert exclusion_3 in measure.exclusions.all()
+    assert copied_measure.exclusions.filter(
+        modified_measure__sid=copied_measure.sid,
+        excluded_geographical_area=exclusion_3.excluded_geographical_area,
+    ).exists()
+    assert not copied_measure.exclusions.filter(
+        modified_measure__sid=exclusion_3.modified_measure.sid,
+    ).exists()
 
 
 def test_transaction_summary(approved_transaction):

--- a/common/tests/test_models.py
+++ b/common/tests/test_models.py
@@ -24,6 +24,7 @@ from common.tests.util import assert_transaction_order
 from common.validators import UpdateType
 from footnotes.models import FootnoteType
 from measures.models import MeasureCondition
+from measures.models import MeasureExcludedGeographicalArea
 from regulations.models import Group
 from regulations.models import Regulation
 from taric.models import Envelope
@@ -622,12 +623,13 @@ def test_copy_fk_related_models():
         "component_sequence_number": 1,
         "condition_code_id": code.pk,
     }
-
+    assert measure.conditions.count() == 0
     copied_measure = measure.copy(
         transaction,
         conditions=[MeasureCondition(**condition_data)],
     )
 
+    assert measure.conditions.count() == 0
     assert copied_measure.conditions.count() == 1
 
 
@@ -687,6 +689,37 @@ def test_copy_nested_field_two_levels_deep():
     )
 
     assert copied_measure.conditions.first().components.first().duty_amount == 0
+
+
+def test_copy_saved_related_models():
+    """Test that copy accepts a queryset of saved objects, creates a new measure
+    with all of these related objects, and preserves original measure's
+    relationships."""
+    workbasket = factories.WorkBasketFactory.create()
+    measure = factories.MeasureFactory.create(transaction=workbasket.new_transaction())
+    exclusion_1 = factories.MeasureExcludedGeographicalAreaFactory.create(
+        transaction=workbasket.new_transaction(),
+        modified_measure=measure,
+    )
+    exclusion_2 = factories.MeasureExcludedGeographicalAreaFactory.create(
+        transaction=workbasket.new_transaction(),
+        modified_measure=measure,
+    )
+    exclusion_3 = factories.MeasureExcludedGeographicalAreaFactory.create(
+        transaction=workbasket.new_transaction(),
+        modified_measure=measure,
+    )
+    exclusions = MeasureExcludedGeographicalArea.objects.exclude(pk=exclusion_1.pk)
+    copied_measure = measure.copy(workbasket.new_transaction(), exclusions=exclusions)
+
+    assert measure.exclusions.count() == 3
+    assert copied_measure.exclusions.count() == 2
+    # assert exclusion_1 in measure.exclusions.all()
+    # assert exclusion_1 not in copied_measure.exclusions.all()
+    # assert exclusion_2 in measure.exclusions.all()
+    # assert exclusion_2 in copied_measure.exclusions.all()
+    # assert exclusion_3 in measure.exclusions.all() /PS-IGNORE
+    # assert exclusion_3 in copied_measure.exclusions.all() /PS-IGNORE
 
 
 def test_transaction_summary(approved_transaction):


### PR DESCRIPTION
<!---
 * Include the JIRA ticket number, eg TP-123, to automatically link.
 * Use 50 characters maximum.
 * Do not end with a full-stop.
--->

## Why
<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Use as many lines as you like.
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions or deliberately ignored edge-cases.
--->
Copy already supports the scenarios outlined in [this PR](https://github.com/uktrade/tamato/pull/458), including the ability to pass in multiple unsaved objects. This PR adds one more: the ability to pass in multiple _saved_ objects. This will be useful for steel quotas work, where we have to copy measures with slightly different sets of exclusions, depending on the validity period. (The new test is based on such a scenario).

## What
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Explain like I'm 5.
 * Use pictures if you can.
--->
- Adds subrecord logic to differentiate between saved and unsaved logic. 
- Fixes bug in unsaved logic, where copies were pointing at the old object, not the new copied one
- Adds test and fixes test for above bug
<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
## Checklist
- Requires migrations?
- Requires dependency updates?
--->

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
