### PR TITLE
Revert "TP2000-225 Fix geo area search"

### DIFF
--- a/geo_areas/tests/test_util.py
+++ b/geo_areas/tests/test_util.py
@@ -36,22 +36,3 @@ def test_with_latest_description_multiple_descriptions():
 
     assert qs.count() == 1
     assert later_description.description == qs.first().description
-
-
-def test_with_latest_description_multiple_descriptions_same_date():
-    """Tests that when a GeographicalArea has more than one description with the
-    same validity start date, the description from the later transaction is used
-    to generate the description string."""
-    area = factories.GeographicalAreaFactory.create()
-    first_description = factories.GeographicalAreaDescriptionFactory.create(
-        validity_start=datetime.today(),
-        described_geographicalarea=area,
-    )
-    second_description = factories.GeographicalAreaDescriptionFactory.create(
-        validity_start=datetime.today(),
-        described_geographicalarea=area,
-    )
-    qs = util.with_latest_description_string(models.GeographicalArea.objects.all())
-
-    assert qs.count() == 1
-    assert second_description.description == qs.first().description

--- a/geo_areas/util.py
+++ b/geo_areas/util.py
@@ -2,22 +2,12 @@ from django.db import models
 
 
 def with_latest_description_string(qs):
-    """Returns a queryset annotated with the latest validity_start date and
-    current version, filtered by these values and then annotated with that
-    latest description object's description field value."""
+    """Returns a queryset annotate with its latest description's validity_start
+    date, filtered by this date and then annotated with that latest description
+    object's description field value."""
     return (
-        qs.annotate(
-            description_current_version=models.Max(
-                "descriptions__version_group__current_version__pk",
-            ),
-            latest_description_date=models.Max("descriptions__validity_start"),
-        )
-        .filter(
-            descriptions__version_group__current_version__pk=models.F(
-                "description_current_version",
-            ),
-            descriptions__validity_start=models.F("latest_description_date"),
-        )
+        qs.annotate(latest_description_date=models.Max("descriptions__validity_start"))
+        .filter(descriptions__validity_start=models.F("latest_description_date"))
         .annotate(
             description=models.F(
                 "descriptions__description",


### PR DESCRIPTION
Reverts uktrade/tamato#617

Lots of countries are missing from search (e.g. Erga Omnes 1011, North Macedonia) and the detail view returns a multiple objects returned for countries with multiple descriptions. I think filtering by transaction order works better (my bad for suggesting to change that), but, looking at it again, I'm not sure we want to be changing the main queryset in GeoAreaMixin and using `objects.all()`, as I think this is causing the multiple objects returned errored. Needs a bit more thought and probably we should separate out the filtering logic and annotation logic from with_latest_description_string.