### PR TITLE
TP2000-506: Add urls for commodities and related objects

### DIFF
--- a/commodities/models/orm.py
+++ b/commodities/models/orm.py
@@ -179,12 +179,6 @@ class GoodsNomenclatureIndent(TrackedModel, ValidityStartMixin):
         item_id = self.indented_goods_nomenclature.item_id
         return self.indent == 0 and item_id[2:] == "00000000"
 
-    def get_url(self):
-        return reverse(
-            "commodity-ui-detail",
-            kwargs={"sid": self.indented_goods_nomenclature.sid},
-        )
-
     def get_good_indents(
         self,
         as_of_transaction: Optional[Transaction] = None,
@@ -290,12 +284,6 @@ class GoodsNomenclatureOrigin(TrackedModel):
 
     indirect_business_rules = (business_rules.NIG5,)
     business_rules = (business_rules.NIG7, UpdateValidity)
-
-    def get_url(self):
-        return reverse(
-            "commodity-ui-detail",
-            kwargs={"sid": self.new_goods_nomenclature.sid},
-        )
 
     def __str__(self):
         return (

--- a/commodities/models/orm.py
+++ b/commodities/models/orm.py
@@ -5,6 +5,7 @@ from typing import Set
 
 from django.db import models
 from django.db.models.query import QuerySet
+from django.urls import reverse
 from polymorphic.managers import PolymorphicManager
 
 from commodities import business_rules
@@ -104,6 +105,9 @@ class GoodsNomenclature(TrackedModel, ValidityMixin, DescribedMixin):
     def __str__(self):
         return self.item_id
 
+    def get_url(self):
+        return reverse("commodity-ui-detail", kwargs={"sid": self.sid})
+
     def get_dependent_measures(self, transaction=None):
         return self.measures.model.objects.filter(
             goods_nomenclature__sid=self.sid,
@@ -174,6 +178,12 @@ class GoodsNomenclatureIndent(TrackedModel, ValidityStartMixin):
         """Returns True if this is a root indent."""
         item_id = self.indented_goods_nomenclature.item_id
         return self.indent == 0 and item_id[2:] == "00000000"
+
+    def get_url(self):
+        return reverse(
+            "commodity-ui-detail",
+            kwargs={"sid": self.indented_goods_nomenclature.sid},
+        )
 
     def get_good_indents(
         self,
@@ -280,6 +290,12 @@ class GoodsNomenclatureOrigin(TrackedModel):
 
     indirect_business_rules = (business_rules.NIG5,)
     business_rules = (business_rules.NIG7, UpdateValidity)
+
+    def get_url(self):
+        return reverse(
+            "commodity-ui-detail",
+            kwargs={"sid": self.new_goods_nomenclature.sid},
+        )
 
     def __str__(self):
         return (


### PR DESCRIPTION
# TP2000-506: Add urls for commodities and related objects
<!---
 * Include the JIRA ticket number, eg TP-123, to automatically link.
 * Use 50 characters maximum.
 * Do not end with a full-stop.
--->

## Why
<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Use as many lines as you like.
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions or deliberately ignored edge-cases.
--->
* Users should be able to click through to see a new commodity code in their workbasket

## What
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Explain like I'm 5.
 * Use pictures if you can.
--->
* Modifies the get_url method on commodity models to link to the commodity detail page

<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
## Checklist
- Requires migrations?
- Requires dependency updates?
--->

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
