### PR TITLE
TP2000-462: Fix double home link on workbasket page

### DIFF
--- a/workbaskets/jinja2/workbaskets/edit-workbasket.jinja
+++ b/workbaskets/jinja2/workbaskets/edit-workbasket.jinja
@@ -5,24 +5,14 @@
 {% set page_subtitle %}What would you like to do?{% endset %}
 
 {% block breadcrumb %}
-  {% if request.GET.edit %}
-    {{ govukBreadcrumbs({
-      "items": [
-        {"text": "Home", "href": url("home")},
-        {"text": "Edit an existing workbasket", "href": url("workbaskets:workbasket-ui-list")},
-        {"text": "Workbasket " ~ request.session.workbasket.id ~ " - Summary", "href": url("workbaskets:workbasket-ui-detail", args=[request.session.workbasket.id]) },
-        {"text": "Workbasket " ~ request.session.workbasket.id ~ " - Menu" }
-      ]
-    }) }}
-  {% else %}
-    {{ govukBreadcrumbs({
-      "items": [
-        {"text": "Home", "href": url("home")},
-        {"text": "Workbasket " ~ request.session.workbasket.id ~ " - Summary", "href": url("workbaskets:workbasket-ui-detail", args=[request.session.workbasket.id]) },
-        {"text": "Workbasket " ~ request.session.workbasket.id ~ " - Menu" }
-      ]
-    }) }}
-  {% endif %}
+  {{ govukBreadcrumbs({
+    "items": [
+      {"text": "Home", "href": url("home")},
+      {"text": "Edit an existing workbasket", "href": url("workbaskets:workbasket-ui-list")},
+      {"text": "Workbasket " ~ request.session.workbasket.id ~ " - Summary", "href": url("workbaskets:workbasket-ui-detail", args=[request.session.workbasket.id]) },
+      {"text": "Workbasket " ~ request.session.workbasket.id ~ " - Menu" }
+    ]
+  }) }}
 {% endblock %}
 
 

--- a/workbaskets/jinja2/workbaskets/review-workbasket.jinja
+++ b/workbaskets/jinja2/workbaskets/review-workbasket.jinja
@@ -1,16 +1,17 @@
 {% extends "layouts/layout.jinja" %}
 
-{% from "components/breadcrumbs.jinja" import breadcrumbs %}
+{% from "components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
 
 {% set page_title %}Workbasket {{ workbasket.id if workbasket else request.session.workbasket.id }}{% endset %}
 {% set page_subtitle %}<span class="govuk-!-font-weight-bold">Summary</span> - View workbasket components{% endset %}
 
 {% block breadcrumb %}
-  {{ breadcrumbs(request, [
+  {{ govukBreadcrumbs({
+      "items": [
       {"text": "Home", "href": url("home")},
       {"text": "Edit an existing workbasket", "href": url("workbaskets:workbasket-ui-list")},
       {"text": "Workbasket " ~ request.session.workbasket.id ~ " - Summary" }
-    ])
+    ]})
   }}
 {% endblock %}
 


### PR DESCRIPTION
# TP2000-462: Fix double home link on workbasket page
<!---
 * Include the JIRA ticket number, eg TP-123, to automatically link.
 * Use 50 characters maximum.
 * Do not end with a full-stop.
--->

## Why
<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Use as many lines as you like.
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions or deliberately ignored edge-cases.
--->
* Fixing bug from previous PR

## What
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Explain like I'm 5.
 * Use pictures if you can.
--->
* Uses govukBreadcrumbs on this page rather than breadcrumbs component to avoid duplicate links

<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
## Checklist
- Requires migrations?
- Requires dependency updates?
--->

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
