### PR TITLE
TP2000-372: Add checkbox to select all workbasket items across all pages

### DIFF
--- a/workbaskets/jinja2/includes/workbaskets/workbasket-selectable-items.jinja
+++ b/workbaskets/jinja2/includes/workbaskets/workbasket-selectable-items.jinja
@@ -43,6 +43,17 @@
     <div class="govuk-grid-column-two-thirds">
       {% if change_count %}
         <h2 class="govuk-body">Select a component you would like to edit or remove:</h2>
+        <div class="govuk-form-group">
+          <fieldset class="govuk-fieldset">
+            <div class="govuk-checkboxes govuk-checkboxes--large">
+              <div class="govuk-checkboxes__item">
+                <input class="govuk-checkboxes__input" id="select-all-pages" name="select-all-pages" type="checkbox">
+                <label class="govuk-label govuk-checkboxes__label govuk-!-padding-right-0" for="selected">Select all {{ change_count }} changes across {{ page_obj.paginator.num_pages }} pages</label>
+              </div>
+            </div>
+          </fieldset>
+        </div>
+
       {% else %}
         <h2 class="govuk-body">There is nothing in your workbasket yet.</h2>
         <a href="{{ url('workbaskets:edit-workbasket', args=[request.session.workbasket.id]) }}" class="govuk-button govuk-button--primary">Edit workbasket</a>

--- a/workbaskets/jinja2/workbaskets/delete_changes.jinja
+++ b/workbaskets/jinja2/workbaskets/delete_changes.jinja
@@ -18,7 +18,7 @@
   <div class="govuk-grid-row govuk-!-margin-bottom-5">
     <div class="govuk-grid-column-full">
       {{ govukWarningText({
-        "text": "Are you sure you want to permanently remove the tariff changes below?",
+        "text": "Are you sure you want to permanently remove the " ~ object_list|length ~ " tariff changes below?",
         "iconFallbackText": "Warning"
       }) }}
 
@@ -56,7 +56,15 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
-      {% include "includes/workbaskets/workbasket-items-accordion.jinja" %}
+      <ul class="govuk-list">
+      {% for obj in object_list %}
+        <li>
+          <a class="govuk-link" href="{{ obj.get_url() or "#" }}">
+            {{ obj._meta.verbose_name.title() }} {{ obj.sid or obj.id }}
+          </a>
+        </li>
+      {% endfor %}
+      </ul>
     </div>
   </div>
 {% endblock %}

--- a/workbaskets/views/ui.py
+++ b/workbaskets/views/ui.py
@@ -367,16 +367,18 @@ class WorkBasketDetail(TemplateResponseMixin, FormMixin, View):
             self.request,
             f"WORKBASKET_SELECTIONS_{self.workbasket.pk}",
         )
-        to_add = {
-            key: value for key, value in form.cleaned_data_no_prefix.items() if value
-        }
-        to_remove = {
-            key: value
-            for key, value in form.cleaned_data_no_prefix.items()
-            if key not in to_add
-        }
-        store.add_items(to_add)
-        store.remove_items(to_remove)
+        store.clear()
+        select_all = self.request.POST.get("select-all-pages")
+        if select_all:
+            object_list = {obj.id: True for obj in self.workbasket.tracked_models}
+            store.add_items(object_list)
+        else:
+            to_add = {
+                key: value
+                for key, value in form.cleaned_data_no_prefix.items()
+                if value
+            }
+            store.add_items(to_add)
         return super().form_valid(form)
 
 


### PR DESCRIPTION
# TP2000-372: Add checkbox to select all workbasket items across all pages
<!---
 * Include the JIRA ticket number, eg TP-123, to automatically link.
 * Use 50 characters maximum.
 * Do not end with a full-stop.
--->

## Why
<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Use as many lines as you like.
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions or deliberately ignored edge-cases.
--->
* The select all checkbox only selects changes on one page
* Users need to be able to select all changes in a workbasket

## What
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Explain like I'm 5.
 * Use pictures if you can.
--->
* A new checkbox has been added to select all changes in the workbasket
* Some content has been tweaked to make it clearer how many changes there are/how many are selected
* The delete confirm page has been simplified to show all changes without pagination without a huge increase in load time

<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
## Checklist
- Requires migrations?
- Requires dependency updates?
--->

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->

<img width="1335" alt="Screenshot 2022-08-25 at 10 41 20" src="https://user-images.githubusercontent.com/25905279/186632406-e27df8fc-efbf-4440-8bb9-7c211113632c.png">

<img width="1321" alt="Screenshot 2022-08-25 at 10 44 13" src="https://user-images.githubusercontent.com/25905279/186632530-399f892e-7b56-4432-94b4-fc1a78d8f418.png">
