### PR TITLE
TP2000-519: Fix measure condition link

### DIFF
--- a/common/tests/test_models.py
+++ b/common/tests/test_models.py
@@ -386,7 +386,7 @@ def test_get_description_dates(description_factory, date_ranges):
     assert future == future_description
 
 
-def test_trackedmodel_get_url(trackedmodel_factory):
+def test_trackedmodel_get_url(trackedmodel_factory, valid_user_client):
     """Verify get_url() returns something sensible and doesn't crash."""
     instance = trackedmodel_factory.create()
     url = instance.get_url()
@@ -402,6 +402,9 @@ def test_trackedmodel_get_url(trackedmodel_factory):
 
     # Verify URL is not local
     assert not urlparse(url).netloc
+
+    response = valid_user_client.get(url)
+    assert response.status_code == 200
 
 
 @pytest.mark.parametrize(

--- a/measures/models.py
+++ b/measures/models.py
@@ -1,7 +1,9 @@
 from datetime import date
+from typing import Optional
 from typing import Set
 
 from django.db import models
+from django.urls import reverse
 
 from common.business_rules import UniqueIdentifyingFields
 from common.business_rules import UpdateValidity
@@ -815,6 +817,14 @@ class MeasureCondition(TrackedModel):
     @property
     def duty_sentence(self) -> str:
         return MeasureConditionComponent.objects.duty_sentence(self)
+
+    def get_url(self) -> Optional[str]:
+        """Generate a URL to a representation of the model in the webapp."""
+        url = reverse(
+            f"{self.get_url_pattern_name_prefix()}-ui-detail",
+            kwargs={"sid": self.dependent_measure.sid},
+        )
+        return f"{url}{self.url_suffix}"
 
 
 class MeasureConditionComponent(TrackedModel):

--- a/pii-ner-exclude.txt
+++ b/pii-ner-exclude.txt
@@ -25,6 +25,7 @@ sort_by(sort_by
 MonetaryUnit
 check_name&d
 f"{c.transaction_check.transaction.created_at:%d
+"Generate a URL to a representation of the model in the webapp
 NM
 kwargs={'wb_pk
 description:</h3


### PR DESCRIPTION
# TP2000-519: Fix measure condition link
<!---
 * Include the JIRA ticket number, eg TP-123, to automatically link.
 * Use 50 characters maximum.
 * Do not end with a full-stop.
--->

## Why
<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Use as many lines as you like.
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions or deliberately ignored edge-cases.
--->
* Measure condition get_url used the measure condition sid to create the url for the linked measure and this was causing a 404

## What
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Explain like I'm 5.
 * Use pictures if you can.
--->
* Use the dependent_measure sid instead when generating the url

<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
## Checklist
- Requires migrations?
- Requires dependency updates?
--->

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
