### PR TITLE
TP2000-432 QuotaAssociation objects have been created with the same main and sub quota

### DIFF
--- a/quotas/business_rules.py
+++ b/quotas/business_rules.py
@@ -250,6 +250,24 @@ class QuotaBlockingPeriodMustReferToANonDeletedQuotaDefinition(
         return quota_definition.quotablocking_set.model
 
 
+class OverlappingQuotaDefinition(BusinessRule):
+    """There may be no overlap in time of two quota definitions with the same
+    quota order number id."""
+
+    def validate(self, quota_definition):
+        if (
+            type(quota_definition)
+            .objects.approved_up_to_transaction(quota_definition.transaction)
+            .filter(
+                order_number=quota_definition.order_number,
+                valid_between__overlap=quota_definition.valid_between,
+            )
+            .exclude(sid=quota_definition.sid)
+            .exists()
+        ):
+            raise self.violation(quota_definition)
+
+
 class QA1(UniqueIdentifyingFields):
     """The association between two quota definitions must be unique."""
 
@@ -366,6 +384,15 @@ class QA6(BusinessRule):
             .count()
             > 1
         ):
+            raise self.violation(association)
+
+
+class SameMainAndSubQuota(BusinessRule):
+    """A quota association may only exist between two distinct quota
+    definitions."""
+
+    def validate(self, association):
+        if association.main_quota.sid == association.sub_quota.sid:
             raise self.violation(association)
 
 

--- a/quotas/models.py
+++ b/quotas/models.py
@@ -225,6 +225,7 @@ class QuotaDefinition(TrackedModel, ValidityMixin):
         business_rules.QuotaAssociationMustReferToANonDeletedSubQuota,
         business_rules.QuotaSuspensionMustReferToANonDeletedQuotaDefinition,
         business_rules.QuotaBlockingPeriodMustReferToANonDeletedQuotaDefinition,
+        business_rules.OverlappingQuotaDefinition,
         UniqueIdentifyingFields,
         UpdateValidity,
     )
@@ -287,6 +288,7 @@ class QuotaAssociation(TrackedModel):
         business_rules.QA5,
         business_rules.QA6,
         UpdateValidity,
+        business_rules.SameMainAndSubQuota,
     )
 
 

--- a/quotas/tests/test_business_rules.py
+++ b/quotas/tests/test_business_rules.py
@@ -461,6 +461,23 @@ def test_linking_models_must_refer_to_a_non_deleted_sub_quota(
     business_rule(deleted.transaction).validate(deleted)
 
 
+def test_overlapping_quota_definition(date_ranges):
+    order_number = factories.QuotaOrderNumberFactory.create()
+    factories.QuotaDefinitionFactory.create(
+        order_number=order_number,
+        valid_between=date_ranges.normal,
+    )
+    overlapping_definition = factories.QuotaDefinitionFactory.create(
+        order_number=order_number,
+        valid_between=date_ranges.overlap_normal,
+    )
+
+    with pytest.raises(BusinessRuleViolation):
+        business_rules.OverlappingQuotaDefinition(
+            overlapping_definition.transaction,
+        ).validate(overlapping_definition)
+
+
 def test_QA1(assert_handles_duplicates):
     """The association between two quota definitions must be unique."""
 
@@ -604,6 +621,7 @@ def test_QA6(existing_relation, new_relation, error_expected):
 def test_QA6_new_association_version():
     """Tests that previous versions of an association are not compared when
     looking for sub-quotas associated with the same main quota."""
+
     original_version = factories.QuotaAssociationFactory.create(
         sub_quota_relation_type="EQ",
     )
@@ -613,6 +631,22 @@ def test_QA6_new_association_version():
     )
 
     business_rules.QA6(later_version.transaction).validate(later_version)
+
+
+def test_same_main_and_sub_quota():
+    """A quota association may only exist between two distinct quota
+    definitions."""
+
+    definition = factories.QuotaDefinitionFactory.create()
+    association = factories.QuotaAssociationFactory.create(
+        main_quota=definition,
+        sub_quota=definition,
+    )
+
+    with pytest.raises(BusinessRuleViolation):
+        business_rules.SameMainAndSubQuota(association.transaction).validate(
+            association,
+        )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
# TP2000-432 QuotaAssociation objects have been created with the same main and sub quota
<!---
 * Include the JIRA ticket number, eg TP-123, to automatically link.
 * Use 50 characters maximum.
 * Do not end with a full-stop.
--->

## Why
<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Use as many lines as you like.
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions or deliberately ignored edge-cases.
--->
It shouldn't be possible to create an association where the same definition is both the parent and the child.

It shouldn't be possible to create overlapping definitions for the same quota order number.

Therefore, we should formalise the above as business rules.

## What
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Explain like I'm 5.
 * Use pictures if you can.
--->
Adds two new rules, tests, and updates model business rules lists
<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
## Checklist
- Requires migrations?
- Requires dependency updates?
--->

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
