### PR TITLE
Add exclusions to quota order number detail view

### DIFF
--- a/quotas/jinja2/includes/quotas/tabs/core_data.jinja
+++ b/quotas/jinja2/includes/quotas/tabs/core_data.jinja
@@ -45,6 +45,11 @@
                 "value": {"text": object.required_certificates.all()|join(", ") if object.is_origin_quota else "-"},
                 "actions": {"items": []}
             },
+            {
+                "key": {"text": "Geographical area exclusions"},
+                "value": {"text": object.geographical_exclusion_descriptions|join(", ") if object.geographical_exclusion_descriptions else "-"},
+                "actions": {"items": []}
+            },
             ]
         })}}
     </div>

--- a/quotas/models.py
+++ b/quotas/models.py
@@ -85,6 +85,16 @@ class QuotaOrderNumber(TrackedModel, ValidityMixin):
     def is_origin_quota(self):
         return any(self.required_certificates.all())
 
+    @property
+    def geographical_exclusion_descriptions(self):
+        result = []
+        for origin in self.quotaordernumberorigin_set.latest_approved():
+            for exclusion in origin.excluded_areas.latest_approved():
+                result.append(exclusion.get_description().description)
+
+        result = sorted(result)
+        return result
+
     class Meta:
         verbose_name = "quota"
 


### PR DESCRIPTION
# TP2000-497 - add exclusions to quota order number details view 

## Background

The Quota order number screen on TAP does not display exclusions applied to a geographical area. Recent Data Engineering work has highlighted the usefulness of having this data visible (and eventually editable). 

## Who
As a tariff manager 

## What
I want to be able to view exclusions applied to a quota order number origin 

## Why
so that I can determine of any exclusions need to be adjusted to meet new requirements
