### PR TITLE
Require the transaction param on diff_components()

### DIFF
--- a/measures/forms.py
+++ b/measures/forms.py
@@ -629,13 +629,13 @@ class MeasureForm(ValidityPeriodForm, BindNestedFormMixin, forms.ModelForm):
                 self.cleaned_data["duty_sentence"],
                 self.cleaned_data["valid_between"].lower,
                 WorkBasket.current(self.request),
-                models.MeasureComponent,
-                "component_measure",
                 # Creating components in the same transaction as the new version
                 # of the measure minimises number of transaction and groups the
                 # creation of measure and related objects in the same
                 # transaction.
-                transaction=instance.transaction,
+                instance.transaction,
+                models.MeasureComponent,
+                "component_measure",
             )
 
         footnote_pks = [

--- a/measures/patterns.py
+++ b/measures/patterns.py
@@ -310,9 +310,9 @@ class MeasureCreationPattern:
                 data.get("applicable_duty"),
                 measure.valid_between.lower,
                 workbasket,
+                condition.transaction,
                 MeasureConditionComponent,
                 "condition",
-                transaction=condition.transaction,
             )
 
     @transaction.atomic

--- a/measures/tests/test_util.py
+++ b/measures/tests/test_util.py
@@ -28,18 +28,20 @@ def test_diff_components_update(
         duty_amount=9.000,
         duty_expression=percent_or_amount,
     )
+    new_measure = original_component.component_measure.new_version(
+        original_component.transaction.workbasket,
+    )
     util.diff_components(
-        original_component.component_measure,
+        new_measure,
         "8.000%",
         original_component.component_measure.valid_between.lower,
         workbasket,
+        new_measure.transaction,
         MeasureComponent,
         "component_measure",
     )
-    components = (
-        original_component.component_measure.components.approved_up_to_transaction(
-            workbasket.current_transaction,
-        )
+    components = new_measure.components.approved_up_to_transaction(
+        workbasket.current_transaction,
     )
 
     assert components.count() == 1
@@ -48,7 +50,7 @@ def test_diff_components_update(
 
     assert new_component.update_type == UpdateType.UPDATE
     assert new_component.version_group == original_component.version_group
-    assert new_component.component_measure == original_component.component_measure
+    assert new_component.component_measure == new_measure
     assert new_component.transaction == workbasket.current_transaction
     assert new_component.duty_amount == 8.000
 
@@ -72,11 +74,15 @@ def test_diff_components_update_multiple(
         monetary_unit=monetary_units["GBP"],
         component_measurement__measurement_unit=measurement_units[1],
     )
+    new_measure = component_1.component_measure.new_version(
+        component_1.transaction.workbasket,
+    )
     util.diff_components(
         component_2.component_measure,
         "13.000% + 254.000 GBP / 100 kg",
         component_1.component_measure.valid_between.lower,
         workbasket,
+        new_measure.transaction,
         MeasureComponent,
         "component_measure",
     )
@@ -106,6 +112,7 @@ def test_diff_components_create(workbasket, duty_sentence_parser):
         "8.000%",
         measure.valid_between.lower,
         workbasket,
+        measure.transaction,
         MeasureComponent,
         "component_measure",
     )
@@ -132,11 +139,15 @@ def test_diff_components_delete(
         duty_amount=9.000,
         duty_expression=percent_or_amount,
     )
+    new_measure = component.component_measure.new_version(
+        component.transaction.workbasket,
+    )
     util.diff_components(
         component.component_measure,
         "",
         component.component_measure.valid_between.lower,
         workbasket,
+        new_measure.transaction,
         MeasureComponent,
         "component_measure",
     )

--- a/measures/util.py
+++ b/measures/util.py
@@ -30,9 +30,9 @@ def diff_components(
     duty_sentence: str,
     start_date: date,
     workbasket: WorkBasket,
+    transaction: Type[Transaction],
     component_output: Type[TrackedModel] = MeasureComponent,
     reverse_attribute: str = "component_measure",
-    transaction: Type[Transaction] = None,
 ):
     """
     Takes a start_date and component_output (MeasureComponent is the default)


### PR DESCRIPTION
# TP2000-457 Refactor component management API
<!---
 * Include the JIRA ticket number, eg TP-123, to automatically link.
 * Use 50 characters maximum.
 * Do not end with a full-stop.
--->

## Why
<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Use as many lines as you like.
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions or deliberately ignored edge-cases.
--->
`MeasureComponent` and `MeasureConditionComponent` objects should be associated with their parent object's transaction. The component management API, `diff_components()`, currently allows this relationship to be bypassed. 

## What
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Explain like I'm 5.
 * Use pictures if you can.
--->
Make the `diff_components()`'s `transaction` parameter mandatory.

<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
--->
## Checklist
- Requires migrations? No
- Requires dependency updates? No

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
Comment on a previous PR that set up this refactor: https://github.com/uktrade/tamato/pull/638#pullrequestreview-1060043241
