### PR TITLE
TP2000-437 500 error on measure create summary page

### DIFF
--- a/measures/forms.py
+++ b/measures/forms.py
@@ -908,7 +908,7 @@ class MeasureGeographicalAreaForm(BindNestedFormMixin, forms.Form):
 
                 elif geo_area_choice == GeoAreaType.GROUP:
                     data_key = SUBFORM_PREFIX_MAPPING[geo_area_choice]
-                    cleaned_data["geo_area_list"] = cleaned_data[data_key]
+                    cleaned_data["geo_area_list"] = [cleaned_data[data_key]]
 
                 elif geo_area_choice == GeoAreaType.COUNTRY:
                     field_name = geographical_area_fields[geo_area_choice]

--- a/measures/tests/test_forms.py
+++ b/measures/tests/test_forms.py
@@ -194,6 +194,8 @@ def test_measure_forms_geo_area_valid_data_geo_group(erga_omnes):
         prefix=GEO_AREA_FORM_PREFIX,
     )
     assert form.is_valid()
+    # https://uktrade.atlassian.net/browse/TP2000-437 500 error where object instead of a list of objects
+    assert type(form.cleaned_data["geo_area_list"]) == list
 
 
 def test_measure_forms_geo_area_valid_data_countries(erga_omnes):


### PR DESCRIPTION
# TP2000-437 500 error on measure create summary page
<!---
 * Include the JIRA ticket number, eg TP-123, to automatically link.
 * Use 50 characters maximum.
 * Do not end with a full-stop.
--->

## Why
<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Use as many lines as you like.
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions or deliberately ignored edge-cases.
--->
We can't currently create measures with a geo area of type GROUP without a 500 on measure create summary page

## What
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Explain like I'm 5.
 * Use pictures if you can.
--->
Ensures that `MeasureGeographicalAreaForm.clean` always returns a list.
<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
## Checklist
- Requires migrations?
- Requires dependency updates?
--->

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
This is a quick fix because it's blocking urgent work, but we should probs refactor more of our form tests to use `parametrize` and add more assertions about what's returned in cleaned data. Ticket [here](https://uktrade.atlassian.net/browse/TP2000-438)