### PR TITLE
TP2000-278 Allow for workbaskets in the TAP page to be selected for inspection

### DIFF
--- a/workbaskets/urls.py
+++ b/workbaskets/urls.py
@@ -56,6 +56,11 @@ ui_patterns = [
         ui_views.WorkBasketDeleteChangesDone.as_view(),
         name="workbasket-ui-delete-changes-done",
     ),
+    path(
+        "list",
+        ui_views.WorkBasketList.as_view(),
+        name="workbasket-ui-list-all",
+    ),
 ]
 
 urlpatterns = [

--- a/workbaskets/urls.py
+++ b/workbaskets/urls.py
@@ -57,7 +57,7 @@ ui_patterns = [
         name="workbasket-ui-delete-changes-done",
     ),
     path(
-        "list",
+        "list-all",
         ui_views.WorkBasketList.as_view(),
         name="workbasket-ui-list-all",
     ),

--- a/workbaskets/views/ui.py
+++ b/workbaskets/views/ui.py
@@ -375,3 +375,17 @@ class WorkBasketDetail(TemplateResponseMixin, FormMixin, View):
         store.add_items(to_add)
         store.remove_items(to_remove)
         return super().form_valid(form)
+
+
+class WorkBasketList(WithPaginationListView):
+    """UI endpoint for viewing and filtering workbaskets."""
+
+    template_name = "workbaskets/list.jinja"
+    filterset_class = WorkBasketFilter
+    search_fields = [
+        "title",
+        "reason",
+    ]
+
+    def get_queryset(self):
+        return WorkBasket.objects.order_by("-updated_at")


### PR DESCRIPTION
# TP2000-278 Allow for workbaskets in the TAP page to be selected for inspection
<!---
 * Include the JIRA ticket number, eg TP-123, to automatically link.
 * Use 50 characters maximum.
 * Do not end with a full-stop.
--->

## Why
<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Use as many lines as you like.
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions or deliberately ignored edge-cases.
--->
The WorkBasketList view was removed as part of multi workbasket work. `SelectWorkbasketView` now lives at the `workbaskets` url, but this doesn't provide a view of PUBLISHED or ARCHIVED baskets. This is useful for TMs (and devs) when comparing the changes in a basket to what's visible in TAP.
## What
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Explain like I'm 5.
 * Use pictures if you can.
--->
Restores `WorkBasketList` view, as added by @paulpepper-trade in [this PR](https://github.com/uktrade/tamato/pull/549) and adds a couple of view tests. The jinja is already there.
<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
## Checklist
- Requires migrations?
- Requires dependency updates?
--->

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
