### PR TITLE
TP2000-311 Envelope schema expects a six-digit number to be present, the TARIC file only contains five

### DIFF
--- a/commodities/assets/commodities_envelope.xsd
+++ b/commodities/assets/commodities_envelope.xsd
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xs:schema targetNamespace="urn:publicid:-:DGTAXUD:GENERAL:ENVELOPE:1.0" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="urn:publicid:-:DGTAXUD:GENERAL:ENVELOPE:1.0" elementFormDefault="qualified" attributeFormDefault="unqualified">
-    <xs:import namespace="urn:publicid:-:DGTAXUD:TARIC:MESSAGE:1.0" schemaLocation="taric3.xsd" />
+    <xs:import namespace="urn:publicid:-:DGTAXUD:TARIC:MESSAGE:1.0" schemaLocation="commodities_taric3.xsd" />
     <xs:element name="envelope">
         <xs:annotation>
             <xs:documentation>Message envelope</xs:documentation>
@@ -41,7 +41,7 @@
             <xs:attribute name="id" use="required">
                 <xs:simpleType>
                     <xs:restriction base="xs:string">
-                        <xs:pattern value="[0-9]{6}"/>
+                        <xs:pattern value="[0-9]{5}"/>
                     </xs:restriction>
                 </xs:simpleType>
             </xs:attribute>

--- a/commodities/assets/commodities_taric3.xsd
+++ b/commodities/assets/commodities_taric3.xsd
@@ -1,0 +1,1803 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Implementation of TARIC3-TMES v5.10 (18/05/2015) -->
+<xs:schema xmlns="urn:publicid:-:DGTAXUD:TARIC:MESSAGE:1.0" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:envelope="urn:publicid:-:DGTAXUD:GENERAL:ENVELOPE:1.0" xmlns:xml="http://www.w3.org/XML/1998/namespace" targetNamespace="urn:publicid:-:DGTAXUD:TARIC:MESSAGE:1.0" elementFormDefault="qualified" attributeFormDefault="unqualified">
+    <xs:import namespace="http://www.w3.org/XML/1998/namespace" schemaLocation="../../common/assets/xml.xsd">
+        <xs:annotation>
+            <xs:documentation>Get access to the xml: attribute groups for xml:lang as declared on
+        &apos;schema&apos; and &apos;documentation&apos;
+      below</xs:documentation>
+        </xs:annotation>
+    </xs:import>
+    <xs:import namespace="urn:publicid:-:DGTAXUD:GENERAL:ENVELOPE:1.0" schemaLocation="commodities_envelope.xsd"/>
+    <!-- Technical data -->
+    <xs:simpleType name="RecordCode">
+        <xs:restriction base="xs:string">
+            <xs:pattern value="\d\d\d"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="RecordSequenceNumber">
+        <xs:restriction base="xs:int">
+            <xs:minInclusive value="1"/>
+            <xs:maxInclusive value="99999999"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="SubRecordCode">
+        <xs:restriction base="xs:string">
+            <xs:pattern value="\d\d"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="TransactionId">
+        <xs:restriction base="xs:int">
+            <xs:minInclusive value="1"/>
+            <xs:maxInclusive value="99999999"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="UpdateType">
+        <xs:restriction base="xs:string">
+            <xs:annotation>
+                <xs:documentation>1-Update, 2-Delete, 3-Insert</xs:documentation>
+            </xs:annotation>
+            <xs:length value="1"/>
+            <xs:enumeration value="1">
+                <xs:annotation>
+                    <xs:documentation>Update</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="2">
+                <xs:annotation>
+                    <xs:documentation>Delete</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="3">
+                <xs:annotation>
+                    <xs:documentation>Insert</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+        </xs:restriction>
+    </xs:simpleType>
+    <!-- Technical elements -->
+    <xs:element name="abstract.record" abstract="true"/>
+    <xs:element name="transmission" substitutionGroup="envelope:abstract.message">
+        <xs:annotation>
+            <xs:documentation>Contains a transmission</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="record">
+                    <xs:complexType>
+                        <xs:sequence>
+                            <xs:element name="transaction.id" type="TransactionId"/>
+                            <xs:element name="record.code" type="RecordCode"/>
+                            <xs:element name="subrecord.code" type="SubRecordCode"/>
+                            <xs:element name="record.sequence.number" type="RecordSequenceNumber"/>
+                            <xs:element name="update.type" type="UpdateType"/>
+                            <xs:element ref="abstract.record"/>
+                        </xs:sequence>
+                    </xs:complexType>
+                </xs:element>
+            </xs:sequence>
+            <xs:attribute ref="xml:lang" default="en-GB"/>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="transmission.comment" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="comment.sid" type="SID"/>
+                <xs:element name="language.id" type="LanguageId"/>
+                <xs:element name="comment.text" type="LongDescription" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <!-- Business data -->
+    <xs:simpleType name="ActionCode">
+        <xs:restriction base="xs:string">
+            <xs:pattern value="\d\d\d?"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="AdditionalCode">
+        <xs:restriction base="xs:string">
+            <xs:length value="3"/>
+            <xs:pattern value="[A-Z0-9][A-Z0-9][A-Z0-9]"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="AdditionalCodeTypeId">
+        <xs:restriction base="xs:string">
+            <xs:length value="1"/>
+            <xs:pattern value="[A-Z0-9]"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="ApplicationCodeAdditionalCode">
+        <xs:restriction base="xs:string">
+            <xs:length value="1"/>
+            <xs:enumeration value="0"/>
+            <xs:enumeration value="1"/>
+            <xs:enumeration value="3"/>
+            <xs:enumeration value="4"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="ApplicationCodeFootnote">
+        <xs:restriction base="xs:string">
+            <xs:length value="1"/>
+            <xs:enumeration value="1"/>
+            <xs:enumeration value="2"/>
+            <xs:enumeration value="3"/>
+            <xs:enumeration value="4"/>
+            <xs:enumeration value="5"/>
+            <xs:enumeration value="6"/>
+            <xs:enumeration value="7"/>
+            <xs:enumeration value="8"/>
+            <xs:enumeration value="9"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="ApprovedFlag">
+        <xs:restriction base="xs:string">
+            <xs:length value="1"/>
+            <xs:enumeration value="0"/>
+            <xs:enumeration value="1"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="AreaCode">
+        <xs:restriction base="xs:string">
+            <xs:length value="1"/>
+            <xs:enumeration value="0"/>
+            <xs:enumeration value="1"/>
+            <xs:enumeration value="2"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="CertificateCode">
+        <xs:restriction base="xs:string">
+            <xs:length value="3"/>
+            <xs:pattern value="[A-Z0-9][A-Z0-9][A-Z0-9]"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="CertificateTypeCode">
+        <xs:restriction base="xs:string">
+            <xs:length value="1"/>
+            <xs:pattern value="[A-Z0-9]"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="ChapterHeading">
+        <xs:restriction base="xs:string">
+            <xs:length value="2"/>
+            <xs:pattern value="[0-9][0-9]"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="Code">
+        <xs:restriction base="xs:string">
+            <xs:maxLength value="10"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="CodeTypeId">
+        <xs:restriction base="xs:string">
+            <xs:maxLength value="4"/>
+            <xs:enumeration value="ACT"/>
+            <xs:enumeration value="COND"/>
+            <xs:enumeration value="DE"/>
+            <xs:enumeration value="GA"/>
+            <xs:enumeration value="MOU"/>
+            <xs:enumeration value="MQC"/>
+            <xs:enumeration value="MT"/>
+            <xs:enumeration value="NG"/>
+            <xs:enumeration value="RLTP"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="CommunityCode">
+        <xs:restriction base="xs:string">
+            <xs:length value="1"/>
+            <xs:enumeration value="1"/>
+            <xs:enumeration value="2"/>
+            <xs:enumeration value="3"/>
+            <xs:enumeration value="4"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="ComponentSequenceNumber">
+        <xs:restriction base="xs:int">
+            <xs:minInclusive value="1"/>
+            <xs:maxInclusive value="999"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="ConditionCode">
+        <xs:restriction base="xs:string">
+            <xs:pattern value="[A-Z][A-Z]?"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="Date">
+        <xs:annotation>
+            <xs:documentation>Date format</xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:date">
+            <xs:pattern value="\d{4}-\d{2}-\d{2}"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="DutyAmount">
+        <xs:restriction base="xs:decimal">
+            <xs:maxInclusive value="9999999.999"/>
+            <xs:fractionDigits value="3"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="DutyAmountApplicabilityCode">
+        <xs:restriction base="xs:int">
+            <xs:enumeration value="0"/>
+            <xs:enumeration value="1"/>
+            <xs:enumeration value="2"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="DutyExpressionId">
+        <xs:restriction base="xs:string">
+            <xs:length value="2"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="ExchangeRate">
+        <xs:restriction base="xs:decimal">
+            <xs:maxInclusive value="99999999.99999999"/>
+            <xs:fractionDigits value="8"/>
+            <xs:minExclusive value="0"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="ExportRefundCode">
+        <xs:restriction base="xs:string">
+            <xs:length value="3"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="FootnoteId">
+        <xs:restriction base="xs:string">
+            <xs:pattern value="[0-9]{5}|[0-9]{3}"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="FootnoteTypeId">
+        <xs:restriction base="xs:string">
+            <xs:pattern value="[A-Z]{2}|[A-Z]{3}"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="GeographicalAreaId">
+        <xs:restriction base="xs:string">
+            <xs:maxLength value="4"/>
+            <xs:pattern value="[A-Z0-9]{2}|[A-Z0-9]{4}"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="GoodsNomenclatureItemId">
+        <xs:restriction base="xs:string">
+            <xs:length value="10"/>
+            <xs:pattern value="[0-9]{10}"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="GoodsNomenclatureGroupId">
+        <xs:restriction base="xs:string">
+            <xs:maxLength value="6"/>
+            <xs:pattern value="[0-9]{6}"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="GoodsNomenclatureGroupType">
+        <xs:restriction base="xs:string">
+            <xs:length value="1"/>
+            <xs:pattern value="[A-Z]"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="LanguageId">
+        <xs:restriction base="xs:string">
+            <xs:length value="2"/>
+            <xs:pattern value="[A-Z][A-Z]"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="LongDescription">
+        <xs:restriction base="xs:string">
+            <xs:maxLength value="20000"/>
+        <!-- RTC 14311 -->
+    </xs:restriction>
+   </xs:simpleType>
+    <xs:simpleType name="MeasureExplosionLevel">
+        <xs:restriction base="xs:int">
+            <xs:enumeration value="2"/>
+            <xs:enumeration value="4"/>
+            <xs:enumeration value="6"/>
+            <xs:enumeration value="8"/>
+            <xs:enumeration value="10"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="MeasurementUnitApplicabilityCode">
+        <xs:restriction base="xs:string">
+            <xs:length value="1"/>
+            <xs:enumeration value="0"/>
+            <xs:enumeration value="1"/>
+            <xs:enumeration value="2"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="MeasurementUnitCode">
+        <xs:restriction base="xs:string">
+            <xs:length value="3"/>
+            <xs:pattern value="[A-Z][A-Z][A-Z]"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="MeasurementUnitQualifierCode">
+        <xs:restriction base="xs:string">
+            <xs:length value="1"/>
+            <xs:pattern value="[A-Z]"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="MeasureTypeId">
+        <xs:restriction base="xs:string">
+            <xs:pattern value="[0-9]{3}|[0-9]{6}"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="MeasureTypeCombination">
+        <xs:restriction base="xs:string">
+            <xs:length value="1"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="MeasureTypeSeriesId">
+        <xs:restriction base="xs:string">
+            <xs:pattern value="[A-Z][A-Z]?"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="MeursingHeadingNumber">
+        <xs:restriction base="xs:string">
+            <xs:pattern value="\d{1,3}"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="MeursingTablePlanId">
+        <xs:restriction base="xs:string">
+            <xs:length value="2"/>
+            <xs:pattern value="\d\d"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="MonetaryUnitApplicabilityCode">
+        <xs:restriction base="xs:string">
+            <xs:length value="1"/>
+            <xs:enumeration value="0"/>
+            <xs:enumeration value="1"/>
+            <xs:enumeration value="2"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="MonetaryUnitCode">
+        <xs:restriction base="xs:string">
+            <xs:length value="3"/>
+            <xs:pattern value="[A-Z]{3}">
+                <xs:annotation>
+                    <xs:appinfo>
+                        <format xmlns="taric-format">AAA</format>
+                    </xs:appinfo>
+                </xs:annotation>
+            </xs:pattern>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="NomenclatureGroupFacilityCode">
+        <xs:restriction base="xs:string">
+            <xs:length value="1"/>
+            <xs:enumeration value="0"/>
+            <xs:enumeration value="2"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="NumberOf">
+        <xs:restriction base="xs:string">
+            <xs:length value="2"/>
+            <xs:pattern value="\d\d"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="OfficialJournalNumber">
+        <xs:restriction base="xs:string">
+            <xs:maxLength value="5"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="OfficialJournalPage">
+        <xs:restriction base="xs:int">
+            <xs:minInclusive value="1"/>
+            <xs:maxInclusive value="9999"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="OrderNumber">
+        <xs:restriction base="xs:string">
+            <xs:length value="6"/>
+            <xs:pattern value="[0-9]{6}"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="OrderNumberCaptureCode">
+        <xs:restriction base="xs:string">
+            <xs:length value="1"/>
+            <xs:enumeration value="1"/>
+            <xs:enumeration value="2"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="OriginCode">
+        <xs:restriction base="xs:string">
+            <xs:length value="1"/>
+            <xs:enumeration value="0"/>
+            <xs:enumeration value="1"/>
+            <xs:enumeration value="2"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="PriorityCode">
+        <xs:restriction base="xs:string">
+            <xs:length value="1"/>
+            <xs:enumeration value="1"/>
+            <xs:enumeration value="2"/>
+            <xs:enumeration value="3"/>
+            <xs:enumeration value="4"/>
+            <xs:enumeration value="5"/>
+            <xs:enumeration value="6"/>
+            <xs:enumeration value="7"/>
+            <xs:enumeration value="8"/>
+            <xs:enumeration value="9"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="ProductLineSuffix">
+        <xs:restriction base="xs:string">
+            <xs:length value="2"/>
+            <xs:pattern value="[0-9][0-9]"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="PublicationCode">
+        <xs:restriction base="xs:string">
+            <xs:length value="1"/>
+            <xs:enumeration value="0"/>
+            <xs:enumeration value="1"/>
+            <xs:enumeration value="2"/>
+            <xs:enumeration value="3"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="PublicationSigle">
+        <xs:restriction base="xs:string">
+            <xs:maxLength value="20"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="QuotaAmount">
+        <xs:restriction base="xs:decimal">
+            <xs:maxInclusive value="99999999999.999"/>
+            <xs:fractionDigits value="3"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="QuotaCoefficient">
+        <xs:restriction base="xs:decimal">
+            <xs:maxInclusive value="99999999999.99999"/>
+            <xs:fractionDigits value="5"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="QuotaBlockingPeriodType">
+        <xs:restriction base="xs:string">
+            <xs:length value="1"/>
+            <xs:pattern value="[0-9]"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="QuotaCriticalStateCode">
+        <xs:restriction base="xs:string">
+            <xs:length value="1"/>
+            <xs:enumeration value="Y"/>
+            <xs:enumeration value="N"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="QuotaCriticalTreshold">
+        <xs:restriction base="xs:int">
+            <xs:minInclusive value="0"/>
+            <xs:maxInclusive value="100"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="QuotaPrecision">
+        <xs:restriction base="xs:string">
+            <xs:length value="1"/>
+            <xs:enumeration value="0"/>
+            <xs:enumeration value="1"/>
+            <xs:enumeration value="2"/>
+            <xs:enumeration value="3"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="QuotaBlockedStateCode">
+        <xs:restriction base="xs:string">
+            <xs:length value="1"/>
+            <xs:enumeration value="Y"/>
+            <xs:enumeration value="N"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="QuotaExhaustedStateCode">
+        <xs:restriction base="xs:string">
+            <xs:length value="1"/>
+            <xs:enumeration value="Y"/>
+            <xs:enumeration value="N"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="QuotaSuspendedStateCode">
+        <xs:restriction base="xs:string">
+            <xs:length value="1"/>
+            <xs:enumeration value="Y"/>
+            <xs:enumeration value="N"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <!-- QTM148 CUSTD00029679 03/08/2013 CUST-DEV2  -->
+    <xs:simpleType name="QuotaClosedCode">
+        <xs:restriction base="xs:string">
+            <xs:length value="1"/>
+            <xs:enumeration value="Y"/>
+            <xs:enumeration value="N"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <!-- CUSTD00029679 - end  -->
+    <xs:simpleType name="QuotaAllocatedPercentage">
+        <xs:restriction base="xs:decimal">
+            <xs:maxInclusive value="999.999"/>
+            <xs:fractionDigits value="3"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="ReductionIndicator">
+        <xs:restriction base="xs:string">
+            <xs:length value="1"/>
+            <xs:enumeration value="1"/>
+            <xs:enumeration value="2"/>
+            <xs:enumeration value="3"/>
+          <xs:enumeration value="4"/>
+      <xs:enumeration value="5"/>
+      <xs:enumeration value="6"/>
+      <xs:enumeration value="7"/>
+      <xs:enumeration value="8"/>
+      <xs:enumeration value="9"/>
+    </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="RelationType">
+        <xs:restriction base="xs:string">
+            <xs:length value="2"/>
+            <xs:enumeration value="EQ"/>
+            <xs:enumeration value="NM"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="RegulationGroupId">
+        <xs:restriction base="xs:string">
+            <xs:length value="3"/>
+            <xs:pattern value="[A-Z][A-Z][A-Z]"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="RegulationId">
+        <xs:restriction base="xs:string">
+            <xs:length value="8"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="RegulationRoleTypeId">
+        <xs:restriction base="xs:string">
+            <xs:length value="1"/>
+            <xs:enumeration value="1"/>
+            <xs:enumeration value="2"/>
+            <xs:enumeration value="3"/>
+            <xs:enumeration value="4"/>
+            <xs:enumeration value="5"/>
+            <xs:enumeration value="6"/>
+            <xs:enumeration value="7"/>
+            <xs:enumeration value="8"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="ReplacementIndicator">
+        <xs:restriction base="xs:string">
+            <xs:length value="1"/>
+            <xs:enumeration value="0"/>
+            <xs:enumeration value="1"/>
+            <xs:enumeration value="2"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="RowColumnCode">
+        <xs:restriction base="xs:string">
+            <xs:length value="1"/>
+            <xs:enumeration value="0"/>
+            <xs:enumeration value="1"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="ShortDescription">
+        <xs:restriction base="xs:string">
+            <xs:maxLength value="500"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="StoppedFlag">
+        <xs:restriction base="xs:string">
+            <xs:length value="1"/>
+            <xs:enumeration value="0"/>
+            <xs:enumeration value="1"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="SID">
+        <xs:restriction base="xs:int">
+            <xs:minInclusive value="1"/>
+            <xs:maxInclusive value="99999999"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="StatisticalIndicator">
+        <xs:restriction base="xs:string">
+            <xs:length value="1"/>
+            <xs:enumeration value="0"/>
+            <xs:enumeration value="1"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="SubHeadingSequenceNumber">
+        <xs:restriction base="xs:string">
+            <xs:pattern value="\d{1,4}"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="SurveillanceNumber">
+        <xs:restriction base="xs:string">
+            <xs:length value="6"/>
+            <xs:pattern value="[0-9]{6}"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="TableLineSequenceNumber">
+        <xs:restriction base="xs:int">
+            <xs:minInclusive value="1"/>
+            <xs:maxInclusive value="99999"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="Timestamp">
+        <xs:annotation>
+            <xs:documentation>Timestamp format</xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:dateTime">
+            <xs:pattern value="\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="TradeMovementCode">
+        <xs:restriction base="xs:string">
+            <xs:length value="1"/>
+            <xs:enumeration value="0"/>
+            <xs:enumeration value="1"/>
+            <xs:enumeration value="2"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <!--Data elements -->
+    <xs:element name="additional.code" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="additional.code.sid" type="SID"/>
+                <xs:element name="additional.code.type.id" type="AdditionalCodeTypeId"/>
+                <xs:element name="additional.code" type="AdditionalCode"/>
+                <xs:element name="validity.start.date" type="Date"/>
+                <xs:element name="validity.end.date" type="Date" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="additional.code.description.period" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="additional.code.description.period.sid" type="SID"/>
+                <xs:element name="additional.code.sid" type="SID"/>
+                <xs:element name="additional.code.type.id" type="AdditionalCodeTypeId"/>
+                <xs:element name="additional.code" type="AdditionalCode"/>
+                <xs:element name="validity.start.date" type="Date"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="additional.code.description" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="additional.code.description.period.sid" type="SID"/>
+                <xs:element name="language.id" type="LanguageId"/>
+                <xs:element name="additional.code.sid" type="SID"/>
+                <xs:element name="additional.code.type.id" type="AdditionalCodeTypeId"/>
+                <xs:element name="additional.code" type="AdditionalCode"/>
+                <xs:element name="description" type="LongDescription" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="additional.code.type" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="additional.code.type.id" type="AdditionalCodeTypeId"/>
+                <xs:element name="validity.start.date" type="Date"/>
+                <xs:element name="validity.end.date" type="Date" minOccurs="0"/>
+                <xs:element name="application.code" type="ApplicationCodeAdditionalCode"/>
+                <xs:element name="meursing.table.plan.id" type="MeursingTablePlanId" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="additional.code.type.description" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="additional.code.type.id" type="AdditionalCodeTypeId"/>
+                <xs:element name="language.id" type="LanguageId"/>
+                <xs:element name="description" type="ShortDescription" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="additional.code.type.measure.type" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="measure.type.id" type="MeasureTypeId"/>
+                <xs:element name="additional.code.type.id" type="AdditionalCodeTypeId"/>
+                <xs:element name="validity.start.date" type="Date"/>
+                <xs:element name="validity.end.date" type="Date" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="base.regulation" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="base.regulation.role" type="RegulationRoleTypeId"/>
+                <xs:element name="base.regulation.id" type="RegulationId"/>
+                <xs:element name="published.date" type="Date" minOccurs="0"/>
+                <xs:element name="officialjournal.number" type="OfficialJournalNumber" minOccurs="0"/>
+                <xs:element name="officialjournal.page" type="OfficialJournalPage" minOccurs="0"/>
+                <xs:element name="validity.start.date" type="Date"/>
+                <xs:element name="validity.end.date" type="Date" minOccurs="0"/>
+                <xs:element name="effective.end.date" type="Date" minOccurs="0"/>
+                <xs:element name="community.code" type="CommunityCode"/>
+                <xs:element name="regulation.group.id" type="RegulationGroupId"/>
+                <xs:element name="antidumping.regulation.role" type="RegulationRoleTypeId" minOccurs="0"/>
+                <xs:element name="related.antidumping.regulation.id" type="RegulationId" minOccurs="0"/>
+                <xs:element name="complete.abrogation.regulation.role" type="RegulationRoleTypeId" minOccurs="0"/>
+                <xs:element name="complete.abrogation.regulation.id" type="RegulationId" minOccurs="0"/>
+                <xs:element name="explicit.abrogation.regulation.role" type="RegulationRoleTypeId" minOccurs="0"/>
+                <xs:element name="explicit.abrogation.regulation.id" type="RegulationId" minOccurs="0"/>
+                <xs:element name="replacement.indicator" type="ReplacementIndicator"/>
+                <xs:element name="stopped.flag" type="StoppedFlag"/>
+                <xs:element name="information.text" type="ShortDescription" minOccurs="0"/>
+                <xs:element name="approved.flag" type="ApprovedFlag"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="ceiling" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="surveillance.number" type="SurveillanceNumber"/>
+                <xs:element name="validity.start.date" type="Date"/>
+                <xs:element name="validity.end.date" type="Date" minOccurs="0"/>
+                <xs:element name="ceiling.reached.date" type="Date"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="certificate" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="certificate.type.code" type="CertificateTypeCode"/>
+                <xs:element name="certificate.code" type="CertificateCode"/>
+                <xs:element name="validity.start.date" type="Date"/>
+                <xs:element name="validity.end.date" type="Date" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="certificate.description.period" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="certificate.description.period.sid" type="SID"/>
+                <xs:element name="certificate.type.code" type="CertificateTypeCode"/>
+                <xs:element name="certificate.code" type="CertificateCode"/>
+                <xs:element name="validity.start.date" type="Date"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="certificate.description" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="certificate.description.period.sid" type="SID"/>
+                <xs:element name="language.id" type="LanguageId"/>
+                <xs:element name="certificate.type.code" type="CertificateTypeCode"/>
+                <xs:element name="certificate.code" type="CertificateCode"/>
+                <xs:element name="description" type="ShortDescription" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="certificate.type" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="certificate.type.code" type="CertificateTypeCode"/>
+                <xs:element name="validity.start.date" type="Date"/>
+                <xs:element name="validity.end.date" type="Date" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="certificate.type.description" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="certificate.type.code" type="CertificateTypeCode"/>
+                <xs:element name="language.id" type="LanguageId"/>
+                <xs:element name="description" type="ShortDescription" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="complete.abrogation.regulation" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="complete.abrogation.regulation.role" type="RegulationRoleTypeId"/>
+                <xs:element name="complete.abrogation.regulation.id" type="RegulationId"/>
+                <xs:element name="published.date" type="Date" minOccurs="0"/>
+                <xs:element name="officialjournal.number" type="OfficialJournalNumber" minOccurs="0"/>
+                <xs:element name="officialjournal.page" type="OfficialJournalPage" minOccurs="0"/>
+                <xs:element name="replacement.indicator" type="ReplacementIndicator"/>
+                <xs:element name="information.text" type="ShortDescription" minOccurs="0"/>
+                <xs:element name="approved.flag" type="ApprovedFlag"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="duty.expression" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="duty.expression.id" type="DutyExpressionId"/>
+                <xs:element name="validity.start.date" type="Date"/>
+                <xs:element name="validity.end.date" type="Date" minOccurs="0"/>
+                <xs:element name="duty.amount.applicability.code" type="DutyAmountApplicabilityCode"/>
+                <xs:element name="measurement.unit.applicability.code" type="MeasurementUnitApplicabilityCode"/>
+                <xs:element name="monetary.unit.applicability.code" type="MonetaryUnitApplicabilityCode"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="duty.expression.description" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="duty.expression.id" type="DutyExpressionId"/>
+                <xs:element name="language.id" type="LanguageId"/>
+                <xs:element name="description" type="ShortDescription" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="explicit.abrogation.regulation" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="explicit.abrogation.regulation.role" type="RegulationRoleTypeId"/>
+                <xs:element name="explicit.abrogation.regulation.id" type="RegulationId"/>
+                <xs:element name="published.date" type="Date" minOccurs="0"/>
+                <xs:element name="officialjournal.number" type="OfficialJournalNumber" minOccurs="0"/>
+                <xs:element name="officialjournal.page" type="OfficialJournalPage" minOccurs="0"/>
+                <xs:element name="replacement.indicator" type="ReplacementIndicator"/>
+                <xs:element name="abrogation.date" type="Date"/>
+                <xs:element name="information.text" type="ShortDescription" minOccurs="0"/>
+                <xs:element name="approved.flag" type="ApprovedFlag"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="export.refund.nomenclature" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="export.refund.nomenclature.sid" type="SID"/>
+                <xs:element name="goods.nomenclature.item.id" type="GoodsNomenclatureItemId"/>
+                <xs:element name="additional.code.type" type="AdditionalCodeTypeId"/>
+                <xs:element name="export.refund.code" type="ExportRefundCode"/>
+                <xs:element name="productline.suffix" type="ProductLineSuffix"/>
+                <xs:element name="validity.start.date" type="Date"/>
+                <xs:element name="validity.end.date" type="Date" minOccurs="0"/>
+                <xs:element name="goods.nomenclature.sid" type="SID"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="export.refund.nomenclature.indents" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="export.refund.nomenclature.indents.sid" type="SID"/>
+                <xs:element name="export.refund.nomenclature.sid" type="SID"/>
+                <xs:element name="validity.start.date" type="Date"/>
+                <xs:element name="number.export.refund.nomenclature.indents" type="NumberOf"/>
+                <xs:element name="goods.nomenclature.item.id" type="GoodsNomenclatureItemId"/>
+                <xs:element name="additional.code.type" type="AdditionalCodeTypeId"/>
+                <xs:element name="export.refund.code" type="ExportRefundCode"/>
+                <xs:element name="productline.suffix" type="ProductLineSuffix"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="export.refund.nomenclature.description.period" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="export.refund.nomenclature.description.period.sid" type="SID"/>
+                <xs:element name="export.refund.nomenclature.sid" type="SID"/>
+                <xs:element name="validity.start.date" type="Date"/>
+                <xs:element name="goods.nomenclature.item.id" type="GoodsNomenclatureItemId"/>
+                <xs:element name="additional.code.type" type="AdditionalCodeTypeId"/>
+                <xs:element name="export.refund.code" type="ExportRefundCode"/>
+                <xs:element name="productline.suffix" type="ProductLineSuffix"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="export.refund.nomenclature.description" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="export.refund.nomenclature.description.period.sid" type="SID"/>
+                <xs:element name="language.id" type="LanguageId"/>
+                <xs:element name="export.refund.nomenclature.sid" type="SID"/>
+                <xs:element name="goods.nomenclature.item.id" type="GoodsNomenclatureItemId"/>
+                <xs:element name="additional.code.type" type="AdditionalCodeTypeId"/>
+                <xs:element name="export.refund.code" type="ExportRefundCode"/>
+                <xs:element name="productline.suffix" type="ProductLineSuffix"/>
+                <xs:element name="description" type="LongDescription" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="footnote" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="footnote.type.id" type="FootnoteTypeId"/>
+                <xs:element name="footnote.id" type="FootnoteId"/>
+                <xs:element name="validity.start.date" type="Date"/>
+                <xs:element name="validity.end.date" type="Date" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="footnote.association.additional.code" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="additional.code.sid" type="SID"/>
+                <xs:element name="footnote.type.id" type="FootnoteTypeId"/>
+                <xs:element name="footnote.id" type="FootnoteId"/>
+                <xs:element name="validity.start.date" type="Date"/>
+                <xs:element name="validity.end.date" type="Date" minOccurs="0"/>
+                <xs:element name="additional.code.type.id" type="AdditionalCodeTypeId"/>
+                <xs:element name="additional.code" type="AdditionalCode"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="footnote.association.ern" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="export.refund.nomenclature.sid" type="SID"/>
+                <xs:element name="footnote.type" type="FootnoteTypeId"/>
+                <xs:element name="footnote.id" type="FootnoteId"/>
+                <xs:element name="validity.start.date" type="Date"/>
+                <xs:element name="validity.end.date" type="Date" minOccurs="0"/>
+                <xs:element name="goods.nomenclature.item.id" type="GoodsNomenclatureItemId"/>
+                <xs:element name="additional.code.type" type="AdditionalCodeTypeId"/>
+                <xs:element name="export.refund.code" type="ExportRefundCode"/>
+                <xs:element name="productline.suffix" type="ProductLineSuffix"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="footnote.association.goods.nomenclature" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="goods.nomenclature.sid" type="SID"/>
+                <xs:element name="footnote.type" type="FootnoteTypeId"/>
+                <xs:element name="footnote.id" type="FootnoteId"/>
+                <xs:element name="validity.start.date" type="Date"/>
+                <xs:element name="validity.end.date" type="Date" minOccurs="0"/>
+                <xs:element name="goods.nomenclature.item.id" type="GoodsNomenclatureItemId"/>
+                <xs:element name="productline.suffix" type="ProductLineSuffix"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="footnote.association.meursing.heading" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="meursing.table.plan.id" type="MeursingTablePlanId"/>
+                <xs:element name="meursing.heading.number" type="MeursingHeadingNumber"/>
+                <xs:element name="row.column.code" type="RowColumnCode"/>
+                <xs:element name="footnote.type" type="FootnoteTypeId"/>
+                <xs:element name="footnote.id" type="FootnoteId"/>
+                <xs:element name="validity.start.date" type="Date"/>
+                <xs:element name="validity.end.date" type="Date" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="footnote.description.period" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="footnote.description.period.sid" type="SID"/>
+                <xs:element name="footnote.type.id" type="FootnoteTypeId"/>
+                <xs:element name="footnote.id" type="FootnoteId"/>
+                <xs:element name="validity.start.date" type="Date"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="footnote.description" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="footnote.description.period.sid" type="SID"/>
+                <xs:element name="language.id" type="LanguageId"/>
+                <xs:element name="footnote.type.id" type="FootnoteTypeId"/>
+                <xs:element name="footnote.id" type="FootnoteId"/>
+                <xs:element name="description" type="LongDescription" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="footnote.type" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="footnote.type.id" type="FootnoteTypeId"/>
+                <xs:element name="validity.start.date" type="Date"/>
+                <xs:element name="validity.end.date" type="Date" minOccurs="0"/>
+                <xs:element name="application.code" type="ApplicationCodeFootnote"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="footnote.type.description" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="footnote.type.id" type="FootnoteTypeId"/>
+                <xs:element name="language.id" type="LanguageId"/>
+                <xs:element name="description" type="ShortDescription" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="fts.regulation.action" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="fts.regulation.role" type="RegulationRoleTypeId"/>
+                <xs:element name="fts.regulation.id" type="RegulationId"/>
+                <xs:element name="stopped.regulation.role" type="RegulationRoleTypeId"/>
+                <xs:element name="stopped.regulation.id" type="RegulationId"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="full.temporary.stop.regulation" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="full.temporary.stop.regulation.role" type="RegulationRoleTypeId"/>
+                <xs:element name="full.temporary.stop.regulation.id" type="RegulationId"/>
+                <xs:element name="published.date" type="Date" minOccurs="0"/>
+                <xs:element name="officialjournal.number" type="OfficialJournalNumber" minOccurs="0"/>
+                <xs:element name="officialjournal.page" type="OfficialJournalPage" minOccurs="0"/>
+                <xs:element name="validity.start.date" type="Date"/>
+                <xs:element name="validity.end.date" type="Date" minOccurs="0"/>
+                <xs:element name="effective.enddate" type="Date" minOccurs="0"/>
+                <xs:element name="complete.abrogation.regulation.role" type="RegulationRoleTypeId" minOccurs="0"/>
+                <xs:element name="complete.abrogation.regulation.id" type="RegulationId" minOccurs="0"/>
+                <xs:element name="explicit.abrogation.regulation.role" type="RegulationRoleTypeId" minOccurs="0"/>
+                <xs:element name="explicit.abrogation.regulation.id" type="RegulationId" minOccurs="0"/>
+                <xs:element name="replacement.indicator" type="ReplacementIndicator"/>
+                <xs:element name="information.text" type="ShortDescription" minOccurs="0"/>
+                <xs:element name="approved.flag" type="ApprovedFlag"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="geographical.area" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="geographical.area.sid" type="SID"/>
+                <xs:element name="geographical.area.id" type="GeographicalAreaId"/>
+                <xs:element name="validity.start.date" type="Date"/>
+                <xs:element name="validity.end.date" type="Date" minOccurs="0"/>
+                <xs:element name="geographical.code" type="AreaCode"/>
+                <xs:element name="parent.geographical.area.group.sid" type="SID" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="geographical.area.description.period" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="geographical.area.description.period.sid" type="SID"/>
+                <xs:element name="geographical.area.sid" type="SID"/>
+                <xs:element name="validity.start.date" type="Date"/>
+                <xs:element name="geographical.area.id" type="GeographicalAreaId"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="geographical.area.description" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="geographical.area.description.period.sid" type="SID"/>
+                <xs:element name="language.id" type="LanguageId"/>
+                <xs:element name="geographical.area.sid" type="SID"/>
+                <xs:element name="geographical.area.id" type="GeographicalAreaId"/>
+                <xs:element name="description" type="ShortDescription" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="geographical.area.membership" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="geographical.area.sid" type="SID"/>
+                <xs:element name="geographical.area.group.sid" type="SID"/>
+                <xs:element name="validity.start.date" type="Date"/>
+                <xs:element name="validity.end.date" type="Date" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="goods.nomenclature" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="goods.nomenclature.sid" type="SID"/>
+                <xs:element name="goods.nomenclature.item.id" type="GoodsNomenclatureItemId"/>
+                <xs:element name="producline.suffix" type="ProductLineSuffix"/>
+                <xs:element name="validity.start.date" type="Date"/>
+                <xs:element name="validity.end.date" type="Date" minOccurs="0"/>
+                <xs:element name="statistical.indicator" type="StatisticalIndicator"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="goods.nomenclature.indents" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="goods.nomenclature.indent.sid" type="SID"/>
+                <xs:element name="goods.nomenclature.sid" type="SID"/>
+                <xs:element name="validity.start.date" type="Date"/>
+                <xs:element name="number.indents" type="NumberOf"/>
+                <xs:element name="goods.nomenclature.item.id" type="GoodsNomenclatureItemId"/>
+                <xs:element name="productline.suffix" type="ProductLineSuffix"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="goods.nomenclature.description.period" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="goods.nomenclature.description.period.sid" type="SID"/>
+                <xs:element name="goods.nomenclature.sid" type="SID"/>
+                <xs:element name="validity.start.date" type="Date"/>
+                <xs:element name="goods.nomenclature.item.id" type="GoodsNomenclatureItemId"/>
+                <xs:element name="productline.suffix" type="ProductLineSuffix"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="goods.nomenclature.description" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="goods.nomenclature.description.period.sid" type="SID"/>
+                <xs:element name="language.id" type="LanguageId"/>
+                <xs:element name="goods.nomenclature.sid" type="SID"/>
+                <xs:element name="goods.nomenclature.item.id" type="GoodsNomenclatureItemId"/>
+                <xs:element name="productline.suffix" type="ProductLineSuffix"/>
+                <xs:element name="description" type="LongDescription" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="goods.nomenclature.group" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="goods.nomenclature.group.type" type="GoodsNomenclatureGroupType"/>
+                <xs:element name="goods.nomenclature.group.id" type="GoodsNomenclatureGroupId"/>
+                <xs:element name="validity.start.date" type="Date"/>
+                <xs:element name="validity.end.date" type="Date" minOccurs="0"/>
+                <xs:element name="nomenclature.group.facility.code" type="NomenclatureGroupFacilityCode"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="goods.nomenclature.group.description" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="goods.nomenclature.group.type" type="GoodsNomenclatureGroupType"/>
+                <xs:element name="goods.nomenclature.group.id" type="GoodsNomenclatureGroupId"/>
+                <xs:element name="language.id" type="LanguageId"/>
+                <xs:element name="description" type="ShortDescription" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="goods.nomenclature.origin" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="goods.nomenclature.sid" type="SID"/>
+                <xs:element name="derived.goods.nomenclature.item.id" type="GoodsNomenclatureItemId"/>
+                <xs:element name="derived.productline.suffix" type="ProductLineSuffix"/>
+                <xs:element name="goods.nomenclature.item.id" type="GoodsNomenclatureItemId"/>
+                <xs:element name="productline.suffix" type="ProductLineSuffix"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="goods.nomenclature.successor" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="goods.nomenclature.sid" type="SID"/>
+                <xs:element name="absorbed.goods.nomenclature.item.id" type="GoodsNomenclatureItemId"/>
+                <xs:element name="absorbed.productline.suffix" type="ProductLineSuffix"/>
+                <xs:element name="goods.nomenclature.item.id" type="GoodsNomenclatureItemId"/>
+                <xs:element name="productline.suffix" type="ProductLineSuffix"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="language" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="language.id" type="LanguageId"/>
+                <xs:element name="validity.start.date" type="Date"/>
+                <xs:element name="validity.end.date" type="Date" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="language.description" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="language.code.id" type="LanguageId"/>
+                <xs:element name="language.id" type="LanguageId"/>
+                <xs:element name="description" type="ShortDescription" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="measure" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="measure.sid" type="SID"/>
+                <xs:element name="measure.type" type="MeasureTypeId"/>
+                <xs:element name="geographical.area" type="GeographicalAreaId"/>
+                <xs:element name="goods.nomenclature.item.id" type="GoodsNomenclatureItemId" minOccurs="0"/>
+                <xs:element name="additional.code.type" type="AdditionalCodeTypeId" minOccurs="0"/>
+                <xs:element name="additional.code" type="AdditionalCode" minOccurs="0"/>
+                <xs:element name="ordernumber" type="OrderNumber" minOccurs="0"/>
+                <xs:element name="reduction.indicator" type="ReductionIndicator" minOccurs="0"/>
+                <xs:element name="validity.start.date" type="Date"/>
+                <xs:element name="measure.generating.regulation.role" type="RegulationRoleTypeId"/>
+                <xs:element name="measure.generating.regulation.id" type="RegulationId"/>
+                <xs:element name="validity.end.date" type="Date" minOccurs="0"/>
+                <xs:element name="justification.regulation.role" type="RegulationRoleTypeId" minOccurs="0"/>
+                <xs:element name="justification.regulation.id" type="RegulationId" minOccurs="0"/>
+                <xs:element name="stopped.flag" type="StoppedFlag"/>
+                <xs:element name="geographical.area.sid" type="SID" minOccurs="0"/>
+                <xs:element name="goods.nomenclature.sid" type="SID" minOccurs="0"/>
+                <xs:element name="additional.code.sid" type="SID" minOccurs="0"/>
+                <xs:element name="export.refund.nomenclature.sid" type="SID" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="measure.component" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="measure.sid" type="SID"/>
+                <xs:element name="duty.expression.id" type="DutyExpressionId"/>
+                <xs:element name="duty.amount" type="DutyAmount" minOccurs="0"/>
+                <xs:element name="monetary.unit.code" type="MonetaryUnitCode" minOccurs="0"/>
+                <xs:element name="measurement.unit.code" type="MeasurementUnitCode" minOccurs="0"/>
+                <xs:element name="measurement.unit.qualifier.code" type="MeasurementUnitQualifierCode" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="measure.condition" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="measure.condition.sid" type="SID"/>
+                <xs:element name="measure.sid" type="SID"/>
+                <xs:element name="condition.code" type="ConditionCode"/>
+                <xs:element name="component.sequence.number" type="ComponentSequenceNumber"/>
+                <xs:element name="condition.duty.amount" type="DutyAmount" minOccurs="0"/>
+                <xs:element name="condition.monetary.unit.code" type="MonetaryUnitCode" minOccurs="0"/>
+                <xs:element name="condition.measurement.unit.code" type="MeasurementUnitCode" minOccurs="0"/>
+                <xs:element name="condition.measurement.unit.qualifier.code" type="MeasurementUnitQualifierCode" minOccurs="0"/>
+                <xs:element name="action.code" type="ActionCode" minOccurs="0"/>
+                <xs:element name="certificate.type.code" type="CertificateTypeCode" minOccurs="0"/>
+                <xs:element name="certificate.code" type="CertificateCode" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="measure.condition.component" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="measure.condition.sid" type="SID"/>
+                <xs:element name="duty.expression.id" type="DutyExpressionId"/>
+                <xs:element name="duty.amount" type="DutyAmount" minOccurs="0"/>
+                <xs:element name="monetary.unit.code" type="MonetaryUnitCode" minOccurs="0"/>
+                <xs:element name="measurement.unit.code" type="MeasurementUnitCode" minOccurs="0"/>
+                <xs:element name="measurement.unit.qualifier.code" type="MeasurementUnitQualifierCode" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="measure.excluded.geographical.area" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="measure.sid" type="SID"/>
+                <xs:element name="excluded.geographical.area" type="GeographicalAreaId"/>
+                <xs:element name="geographical.area.sid" type="SID"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="footnote.association.measure" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="measure.sid" type="SID"/>
+                <xs:element name="footnote.type.id" type="FootnoteTypeId"/>
+                <xs:element name="footnote.id" type="FootnoteId"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="measure.partial.temporary.stop" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="measure.sid" type="SID"/>
+                <xs:element name="validity.start.date" type="Date"/>
+                <xs:element name="validity.end.date" type="Date" minOccurs="0"/>
+                <xs:element name="partial.temporary.stop.regulation.id" type="RegulationId"/>
+                <xs:element name="partial.temporary.stop.regulation.officialjournal.number" type="OfficialJournalNumber" minOccurs="0"/>
+                <xs:element name="partial.temporary.stop.regulation.officialjournal.page" type="OfficialJournalPage" minOccurs="0"/>
+                <xs:element name="abrogation.regulation.id" type="RegulationId" minOccurs="0"/>
+                <xs:element name="abrogation.regulation.officialjournal.number" type="OfficialJournalNumber" minOccurs="0"/>
+                <xs:element name="abrogation.regulation.officialjournal.page" type="OfficialJournalPage" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="measure.condition.code" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="condition.code" type="ConditionCode"/>
+                <xs:element name="validity.start.date" type="Date"/>
+                <xs:element name="validity.end.date" type="Date" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="measure.condition.code.description" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="condition.code" type="ConditionCode"/>
+                <xs:element name="language.id" type="LanguageId"/>
+                <xs:element name="description" type="ShortDescription" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="measure.action" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="action.code" type="ActionCode"/>
+                <xs:element name="validity.start.date" type="Date"/>
+                <xs:element name="validity.end.date" type="Date" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="measure.action.description" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="action.code" type="ActionCode"/>
+                <xs:element name="language.id" type="LanguageId"/>
+                <xs:element name="description" type="ShortDescription" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="measure.type" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="measure.type.id" type="MeasureTypeId"/>
+                <xs:element name="validity.start.date" type="Date"/>
+                <xs:element name="validity.end.date" type="Date" minOccurs="0"/>
+                <xs:element name="trade.movement.code" type="TradeMovementCode"/>
+                <xs:element name="priority.code" type="PriorityCode"/>
+                <xs:element name="measure.component.applicable.code" type="MeasurementUnitApplicabilityCode"/>
+                <xs:element name="origin.dest.code" type="OriginCode"/>
+                <xs:element name="order.number.capture.code" type="OrderNumberCaptureCode"/>
+                <xs:element name="measure.explosion.level" type="MeasureExplosionLevel"/>
+                <xs:element name="measure.type.series.id" type="MeasureTypeSeriesId"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="measure.type.description" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="measure.type.id" type="MeasureTypeId"/>
+                <xs:element name="language.id" type="LanguageId"/>
+                <xs:element name="description" type="ShortDescription" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="measure.type.series" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="measure.type.series.id" type="MeasureTypeSeriesId"/>
+                <xs:element name="validity.start.date" type="Date"/>
+                <xs:element name="validity.end.date" type="Date" minOccurs="0"/>
+                <xs:element name="measure.type.combination" type="MeasureTypeCombination"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="measure.type.series.description" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="measure.type.series.id" type="MeasureTypeSeriesId"/>
+                <xs:element name="language.id" type="LanguageId"/>
+                <xs:element name="description" type="ShortDescription" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="measurement.unit" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="measurement.unit.code" type="MeasurementUnitCode"/>
+                <xs:element name="validity.start.date" type="Date"/>
+                <xs:element name="validity.end.date" type="Date" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="measurement.unit.description" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="measurement.unit.code" type="MeasurementUnitCode"/>
+                <xs:element name="language.id" type="LanguageId"/>
+                <xs:element name="description" type="ShortDescription" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="measurement.unit.qualifier" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="measurement.unit.qualifier.code" type="MeasurementUnitQualifierCode"/>
+                <xs:element name="validity.start.date" type="Date"/>
+                <xs:element name="validity.end.date" type="Date" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="measurement.unit.qualifier.description" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="measurement.unit.qualifier.code" type="MeasurementUnitQualifierCode"/>
+                <xs:element name="language.id" type="LanguageId"/>
+                <xs:element name="description" type="ShortDescription" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="measurement" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="measurement.unit.code" type="MeasurementUnitCode"/>
+                <xs:element name="measurement.unit.qualifier.code" type="MeasurementUnitQualifierCode"/>
+                <xs:element name="validity.start.date" type="Date"/>
+                <xs:element name="validity.end.date" type="Date" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="meursing.table.plan" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="meursing.table.plan.id" type="MeursingTablePlanId"/>
+                <xs:element name="validity.start.date" type="Date"/>
+                <xs:element name="validity.end.date" type="Date" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="meursing.heading" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="meursing.table.plan.id" type="MeursingTablePlanId"/>
+                <xs:element name="meursing.heading.number" type="MeursingHeadingNumber"/>
+                <xs:element name="row.column.code" type="RowColumnCode"/>
+                <xs:element name="validity.start.date" type="Date"/>
+                <xs:element name="validity.end.date" type="Date" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="meursing.heading.text" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="meursing.table.plan.id" type="MeursingTablePlanId"/>
+                <xs:element name="meursing.heading.number" type="MeursingHeadingNumber"/>
+                <xs:element name="row.column.code" type="RowColumnCode"/>
+                <xs:element name="language.id" type="LanguageId"/>
+                <xs:element name="description" type="ShortDescription" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="meursing.subheading" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="meursing.table.plan.id" type="MeursingTablePlanId"/>
+                <xs:element name="meursing.heading.number" type="MeursingHeadingNumber"/>
+                <xs:element name="row.column.code" type="RowColumnCode"/>
+                <xs:element name="subheading.sequence.number" type="SubHeadingSequenceNumber"/>
+                <xs:element name="validity.start.date" type="Date"/>
+                <xs:element name="validity.end.date" type="Date" minOccurs="0"/>
+                <xs:element name="description" type="ShortDescription" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="meursing.additional.code" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="meursing.additional.code.sid" type="SID"/>
+                <xs:element name="validity.end.date" type="Date" minOccurs="0"/>
+                <xs:element name="additional.code" type="AdditionalCode"/>
+                <xs:element name="validity.start.date" type="Date"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="meursing.table.cell.component" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="meursing.additional.code.sid" type="SID"/>
+                <xs:element name="meursing.table.plan.id" type="MeursingTablePlanId"/>
+                <xs:element name="heading.number" type="MeursingHeadingNumber"/>
+                <xs:element name="row.column.code" type="RowColumnCode"/>
+                <xs:element name="subheading.sequence.number" type="SubHeadingSequenceNumber"/>
+                <xs:element name="validity.start.date" type="Date"/>
+                <xs:element name="validity.end.date" type="Date" minOccurs="0"/>
+                <xs:element name="additional.code" type="AdditionalCode"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="modification.regulation" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="modification.regulation.role" type="RegulationRoleTypeId"/>
+                <xs:element name="modification.regulation.id" type="RegulationId"/>
+                <xs:element name="published.date" type="Date" minOccurs="0"/>
+                <xs:element name="officialjournal.number" type="OfficialJournalNumber" minOccurs="0"/>
+                <xs:element name="officialjournal.page" type="OfficialJournalPage" minOccurs="0"/>
+                <xs:element name="validity.start.date" type="Date"/>
+                <xs:element name="validity.end.date" type="Date" minOccurs="0"/>
+                <xs:element name="effective.end.date" type="Date" minOccurs="0"/>
+                <xs:element name="base.regulation.role" type="RegulationRoleTypeId"/>
+                <xs:element name="base.regulation.id" type="RegulationId"/>
+                <xs:element name="complete.abrogation.regulation.role" type="RegulationRoleTypeId" minOccurs="0"/>
+                <xs:element name="complete.abrogation.regulation.id" type="RegulationId" minOccurs="0"/>
+                <xs:element name="explicit.abrogation.regulation.role" type="RegulationRoleTypeId" minOccurs="0"/>
+                <xs:element name="explicit.abrogation.regulation.id" type="RegulationId" minOccurs="0"/>
+                <xs:element name="replacement.indicator" type="ReplacementIndicator"/>
+                <xs:element name="stopped.flag" type="StoppedFlag"/>
+                <xs:element name="information.text" type="ShortDescription" minOccurs="0"/>
+                <xs:element name="approved.flag" type="ApprovedFlag"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="monetary.exchange.period" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="monetary.exchange.period.sid" type="SID"/>
+                <xs:element name="parent.monetary.unit.code" type="MonetaryUnitCode"/>
+                <xs:element name="validity.start.date" type="Date"/>
+                <xs:element name="validity.end.date" type="Date" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="monetary.exchange.rate" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="monetary.exchange.period.sid" type="SID"/>
+                <xs:element name="child.monetary.unit.code" type="MonetaryUnitCode"/>
+                <xs:element name="exchange.rate" type="ExchangeRate"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="monetary.unit" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="monetary.unit.code" type="MonetaryUnitCode"/>
+                <xs:element name="validity.start.date" type="Date"/>
+                <xs:element name="validity.end.date" type="Date" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="monetary.unit.description" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="monetary.unit.code" type="MonetaryUnitCode"/>
+                <xs:element name="language.id" type="LanguageId"/>
+                <xs:element name="description" type="ShortDescription" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="nomenclature.group.membership" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="goods.nomenclature.sid" type="SID"/>
+                <xs:element name="goods.nomenclature.group.type" type="GoodsNomenclatureGroupType"/>
+                <xs:element name="goods.nomenclature.group.id" type="GoodsNomenclatureGroupId"/>
+                <xs:element name="validity.start.date" type="Date"/>
+                <xs:element name="validity.end.date" type="Date" minOccurs="0"/>
+                <xs:element name="goods.nomenclature.item.id" type="GoodsNomenclatureItemId"/>
+                <xs:element name="productline.suffix" type="ProductLineSuffix"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="prorogation.regulation" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="prorogation.regulation.role" type="RegulationRoleTypeId"/>
+                <xs:element name="prorogation.regulation.id" type="RegulationId"/>
+                <xs:element name="published.date" type="Date" minOccurs="0"/>
+                <xs:element name="officialjournal.number" type="OfficialJournalNumber" minOccurs="0"/>
+                <xs:element name="officialjournal.page" type="OfficialJournalPage" minOccurs="0"/>
+                <xs:element name="replacement.indicator" type="ReplacementIndicator"/>
+                <xs:element name="information.text" type="ShortDescription" minOccurs="0"/>
+                <xs:element name="approved.flag" type="ApprovedFlag"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="prorogation.regulation.action" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="prorogation.regulation.role" type="RegulationRoleTypeId"/>
+                <xs:element name="prorogation.regulation.id" type="RegulationId"/>
+                <xs:element name="prorogated.regulation.role" type="RegulationRoleTypeId"/>
+                <xs:element name="prorogated.regulation.id" type="RegulationId"/>
+                <xs:element name="prorogated.date" type="Date" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="publication.sigle" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="code.type.id" type="CodeTypeId"/>
+                <xs:element name="code" type="Code"/>
+                <xs:element name="validity.start.date" type="Date"/>
+                <xs:element name="validity.end.date" type="Date" minOccurs="0"/>
+                <xs:element name="publication.code" type="PublicationCode"/>
+                <xs:element name="publication.sigle" type="PublicationSigle" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="quota.order.number" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="quota.order.number.sid" type="SID"/>
+                <xs:element name="quota.order.number.id" type="OrderNumber"/>
+                <xs:element name="validity.start.date" type="Date"/>
+                <xs:element name="validity.end.date" type="Date" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="quota.order.number.origin" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="quota.order.number.origin.sid" type="SID"/>
+                <xs:element name="quota.order.number.sid" type="SID"/>
+                <xs:element name="geographical.area.id" type="GeographicalAreaId"/>
+                <xs:element name="validity.start.date" type="Date"/>
+                <xs:element name="validity.end.date" type="Date" minOccurs="0"/>
+                <xs:element name="geographical.area.sid" type="SID"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="quota.order.number.origin.exclusions" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="quota.order.number.origin.sid" type="SID"/>
+                <xs:element name="excluded.geographical.area.sid" type="SID"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="quota.definition" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="quota.definition.sid" type="SID"/>
+                <xs:element name="quota.order.number.id" type="OrderNumber"/>
+                <xs:element name="validity.start.date" type="Date"/>
+                <xs:element name="validity.end.date" type="Date" minOccurs="0"/>
+                <xs:element name="quota.order.number.sid" type="SID"/>
+                <xs:element name="volume" type="QuotaAmount"/>
+                <xs:element name="initial.volume" type="QuotaAmount"/>
+                <xs:element name="monetary.unit.code" type="MonetaryUnitCode" minOccurs="0"/>
+                <xs:element name="measurement.unit.code" type="MeasurementUnitCode" minOccurs="0"/>
+                <xs:element name="measurement.unit.qualifier.code" type="MeasurementUnitQualifierCode" minOccurs="0"/>
+                <xs:element name="maximum.precision" type="QuotaPrecision"/>
+                <xs:element name="critical.state" type="QuotaCriticalStateCode"/>
+                <xs:element name="critical.threshold" type="QuotaCriticalTreshold"/>
+                <xs:element name="description" type="ShortDescription" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="quota.association" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="main.quota.definition.sid" type="SID"/>
+                <xs:element name="sub.quota.definition.sid" type="SID"/>
+                <xs:element name="relation.type" type="RelationType"/>
+                <xs:element name="coefficient" type="QuotaCoefficient" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="quota.blocking.period" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="quota.blocking.period.sid" type="SID"/>
+                <xs:element name="quota.definition.sid" type="SID"/>
+                <xs:element name="blocking.start.date" type="Date"/>
+                <xs:element name="blocking.end.date" type="Date"/>
+                <xs:element name="blocking.period.type" type="QuotaBlockingPeriodType"/>
+                <xs:element name="description" type="ShortDescription" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="quota.suspension.period" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="quota.suspension.period.sid" type="SID"/>
+                <xs:element name="quota.definition.sid" type="SID"/>
+                <xs:element name="suspension.start.date" type="Date"/>
+                <xs:element name="suspension.end.date" type="Date"/>
+                <xs:element name="description" type="ShortDescription" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="quota.extended.information" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="quota.definition.sid" type="SID"/>
+                <xs:element name="balance" type="QuotaAmount"/>
+                <xs:element name="imported.amount" type="QuotaAmount"/>
+                <xs:element name="last.allocation.date" type="Date" minOccurs="0"/>
+                <xs:element name="allocated.percentage" type="QuotaAllocatedPercentage" minOccurs="0"/>
+                <xs:element name="last.import.date" type="Date" minOccurs="0"/>
+                <xs:element name="quota.exhaustion.state" type="QuotaExhaustedStateCode"/>
+                <xs:element name="exhaustion.date" type="Date" minOccurs="0"/>
+                <xs:element name="quota.blocked.state" type="QuotaBlockedStateCode"/>
+                <xs:element name="quota.suspended.state" type="QuotaSuspendedStateCode"/>
+                <xs:element name="total.awaiting.allocation" type="QuotaAmount"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="quota.balance.event" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="quota.definition.sid" type="SID"/>
+                <xs:element name="occurrence.timestamp" type="Timestamp"/>
+                <xs:element name="old.balance" type="QuotaAmount"/>
+                <xs:element name="new.balance" type="QuotaAmount"/>
+                <xs:element name="imported.amount" type="QuotaAmount"/>
+                <xs:element name="last.import.date.in.allocation" type="Date" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="quota.unblocking.event" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="quota.definition.sid" type="SID"/>
+                <xs:element name="occurrence.timestamp" type="Timestamp"/>
+                <xs:element name="unblocking.date" type="Date"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="quota.critical.event" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="quota.definition.sid" type="SID"/>
+                <xs:element name="occurrence.timestamp" type="Timestamp"/>
+                <xs:element name="critical.state" type="QuotaCriticalStateCode"/>
+                <xs:element name="critical.state.change.date" type="Date" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="quota.exhaustion.event" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="quota.definition.sid" type="SID"/>
+                <xs:element name="occurrence.timestamp" type="Timestamp"/>
+                <xs:element name="exhaustion.date" type="Date"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="quota.reopening.event" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="quota.definition.sid" type="SID"/>
+                <xs:element name="occurrence.timestamp" type="Timestamp"/>
+                <xs:element name="reopening.date" type="Date"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="quota.unsuspension.event" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="quota.definition.sid" type="SID"/>
+                <xs:element name="occurrence.timestamp" type="Timestamp"/>
+                <xs:element name="unsuspension.date" type="Date"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="quota.closed.and.transferred.event" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="quota.definition.sid" type="SID"/>
+                <xs:element name="occurrence.timestamp" type="Timestamp"/>
+                <!-- QTM148 CUSTD00029679 03/08/2013 CUST-DEV2  -->
+                <!--    <xs:element name="closing.date" type="Date"/> -->
+                <xs:element name="transfer.date" type="Date"/>
+                <xs:element name="quota.closed" type="QuotaClosedCode"/>
+                <!-- CUSTD00029679 - end -->
+                <xs:element name="transferred.amount" type="QuotaAmount"/>
+                <xs:element name="target.quota.definition.sid" type="SID"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="regulation.group" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="regulation.group.id" type="RegulationGroupId"/>
+                <xs:element name="validity.start.date" type="Date"/>
+                <xs:element name="validity.end.date" type="Date" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="regulation.group.description" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="regulation.group.id" type="RegulationGroupId"/>
+                <xs:element name="language.id" type="LanguageId"/>
+                <xs:element name="description" type="ShortDescription" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="regulation.role.type" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="regulation.role.type.id" type="RegulationRoleTypeId"/>
+                <xs:element name="validity.start.date" type="Date"/>
+                <xs:element name="validity.end.date" type="Date" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="regulation.role.type.description" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="regulation.role.type.id" type="RegulationRoleTypeId"/>
+                <xs:element name="language.id" type="LanguageId"/>
+                <xs:element name="description" type="ShortDescription" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="regulation.replacement" substitutionGroup="abstract.record">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="replacing.regulation.role" type="RegulationRoleTypeId"/>
+                <xs:element name="replacing.regulation.id" type="RegulationId"/>
+                <xs:element name="replaced.regulation.role" type="RegulationRoleTypeId"/>
+                <xs:element name="replaced.regulation.id" type="RegulationId"/>
+                <xs:element name="measure.type.id" type="MeasureTypeId" minOccurs="0"/>
+                <xs:element name="geographical.area.id" type="GeographicalAreaId" minOccurs="0"/>
+                <xs:element name="chapter.heading" type="ChapterHeading" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+</xs:schema>

--- a/commodities/forms.py
+++ b/commodities/forms.py
@@ -66,7 +66,7 @@ class CommodityImportForm(forms.ModelForm):
                 capture_exception(e)
             raise ValidationError(generic_error_message)
 
-        with open(settings.PATH_XSD_TARIC) as xsd_file:
+        with open(settings.PATH_XSD_COMMODITIES_TARIC) as xsd_file:
             xmlschema = lxml.etree.XMLSchema(file=xsd_file)
 
         try:

--- a/commodities/tests/test_files/invalid.xml
+++ b/commodities/tests/test_files/invalid.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<env:foo id="220001" xmlns="urn:publicid:-:DGTAXUD:TARIC:MESSAGE:1.0" xmlns:env="urn:publicid:-:DGTAXUD:GENERAL:ENVELOPE:1.0">
+<env:foo id="22001" xmlns="urn:publicid:-:DGTAXUD:TARIC:MESSAGE:1.0" xmlns:env="urn:publicid:-:DGTAXUD:GENERAL:ENVELOPE:1.0">
 	<env:bar id="392602">
 		<env:app.message id="1">
 			<oub:transmission xmlns:env="urn:publicid:-:DGTAXUD:GENERAL:ENVELOPE:1.0" xmlns:oub="urn:publicid:-:DGTAXUD:TARIC:MESSAGE:1.0">

--- a/commodities/tests/test_files/invalid_id.xml
+++ b/commodities/tests/test_files/invalid_id.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<env:envelope id="22001" xmlns="urn:publicid:-:DGTAXUD:TARIC:MESSAGE:1.0" xmlns:env="urn:publicid:-:DGTAXUD:GENERAL:ENVELOPE:1.0">
+<env:envelope id="220001" xmlns="urn:publicid:-:DGTAXUD:TARIC:MESSAGE:1.0" xmlns:env="urn:publicid:-:DGTAXUD:GENERAL:ENVELOPE:1.0">
 	<env:transaction id="392602">
 		<env:app.message id="1">
 			<oub:transmission xmlns:env="urn:publicid:-:DGTAXUD:GENERAL:ENVELOPE:1.0" xmlns:oub="urn:publicid:-:DGTAXUD:TARIC:MESSAGE:1.0">
@@ -16,3 +16,9 @@
 						<oub:validity.start.date>2016-09-15</oub:validity.start.date>
 						<oub:validity.end.date>2021-12-31</oub:validity.end.date>
 						<oub:statistical.indicator>0</oub:statistical.indicator>
+					</oub:goods.nomenclature>
+				</oub:record>
+			</oub:transmission>
+		</env:app.message>
+	</env:transaction>
+</env:envelope>

--- a/commodities/tests/test_files/valid.xml
+++ b/commodities/tests/test_files/valid.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<env:envelope id="220001" xmlns="urn:publicid:-:DGTAXUD:TARIC:MESSAGE:1.0" xmlns:env="urn:publicid:-:DGTAXUD:GENERAL:ENVELOPE:1.0">
+<env:envelope id="22001" xmlns="urn:publicid:-:DGTAXUD:TARIC:MESSAGE:1.0" xmlns:env="urn:publicid:-:DGTAXUD:GENERAL:ENVELOPE:1.0">
 	<env:transaction id="392602">
 		<env:app.message id="1">
 			<oub:transmission xmlns:env="urn:publicid:-:DGTAXUD:GENERAL:ENVELOPE:1.0" xmlns:oub="urn:publicid:-:DGTAXUD:TARIC:MESSAGE:1.0">

--- a/commodities/tests/test_forms.py
+++ b/commodities/tests/test_forms.py
@@ -1,0 +1,21 @@
+from os import path
+
+from django.core.files.uploadedfile import SimpleUploadedFile
+
+from commodities import forms
+
+TEST_FILES_PATH = path.join(path.dirname(__file__), "test_files")
+
+
+def test_import_form_invalid_envelope_id():
+    upload_file = open(f"{TEST_FILES_PATH}/valid.xml", "rb")
+    file_data = {
+        "taric_file": SimpleUploadedFile(
+            upload_file.name,
+            upload_file.read(),
+            content_type="text/xml",
+        ),
+    }
+    form = forms.CommodityImportForm({}, file_data)
+
+    assert form.is_valid()

--- a/commodities/tests/test_forms.py
+++ b/commodities/tests/test_forms.py
@@ -8,32 +8,32 @@ TEST_FILES_PATH = path.join(path.dirname(__file__), "test_files")
 
 
 def test_import_form_valid_envelope_id():
-    upload_file = open(f"{TEST_FILES_PATH}/valid.xml", "rb")
-    file_data = {
-        "taric_file": SimpleUploadedFile(
-            upload_file.name,
-            upload_file.read(),
-            content_type="text/xml",
-        ),
-    }
-    form = forms.CommodityImportForm({}, file_data)
+    with open(f"{TEST_FILES_PATH}/valid.xml", "rb") as upload_file:
+        file_data = {
+            "taric_file": SimpleUploadedFile(
+                upload_file.name,
+                upload_file.read(),
+                content_type="text/xml",
+            ),
+        }
+        form = forms.CommodityImportForm({}, file_data)
 
-    assert form.is_valid()
+        assert form.is_valid()
 
 
 def test_import_form_invalid_envelope_id():
-    upload_file = open(f"{TEST_FILES_PATH}/invalid_id.xml", "rb")
-    file_data = {
-        "taric_file": SimpleUploadedFile(
-            upload_file.name,
-            upload_file.read(),
-            content_type="text/xml",
-        ),
-    }
-    form = forms.CommodityImportForm({}, file_data)
+    with open(f"{TEST_FILES_PATH}/invalid_id.xml", "rb") as upload_file:
+        file_data = {
+            "taric_file": SimpleUploadedFile(
+                upload_file.name,
+                upload_file.read(),
+                content_type="text/xml",
+            ),
+        }
+        form = forms.CommodityImportForm({}, file_data)
 
-    assert not form.is_valid()
-    assert (
-        "The selected file could not be uploaded - try again"
-        in form.errors["taric_file"]
-    )
+        assert not form.is_valid()
+        assert (
+            "The selected file could not be uploaded - try again"
+            in form.errors["taric_file"]
+        )

--- a/commodities/tests/test_forms.py
+++ b/commodities/tests/test_forms.py
@@ -7,7 +7,7 @@ from commodities import forms
 TEST_FILES_PATH = path.join(path.dirname(__file__), "test_files")
 
 
-def test_import_form_invalid_envelope_id():
+def test_import_form_valid_envelope_id():
     upload_file = open(f"{TEST_FILES_PATH}/valid.xml", "rb")
     file_data = {
         "taric_file": SimpleUploadedFile(
@@ -19,3 +19,21 @@ def test_import_form_invalid_envelope_id():
     form = forms.CommodityImportForm({}, file_data)
 
     assert form.is_valid()
+
+
+def test_import_form_invalid_envelope_id():
+    upload_file = open(f"{TEST_FILES_PATH}/invalid_id.xml", "rb")
+    file_data = {
+        "taric_file": SimpleUploadedFile(
+            upload_file.name,
+            upload_file.read(),
+            content_type="text/xml",
+        ),
+    }
+    form = forms.CommodityImportForm({}, file_data)
+
+    assert not form.is_valid()
+    assert (
+        "The selected file could not be uploaded - try again"
+        in form.errors["taric_file"]
+    )

--- a/common/assets/envelope.xsd
+++ b/common/assets/envelope.xsd
@@ -41,7 +41,7 @@
             <xs:attribute name="id" use="required">
                 <xs:simpleType>
                     <xs:restriction base="xs:string">
-                        <xs:pattern value="[0-9]{6}"/>
+                        <xs:pattern value="[0-9]{5}"/>
                     </xs:restriction>
                 </xs:simpleType>
             </xs:attribute>

--- a/importer/views.py
+++ b/importer/views.py
@@ -11,7 +11,7 @@ from importer.filters import ImportBatchFilter
 
 
 class ImportBatchList(RequiresSuperuserMixin, WithPaginationListView):
-    """UI endpoint for viewing and filtering Additional Codes."""
+    """UI endpoint for viewing and filtering Import Batches."""
 
     queryset = (
         models.ImportBatch.objects.all()

--- a/pii-ner-exclude.txt
+++ b/pii-ner-exclude.txt
@@ -1148,3 +1148,4 @@ self.linked_model
 WorkBasketOutputFormat
 param kwargs:
 Enum
+schemaLocation="commodities_envelope.xsd"/

--- a/settings/common.py
+++ b/settings/common.py
@@ -479,6 +479,15 @@ PATH_ASSETS = Path(BASE_DIR, "common", "assets")
 PATH_XSD_ENVELOPE = Path(PATH_ASSETS, "envelope.xsd")
 PATH_XSD_TARIC = Path(PATH_ASSETS, "taric3.xsd")
 
+PATH_COMMODITIES_ASSETS = Path(BASE_DIR, "commodities", "assets")
+
+PATH_XSD_COMMODITIES_ENVELOPE = Path(
+    PATH_COMMODITIES_ASSETS,
+    "commodities_envelope.xsd",
+)
+PATH_XSD_COMMODITIES_TARIC = Path(PATH_COMMODITIES_ASSETS, "commodities_taric3.xsd")
+
+
 # Default username for envelope data imports
 DATA_IMPORT_USERNAME = os.environ.get("TAMATO_IMPORT_USERNAME", "test")
 


### PR DESCRIPTION
# TP2000-311 Envelope schema expects a six-digit number to be present, the TARIC file only contains five
<!---
 * Include the JIRA ticket number, eg TP-123, to automatically link.
 * Use 50 characters maximum.
 * Do not end with a full-stop.
--->

## Why
<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Use as many lines as you like.
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions or deliberately ignored edge-cases.
--->
Currently we have to manually update the envelope id on files sent to us by the EU before they can be imported
## What
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Explain like I'm 5.
 * Use pictures if you can.
--->
Updates envelope xml schema to expect a 5 digit id.
<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
## Checklist
- Requires migrations?
- Requires dependency updates?
--->

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
