### PR TITLE
TP2000-510: Display object SID on violation detail page

### DIFF
--- a/workbaskets/jinja2/workbaskets/violation_detail.jinja
+++ b/workbaskets/jinja2/workbaskets/violation_detail.jinja
@@ -28,7 +28,7 @@ details
   <div class="govuk-grid-column-two-thirds">
     {% set object_link %}
     <a href="{{ object.model.get_url() }}" class="govuk-link">{{ object.model._meta.verbose_name.title() }}
-      {{ object.model.id }}</a>
+      {{ object.model.sid or object.model.id }}</a>
     {% endset %}
     <h2 class="govuk-heading-m">Rule violation details - {{ object_link }}</h2>
     <hr class="govuk-section-break govuk-section-break--s govuk-section-break--visible">


### PR DESCRIPTION
# TP2000-510: Display object SID on violation detail page
<!---
 * Include the JIRA ticket number, eg TP-123, to automatically link.
 * Use 50 characters maximum.
 * Do not end with a full-stop.
--->

## Why
<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Use as many lines as you like.
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions or deliberately ignored edge-cases.
--->
* We want to show the SID not the ID for the object the rule violation relates to

## What
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Explain like I'm 5.
 * Use pictures if you can.
--->
* Displays the SID if available, the ID if not

<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
## Checklist
- Requires migrations?
- Requires dependency updates?
--->

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
