### PR TITLE
TP2000-434 QA6 should use approved_up_to_transaction

### DIFF
--- a/quotas/business_rules.py
+++ b/quotas/business_rules.py
@@ -355,11 +355,14 @@ class QA6(BusinessRule):
 
     def validate(self, association):
         if (
-            association.main_quota.sub_quota_associations.values(
+            association.main_quota.sub_quota_associations.approved_up_to_transaction(
+                association.transaction,
+            )
+            .values(
                 "sub_quota_relation_type",
             )
             .order_by("sub_quota_relation_type")
-            .distinct("sub_quota_relation_type")
+            .distinct()
             .count()
             > 1
         ):

--- a/quotas/tests/test_business_rules.py
+++ b/quotas/tests/test_business_rules.py
@@ -600,6 +600,21 @@ def test_QA6(existing_relation, new_relation, error_expected):
         business_rules.QA6(assoc.transaction).validate(assoc)
 
 
+# https://uktrade.atlassian.net/browse/TP2000-434
+def test_QA6_new_association_version():
+    """Tests that previous versions of an association are not compared when
+    looking for sub-quotas associated with the same main quota."""
+    original_version = factories.QuotaAssociationFactory.create(
+        sub_quota_relation_type="EQ",
+    )
+    later_version = original_version.new_version(
+        original_version.transaction.workbasket,
+        sub_quota_relation_type="NM",
+    )
+
+    business_rules.QA6(later_version.transaction).validate(later_version)
+
+
 @pytest.mark.parametrize(
     ("mechanism", "error_expected"),
     (


### PR DESCRIPTION
# TP2000-434 QA6 should use approved_up_to_transaction
<!---
 * Include the JIRA ticket number, eg TP-123, to automatically link.
 * Use 50 characters maximum.
 * Do not end with a full-stop.
--->

## Why
<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Use as many lines as you like.
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions or deliberately ignored edge-cases.
--->
It's not currently possible to update a QuotaAssociation and change its sub_quota_relation_type without QA6 seeing the old version as clashing with the new one.
## What
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Explain like I'm 5.
 * Use pictures if you can.
--->
Updates QA6 to use `approved_up_to_transaction` and adds test for bug scenario
<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
## Checklist
- Requires migrations?
- Requires dependency updates?
--->

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
