### PR TITLE
Tp2000 556 duplicate task id error in workbasket admin

### DIFF
--- a/workbaskets/admin.py
+++ b/workbaskets/admin.py
@@ -30,10 +30,6 @@ class WorkBasketAdminForm(forms.ModelForm):
         )
 
     transition = forms.ChoiceField(required=False)
-    rule_check_task_id = forms.CharField(
-        required=False,
-        widget=AdminTextInputWidget(),
-    )
     rule_check_task_status = forms.CharField(
         required=False,
         widget=AdminTextInputWidget(),


### PR DESCRIPTION
# TP2000-556 duplicate task id error in workbasket admin
<!---
 * Include the JIRA ticket number, eg TP-123, to automatically link.
 * Use 50 characters maximum.
 * Do not end with a full-stop.
--->

## Why
<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Use as many lines as you like.
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions or deliberately ignored edge-cases.
--->
Currently when an empty `rule_check_task_id` value is provided to the workbasket admin form, this is saved as an empty string, which leads to a duplicate value error. We should instead save it as `None`.

## What
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Explain like I'm 5.
 * Use pictures if you can.
--->
Remove `rule_check_task_id` field declaration from form and add unit test.

<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
## Checklist
- Requires migrations?
- Requires dependency updates?
--->

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
