### PR TITLE
TP2000-534 CertificateDoesNotExist error on measure/create/conditions step

### DIFF
--- a/measures/forms.py
+++ b/measures/forms.py
@@ -272,7 +272,7 @@ class MeasureConditionsFormMixin(forms.ModelForm):
     )
     required_certificate = AutoCompleteField(
         label="Certificate, licence or document",
-        queryset=Certificate.objects.all(),
+        queryset=Certificate.objects.current(),
         required=False,
     )
     action = forms.ModelChoiceField(

--- a/measures/tests/test_forms.py
+++ b/measures/tests/test_forms.py
@@ -708,16 +708,19 @@ def test_measure_forms_conditions_clears_unneeded_certificate(date_ranges):
         prefix="",
         initial=initial_data,
     )
-    form_expects_certificate.is_valid()
-    assert form_expects_certificate.cleaned_data["required_certificate"] == certificate
+    with override_current_transaction(action.transaction):
+        form_expects_certificate.is_valid()
+        assert (
+            form_expects_certificate.cleaned_data["required_certificate"] == certificate
+        )
 
-    form_expects_no_certificate = forms.MeasureConditionsForm(
-        dict(data, **{"condition_code": code_without_certificate.pk}),
-        prefix="",
-        initial=initial_data,
-    )
-    assert form_expects_no_certificate.is_valid()
-    assert form_expects_no_certificate.cleaned_data["required_certificate"] is None
+        form_expects_no_certificate = forms.MeasureConditionsForm(
+            dict(data, **{"condition_code": code_without_certificate.pk}),
+            prefix="",
+            initial=initial_data,
+        )
+        assert form_expects_no_certificate.is_valid()
+        assert form_expects_no_certificate.cleaned_data["required_certificate"] is None
 
 
 def test_measure_forms_conditions_wizard_clears_unneeded_certificate(date_ranges):
@@ -741,16 +744,19 @@ def test_measure_forms_conditions_wizard_clears_unneeded_certificate(date_ranges
         prefix="",
         measure_start_date=date_ranges.normal,
     )
-    form_expects_certificate.is_valid()
-    assert form_expects_certificate.cleaned_data["required_certificate"] == certificate
+    with override_current_transaction(action.transaction):
+        form_expects_certificate.is_valid()
+        assert (
+            form_expects_certificate.cleaned_data["required_certificate"] == certificate
+        )
 
-    form_expects_no_certificate = forms.MeasureConditionsWizardStepForm(
-        dict(data, **{"condition_code": code_without_certificate.pk}),
-        prefix="",
-        measure_start_date=date_ranges.normal,
-    )
-    assert form_expects_no_certificate.is_valid()
-    assert form_expects_no_certificate.cleaned_data["required_certificate"] is None
+        form_expects_no_certificate = forms.MeasureConditionsWizardStepForm(
+            dict(data, **{"condition_code": code_without_certificate.pk}),
+            prefix="",
+            measure_start_date=date_ranges.normal,
+        )
+        assert form_expects_no_certificate.is_valid()
+        assert form_expects_no_certificate.cleaned_data["required_certificate"] is None
 
 
 def test_measure_form_valid_data(erga_omnes, session_with_workbasket):


### PR DESCRIPTION
# TP2000-534 CertificateDoesNotExist error on measure/create/conditions step
<!---
 * Include the JIRA ticket number, eg TP-123, to automatically link.
 * Use 50 characters maximum.
 * Do not end with a full-stop.
--->

## Why
<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Use as many lines as you like.
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions or deliberately ignored edge-cases.
--->
It shouldn't be possible to create measures with deleted certificates or certificates currently in a different, EDITING workbasket.

## What
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Explain like I'm 5.
 * Use pictures if you can.
--->
Updates `MeasureConditionsFormMixin.required_certificate` to use current queryset.
<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
## Checklist
- Requires migrations?
- Requires dependency updates?
--->

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
