### PR TITLE
TP2000-278 allow for workbaskets in the tap page to be selected for inspection (pt. 2)

### DIFF
--- a/workbaskets/jinja2/includes/workbaskets/workbasket-list.jinja
+++ b/workbaskets/jinja2/includes/workbaskets/workbasket-list.jinja
@@ -7,7 +7,7 @@
   {%- set workbasket_linked_id -%}
     <a
       class="govuk-link"
-      href="{{ url("workbaskets:workbasket-ui-detail", kwargs={"pk": workbasket.pk}) }}"
+      href="{{ url("workbaskets:workbasket-ui-changes", kwargs={"pk": workbasket.pk}) }}"
     >{{ workbasket.pk }}</a>
   {%- endset -%}
   {{ table_rows.append([

--- a/workbaskets/jinja2/workbaskets/list.jinja
+++ b/workbaskets/jinja2/workbaskets/list.jinja
@@ -1,5 +1,5 @@
 {% extends "layouts/list.jinja" %}
 
-{% set form_url = "workbaskets:workbasket-ui-list" %}
+{% set form_url = "workbaskets:workbasket-ui-list-all" %}
 {% set ommit_create_link = True %}
 {% set list_include = "includes/workbaskets/workbasket-list.jinja" %}

--- a/workbaskets/jinja2/workbaskets/review-workbasket.jinja
+++ b/workbaskets/jinja2/workbaskets/review-workbasket.jinja
@@ -2,7 +2,7 @@
 
 {% from "components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
 
-{% set page_title %}Workbasket {{ request.session.workbasket.id }}{% endset %}
+{% set page_title %}Workbasket {{ workbasket.id if workbasket else request.session.workbasket.id }}{% endset %}
 {% set page_subtitle %}<span class="govuk-!-font-weight-bold">Summary</span> - View workbasket components{% endset %}
 
 {% block breadcrumb %}

--- a/workbaskets/urls.py
+++ b/workbaskets/urls.py
@@ -56,6 +56,11 @@ ui_patterns = [
         ui_views.WorkBasketDeleteChangesDone.as_view(),
         name="workbasket-ui-delete-changes-done",
     ),
+    path(
+        "list",
+        ui_views.WorkBasketList.as_view(),
+        name="workbasket-ui-list-all",
+    ),
 ]
 
 urlpatterns = [

--- a/workbaskets/urls.py
+++ b/workbaskets/urls.py
@@ -57,7 +57,7 @@ ui_patterns = [
         name="workbasket-ui-delete-changes-done",
     ),
     path(
-        "list",
+        "list-all",
         ui_views.WorkBasketList.as_view(),
         name="workbasket-ui-list-all",
     ),

--- a/workbaskets/urls.py
+++ b/workbaskets/urls.py
@@ -61,6 +61,11 @@ ui_patterns = [
         ui_views.WorkBasketList.as_view(),
         name="workbasket-ui-list-all",
     ),
+    path(
+        f"<pk>/changes/",
+        ui_views.WorkBasketChanges.as_view(),
+        name="workbasket-ui-changes",
+    ),
 ]
 
 urlpatterns = [

--- a/workbaskets/views/ui.py
+++ b/workbaskets/views/ui.py
@@ -375,3 +375,17 @@ class WorkBasketDetail(TemplateResponseMixin, FormMixin, View):
         store.add_items(to_add)
         store.remove_items(to_remove)
         return super().form_valid(form)
+
+
+class WorkBasketList(WithPaginationListView):
+    """UI endpoint for viewing and filtering workbaskets."""
+
+    template_name = "workbaskets/list.jinja"
+    filterset_class = WorkBasketFilter
+    search_fields = [
+        "title",
+        "reason",
+    ]
+
+    def get_queryset(self):
+        return WorkBasket.objects.order_by("-updated_at")


### PR DESCRIPTION
# TP2000-278 allow for workbaskets in the tap page to be selected for inspection (pt. 2)
<!---
 * Include the JIRA ticket number, eg TP-123, to automatically link.
 * Use 50 characters maximum.
 * Do not end with a full-stop.
--->

## Why
<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Use as many lines as you like.
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions or deliberately ignored edge-cases.
--->
When the user is on the workbaskets/list-all page and clicks on a workbasket they are taken to the WorkBasketDetail view which gives them the option to edit the basket. We don't want this as the point of the list-all endpoint is to give a view of published and archived baskets, which shouldn't be editable.

## What
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Explain like I'm 5.
 * Use pictures if you can.
--->
- Restores the old WorkBasketDetail view as WorkBasketChanges
- Update workbasket list.jinja to use new list-all endpoint instead of list
<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
## Checklist
- Requires migrations?
- Requires dependency updates?
--->

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
