### PR TITLE
TP2000-492 import_chunk task duplicate key error

### DIFF
--- a/importer/forms.py
+++ b/importer/forms.py
@@ -1,8 +1,8 @@
 import lxml
 import magic
 from crispy_forms_gds.helper import FormHelper
-from crispy_forms_gds.layout import Button
 from crispy_forms_gds.layout import Layout
+from crispy_forms_gds.layout import Submit
 from defusedxml.common import DTDForbidden
 from django import forms
 from django.contrib.auth.models import User
@@ -102,7 +102,12 @@ class UploadTaricForm(ImportForm):
 
         self.helper.layout = Layout(
             *self.fields,
-            Button("submit", "Upload"),
+            Submit(
+                "submit",
+                "Upload",
+                data_module="govuk-button",
+                data_prevent_double_click="true",
+            ),
         )
 
     @transaction.atomic


### PR DESCRIPTION
# TP2000-492 import_chunk task duplicate key error
<!---
 * Include the JIRA ticket number, eg TP-123, to automatically link.
 * Use 50 characters maximum.
 * Do not end with a full-stop.
--->

## Why
<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Use as many lines as you like.
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions or deliberately ignored edge-cases.
--->
We're seeing duplicate key errors in production when using the importer https://sentry.ci.uktrade.digital/organizations/dit/issues/64553/?environment=production&project=200&referrer=alert_email
## What
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Explain like I'm 5.
 * Use pictures if you can.
--->
Adds prevent-double-click attribute to importer form submit button
<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
## Checklist
- Requires migrations?
- Requires dependency updates?
--->

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
