### PR TITLE
TP2000-452  Incorrect ordering on components queryset

### DIFF
--- a/measures/tests/test_views.py
+++ b/measures/tests/test_views.py
@@ -24,6 +24,7 @@ from measures.business_rules import ME70
 from measures.models import FootnoteAssociationMeasure
 from measures.models import Measure
 from measures.models import MeasureCondition
+from measures.models import MeasureConditionComponent
 from measures.models import MeasureExcludedGeographicalArea
 from measures.validators import validate_duties
 from measures.views import MeasureCreateWizard
@@ -469,7 +470,9 @@ def test_measure_update_create_conditions(
     )
     assert condition.update_type == UpdateType.CREATE
 
-    components = condition.components.approved_up_to_transaction(tx).all()
+    components = condition.components.approved_up_to_transaction(tx).order_by(
+        *MeasureConditionComponent._meta.ordering
+    )
 
     assert components.count() == 2
     assert components.first().duty_amount == 3.5


### PR DESCRIPTION
# TP2000-452  Incorrect ordering on components queryset
<!---
 * Include the JIRA ticket number, eg TP-123, to automatically link.
 * Use 50 characters maximum.
 * Do not end with a full-stop.
--->

## Why
<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Use as many lines as you like.
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions or deliberately ignored edge-cases.
--->
`measures.tests.test_views.test_measure_update_create_conditions()` assumed an ordering of `MeasureConditionComponent`s in a QuerySet. However, the application of `TrackedModelQuerySet.approved_up_to_transaction()` to a QuerySet prevents the correct application of `Model.Meta.ordering`.

## What
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Explain like I'm 5.
 * Use pictures if you can.
--->
This PR explicitly applies an order on the `MeasureConditionComponent` QuerySet so that the `MeasureConditionComponent.condition.sid` and `MeasureConditionComponent.duty_expression.sid` attributes values can be validated correctly.

<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
--->
## Checklist
- Requires migrations? No
- Requires dependency updates? No

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
