### PR TITLE
TP2000-436: Fix use of index url that no longer exists

### DIFF
--- a/commodities/jinja2/commodities/import-success.jinja
+++ b/commodities/jinja2/commodities/import-success.jinja
@@ -20,7 +20,7 @@
       <h1 class="govuk-heading-xl">Your file is being imported</h1>
       <p class="govuk-body">We have confirmed that the file is valid and are processing the changes. This might take up to 20 minutes.</p>
       <p class="govuk-body">You will be able to review the changes and finish the import from the main page.</p>
-      <a href="{{ url('index') }}" class="govuk-button govuk-button--secondary">Return to the main page</a>
+      {% include "includes/common/main-menu-link.jinja" %}
     </div>
   </div>
 {% endblock %}

--- a/common/jinja2/includes/common/main-menu-link.jinja
+++ b/common/jinja2/includes/common/main-menu-link.jinja
@@ -1,0 +1,3 @@
+{% if request.session.workbasket %}
+  <li><a href="{{ url('workbaskets:edit-workbasket', args=[request.session.workbasket.id]) }}">Return to main menu</a></li>
+{% endif %}

--- a/common/jinja2/layouts/confirm.jinja
+++ b/common/jinja2/layouts/confirm.jinja
@@ -32,9 +32,7 @@
       <ul class="govuk-list govuk-list-spaced">
         <li><a class="govuk-link" href="{{ object.get_url() }}">View {{ object._meta.verbose_name }} {{ object|string }}</a></li>
         <li><a href="{{ object.get_url("list") }}">Manage more {{ object._meta.verbose_name_plural }}</a></li>
-        {% if request.session.workbasket %}
-        <li><a href="{{ url('workbaskets:edit-workbasket', args=[request.session.workbasket.id]) }}">Return to main menu</a></li>
-        {% endif %}
+        {% include "includes/common/main-menu-link.jinja" %}
       </ul>
     </div>
   </div>

--- a/measures/jinja2/measures/confirm-create-multiple.jinja
+++ b/measures/jinja2/measures/confirm-create-multiple.jinja
@@ -49,9 +49,7 @@
       <ul class="govuk-list govuk-list-spaced">
         <li><a class="govuk-link" href="{{ created_measures.0.get_url('create') }}">Create a new measure</a></li>
         <li><a href="{{ created_measures.0.get_url('list') }}">Manage more {{ created_measures.0._meta.verbose_name_plural }}</a></li>
-        {% if request.session.workbasket %}
-        <li><a href="{{ url('workbaskets:edit-workbasket', args=[request.session.workbasket.id]) }}">Return to main menu</a></li>
-        {% endif %}
+        {% include "includes/common/main-menu-link.jinja" %}
       </ul>
     </div>
   </div>

--- a/workbaskets/jinja2/workbaskets/delete_changes_confirm.jinja
+++ b/workbaskets/jinja2/workbaskets/delete_changes_confirm.jinja
@@ -35,7 +35,7 @@
     }) }}
 
     <p class="govuk-body">
-      <a href="{{ url('index') }}" class="govuk-link">Return to main menu</a>
+      {% include "includes/common/main-menu-link.jinja" %}
     </p>
   </div>
 </div>

--- a/workbaskets/tests/test_views.py
+++ b/workbaskets/tests/test_views.py
@@ -335,3 +335,12 @@ def test_review_workbasket_redirects(
 
     elif form_action == "page-next":
         assert "?page=3" in response.url
+
+
+def test_delete_changes_confirm_200(valid_user_client, session_workbasket):
+    url = reverse(
+        "workbaskets:workbasket-ui-delete-changes-done",
+        kwargs={"pk": session_workbasket.pk},
+    )
+    response = valid_user_client.get(url)
+    assert response.status_code == 200


### PR DESCRIPTION
# TP2000-436: Fix use of index url that no longer exists
<!---
 * Include the JIRA ticket number, eg TP-123, to automatically link.
 * Use 50 characters maximum.
 * Do not end with a full-stop.
--->

## Why
<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Use as many lines as you like.
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions or deliberately ignored edge-cases.
--->
* "index" url is gone. We use the workbasket main menu instead

## What
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Explain like I'm 5.
 * Use pictures if you can.
--->
* Replaces any remaining uses of "index" in templates and makes the main menu link into a reusable template

<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
## Checklist
- Requires migrations?
- Requires dependency updates?
--->

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
