### PR TITLE
TP2000-486 Failure "... multiple values for argument 'record_group'" when importing envelope created by dump_transactions

### DIFF
--- a/importer/forms.py
+++ b/importer/forms.py
@@ -32,6 +32,7 @@ def get_mime_type(file):
 
 class ImportForm(forms.ModelForm):
     def process_file(
+        self,
         file,
         batch,
         user,


### PR DESCRIPTION
# TP2000-486 Failure "... multiple values for argument 'record_group'" when importing envelope created by dump_transactions
<!---
 * Include the JIRA ticket number, eg TP-123, to automatically link.
 * Use 50 characters maximum.
 * Do not end with a full-stop.
--->

## Why
<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Use as many lines as you like.
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions or deliberately ignored edge-cases.
--->
We can't currently import envelopes
## What
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Explain like I'm 5.
 * Use pictures if you can.
--->
Add missing `self` arg to `process_file` and `form.save()` test
<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
## Checklist
- Requires migrations?
- Requires dependency updates?
--->

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
