### PR TITLE
TP2000-410 editing measure exclusions only excludes first country of group

### DIFF
--- a/measures/forms.py
+++ b/measures/forms.py
@@ -623,7 +623,7 @@ class MeasureForm(ValidityPeriodForm, BindNestedFormMixin, forms.ModelForm):
                         exclusion,
                     )
                 )
-                next(pattern)
+                [p for p in pattern]
 
         if (
             self.request.session[f"instance_duty_sentence_{self.instance.sid}"]

--- a/measures/jinja2/includes/measures/tabs/core_data.jinja
+++ b/measures/jinja2/includes/measures/tabs/core_data.jinja
@@ -1,8 +1,8 @@
 {%- extends "includes/common/tabs/core_data.jinja" -%}
 
 {% set geographical_exclusions %}
-{% if object.exclusions.all() %}
-	{% for exclusion in object.exclusions.all() %}
+{% if object.exclusions.current() %}
+	{% for exclusion in object.exclusions.current() %}
 		{{ exclusion.excluded_geographical_area.get_description().description }}{{ ", " if not loop.last else "" }}
 	{% endfor %}
 {% else %}-{% endif %}

--- a/measures/tests/test_views.py
+++ b/measures/tests/test_views.py
@@ -653,6 +653,26 @@ def test_measure_update_invalid_conditions(
     )
 
 
+def test_measure_update_group_exclusion(client, valid_user, erga_omnes):
+    measure = factories.MeasureFactory.create(geographical_area=erga_omnes)
+    geo_group = factories.GeoGroupFactory.create()
+    area_1 = factories.GeographicalMembershipFactory.create(geo_group=geo_group).member
+    area_2 = factories.GeographicalMembershipFactory.create(geo_group=geo_group).member
+    url = reverse("measure-ui-edit", args=(measure.sid,))
+    client.force_login(valid_user)
+    data = model_to_dict(measure)
+    data = {k: v for k, v in data.items() if v is not None}
+    start_date = data["valid_between"].lower
+    data.update(
+        start_date_0=start_date.day,
+        start_date_1=start_date.month,
+        start_date_2=start_date.year,
+    )
+    response = client.post(url, data=data)
+
+    assert 0
+
+
 @pytest.mark.django_db
 def test_measure_form_wizard_start(valid_user_client):
     url = reverse("measure-ui-create", kwargs={"step": "start"})

--- a/measures/tests/test_views.py
+++ b/measures/tests/test_views.py
@@ -24,6 +24,7 @@ from measures.business_rules import ME70
 from measures.models import FootnoteAssociationMeasure
 from measures.models import Measure
 from measures.models import MeasureCondition
+from measures.models import MeasureExcludedGeographicalArea
 from measures.validators import validate_duties
 from measures.views import MeasureCreateWizard
 from measures.views import MeasureFootnotesUpdate
@@ -654,23 +655,58 @@ def test_measure_update_invalid_conditions(
 
 
 def test_measure_update_group_exclusion(client, valid_user, erga_omnes):
+    """
+    Tests that measure edit view handles exclusion of one group from another
+    group.
+
+    We create an erga omnes measure and a group containing two areas that also
+    belong to the erga omnes group. Then post to edit endpoint with this group
+    as an exclusion and check that two MeasureExcludedGeographicalArea objects
+    are created with the two area sids in that excluded group.
+    """
     measure = factories.MeasureFactory.create(geographical_area=erga_omnes)
     geo_group = factories.GeoGroupFactory.create()
     area_1 = factories.GeographicalMembershipFactory.create(geo_group=geo_group).member
     area_2 = factories.GeographicalMembershipFactory.create(geo_group=geo_group).member
+    factories.GeographicalMembershipFactory.create(geo_group=erga_omnes, member=area_1)
+    factories.GeographicalMembershipFactory.create(geo_group=erga_omnes, member=area_2)
     url = reverse("measure-ui-edit", args=(measure.sid,))
     client.force_login(valid_user)
     data = model_to_dict(measure)
     data = {k: v for k, v in data.items() if v is not None}
     start_date = data["valid_between"].lower
     data.update(
-        start_date_0=start_date.day,
-        start_date_1=start_date.month,
-        start_date_2=start_date.year,
+        {
+            "start_date_0": start_date.day,
+            "start_date_1": start_date.month,
+            "start_date_2": start_date.year,
+            "geo_area": "ERGA_OMNES",
+            "erga_omnes_exclusions_formset-__prefix__-erga_omnes_exclusion": geo_group.pk,
+        },
     )
-    response = client.post(url, data=data)
 
-    assert 0
+    assert not MeasureExcludedGeographicalArea.objects.approved_up_to_transaction(
+        Transaction.objects.last(),
+    ).exists()
+
+    client.post(url, data=data)
+    measure_area_exclusions = (
+        MeasureExcludedGeographicalArea.objects.approved_up_to_transaction(
+            Transaction.objects.last(),
+        )
+    )
+
+    assert measure_area_exclusions.count() == 2
+
+    area_sids = [
+        sid[0]
+        for sid in measure_area_exclusions.values_list(
+            "excluded_geographical_area__sid",
+        )
+    ]
+
+    assert area_1.sid in area_sids
+    assert area_2.sid in area_sids
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
# TP2000-410 editing measure exclusions only excludes first country of group
<!---
 * Include the JIRA ticket number, eg TP-123, to automatically link.
 * Use 50 characters maximum.
 * Do not end with a full-stop.
--->

## Why
<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Use as many lines as you like.
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions or deliberately ignored edge-cases.
--->
When trying to edit a measure and exclude one area group from another (e.g. ERGA OMNES), we would expect a MeasureExcludedGeographicalArea object to be created for each area in the excluded group. Instead only the first country is getting an exclusion created for it.

## What
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Explain like I'm 5.
 * Use pictures if you can.
--->
Unpack iterator returned by `create_measure_excluded_geographical_areas`. (I thought `next()` was meant to do this and don't know why it doesn't. Can anyone explain?)
<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
## Checklist
- Requires migrations?
- Requires dependency updates?
--->

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
