### PR TITLE
TP2000-472 and TP2000-473 separate regulation + quota into create measure steps

### DIFF
--- a/measures/forms.py
+++ b/measures/forms.py
@@ -757,8 +757,6 @@ class MeasureDetailsForm(
         model = models.Measure
         fields = [
             "measure_type",
-            "generating_regulation",
-            "order_number",
             "valid_between",
         ]
 
@@ -766,20 +764,6 @@ class MeasureDetailsForm(
         label="Measure type",
         help_text="Select the appropriate measure type.",
         queryset=models.MeasureType.objects.all(),
-    )
-    generating_regulation = AutoCompleteField(
-        label="Regulation ID",
-        help_text="Select the regulation which provides the legal basis for the measure.",
-        queryset=Regulation.objects.all(),
-    )
-    order_number = AutoCompleteField(
-        label="Quota order number",
-        help_text=(
-            "Select the quota order number if a quota measure type has been selected. "
-            "Leave this field blank if the measure is not a quota."
-        ),
-        queryset=QuotaOrderNumber.objects.all(),
-        required=False,
     )
 
     def __init__(self, *args, **kwargs):
@@ -790,8 +774,6 @@ class MeasureDetailsForm(
         self.helper.legend_size = Size.SMALL
         self.helper.layout = Layout(
             "measure_type",
-            "generating_regulation",
-            "order_number",
             "start_date",
             "end_date",
             Submit(
@@ -817,6 +799,70 @@ class MeasureDetailsForm(
                 )
 
         return cleaned_data
+
+
+class MeasureRegulationIdForm(forms.Form):
+    class Meta:
+        model = models.Measure
+        fields = [
+            "generating_regulation",
+        ]
+
+    generating_regulation = AutoCompleteField(
+        label="Regulation ID",
+        help_text="Select the regulation which provides the legal basis for the measure.",
+        queryset=Regulation.objects.all(),
+    )
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self.helper = FormHelper(self)
+        self.helper.label_size = Size.SMALL
+        self.helper.legend_size = Size.SMALL
+        self.helper.layout = Layout(
+            "generating_regulation",
+            Submit(
+                "submit",
+                "Continue",
+                data_module="govuk-button",
+                data_prevent_double_click="true",
+            ),
+        )
+
+
+class MeasureQuotaOrderNumberForm(forms.Form):
+    class Meta:
+        model = models.Measure
+        fields = [
+            "order_number",
+        ]
+
+    order_number = AutoCompleteField(
+        label="Quota order number",
+        help_text=(
+            "Select the quota order number if a quota measure type has been selected. "
+            "Leave this field blank if the measure is not a quota."
+        ),
+        queryset=QuotaOrderNumber.objects.all(),
+        required=False,
+    )
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self.helper = FormHelper(self)
+        self.helper.label_size = Size.SMALL
+        self.helper.legend_size = Size.SMALL
+        self.helper.layout = Layout(
+            "order_number",
+            Submit(
+                "submit",
+                "Continue",
+                data_module="govuk-button",
+                data_prevent_double_click="true",
+            ),
+        )
 
 
 class MeasureGeographicalAreaForm(BindNestedFormMixin, forms.Form):

--- a/measures/jinja2/measures/create-review.jinja
+++ b/measures/jinja2/measures/create-review.jinja
@@ -55,10 +55,20 @@
   {% call(rows, data) review_step("measure_details") %}
     {{ rows.extend([
       ("Measure type", data["measure_type"] ~ " - " ~ data["measure_type"].description),
-      ("Regulation ID", data["generating_regulation"]),
-      ("Quota order number", data["order_number"]),
       ("Measure start date", "{:%d/%m/%Y}".format(data["valid_between"].lower) if data["valid_between"] and data["valid_between"].lower else "-"),
       ("Measure end date", "{:%d/%m/%Y}".format(data["valid_between"].upper) if data["valid_between"] and data["valid_between"].upper else "-"),
+    ]) }}
+  {% endcall %}
+
+  {% call(rows, data) review_step("regulation_id") %}
+    {{ rows.extend([
+      ("Regulation ID", data["generating_regulation"]),
+    ]) }}
+  {% endcall %}
+
+  {% call(rows, data) review_step("quota_order_number") %}
+    {{ rows.extend([
+      ("Quota order number", data["order_number"]),
     ]) }}
   {% endcall %}
 

--- a/measures/tests/conftest.py
+++ b/measures/tests/conftest.py
@@ -435,6 +435,11 @@ def regulation():
 
 
 @pytest.fixture()
+def quota_order_number():
+    return factories.QuotaOrderNumberFactory()
+
+
+@pytest.fixture()
 def commodity1():
     return factories.GoodsNomenclatureFactory.create()
 

--- a/measures/tests/test_forms.py
+++ b/measures/tests/test_forms.py
@@ -63,17 +63,31 @@ def test_measure_form_invalid_conditions_data(
     # formset errors messages are test in view tests
 
 
-def test_measure_forms_details_valid_data(measure_type, regulation, erga_omnes):
+def test_measure_forms_details_valid_data(measure_type, erga_omnes):
     data = {
         "measure_type": measure_type.pk,
-        "generating_regulation": regulation.pk,
-        "order_number": None,
         "start_date_0": 2,
         "start_date_1": 4,
         "start_date_2": 2021,
         "geographical_area": erga_omnes.pk,
     }
     form = forms.MeasureDetailsForm(data, prefix="")
+    assert form.is_valid()
+
+
+def test_measure_forms_regulation_id_valid_data(regulation):
+    data = {
+        "generating_regulation": regulation.pk,
+    }
+    form = forms.MeasureRegulationIdForm(data, prefix="")
+    assert form.is_valid()
+
+
+def test_measure_forms_quota_order_number_valid_data(quota_order_number):
+    data = {
+        "order_number": quota_order_number.pk,
+    }
+    form = forms.MeasureQuotaOrderNumberForm(data, prefix="")
     assert form.is_valid()
 
 
@@ -327,8 +341,6 @@ def test_measure_forms_geo_area_invalid_data_error_messages(data, error, erga_om
 def test_measure_forms_details_invalid_data():
     data = {
         "measure_type": "foo",
-        "generating_regulation": "bar",
-        "order_number": None,
         "start_date_0": 2,
         "start_date_1": 4,
         "start_date_2": 2021,
@@ -338,7 +350,30 @@ def test_measure_forms_details_invalid_data():
         "Select a valid choice. That choice is not one of the available choices.",
     ]
     assert form.errors["measure_type"] == error_string
+    assert not form.is_valid()
+
+
+def test_measure_forms_regulation_id_invalid_data():
+    data = {
+        "generating_regulation": "bar",
+    }
+    form = forms.MeasureRegulationIdForm(data, initial={}, prefix="")
+    error_string = [
+        "Select a valid choice. That choice is not one of the available choices.",
+    ]
     assert form.errors["generating_regulation"] == error_string
+    assert not form.is_valid()
+
+
+def test_measure_forms_quota_order_number_invalid_data():
+    data = {
+        "order_number": "foo",
+    }
+    form = forms.MeasureQuotaOrderNumberForm(data, initial={}, prefix="")
+    error_string = [
+        "Select a valid choice. That choice is not one of the available choices.",
+    ]
+    assert form.errors["order_number"] == error_string
     assert not form.is_valid()
 
 

--- a/measures/tests/test_views.py
+++ b/measures/tests/test_views.py
@@ -727,6 +727,7 @@ def test_measure_form_wizard_finish(
     valid_user_client,
     measure_type,
     regulation,
+    quota_order_number,
     duty_sentence_parser,
     erga_omnes,
 ):
@@ -743,10 +744,23 @@ def test_measure_form_wizard_finish(
             "data": {
                 "measure_create_wizard-current_step": "measure_details",
                 "measure_details-measure_type": measure_type.pk,
-                "measure_details-generating_regulation": regulation.pk,
                 "measure_details-start_date_0": 2,
                 "measure_details-start_date_1": 4,
                 "measure_details-start_date_2": 2021,
+            },
+            "next_step": "regulation_id",
+        },
+        {
+            "data": {
+                "measure_create_wizard-current_step": "regulation_id",
+                "regulation_id-generating_regulation": regulation.pk,
+            },
+            "next_step": "quota_order_number",
+        },
+        {
+            "data": {
+                "measure_create_wizard-current_step": "quota_order_number",
+                "quota_order_number-order_number": quota_order_number.pk,
             },
             "next_step": "geographical_area",
         },

--- a/measures/views.py
+++ b/measures/views.py
@@ -101,6 +101,8 @@ class MeasureCreateWizard(
 
     START = "start"
     MEASURE_DETAILS = "measure_details"
+    REGULATION_ID = "regulation_id"
+    QUOTA_ORDER_NUMBER = "quota_order_number"
     GEOGRAPHICAL_AREA = "geographical_area"
     COMMODITIES = "commodities"
     ADDITIONAL_CODE = "additional_code"
@@ -112,6 +114,8 @@ class MeasureCreateWizard(
     form_list = [
         (START, forms.MeasureCreateStartForm),
         (MEASURE_DETAILS, forms.MeasureDetailsForm),
+        (REGULATION_ID, forms.MeasureRegulationIdForm),
+        (QUOTA_ORDER_NUMBER, forms.MeasureQuotaOrderNumberForm),
         (GEOGRAPHICAL_AREA, forms.MeasureGeographicalAreaForm),
         (COMMODITIES, forms.MeasureCommodityAndDutiesFormSet),
         (ADDITIONAL_CODE, forms.MeasureAdditionalCodeForm),
@@ -123,6 +127,8 @@ class MeasureCreateWizard(
     templates = {
         START: "measures/create-start.jinja",
         MEASURE_DETAILS: "measures/create-wizard-step.jinja",
+        REGULATION_ID: "measures/create-wizard-step.jinja",
+        QUOTA_ORDER_NUMBER: "measures/create-wizard-step.jinja",
         GEOGRAPHICAL_AREA: "measures/create-wizard-step.jinja",
         COMMODITIES: "measures/create-formset.jinja",
         ADDITIONAL_CODE: "measures/create-wizard-step.jinja",
@@ -140,6 +146,14 @@ class MeasureCreateWizard(
         MEASURE_DETAILS: {
             "title": "Enter the basic data",
             "link_text": "Measure details",
+        },
+        REGULATION_ID: {
+            "title": "Enter the Regulation ID",
+            "link_text": "Regulation ID",
+        },
+        QUOTA_ORDER_NUMBER: {
+            "title": "Enter the Quota Order Number",
+            "link_text": "Quota Order Number",
         },
         GEOGRAPHICAL_AREA: {
             "title": "Select the geographical area",

--- a/pii-ner-exclude.txt
+++ b/pii-ner-exclude.txt
@@ -1214,3 +1214,5 @@ Comodity Description"
 f"/commodities/{commodity2.sid}/
 f"{first_line_of(workbasket.reason
 WorkBasketOutputFormat Enum
+Enter the Regulation ID
+Enter the Quota Order Number


### PR DESCRIPTION
# TP2000-472 + TP2000-473 regulation & quota steps
<!---
 * Include the JIRA ticket number, eg TP-123, to automatically link.
 * Use 50 characters maximum.
 * Do not end with a full-stop.
--->

## Why
<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Use as many lines as you like.
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions or deliberately ignored edge-cases.
--->
In preparation for the create measure wizard's steps / forms being used to edit measures, the regulation Id and quota order number fields must be separated out from the details step into their own step. 

## What
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Explain like I'm 5.
 * Use pictures if you can.
--->
This PR puts regulation Id and quota order number in their own forms and steps within the create measure wizard, adding related form and view unit tests.

<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
--->
## Checklist
- Requires migrations? No
- Requires dependency updates? No

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
