### PR TITLE
TP2000-449 add volumes business rule

### DIFF
--- a/quotas/business_rules.py
+++ b/quotas/business_rules.py
@@ -268,6 +268,20 @@ class OverlappingQuotaDefinition(BusinessRule):
             raise self.violation(quota_definition)
 
 
+class VolumeAndInitialVolumeMustMatch(BusinessRule):
+    """Unless it is the main quota in a quota association, a definition's volume
+    and initial_volume values should always be the same."""
+
+    def validate(self, quota_definition):
+        if quota_definition.sub_quota_associations.approved_up_to_transaction(
+            self.transaction,
+        ).exists():
+            return True
+
+        if quota_definition.volume != quota_definition.initial_volume:
+            raise self.violation(quota_definition)
+
+
 class QA1(UniqueIdentifyingFields):
     """The association between two quota definitions must be unique."""
 

--- a/quotas/models.py
+++ b/quotas/models.py
@@ -226,6 +226,7 @@ class QuotaDefinition(TrackedModel, ValidityMixin):
         business_rules.QuotaSuspensionMustReferToANonDeletedQuotaDefinition,
         business_rules.QuotaBlockingPeriodMustReferToANonDeletedQuotaDefinition,
         business_rules.OverlappingQuotaDefinition,
+        business_rules.VolumeAndInitialVolumeMustMatch,
         UniqueIdentifyingFields,
         UpdateValidity,
     )

--- a/quotas/tests/test_business_rules.py
+++ b/quotas/tests/test_business_rules.py
@@ -478,6 +478,35 @@ def test_overlapping_quota_definition(date_ranges):
         ).validate(overlapping_definition)
 
 
+def test_volume_and_initial_volume_must_match():
+    definition = factories.QuotaDefinitionFactory.create(
+        volume=1.000,
+        initial_volume=2.000,
+    )
+
+    with pytest.raises(BusinessRuleViolation) as violation:
+        business_rules.VolumeAndInitialVolumeMustMatch(definition.transaction).validate(
+            definition,
+        )
+
+    assert (
+        "Unless it is the main quota in a quota association, a definition's volume and initial_volume values should always be the same."
+        in str(violation)
+    )
+
+
+def test_volume_and_initial_volume_must_match_main_quota():
+    definition = factories.QuotaDefinitionFactory.create(
+        volume=1.000,
+        initial_volume=2.000,
+    )
+    association = factories.QuotaAssociationFactory.create(main_quota=definition)
+    assert 0
+    business_rules.VolumeAndInitialVolumeMustMatch(association.transaction).validate(
+        definition,
+    )
+
+
 def test_QA1(assert_handles_duplicates):
     """The association between two quota definitions must be unique."""
 

--- a/quotas/tests/test_business_rules.py
+++ b/quotas/tests/test_business_rules.py
@@ -479,6 +479,9 @@ def test_overlapping_quota_definition(date_ranges):
 
 
 def test_volume_and_initial_volume_must_match():
+    """Unless it is the main quota in a quota association, a definition's volume
+    and initial_volume values should always be the same."""
+
     definition = factories.QuotaDefinitionFactory.create(
         volume=1.000,
         initial_volume=2.000,
@@ -496,14 +499,50 @@ def test_volume_and_initial_volume_must_match():
 
 
 def test_volume_and_initial_volume_must_match_main_quota():
+    """Test that VolumeAndInitialVolumeMustMatch does not raise a violation when
+    definition with different volume and initial_volume values is used as parent
+    quota in an association."""
+
     definition = factories.QuotaDefinitionFactory.create(
         volume=1.000,
         initial_volume=2.000,
     )
-    association = factories.QuotaAssociationFactory.create(main_quota=definition)
-    assert 0
+    association = factories.QuotaAssociationFactory.create(
+        transaction=definition.transaction,
+        main_quota=definition,
+        sub_quota__transaction=definition.transaction,
+    )
+
     business_rules.VolumeAndInitialVolumeMustMatch(association.transaction).validate(
         definition,
+    )
+
+
+def test_volume_and_initial_volume_must_match_sub_quota():
+    """Test that VolumeAndInitialVolumeMustMatch raises a violation when
+    definition with different volume and initial_volume values is used as child
+    quota in an association."""
+
+    definition = factories.QuotaDefinitionFactory.create(
+        volume=1.000,
+        initial_volume=2.000,
+    )
+    association = factories.QuotaAssociationFactory.create(
+        transaction=definition.transaction,
+        sub_quota=definition,
+        main_quota__transaction=definition.transaction,
+    )
+
+    with pytest.raises(BusinessRuleViolation) as violation:
+        business_rules.VolumeAndInitialVolumeMustMatch(
+            association.transaction,
+        ).validate(
+            definition,
+        )
+
+    assert (
+        "Unless it is the main quota in a quota association, a definition's volume and initial_volume values should always be the same."
+        in str(violation)
     )
 
 


### PR DESCRIPTION
# TP2000-449 add volumes business rule
<!---
 * Include the JIRA ticket number, eg TP-123, to automatically link.
 * Use 50 characters maximum.
 * Do not end with a full-stop.
--->

## Why
<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Use as many lines as you like.
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions or deliberately ignored edge-cases.
--->
HMRC have flagged that several recent steel quota definitions have been created with `volume` and `initial_volume` values that do not match. Doug and Tom's investigation has also revealed past instances of this, which shouldn't have been allowed either.

## What
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Explain like I'm 5.
 * Use pictures if you can.
--->
Adds a rule preventing the creation of a `QuotaDefinition` with different `volume` and `initial_volume` values, unless that definition is used as the `main_quota` in a `QuotaAssociation`.

This rule implicitly enforces that, in order for a quota definition to be created with different `volume` and `initial_volume` values, an association will have to be created in the same or earlier transaction with that definition as its `main_quota`
<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
## Checklist
- Requires migrations?
- Requires dependency updates?
--->

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
