### PR TITLE
TP2000-537 Restrict dump transactions to checked workbaskets

### DIFF
--- a/pii-ner-exclude.txt
+++ b/pii-ner-exclude.txt
@@ -1236,3 +1236,4 @@ MEASURE_SID
 0005_workbasket_rule_check_task_id
 run_business_rules_form
 f"empty
+Exit

--- a/workbaskets/validators.py
+++ b/workbaskets/validators.py
@@ -24,3 +24,18 @@ class WorkflowStatus(models.TextChoices):
             cls.SENT,
             cls.PUBLISHED,
         )
+
+    @classmethod
+    def unchecked_statuses(cls):
+        """
+        A successful transition out of EDITING may only occur when all business
+        rule checks have succeeded.
+
+        WorkBaskets with the following set of statuses may have successful rule
+        checks, but this isn't guarenteed.
+        """
+        return (
+            cls.ARCHIVED,
+            cls.EDITING,
+            cls.ERRORED,
+        )


### PR DESCRIPTION
# TP2000-537 Restrict dumps to checked workbaskets
<!---
 * Include the JIRA ticket number, eg TP-123, to automatically link.
 * Use 50 characters maximum.
 * Do not end with a full-stop.
--->

## Why
<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Use as many lines as you like.
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions or deliberately ignored edge-cases.
--->
Normally, it's expected that `dump_transactions` is only called on workbaskets that have had a complete and successful business rule check - i.e. those that are error-free. However, it's currently possible to accidentally export an unchecked workbasket leading to subsequence processing problems when using exported envelope. 

## What
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Explain like I'm 5.
 * Use pictures if you can.
--->
This PR restricts dumping workbaskets to those that are known to have been checked. A flag, `--force-unchecked-rules`, has been added to allow explicit override of this behaviour for more uncommon situations. 

<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
--->
## Checklist
- Requires migrations? No
- Requires dependency updates? No

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
