### PR TITLE
TP2000-446 Implement a guard against double form submits

### DIFF
--- a/additional_codes/forms.py
+++ b/additional_codes/forms.py
@@ -54,7 +54,7 @@ class AdditionalCodeForm(ValidityPeriodForm):
             Field("type"),
             Field("start_date"),
             Field("end_date"),
-            Submit("submit", "Save"),
+            Submit("submit", "Save", data_prevent_double_click="true"),
         )
 
     def clean(self):
@@ -122,7 +122,7 @@ class AdditionalCodeCreateForm(ValidityPeriodForm):
             "start_date",
             Field.textarea("description", rows=5),
             DescriptionHelpBox(),
-            Submit("submit", "Save"),
+            Submit("submit", "Save", data_prevent_double_click="true"),
         )
 
     def clean(self):

--- a/additional_codes/forms.py
+++ b/additional_codes/forms.py
@@ -54,7 +54,12 @@ class AdditionalCodeForm(ValidityPeriodForm):
             Field("type"),
             Field("start_date"),
             Field("end_date"),
-            Submit("submit", "Save", data_prevent_double_click="true"),
+            Submit(
+                "submit",
+                "Save",
+                data_module="govuk-button",
+                data_prevent_double_click="true",
+            ),
         )
 
     def clean(self):
@@ -122,7 +127,12 @@ class AdditionalCodeCreateForm(ValidityPeriodForm):
             "start_date",
             Field.textarea("description", rows=5),
             DescriptionHelpBox(),
-            Submit("submit", "Save", data_prevent_double_click="true"),
+            Submit(
+                "submit",
+                "Save",
+                data_module="govuk-button",
+                data_prevent_double_click="true",
+            ),
         )
 
     def clean(self):

--- a/certificates/forms.py
+++ b/certificates/forms.py
@@ -57,7 +57,12 @@ class CertificateCreateForm(ValidityPeriodForm):
             "start_date",
             Field.textarea("description", rows=5),
             DescriptionHelpBox(),
-            Submit("submit", "Save", data_prevent_double_click="true"),
+            Submit(
+                "submit",
+                "Save",
+                data_module="govuk-button",
+                data_prevent_double_click="true",
+            ),
         )
 
     def clean_sid(self):
@@ -142,7 +147,12 @@ class CertificateForm(ValidityPeriodForm):
             "certificate_type",
             "start_date",
             "end_date",
-            Submit("submit", "Save", data_prevent_double_click="true"),
+            Submit(
+                "submit",
+                "Save",
+                data_module="govuk-button",
+                data_prevent_double_click="true",
+            ),
         )
 
     def clean(self):

--- a/certificates/forms.py
+++ b/certificates/forms.py
@@ -57,7 +57,7 @@ class CertificateCreateForm(ValidityPeriodForm):
             "start_date",
             Field.textarea("description", rows=5),
             DescriptionHelpBox(),
-            Submit("submit", "Save"),
+            Submit("submit", "Save", data_prevent_double_click="true"),
         )
 
     def clean_sid(self):
@@ -142,7 +142,7 @@ class CertificateForm(ValidityPeriodForm):
             "certificate_type",
             "start_date",
             "end_date",
-            Submit("submit", "Save"),
+            Submit("submit", "Save", data_prevent_double_click="true"),
         )
 
     def clean(self):

--- a/commodities/forms.py
+++ b/commodities/forms.py
@@ -43,7 +43,12 @@ class CommodityImportForm(forms.ModelForm):
         self.helper = FormHelper(self)
         self.helper.layout = Layout(
             "taric_file",
-            Submit("submit", "Continue", data_prevent_double_click="true"),
+            Submit(
+                "submit",
+                "Continue",
+                data_module="govuk-button",
+                data_prevent_double_click="true",
+            ),
         )
 
     def clean_taric_file(self):

--- a/commodities/forms.py
+++ b/commodities/forms.py
@@ -43,7 +43,7 @@ class CommodityImportForm(forms.ModelForm):
         self.helper = FormHelper(self)
         self.helper.layout = Layout(
             "taric_file",
-            Submit("submit", "Continue"),
+            Submit("submit", "Continue", data_prevent_double_click="true"),
         )
 
     def clean_taric_file(self):

--- a/common/forms.py
+++ b/common/forms.py
@@ -175,7 +175,7 @@ class HomeForm(forms.Form):
         self.helper.legend_size = Size.EXTRA_LARGE
         self.helper.layout = Layout(
             "workbasket_action",
-            Submit("submit", "Continue"),
+            Submit("submit", "Continue", data_prevent_double_click="true"),
         )
 
 
@@ -289,7 +289,7 @@ class DescriptionForm(forms.ModelForm):
         self.helper.layout = Layout(
             Field("validity_start", context={"legend_size": "govuk-label--s"}),
             Field.textarea("description", label_size=Size.SMALL, rows=5),
-            Submit("submit", "Save"),
+            Submit("submit", "Save", data_prevent_double_click="true"),
         )
 
     class Meta:
@@ -376,7 +376,12 @@ class DeleteForm(forms.ModelForm):
         self.helper.label_size = Size.SMALL
         self.helper.legend_size = Size.SMALL
         self.helper.layout = Layout(
-            Submit("submit", "Delete", css_class="govuk-button--warning"),
+            Submit(
+                "submit",
+                "Delete",
+                css_class="govuk-button--warning",
+                data_prevent_double_click="true",
+            ),
         )
 
 

--- a/common/forms.py
+++ b/common/forms.py
@@ -175,7 +175,12 @@ class HomeForm(forms.Form):
         self.helper.legend_size = Size.EXTRA_LARGE
         self.helper.layout = Layout(
             "workbasket_action",
-            Submit("submit", "Continue", data_prevent_double_click="true"),
+            Submit(
+                "submit",
+                "Continue",
+                data_module="govuk-button",
+                data_prevent_double_click="true",
+            ),
         )
 
 
@@ -289,7 +294,12 @@ class DescriptionForm(forms.ModelForm):
         self.helper.layout = Layout(
             Field("validity_start", context={"legend_size": "govuk-label--s"}),
             Field.textarea("description", label_size=Size.SMALL, rows=5),
-            Submit("submit", "Save", data_prevent_double_click="true"),
+            Submit(
+                "submit",
+                "Save",
+                data_module="govuk-button",
+                data_prevent_double_click="true",
+            ),
         )
 
     class Meta:
@@ -380,6 +390,7 @@ class DeleteForm(forms.ModelForm):
                 "submit",
                 "Delete",
                 css_class="govuk-button--warning",
+                data_module="govuk-button",
                 data_prevent_double_click="true",
             ),
         )

--- a/footnotes/forms.py
+++ b/footnotes/forms.py
@@ -53,7 +53,7 @@ class FootnoteForm(ValidityPeriodForm):
             Field("footnote_type"),
             Field("start_date"),
             Field("end_date"),
-            Submit("submit", "Save"),
+            Submit("submit", "Save", data_prevent_double_click="true"),
         )
 
     def clean(self):
@@ -111,7 +111,7 @@ class FootnoteCreateForm(ValidityPeriodForm):
             "start_date",
             Field.textarea("description", rows=5),
             DescriptionHelpBox(),
-            Submit("submit", "Save"),
+            Submit("submit", "Save", data_prevent_double_click="true"),
         )
 
     def clean(self):

--- a/footnotes/forms.py
+++ b/footnotes/forms.py
@@ -53,7 +53,12 @@ class FootnoteForm(ValidityPeriodForm):
             Field("footnote_type"),
             Field("start_date"),
             Field("end_date"),
-            Submit("submit", "Save", data_prevent_double_click="true"),
+            Submit(
+                "submit",
+                "Save",
+                data_module="govuk-button",
+                data_prevent_double_click="true",
+            ),
         )
 
     def clean(self):
@@ -111,7 +116,12 @@ class FootnoteCreateForm(ValidityPeriodForm):
             "start_date",
             Field.textarea("description", rows=5),
             DescriptionHelpBox(),
-            Submit("submit", "Save", data_prevent_double_click="true"),
+            Submit(
+                "submit",
+                "Save",
+                data_module="govuk-button",
+                data_prevent_double_click="true",
+            ),
         )
 
     def clean(self):

--- a/footnotes/jinja2/footnotes/edit_description.jinja
+++ b/footnotes/jinja2/footnotes/edit_description.jinja
@@ -43,6 +43,6 @@
     }) }}
 
     <h2 class="govuk-heading-m">Finish now</h2>
-    {{ govukButton({"text": "Add to workbasket"}) }} <span class="govuk-body"><a href="#">Cancel</a></span>
+    {{ govukButton({"text": "Add to workbasket", "preventDoubleClick": true,}) }} <span class="govuk-body"><a href="#">Cancel</a></span>
   {% endcall %}
 {% endblock %}

--- a/measures/forms.py
+++ b/measures/forms.py
@@ -796,7 +796,7 @@ class MeasureDetailsForm(
             "order_number",
             "start_date",
             "end_date",
-            Submit("submit", "Continue"),
+            Submit("submit", "Continue", data_prevent_double_click="true"),
         )
 
     def clean(self):
@@ -865,7 +865,7 @@ class MeasureGeographicalAreaForm(BindNestedFormMixin, forms.Form):
                     "from or exports to the selected area."
                 ),
             ),
-            Submit("submit", "Continue"),
+            Submit("submit", "Continue", data_prevent_double_click="true"),
         )
 
     @property
@@ -933,7 +933,7 @@ class MeasureAdditionalCodeForm(forms.ModelForm):
         self.helper = FormHelper(self)
         self.helper.layout = Layout(
             "additional_code",
-            Submit("submit", "Continue"),
+            Submit("submit", "Continue", data_prevent_double_click="true"),
         )
 
 

--- a/measures/forms.py
+++ b/measures/forms.py
@@ -796,7 +796,12 @@ class MeasureDetailsForm(
             "order_number",
             "start_date",
             "end_date",
-            Submit("submit", "Continue", data_prevent_double_click="true"),
+            Submit(
+                "submit",
+                "Continue",
+                data_module="govuk-button",
+                data_prevent_double_click="true",
+            ),
         )
 
     def clean(self):
@@ -865,7 +870,12 @@ class MeasureGeographicalAreaForm(BindNestedFormMixin, forms.Form):
                     "from or exports to the selected area."
                 ),
             ),
-            Submit("submit", "Continue", data_prevent_double_click="true"),
+            Submit(
+                "submit",
+                "Continue",
+                data_module="govuk-button",
+                data_prevent_double_click="true",
+            ),
         )
 
     @property
@@ -933,7 +943,12 @@ class MeasureAdditionalCodeForm(forms.ModelForm):
         self.helper = FormHelper(self)
         self.helper.layout = Layout(
             "additional_code",
-            Submit("submit", "Continue", data_prevent_double_click="true"),
+            Submit(
+                "submit",
+                "Continue",
+                data_module="govuk-button",
+                data_prevent_double_click="true",
+            ),
         )
 
 

--- a/measures/jinja2/measures/create-review.jinja
+++ b/measures/jinja2/measures/create-review.jinja
@@ -115,5 +115,5 @@
     {% endif %}
   {% endcall %}
 
-  {{ govukButton({"text": "Create"}) }}
+  {{ govukButton({"text": "Create", "preventDoubleClick": true,}) }}
 {% endblock %}

--- a/measures/jinja2/measures/edit.jinja
+++ b/measures/jinja2/measures/edit.jinja
@@ -144,6 +144,7 @@
             }) }}
             {{ govukButton({
                 "text":"Save",
+                "preventDoubleClick": true,
             }) }}
         </div>
     </div>

--- a/regulations/forms.py
+++ b/regulations/forms.py
@@ -144,7 +144,7 @@ class RegulationCreateForm(RegulationFormBase):
                 ),
                 "approved",
             ),
-            Submit("submit", "Save"),
+            Submit("submit", "Save", data_prevent_double_click="true"),
         )
 
     def _make_partial_regulation_id(
@@ -295,7 +295,7 @@ class RegulationEditForm(RegulationFormBase):
                 ),
                 "approved",
             ),
-            Submit("submit", "Save"),
+            Submit("submit", "Save", data_prevent_double_click="true"),
         )
 
     def clean(self):

--- a/regulations/forms.py
+++ b/regulations/forms.py
@@ -144,7 +144,12 @@ class RegulationCreateForm(RegulationFormBase):
                 ),
                 "approved",
             ),
-            Submit("submit", "Save", data_prevent_double_click="true"),
+            Submit(
+                "submit",
+                "Save",
+                data_module="govuk-button",
+                data_prevent_double_click="true",
+            ),
         )
 
     def _make_partial_regulation_id(
@@ -295,7 +300,12 @@ class RegulationEditForm(RegulationFormBase):
                 ),
                 "approved",
             ),
-            Submit("submit", "Save", data_prevent_double_click="true"),
+            Submit(
+                "submit",
+                "Save",
+                data_module="govuk-button",
+                data_prevent_double_click="true",
+            ),
         )
 
     def clean(self):

--- a/workbaskets/forms.py
+++ b/workbaskets/forms.py
@@ -36,7 +36,7 @@ class WorkbasketCreateForm(forms.ModelForm):
             "title",
             Field.textarea("reason", rows=5),
             DescriptionHelpBox(),
-            Submit("submit", "Create"),
+            Submit("submit", "Create", data_prevent_double_click="true"),
         )
 
     class Meta:

--- a/workbaskets/forms.py
+++ b/workbaskets/forms.py
@@ -36,7 +36,12 @@ class WorkbasketCreateForm(forms.ModelForm):
             "title",
             Field.textarea("reason", rows=5),
             DescriptionHelpBox(),
-            Submit("submit", "Create", data_prevent_double_click="true"),
+            Submit(
+                "submit",
+                "Create",
+                data_module="govuk-button",
+                data_prevent_double_click="true",
+            ),
         )
 
     class Meta:


### PR DESCRIPTION
# TP2000-446 Implement a guard against double form submits
<!---
 * Include the JIRA ticket number, eg TP-123, to automatically link.
 * Use 50 characters maximum.
 * Do not end with a full-stop.
--->

## Why
<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Use as many lines as you like.
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions or deliberately ignored edge-cases.
--->
Double clicking a form submit button leads to transactions being created with duplicate composite_key values and causes a 500 integrity error.

## What
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Explain like I'm 5.
 * Use pictures if you can.
--->
Add the govuk prevent double click attribute across submit buttons
<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
## Checklist
- Requires migrations?
- Requires dependency updates?
--->

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
