### PR TITLE
TP-495  sync_run_checks command throws 500

### DIFF
--- a/workbaskets/management/commands/set_workbasket_status.py
+++ b/workbaskets/management/commands/set_workbasket_status.py
@@ -20,9 +20,7 @@ class Command(WorkBasketCommandMixin, BaseCommand):
         parser.add_argument("STATUS", choices=WorkflowStatus)
 
     def handle(self, *args: Any, **options: Any) -> Optional[str]:
-        workbasket = WorkBasket.objects.get(
-            pk=int(options["WORKBASKET_PK"]),
-        )
+        workbasket = self.get_workbasket_or_exit(int(options["WORKBASKET_PK"]))
         if workbasket.status == options["STATUS"]:
             self.stdout.write(
                 f"WorkBasket {workbasket.pk} is already in "

--- a/workbaskets/management/commands/sync_run_checks.py
+++ b/workbaskets/management/commands/sync_run_checks.py
@@ -6,7 +6,6 @@ from django.core.management import BaseCommand
 from django.core.management.base import CommandParser
 
 from workbaskets.management.util import WorkBasketCommandMixin
-from workbaskets.models import WorkBasket
 from workbaskets.tasks import check_workbasket_sync
 
 logger = logging.getLogger(__name__)
@@ -22,9 +21,7 @@ class Command(WorkBasketCommandMixin, BaseCommand):
         parser.add_argument("WORKBASKET_PK", type=int)
 
     def handle(self, *args: Any, **options: Any) -> Optional[str]:
-        workbasket = WorkBasket.objects.get(
-            pk=int(options["WORKBASKET_PK"]),
-        )
+        workbasket = self.get_workbasket_or_exit(int(options["WORKBASKET_PK"]))
         self.stdout.write(
             f"Starting business rule checks against WorkBasket {workbasket}...",
         )

--- a/workbaskets/management/commands/workbasket_info.py
+++ b/workbaskets/management/commands/workbasket_info.py
@@ -6,7 +6,6 @@ from django.core.management import BaseCommand
 from django.core.management.base import CommandParser
 
 from workbaskets.management.util import WorkBasketCommandMixin
-from workbaskets.models import WorkBasket
 
 logger = logging.getLogger(__name__)
 
@@ -18,17 +17,7 @@ class Command(WorkBasketCommandMixin, BaseCommand):
         parser.add_argument("WORKBASKET_PK", type=int)
 
     def handle(self, *args: Any, **options: Any) -> Optional[str]:
-        workbasket_pk = int(options["WORKBASKET_PK"])
-        try:
-            workbasket = WorkBasket.objects.get(
-                pk=workbasket_pk,
-            )
-        except WorkBasket.DoesNotExist:
-            self.stderr.write(
-                self.style.ERROR(f"Workbasket pk={workbasket_pk} not found."),
-            )
-            exit(1)
-
+        workbasket = self.get_workbasket_or_exit(int(options["WORKBASKET_PK"]))
         self.stdout.write(
             self.style.SUCCESS(
                 f"WorkBaskets {workbasket.pk} status {workbasket.status}",

--- a/workbaskets/management/util.py
+++ b/workbaskets/management/util.py
@@ -1,5 +1,7 @@
 import enum
 
+from workbaskets.models import WorkBasket
+
 
 class WorkBasketOutputFormat(enum.Enum):
     READABLE = 1
@@ -77,3 +79,20 @@ class WorkBasketCommandMixin:
 
         for w in workbaskets:
             self.output_workbasket(w, show_transaction_info, output_format)
+
+    def get_workbasket_or_exit(self, workbasket_pk):
+        """
+        Get the workbasket instance by its primary key, workbasket_pk.
+
+        If no matching workbasket is found, then output an error message and
+        exit the process.
+        """
+        try:
+            return WorkBasket.objects.get(
+                pk=workbasket_pk,
+            )
+        except WorkBasket.DoesNotExist:
+            self.stderr.write(
+                self.style.ERROR(f"Workbasket pk={workbasket_pk} not found."),
+            )
+            exit(1)


### PR DESCRIPTION
# TP-495 sync_run_checks command throws 500
<!---
 * Include the JIRA ticket number, eg TP-123, to automatically link.
 * Use 50 characters maximum.
 * Do not end with a full-stop.
--->

## Why
<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Use as many lines as you like.
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions or deliberately ignored edge-cases.
--->
Django management commands `sync_run_checks` and `set_workbasket_status` don't gracefully handle incorrect workbasket identifier values.

## What
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Explain like I'm 5.
 * Use pictures if you can.
--->
Factor out the behaviour to get a workbasket by its primary key, gracefully failing if no workbasket is found. Apply the refactored code to the Django management commands  `sync_run_checks` and `set_workbasket_status`.

<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
--->
## Checklist
- Requires migrations? No
- Requires dependency updates? No

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
