### PR TITLE
TP2000-450 Certificate.MultipleObjectsReturned error on certificate description create

### DIFF
--- a/certificates/tests/test_views.py
+++ b/certificates/tests/test_views.py
@@ -4,7 +4,9 @@ import pytest
 from django.urls import reverse
 
 from certificates import models
+from certificates.views import CertificateDescriptionCreate
 from certificates.views import CertificateList
+from common.models.utils import override_current_transaction
 from common.tests import factories
 from common.tests.util import assert_model_view_renders
 from common.tests.util import get_class_based_view_urls_matching_url
@@ -12,6 +14,8 @@ from common.tests.util import view_is_subclass
 from common.tests.util import view_urlpattern_ids
 from common.views import TamatoListView
 from common.views import TrackedModelDetailMixin
+
+pytestmark = pytest.mark.django_db
 
 
 @pytest.mark.parametrize(
@@ -86,3 +90,21 @@ def test_certificate_list_view(view, url_pattern, valid_user_client):
     """Verify that certificate list view is under the url certificates/ and
     doesn't return an error."""
     assert_model_view_renders(view, url_pattern, valid_user_client)
+
+
+# https://uktrade.atlassian.net/browse/TP2000-450 /PS-IGNORE
+def test_description_create_get_initial():
+    """Test that, where more than one version of a certificate exists,
+    get_initial returns only the current version."""
+    certificate = factories.CertificateFactory.create()
+    new_version = certificate.new_version(certificate.transaction.workbasket)
+    view = CertificateDescriptionCreate(
+        kwargs={
+            "certificate_type__sid": certificate.certificate_type.sid,
+            "sid": certificate.sid,
+        },
+    )
+    with override_current_transaction(new_version.transaction):
+        initial = view.get_initial()
+
+        assert initial["described_certificate"] == new_version

--- a/certificates/views.py
+++ b/certificates/views.py
@@ -157,7 +157,7 @@ class CertificateDescriptionCreate(
 ):
     def get_initial(self):
         initial = super().get_initial()
-        initial["described_certificate"] = models.Certificate.objects.get(
+        initial["described_certificate"] = models.Certificate.objects.current().get(
             certificate_type__sid=(self.kwargs.get("certificate_type__sid")),
             sid=(self.kwargs.get("sid")),
         )


### PR DESCRIPTION
# TP2000-450 Certificate.MultipleObjectsReturned error on certificate description create
<!---
 * Include the JIRA ticket number, eg TP-123, to automatically link.
 * Use 50 characters maximum.
 * Do not end with a full-stop.
--->

## Why
<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Use as many lines as you like.
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions or deliberately ignored edge-cases.
--->
We're getting MultipleObjectsReturned errors when trying to create a description for a certificate with more than one version.
## What
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Explain like I'm 5.
 * Use pictures if you can.
--->
Updates `CertificateDescriptionCreate.get_initial` to use `objects.current()`
<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
## Checklist
- Requires migrations?
- Requires dependency updates?
--->
- Requires migrations? No
- Requires dependency updates? No
<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
Original sentry error https://sentry.ci.uktrade.digital/organizations/dit/issues/64174/?environment=production&project=200&referrer=alert_email