### PR TITLE
Tops 645 nig2 parent lookup update

### DIFF
--- a/commodities/business_rules.py
+++ b/commodities/business_rules.py
@@ -84,7 +84,10 @@ class NIG2(BusinessRule):
             self.transaction,
         ).valid_between
 
-        if not child_validity.upper_inf and child_validity.upper < datetime.today().date():
+        if (
+            not child_validity.upper_inf
+            and child_validity.upper < datetime.today().date()
+        ):
             return True
 
         multi_parent_validity = None
@@ -108,7 +111,6 @@ class NIG2(BusinessRule):
 
         if child_start_date < datetime.today().date():
             child_start_date = datetime.today().date()
-
 
         child_validity = TaricDateRange(child_start_date, child_validity.upper)
 

--- a/commodities/business_rules.py
+++ b/commodities/business_rules.py
@@ -64,25 +64,19 @@ class NIG2(BusinessRule):
 
         return validity_range_contains_range(parent_validity, child_validity)
 
-    def parents_span_childs_future(self, parents, child):
+    def parents_span_child(self, parents, child):
         if len(parents) == 0:
             raise Exception("No parents")
 
         # get all date ranges
         parents_validity = []
         for parent in parents:
-            parents_validity.append(
-                parent.indented_goods_nomenclature.version_at(
-                    self.transaction,
-                ).valid_between,
-            )
+            parents_validity.append(parent.valid_between)
 
         # sort by start date so any gaps will be obvious
         parents_validity.sort(key=lambda daterange: daterange.lower)
 
-        child_validity = child.indented_goods_nomenclature.version_at(
-            self.transaction,
-        ).valid_between
+        child_validity = child.valid_between
 
         multi_parent_validity = None
 
@@ -96,11 +90,12 @@ class NIG2(BusinessRule):
                         parent_validity,
                     )
 
-        multi_parent_validity = TaricDateRange(
-            datetime.today(),
-            multi_parent_validity.upper,
+        print(
+            f"parents start : {multi_parent_validity.lower}, parents end : {multi_parent_validity.upper}",
         )
-        child_validity = TaricDateRange(datetime.today(), child_validity.upper)
+        print(
+            f"child start : {child_validity.lower}, child end : {child_validity.upper}",
+        )
 
         return validity_range_contains_range(multi_parent_validity, child_validity)
 
@@ -124,12 +119,11 @@ class NIG2(BusinessRule):
         collection = get_chapter_collection(good)
         snapshot = collection.get_snapshot(self.transaction, datetime.today())
 
-        potential_parents = snapshot.get_potential_parents(commodity)
-
-        if len(potential_parents) == 0:
+        parent = snapshot.get_parent(commodity)
+        if not parent:
             return
 
-        if not self.parents_span_childs_future(potential_parents, indent):
+        if not self.parent_spans_childs_future(parent.indent_obj, indent):
             raise self.violation(indent)
 
 

--- a/commodities/business_rules.py
+++ b/commodities/business_rules.py
@@ -51,19 +51,6 @@ class NIG2(BusinessRule):
         ).valid_between
         return validity_range_contains_range(parent_validity, child_validity)
 
-    def parent_spans_childs_future(self, parent, child) -> bool:
-        parent_validity = parent.indented_goods_nomenclature.version_at(
-            self.transaction,
-        ).valid_between
-        child_validity = child.indented_goods_nomenclature.version_at(
-            self.transaction,
-        ).valid_between
-
-        parent_validity = TaricDateRange(datetime.today(), parent_validity.upper)
-        child_validity = TaricDateRange(datetime.today(), child_validity.upper)
-
-        return validity_range_contains_range(parent_validity, child_validity)
-
     def parents_span_childs_future(self, parents, child):
         if len(parents) == 0:
             raise Exception("No parents")

--- a/commodities/business_rules.py
+++ b/commodities/business_rules.py
@@ -84,6 +84,9 @@ class NIG2(BusinessRule):
             self.transaction,
         ).valid_between
 
+        if not child_validity.upper_inf and child_validity.upper < datetime.today().date():
+            return True
+
         multi_parent_validity = None
 
         for parent_validity in parents_validity:
@@ -97,10 +100,17 @@ class NIG2(BusinessRule):
                     )
 
         multi_parent_validity = TaricDateRange(
-            datetime.today(),
+            datetime.today().date(),
             multi_parent_validity.upper,
         )
-        child_validity = TaricDateRange(datetime.today(), child_validity.upper)
+
+        child_start_date = child_validity.lower
+
+        if child_start_date < datetime.today().date():
+            child_start_date = datetime.today().date()
+
+
+        child_validity = TaricDateRange(child_start_date, child_validity.upper)
 
         return validity_range_contains_range(multi_parent_validity, child_validity)
 

--- a/commodities/models/dc.py
+++ b/commodities/models/dc.py
@@ -390,6 +390,25 @@ class CommodityTreeSnapshot(CommodityTreeBase):
 
         super().__post_init__()
 
+    def get_potential_parents(self, commodity: Commodity) -> List[Commodity]:
+        """gets possible parents, for queries where a parent may be end-dated,
+        and another parent could potentially be present to inherit the child."""
+        parent = self.get_parent(commodity)
+        grandparent = self.get_parent(parent)
+        parents = self.get_children(grandparent)
+
+        result = []
+
+        for parent in parents:
+            if int(parent.item_id) < int(commodity.item_id):
+                result.append(parent.indent_obj)
+            elif int(parent.item_id) == int(commodity.item_id) and int(
+                parent.suffix,
+            ) < int(commodity.suffix):
+                result.append(parent.indent_obj)
+
+        return result
+
     def get_parent(self, commodity: Commodity) -> Optional[Commodity]:
         """Returns the parent of a commodity in the snapshot tree."""
         return self.edges.get(commodity)

--- a/commodities/models/dc.py
+++ b/commodities/models/dc.py
@@ -393,6 +393,7 @@ class CommodityTreeSnapshot(CommodityTreeBase):
     def get_potential_parents(self, commodity: Commodity) -> List[Commodity]:
         """gets possible parents, for queries where a parent may be end-dated,
         and another parent could potentially be present to inherit the child."""
+
         parent = self.get_parent(commodity)
         grandparent = self.get_parent(parent)
         parents = self.get_children(grandparent)

--- a/commodities/tests/test_business_rules.py
+++ b/commodities/tests/test_business_rules.py
@@ -53,7 +53,6 @@ def test_NIG1(date_ranges):
         "all_closed_and_span",
     ),
 )
-
 def test_NIG2(
     date_ranges,
     parent_validity,

--- a/commodities/tests/test_business_rules.py
+++ b/commodities/tests/test_business_rules.py
@@ -122,6 +122,10 @@ def test_NIG2_only_checks_future_dates_of_parent(date_ranges):
         business_rules.NIG2(type(child.transaction).objects.last()).validate(child)
 
 
+# need to test that this works when parent of child does not have a parent
+# add failing test where a parents parents children > child item id and has an allowable date range but is not considered
+
+
 def test_NIG2_is_valid_with_multiple_parents_spanning_child_valid_period(date_ranges):
     grand_parent = factories.GoodsNomenclatureIndentFactory.create(
         indented_goods_nomenclature__valid_between=getattr(
@@ -254,7 +258,7 @@ def test_NIG2_parents_span_child_valid(
     child_validity,
     expected,
 ):
-    target = business_rules.NIG2().parents_span_child
+    target = business_rules.NIG2().parents_span_childs_future
     good = factories.GoodsNomenclatureFactory.create()
     parents = []
 

--- a/commodities/tests/test_business_rules.py
+++ b/commodities/tests/test_business_rules.py
@@ -108,6 +108,12 @@ def test_NIG2_only_checks_future_dates_of_parent(date_ranges):
         indented_goods_nomenclature__item_id="2901000000",
         indent=0,
     )
+    #
+    # parent_2 = factories.GoodsNomenclatureIndentFactory.create(
+    #     indented_goods_nomenclature__valid_between=getattr(date_ranges, "starts_2_months_ago_to_delta", ),
+    #     indented_goods_nomenclature__item_id="2901200000",
+    #     indent=0,
+    # )
 
     child = factories.GoodsNomenclatureIndentFactory.create(
         indented_goods_nomenclature__valid_between=getattr(
@@ -116,65 +122,6 @@ def test_NIG2_only_checks_future_dates_of_parent(date_ranges):
         ),
         indented_goods_nomenclature__item_id="2901210000",
         indent=1,
-    )
-
-    with raises_if(BusinessRuleViolation, False):
-        business_rules.NIG2(type(child.transaction).objects.last()).validate(child)
-
-
-def test_NIG2_is_valid_with_multiple_parents_spanning_child_valid_period(date_ranges):
-    grand_parent = factories.GoodsNomenclatureIndentFactory.create(
-        indented_goods_nomenclature__valid_between=getattr(
-            date_ranges,
-            "starts_delta_no_end",
-        ),
-        indented_goods_nomenclature__item_id="2901000000",
-        indent=0,
-    )
-
-    distant_parent_1 = factories.GoodsNomenclatureIndentFactory.create(
-        indented_goods_nomenclature__valid_between=getattr(
-            date_ranges,
-            "starts_2_months_ago_to_delta",
-        ),
-        indented_goods_nomenclature__item_id="2901200000",
-        indent=1,
-    )
-
-    distant_parent_2 = factories.GoodsNomenclatureIndentFactory.create(
-        indented_goods_nomenclature__valid_between=getattr(
-            date_ranges,
-            "starts_1_month_ago_no_end",
-        ),
-        indented_goods_nomenclature__item_id="2901400000",
-        indent=1,
-    )
-
-    parent_closest = factories.GoodsNomenclatureIndentFactory.create(
-        indented_goods_nomenclature__valid_between=getattr(
-            date_ranges,
-            "starts_1_month_ago_to_1_month_ahead",
-        ),
-        indented_goods_nomenclature__item_id="2901500000",
-        indent=1,
-    )
-
-    not_a_parent = factories.GoodsNomenclatureIndentFactory.create(
-        indented_goods_nomenclature__valid_between=getattr(
-            date_ranges,
-            "starts_1_month_ago_no_end",
-        ),
-        indented_goods_nomenclature__item_id="2901700000",
-        indent=1,
-    )
-
-    child = factories.GoodsNomenclatureIndentFactory.create(
-        indented_goods_nomenclature__valid_between=getattr(
-            date_ranges,
-            "starts_1_month_ago_no_end",
-        ),
-        indented_goods_nomenclature__item_id="2901510000",
-        indent=2,
     )
 
     with raises_if(BusinessRuleViolation, False):

--- a/commodities/tests/test_business_rules.py
+++ b/commodities/tests/test_business_rules.py
@@ -108,12 +108,6 @@ def test_NIG2_only_checks_future_dates_of_parent(date_ranges):
         indented_goods_nomenclature__item_id="2901000000",
         indent=0,
     )
-    #
-    # parent_2 = factories.GoodsNomenclatureIndentFactory.create(
-    #     indented_goods_nomenclature__valid_between=getattr(date_ranges, "starts_2_months_ago_to_delta", ),
-    #     indented_goods_nomenclature__item_id="2901200000",
-    #     indent=0,
-    # )
 
     child = factories.GoodsNomenclatureIndentFactory.create(
         indented_goods_nomenclature__valid_between=getattr(
@@ -122,6 +116,65 @@ def test_NIG2_only_checks_future_dates_of_parent(date_ranges):
         ),
         indented_goods_nomenclature__item_id="2901210000",
         indent=1,
+    )
+
+    with raises_if(BusinessRuleViolation, False):
+        business_rules.NIG2(type(child.transaction).objects.last()).validate(child)
+
+
+def test_NIG2_is_valid_with_multiple_parents_spanning_child_valid_period(date_ranges):
+    grand_parent = factories.GoodsNomenclatureIndentFactory.create(
+        indented_goods_nomenclature__valid_between=getattr(
+            date_ranges,
+            "starts_delta_no_end",
+        ),
+        indented_goods_nomenclature__item_id="2901000000",
+        indent=0,
+    )
+
+    distant_parent_1 = factories.GoodsNomenclatureIndentFactory.create(
+        indented_goods_nomenclature__valid_between=getattr(
+            date_ranges,
+            "starts_2_months_ago_to_delta",
+        ),
+        indented_goods_nomenclature__item_id="2901200000",
+        indent=1,
+    )
+
+    distant_parent_2 = factories.GoodsNomenclatureIndentFactory.create(
+        indented_goods_nomenclature__valid_between=getattr(
+            date_ranges,
+            "starts_1_month_ago_no_end",
+        ),
+        indented_goods_nomenclature__item_id="2901400000",
+        indent=1,
+    )
+
+    parent_closest = factories.GoodsNomenclatureIndentFactory.create(
+        indented_goods_nomenclature__valid_between=getattr(
+            date_ranges,
+            "starts_1_month_ago_to_1_month_ahead",
+        ),
+        indented_goods_nomenclature__item_id="2901500000",
+        indent=1,
+    )
+
+    not_a_parent = factories.GoodsNomenclatureIndentFactory.create(
+        indented_goods_nomenclature__valid_between=getattr(
+            date_ranges,
+            "starts_1_month_ago_no_end",
+        ),
+        indented_goods_nomenclature__item_id="2901700000",
+        indent=1,
+    )
+
+    child = factories.GoodsNomenclatureIndentFactory.create(
+        indented_goods_nomenclature__valid_between=getattr(
+            date_ranges,
+            "starts_1_month_ago_no_end",
+        ),
+        indented_goods_nomenclature__item_id="2901510000",
+        indent=2,
     )
 
     with raises_if(BusinessRuleViolation, False):

--- a/commodities/tests/test_business_rules.py
+++ b/commodities/tests/test_business_rules.py
@@ -53,6 +53,7 @@ def test_NIG1(date_ranges):
         "all_closed_and_span",
     ),
 )
+
 def test_NIG2(
     date_ranges,
     parent_validity,
@@ -94,7 +95,7 @@ def test_NIG2(
 
 def test_NIG2_only_checks_future_dates_of_parent(date_ranges):
     """
-    The validity period of the goods nomenclature must be within the validity
+    The validity period o f the goods nomenclature must be within the validity
     period of the product line above in the hierarchy.
 
     Also covers NIG3
@@ -241,7 +242,7 @@ def test_NIG2_is_valid_with_multiple_parents_spanning_child_valid_period(date_ra
                 "starts_1_month_ago_no_end",
             ],
             "starts_2_months_ago_to_1_month_ago",
-            False,
+            True,
         ),
         (
             [
@@ -264,15 +265,15 @@ def test_NIG2_parents_span_child_valid(
 
     for parent_validity in parent_validities:
         validity = getattr(date_ranges, parent_validity)
-        parent = factories.GoodsNomenclatureFactory.create(
-            sid=good.sid,
-            valid_between=validity,
+        parent = factories.GoodsNomenclatureIndentFactory.create(
+            indented_goods_nomenclature__valid_between=validity,
+            indented_goods_nomenclature__sid=good.sid,
         )
         parents.append(parent)
 
-    child = factories.GoodsNomenclatureFactory.create(
-        sid=good.sid,
-        valid_between=getattr(date_ranges, child_validity),
+    child = factories.GoodsNomenclatureIndentFactory.create(
+        indented_goods_nomenclature__valid_between=getattr(date_ranges, child_validity),
+        indented_goods_nomenclature__sid=good.sid,
     )
 
     assert target(parents, child) == expected

--- a/common/tests/util.py
+++ b/common/tests/util.py
@@ -632,17 +632,23 @@ class Dates:
         "future": (relativedelta(weeks=+10), relativedelta(weeks=+20)),
         "no_end": (relativedelta(), None),
         "normal_first_half": (relativedelta(), relativedelta(days=+14)),
+        "starts_1_month_ago_to_delta": (relativedelta(months=-1), relativedelta()),
+        "starts_delta_to_1_month_ahead": (relativedelta(), relativedelta(months=1)),
         "starts_1_month_ago_to_1_month_ahead": (
             relativedelta(months=-1),
             relativedelta(months=1),
         ),
-        "starts_1_month_ahead_to_2_months_ahead": (
-            relativedelta(months=1),
-            relativedelta(months=2),
-        ),
+        "starts_1_month_ago_no_end": (relativedelta(months=-1), None),
+        "starts_2_months_ago_no_end": (relativedelta(months=-2), None),
+        "starts_delta_no_end": (relativedelta(), None),
         "starts_2_months_ago_to_1_month_ago": (
             relativedelta(months=-2),
             relativedelta(months=-1),
+        ),
+        "starts_2_months_ago_to_delta": (relativedelta(months=-2), relativedelta()),
+        "starts_1_month_ahead_to_2_months_ahead": (
+            relativedelta(months=1),
+            relativedelta(months=2),
         ),
     }
 

--- a/common/tests/util.py
+++ b/common/tests/util.py
@@ -650,6 +650,10 @@ class Dates:
             relativedelta(months=1),
             relativedelta(months=2),
         ),
+        "starts_1_month_ahead_no_end": (
+            relativedelta(months=1),
+            None,
+        ),
     }
 
     @property

--- a/pii-ner-exclude.txt
+++ b/pii-ner-exclude.txt
@@ -1233,6 +1233,8 @@ Enter the Quota Order Number
 tranxs #
 WorkBasket Contents
 MEASURE_SID
+Merge
+indent=0
 0005_workbasket_rule_check_task_id
 run_business_rules_form
 f"empty


### PR DESCRIPTION
# TOPS-645

## background
NIG2 and the wording surrounding it is a bit of a grey area, we have however observed data coming from the EU that gave us insights that the interpretation we have differs from the interpretation the EU has. This is causing issues when we are getting data from the EU. 

The rule states: "The validity period of the goods nomenclature must be within the validity period of the product line above in the hierarchy."

## currently
NIG2 will fail if the "current" parent does not encapsulate the valid between date period, so if a child good nomenclature is valid between 1/1/20202 and 1/2/2022 and the parent is valid between 1/1/2022 and 15/1/2022 (even if there is another parent that would be next in the chain with a valid period of 1/1/20202 and 1/2/2022 or more) the validation will fail (as of today) note : the rule is looking at historical dates!

## proposed
a child is valid if it has valid parents (note plural) from today forward, not looking at the start date of the child but from todays date forward, looking at all valid parents (which we are defining as the grandparents children, where the item id is less than or equal to the child's item id, or where the item ids are equal but the suffix is less than the child's suffix). We then join all the parents valid between dates where they overlap to create a valid date range that the child valid range can be compared against - if the child's valid range falls within the joint parents range - the rule passes
