### PR TITLE
TP2000-538 Multi-version support for me32_clashes

### DIFF
--- a/workbaskets/management/commands/me32_clashes.py
+++ b/workbaskets/management/commands/me32_clashes.py
@@ -40,7 +40,7 @@ class Command(WorkBasketCommandMixin, BaseCommand):
             measures = list(
                 Measure.objects.filter(
                     sid=sid,
-                    transaction__workbasket__pk=workbasket.pk,
+                    transaction__workbasket=workbasket,
                 ),
             )
             workbasket_info = f" in workbasket.pk={workbasket.pk}"

--- a/workbaskets/management/commands/me32_clashes.py
+++ b/workbaskets/management/commands/me32_clashes.py
@@ -13,33 +13,73 @@ logger = logging.getLogger(__name__)
 
 
 class Command(WorkBasketCommandMixin, BaseCommand):
-    help = "Show clashes for a given measure, if any exist."
+    help = (
+        "Show clashes for a given measure, if any exist. If no --workbasket "
+        "parameter is supplied then only the most recent (last) measure "
+        "instance is checked for clashes. Supplying the --workbasket parameter "
+        "ensures that all CREATE and UPDATE instances in the workbasket are "
+        "checked for clashes."
+    )
 
     def add_arguments(self, parser: CommandParser) -> None:
         parser.add_argument("MEASURE_SID", type=int)
+        parser.add_argument(
+            "--workbasket-pk",
+            type=int,
+            help=("Check all instances of the meausre in the given workbasket."),
+        )
 
     def handle(self, *args: Any, **options: Any) -> Optional[str]:
         sid = int(options["MEASURE_SID"])
-        measure = Measure.objects.filter(sid=sid).order_by("transaction").last()
-        if not measure:
+        workbasket_info = ""
+
+        if options["workbasket_pk"]:
+            workbasket = self.get_workbasket_or_exit(
+                int(options["workbasket_pk"]),
+            )
+            measures = list(
+                Measure.objects.filter(
+                    sid=sid,
+                    transaction__workbasket__pk=workbasket.pk,
+                ),
+            )
+            workbasket_info = f" in workbasket.pk={workbasket.pk}"
+        else:
+            measures = [
+                Measure.objects.filter(sid=sid).order_by("transaction").last(),
+            ]
+
+        if not measures:
             self.stderr.write(
                 self.style.ERROR(f"measure sid={sid} not found."),
             )
             exit(1)
 
-        me32 = ME32(measure.transaction)
-        clashes = me32.clashing_measures(measure)
-
         self.stdout.write(
-            self.style.SUCCESS(
-                f"{clashes.count()} ME32 rule clashe(s) against " f"Measure.sid={sid}.",
-            ),
+            f"Checking {len(measures)} measure instance(s)" f"{workbasket_info}.",
         )
-        if clashes:
-            self.stdout.write("Clashes:")
-            for c in clashes:
-                self.stdout.write(
-                    self.style.ERROR(
-                        self.stdout.write(f"     Measure.sid={c.sid}"),
-                    ),
-                )
+
+        for measure in measures:
+            me32 = ME32(measure.transaction)
+            clashes = me32.clashing_measures(measure)
+
+            self.stdout.write(
+                self.style.SUCCESS(
+                    f"{clashes.count()} ME32 rule clashe(s) against "
+                    f"Measure sid={sid}, update_type={measure.update_type}, "
+                    f"transaction.id={measure.transaction.id}.",
+                ),
+            )
+            if clashes:
+                self.stdout.write("Clashes:")
+                for c in clashes:
+                    self.stdout.write(
+                        self.style.ERROR(
+                            self.stdout.write(
+                                f"     Measure: "
+                                f"sid={c.sid}, update_type={c.update_type}, "
+                                f"transaction.id={c.transaction.id}, "
+                                f"workbasket.pk={c.transaction.workbasket.pk},",
+                            ),
+                        ),
+                    )

--- a/workbaskets/management/commands/me32_clashes.py
+++ b/workbaskets/management/commands/me32_clashes.py
@@ -76,10 +76,10 @@ class Command(WorkBasketCommandMixin, BaseCommand):
                     self.stdout.write(
                         self.style.ERROR(
                             self.stdout.write(
-                                f"     Measure: "
+                                f"     Measure "
                                 f"sid={c.sid}, update_type={c.update_type}, "
                                 f"transaction.id={c.transaction.id}, "
-                                f"workbasket.pk={c.transaction.workbasket.pk},",
+                                f"workbasket.pk={c.transaction.workbasket.pk}.",
                             ),
                         ),
                     )


### PR DESCRIPTION
TP2000-538 Multi-version support for me32_clashes
<!---
 * Include the JIRA ticket number, eg TP-123, to automatically link.
 * Use 50 characters maximum.
 * Do not end with a full-stop.
--->

## Why
<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Use as many lines as you like.
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions or deliberately ignored edge-cases.
--->
The `me32_clashes` Django management command (a command-line tool) will only find clashes for the last, most recent version of a measure.

## What
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Explain like I'm 5.
 * Use pictures if you can.
--->
This PR adds support for checking for ME32 clashes against all versions of a measure in a workbasket by adding a `--workbasket ` flag, without which the old behaviour is preserved.

<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
--->
## Checklist
- Requires migrations? No
- Requires dependency updates? No

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
