### PR TITLE
Update VolumeAndInitialVolumeMustMatch

### DIFF
--- a/common/tests/util.py
+++ b/common/tests/util.py
@@ -632,6 +632,18 @@ class Dates:
         "future": (relativedelta(weeks=+10), relativedelta(weeks=+20)),
         "no_end": (relativedelta(), None),
         "normal_first_half": (relativedelta(), relativedelta(days=+14)),
+        "starts_1_month_ago_to_1_month_ahead": (
+            relativedelta(months=-1),
+            relativedelta(months=1),
+        ),
+        "starts_1_month_ahead_to_2_months_ahead": (
+            relativedelta(months=1),
+            relativedelta(months=2),
+        ),
+        "starts_2_months_ago_to_1_month_ago": (
+            relativedelta(months=-2),
+            relativedelta(months=-1),
+        ),
     }
 
     @property

--- a/quotas/business_rules.py
+++ b/quotas/business_rules.py
@@ -1,4 +1,5 @@
 """Business rules for quotas."""
+import datetime
 from datetime import date
 from decimal import Decimal
 
@@ -285,10 +286,19 @@ class OverlappingQuotaDefinition(BusinessRule):
 
 
 class VolumeAndInitialVolumeMustMatch(BusinessRule):
-    """Unless it is the main quota in a quota association, a definition's volume
-    and initial_volume values should always be the same."""
+    """
+    Unless it is the main quota in a quota association, a definition's volume
+    and initial_volume values should always be the same.
+
+    the exception is when we are updating quotas in the current period, these
+    can have differing vol and initial vol
+    """
 
     def validate(self, quota_definition):
+
+        if quota_definition.valid_between.lower < datetime.date.today():
+            return True
+
         if quota_definition.sub_quota_associations.approved_up_to_transaction(
             self.transaction,
         ).exists():


### PR DESCRIPTION
Update business rules to allow differences in volume vs initial volume for current period order definitions

# TOPS-674

## Why
* business rules should only apply for future periods, as we may have differences coming in to reflect real world figures for current period

## What
* only check future quota definitions for matching values

# details
* Added a simple change to the rule to pass if start date is in the past
* added unit tests to cover the past, current  and future  cases