### PR TITLE
TP2000-535 Admin management for WorkBasket rule checks

### DIFF
--- a/additional_codes/views.py
+++ b/additional_codes/views.py
@@ -25,9 +25,9 @@ from common.views import TamatoListView
 from common.views import TrackedModelDetailMixin
 from common.views import TrackedModelDetailView
 from workbaskets.models import WorkBasket
-from workbaskets.views.generic import DraftCreateView
-from workbaskets.views.generic import DraftDeleteView
-from workbaskets.views.generic import DraftUpdateView
+from workbaskets.views.generic import CreateTaricCreateView
+from workbaskets.views.generic import CreateTaricDeleteView
+from workbaskets.views.generic import CreateTaricUpdateView
 
 
 class AdditionalCodeViewSet(viewsets.ReadOnlyModelViewSet):
@@ -95,7 +95,7 @@ class AdditionalCodeList(AdditionalCodeMixin, TamatoListView):
     ]
 
 
-class AdditionalCodeCreate(DraftCreateView):
+class AdditionalCodeCreate(CreateTaricCreateView):
     template_name = "additional_codes/create.jinja"
     form_class = AdditionalCodeCreateForm
 
@@ -131,7 +131,7 @@ class AdditionalCodeDetail(AdditionalCodeMixin, TrackedModelDetailView):
 class AdditionalCodeUpdate(
     AdditionalCodeMixin,
     TrackedModelDetailMixin,
-    DraftUpdateView,
+    CreateTaricUpdateView,
 ):
     form_class = AdditionalCodeForm
 
@@ -148,7 +148,7 @@ class AdditionalCodeUpdate(
 class AdditionalCodeDescriptionCreate(
     AdditionalCodeCreateDescriptionMixin,
     TrackedModelDetailMixin,
-    DraftCreateView,
+    CreateTaricCreateView,
 ):
     def get_initial(self):
         initial = super().get_initial()
@@ -164,7 +164,7 @@ class AdditionalCodeDescriptionCreate(
 class AdditionalCodeDescriptionUpdate(
     AdditionalCodeDescriptionMixin,
     TrackedModelDetailMixin,
-    DraftUpdateView,
+    CreateTaricUpdateView,
 ):
     form_class = AdditionalCodeDescriptionForm
     template_name = "common/edit_description.jinja"
@@ -191,7 +191,7 @@ class AdditionalCodeConfirmUpdate(AdditionalCodeMixin, TrackedModelDetailView):
 class AdditionalCodeDelete(
     AdditionalCodeMixin,
     TrackedModelDetailMixin,
-    DraftDeleteView,
+    CreateTaricDeleteView,
 ):
     form_class = AdditionalCodeDeleteForm
     success_path = "list"
@@ -202,7 +202,7 @@ class AdditionalCodeDelete(
 class AdditionalCodeDescriptionDelete(
     AdditionalCodeDescriptionMixin,
     TrackedModelDetailMixin,
-    DraftDeleteView,
+    CreateTaricDeleteView,
 ):
     form_class = AdditionalCodeDescriptionDeleteForm
     success_path = "detail"

--- a/certificates/views.py
+++ b/certificates/views.py
@@ -17,9 +17,9 @@ from common.views import TamatoListView
 from common.views import TrackedModelDetailMixin
 from common.views import TrackedModelDetailView
 from workbaskets.models import WorkBasket
-from workbaskets.views.generic import DraftCreateView
-from workbaskets.views.generic import DraftDeleteView
-from workbaskets.views.generic import DraftUpdateView
+from workbaskets.views.generic import CreateTaricCreateView
+from workbaskets.views.generic import CreateTaricDeleteView
+from workbaskets.views.generic import CreateTaricUpdateView
 
 
 class CertificatesViewSet(viewsets.ReadOnlyModelViewSet):
@@ -69,7 +69,7 @@ class CertificateList(CertificateMixin, TamatoListView):
     ]
 
 
-class CertificateCreate(DraftCreateView):
+class CertificateCreate(CreateTaricCreateView):
     """UI endpoint for creating Certificates."""  # /PS-IGNORE
 
     template_name = "certificates/create.jinja"
@@ -114,7 +114,7 @@ class CertificateDetail(CertificateMixin, TrackedModelDetailView):
 class CertificateUpdate(
     CertificateMixin,
     TrackedModelDetailMixin,
-    DraftUpdateView,
+    CreateTaricUpdateView,
 ):
     form_class = forms.CertificateForm
 
@@ -153,7 +153,7 @@ class CertificateCreateDescriptionMixin:
 class CertificateDescriptionCreate(
     CertificateCreateDescriptionMixin,
     TrackedModelDetailMixin,
-    DraftCreateView,
+    CreateTaricCreateView,
 ):
     def get_initial(self):
         initial = super().get_initial()
@@ -170,7 +170,7 @@ class CertificateDescriptionCreate(
 class CertificateUpdateDescription(
     CertificateDescriptionMixin,
     TrackedModelDetailMixin,
-    DraftUpdateView,
+    CreateTaricUpdateView,
 ):
     form_class = forms.CertificateDescriptionForm
     template_name = "common/edit_description.jinja"
@@ -193,7 +193,7 @@ class CertificateDescriptionConfirmUpdate(
 class CertificateDelete(
     CertificateMixin,
     TrackedModelDetailMixin,
-    DraftDeleteView,
+    CreateTaricDeleteView,
 ):
     form_class = forms.CertificateDeleteForm
     success_path = "list"
@@ -204,7 +204,7 @@ class CertificateDelete(
 class CertificateDescriptionDelete(
     CertificateDescriptionMixin,
     TrackedModelDetailMixin,
-    DraftDeleteView,
+    CreateTaricDeleteView,
 ):
     form_class = forms.CertificateDescriptionDeleteForm
     success_path = "detail"

--- a/common/paths.py
+++ b/common/paths.py
@@ -89,9 +89,6 @@ def get_ui_paths(
     view_info is a list of 4-tuples, each comprising:
     (app_name_singular, class_suffix, pathname, pattern)
     """
-    from pprint import pprint
-
-    pprint(view_info)
 
     paths = []
     for app_name_singular, class_suffix, pathname, pattern in view_info:

--- a/common/paths.py
+++ b/common/paths.py
@@ -19,6 +19,8 @@ OBJECT_ACTIONS = {
     "ConfirmUpdate": "confirm-update",
     "Delete": "delete",
     "DescriptionCreate": "description-create",
+    "EditUpdate": "edit-taric-update",
+    "EditCreate": "edit-taric-create",
 }
 
 
@@ -82,5 +84,7 @@ def get_ui_paths(
                 url = pattern + ("/" if pattern else "") + pathname
 
                 paths.append(path(url, view.as_view(), name=name))
+            else:
+                logger.debug("No view matching ")
 
     return paths

--- a/common/views.py
+++ b/common/views.py
@@ -221,6 +221,14 @@ class TrackedModelChangeView(
         return self.object.get_url(self.success_path)
 
     def get_result_object(self, form):
+        """
+        Overridable used to get a saved result.
+
+        In the default case (this implementation) a new version of a
+        TrackedModel instance is created. However, this function may be
+        overridden to provide alternative behaviour, such as simply updating the
+        TrackedModel instance.
+        """
         # compares changed data against model fields to prevent unexpected kwarg TypeError
         # e.g. `geographical_area_group` is a field on `MeasureUpdateForm` and included in cleaned data,
         # but isn't a field on `Measure` and would cause a TypeError on model save()

--- a/footnotes/views.py
+++ b/footnotes/views.py
@@ -18,9 +18,9 @@ from footnotes.filters import FootnoteFilter
 from footnotes.filters import FootnoteFilterBackend
 from footnotes.serializers import FootnoteTypeSerializer
 from workbaskets.models import WorkBasket
-from workbaskets.views.generic import DraftCreateView
-from workbaskets.views.generic import DraftDeleteView
-from workbaskets.views.generic import DraftUpdateView
+from workbaskets.views.generic import CreateTaricCreateView
+from workbaskets.views.generic import CreateTaricDeleteView
+from workbaskets.views.generic import CreateTaricUpdateView
 
 
 class FootnoteViewSet(viewsets.ReadOnlyModelViewSet):
@@ -101,7 +101,7 @@ class FootnoteList(FootnoteMixin, TamatoListView):
     ]
 
 
-class FootnoteCreate(DraftCreateView):
+class FootnoteCreate(CreateTaricCreateView):
     template_name = "footnotes/create.jinja"
     form_class = forms.FootnoteCreateForm
 
@@ -138,7 +138,7 @@ class FootnoteDetail(FootnoteMixin, TrackedModelDetailView):
 class FootnoteUpdate(
     FootnoteMixin,
     TrackedModelDetailMixin,
-    DraftUpdateView,
+    CreateTaricUpdateView,
 ):
     form_class = forms.FootnoteForm
 
@@ -159,7 +159,7 @@ class FootnoteConfirmUpdate(FootnoteMixin, TrackedModelDetailView):
 class FootnoteDelete(
     FootnoteMixin,
     TrackedModelDetailMixin,
-    DraftDeleteView,
+    CreateTaricDeleteView,
 ):
     form_class = forms.FootnoteDeleteForm
     success_path = "list"
@@ -174,7 +174,7 @@ class FootnoteDelete(
 class FootnoteDescriptionCreate(
     FootnoteCreateDescriptionMixin,
     TrackedModelDetailMixin,
-    DraftCreateView,
+    CreateTaricCreateView,
 ):
     def get_initial(self):
         initial = super().get_initial()
@@ -193,7 +193,7 @@ class FootnoteDescriptionCreate(
 class FootnoteDescriptionUpdate(
     FootnoteDescriptionMixin,
     TrackedModelDetailMixin,
-    DraftUpdateView,
+    CreateTaricUpdateView,
 ):
     form_class = forms.FootnoteDescriptionForm
     template_name = "common/edit_description.jinja"
@@ -216,7 +216,7 @@ class FootnoteDescriptionConfirmUpdate(
 class FootnoteDescriptionDelete(
     FootnoteDescriptionMixin,
     TrackedModelDetailMixin,
-    DraftDeleteView,
+    CreateTaricDeleteView,
 ):
     form_class = forms.FootnoteDescriptionDeleteForm
     success_path = "detail"

--- a/geo_areas/views.py
+++ b/geo_areas/views.py
@@ -15,8 +15,8 @@ from geo_areas.forms import GeographicalAreaCreateDescriptionForm
 from geo_areas.models import GeographicalArea
 from geo_areas.models import GeographicalAreaDescription
 from workbaskets.models import WorkBasket
-from workbaskets.views.generic import DraftCreateView
-from workbaskets.views.generic import DraftDeleteView
+from workbaskets.views.generic import CreateTaricCreateView
+from workbaskets.views.generic import CreateTaricDeleteView
 
 
 class GeoAreaViewSet(viewsets.ReadOnlyModelViewSet):
@@ -63,7 +63,10 @@ class GeoAreaCreateDescriptionMixin:
         return context
 
 
-class GeoAreaList(GeoAreaMixin, TamatoListView):
+class GeoAreaList(
+    GeoAreaMixin,
+    TamatoListView,
+):
     template_name = "geo_areas/list.jinja"
     filterset_class = GeographicalAreaFilter
     filterset_class.search_fields = ["area_id", "description"]
@@ -72,11 +75,18 @@ class GeoAreaList(GeoAreaMixin, TamatoListView):
         return GeographicalArea.objects.current().with_current_descriptions()
 
 
-class GeoAreaDetail(GeoAreaMixin, TrackedModelDetailView):
+class GeoAreaDetail(
+    GeoAreaMixin,
+    TrackedModelDetailView,
+):
     template_name = "geo_areas/detail.jinja"
 
 
-class GeoAreaDelete(GeoAreaMixin, TrackedModelDetailMixin, DraftDeleteView):
+class GeoAreaDelete(
+    GeoAreaMixin,
+    TrackedModelDetailMixin,
+    CreateTaricDeleteView,
+):
     form_class = forms.GeographicalAreaDeleteForm
     success_path = "list"
 
@@ -89,7 +99,7 @@ class GeoAreaDelete(GeoAreaMixin, TrackedModelDetailMixin, DraftDeleteView):
 class GeoAreaDescriptionCreate(
     GeoAreaCreateDescriptionMixin,
     TrackedModelDetailMixin,
-    DraftCreateView,
+    CreateTaricCreateView,
 ):
     def get_initial(self):
         initial = super().get_initial()
@@ -112,7 +122,7 @@ class GeoAreaDescriptionConfirmCreate(
 class GeoAreaDescriptionDelete(
     GeoAreaDescriptionMixin,
     TrackedModelDetailMixin,
-    DraftDeleteView,
+    CreateTaricDeleteView,
 ):
     form_class = forms.GeographicalAreaDescriptionDeleteForm
     success_path = "detail"

--- a/measures/views.py
+++ b/measures/views.py
@@ -33,8 +33,8 @@ from measures.parsers import DutySentenceParser
 from measures.patterns import MeasureCreationPattern
 from workbaskets.models import WorkBasket
 from workbaskets.views.decorators import require_current_workbasket
-from workbaskets.views.generic import DraftDeleteView
-from workbaskets.views.generic import DraftUpdateView
+from workbaskets.views.generic import CreateTaricDeleteView
+from workbaskets.views.generic import CreateTaricUpdateView
 
 
 class MeasureTypeViewSet(viewsets.ReadOnlyModelViewSet):
@@ -322,7 +322,7 @@ class MeasureCreateWizard(
 class MeasureUpdate(
     MeasureMixin,
     TrackedModelDetailMixin,
-    DraftUpdateView,
+    CreateTaricUpdateView,
 ):
     form_class = forms.MeasureForm
     permission_required = "common.change_trackedmodel"
@@ -533,7 +533,7 @@ class MeasureFootnotesUpdate(View):
 class MeasureDelete(
     MeasureMixin,
     TrackedModelDetailMixin,
-    DraftDeleteView,
+    CreateTaricDeleteView,
 ):
     form_class = forms.MeasureDeleteForm
     success_path = "list"

--- a/pii-ner-exclude.txt
+++ b/pii-ner-exclude.txt
@@ -1232,3 +1232,7 @@ Enter the Quota Order Number
 tranxs #
 WorkBasket Contents
 MEASURE_SID
+EditUpdate
+EditCreate
+Create or Update - Delete
+

--- a/pii-ner-exclude.txt
+++ b/pii-ner-exclude.txt
@@ -1238,4 +1238,4 @@ EditCreate
 Create or Update - Delete
 0005_workbasket_rule_check_task_id
 run_business_rules_form
-
+f"empty

--- a/quotas/views.py
+++ b/quotas/views.py
@@ -12,7 +12,7 @@ from quotas import serializers
 from quotas.filters import OrderNumberFilterBackend
 from quotas.filters import QuotaFilter
 from workbaskets.models import WorkBasket
-from workbaskets.views.generic import DraftDeleteView
+from workbaskets.views.generic import CreateTaricDeleteView
 
 
 class QuotaOrderNumberViewset(viewsets.ReadOnlyModelViewSet):
@@ -87,7 +87,7 @@ class QuotaDetail(QuotaMixin, TrackedModelDetailView):
     template_name = "quotas/detail.jinja"
 
 
-class QuotaDelete(QuotaMixin, TrackedModelDetailMixin, DraftDeleteView):
+class QuotaDelete(QuotaMixin, TrackedModelDetailMixin, CreateTaricDeleteView):
     form_class = forms.QuotaDeleteForm
     success_path = "list"
 

--- a/regulations/views.py
+++ b/regulations/views.py
@@ -15,9 +15,9 @@ from regulations.forms import RegulationDeleteForm
 from regulations.forms import RegulationEditForm
 from regulations.models import Regulation
 from workbaskets.models import WorkBasket
-from workbaskets.views.generic import DraftCreateView
-from workbaskets.views.generic import DraftDeleteView
-from workbaskets.views.generic import DraftUpdateView
+from workbaskets.views.generic import CreateTaricCreateView
+from workbaskets.views.generic import CreateTaricDeleteView
+from workbaskets.views.generic import CreateTaricUpdateView
 
 
 class RegulationViewSet(viewsets.ReadOnlyModelViewSet):
@@ -57,7 +57,7 @@ class RegulationDetail(RegulationMixin, TrackedModelDetailView):
     template_name = "regulations/detail.jinja"
 
 
-class RegulationCreate(DraftCreateView):
+class RegulationCreate(CreateTaricCreateView):
     """UI to create new regulations."""
 
     template_name = "regulations/create.jinja"
@@ -83,7 +83,7 @@ class RegulationConfirmCreate(TrackedModelDetailView):
 class RegulationUpdate(
     RegulationMixin,
     TrackedModelDetailMixin,
-    DraftUpdateView,
+    CreateTaricUpdateView,
 ):
     template_name = "regulations/edit.jinja"
     form_class = RegulationEditForm
@@ -106,7 +106,7 @@ class RegulationConfirmUpdate(
 class RegulationDelete(
     RegulationMixin,
     TrackedModelDetailMixin,
-    DraftDeleteView,
+    CreateTaricDeleteView,
 ):
     form_class = RegulationDeleteForm
     success_path = "list"

--- a/workbaskets/templates/admin/workbaskets/change_form.html
+++ b/workbaskets/templates/admin/workbaskets/change_form.html
@@ -6,6 +6,7 @@
 {% block submit_buttons_bottom %}
     {{ block.super }}
 
+    {% if original.status == 'EDITING' or original.status == 'ARCHIVED' %}
     <div class="submit-row">
         <span>
             {{ original.tracked_models.count }}
@@ -22,4 +23,5 @@
             {% if not original.tracked_models.count and not original.transactions.count %}disabled{% endif %}
         >
     </div>
+    {% endif %}
 {% endblock %}

--- a/workbaskets/views/generic.py
+++ b/workbaskets/views/generic.py
@@ -7,7 +7,7 @@ from workbaskets.views.decorators import require_current_workbasket
 
 
 @method_decorator(require_current_workbasket, name="dispatch")
-class DraftCreateView(
+class CreateTaricCreateView(
     TrackedModelChangeView,
     generic.CreateView,
 ):
@@ -30,7 +30,7 @@ class DraftCreateView(
 
 
 @method_decorator(require_current_workbasket, name="dispatch")
-class DraftUpdateView(
+class CreateTaricUpdateView(
     TrackedModelChangeView,
     generic.UpdateView,
 ):
@@ -44,7 +44,7 @@ class DraftUpdateView(
 
 
 @method_decorator(require_current_workbasket, name="dispatch")
-class DraftDeleteView(
+class CreateTaricDeleteView(
     TrackedModelChangeView,
     generic.UpdateView,
 ):
@@ -53,3 +53,39 @@ class DraftDeleteView(
     update_type = UpdateType.DELETE
     permission_required = "common.add_trackedmodel"
     template_name = "common/delete.jinja"
+
+
+@method_decorator(require_current_workbasket, name="dispatch")
+class EditTaricCreateOrUpdateView(
+    TrackedModelChangeView,
+    generic.UpdateView,
+):
+    """
+    View used to change an existing model instance in the current workbasket
+    without creating a new version. The model instance may have an update_type.
+
+    of either Create or Update - Delete is not an editable update type.
+    """
+
+    permission_required = "common.add_trackedmodel"
+    success_path = "confirm-update"
+
+    # NOTE:
+    # * update_type isn't required as this class will update from the form,
+    #   leaving the update_type of the object as is.
+    # @property
+    # def update_type(self):
+    #    return self.update_type
+    # TODO:
+    # * Any reason to break out into two separate view classes?
+    #       class EditTaricCreateView
+    #       class EditTaricUpdateView
+
+    def get_template_names(self):
+        return "common/edit.jinja"
+
+    def get_result_object(self, form):
+        """Override the default behaviour in order to only update the existing
+        instance of the TrackedModel (i.e. without changing the object's
+        version)."""
+        return form.save()


### PR DESCRIPTION
# TP2000-535 Admin mgmt for WorkBasket rule checks
<!---
 * Include the JIRA ticket number, eg TP-123, to automatically link.
 * Use 50 characters maximum.
 * Do not end with a full-stop.
--->

## Why
<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Use as many lines as you like.
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions or deliberately ignored edge-cases.
--->
An engineer must currently execute bespoke python code in order to check and terminate WorkBasket rule checks. This activity should be available through the Django admin site.

## What
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Explain like I'm 5.
 * Use pictures if you can.
--->
This PR:

- Adds a method to the WorkBasket class that terminates any rule check running in a task.
- Adds a property to get a WorkBasket's rule check task status.
- Adds a rule check section to the WorkBasket's Django admin edit form, showing task details and an option to terminate a rule check.

![image](https://user-images.githubusercontent.com/85895113/193633783-b7e55d86-2cbe-4522-b6b4-3972d1005bbf.png)


<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
--->
## Checklist
- Requires migrations? No
- Requires dependency updates? No

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
