### PR TITLE
TP2000-571 Cannot import QuotaDefinition with description greater than 500 characters

### DIFF
--- a/commodities/assets/commodities_taric3.xsd
+++ b/commodities/assets/commodities_taric3.xsd
@@ -577,7 +577,7 @@
     </xs:simpleType>
     <xs:simpleType name="ShortDescription">
         <xs:restriction base="xs:string">
-            <xs:maxLength value="500"/>
+            <xs:maxLength value="1000"/>
         </xs:restriction>
     </xs:simpleType>
     <xs:simpleType name="StoppedFlag">

--- a/commodities/forms.py
+++ b/commodities/forms.py
@@ -8,6 +8,7 @@ from crispy_forms_gds.layout import Layout
 from crispy_forms_gds.layout import Size
 from crispy_forms_gds.layout import Submit
 from django import forms
+from django.conf import settings
 from django.contrib.auth.models import User
 from django.db import transaction
 
@@ -35,6 +36,7 @@ class CommodityImportForm(ImportForm):
         help_text="",
         label="Select an XML file",
     )
+    xsd_file = settings.PATH_XSD_COMMODITIES_TARIC
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/commodities/tests/test_files/quota_definition.xml
+++ b/commodities/tests/test_files/quota_definition.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<env:envelope id="22001" xmlns="urn:publicid:-:DGTAXUD:TARIC:MESSAGE:1.0" xmlns:env="urn:publicid:-:DGTAXUD:GENERAL:ENVELOPE:1.0">
+	<env:transaction id="392602">
+		<env:app.message id="1">
+			<oub:transmission xmlns:env="urn:publicid:-:DGTAXUD:GENERAL:ENVELOPE:1.0" xmlns:oub="urn:publicid:-:DGTAXUD:TARIC:MESSAGE:1.0">
+				<oub:record>
+                    <oub:transaction.id>19802301</oub:transaction.id>
+                    <oub:record.code>370</oub:record.code>
+                    <oub:subrecord.code>00</oub:subrecord.code>
+                    <oub:record.sequence.number>450</oub:record.sequence.number>
+                    <oub:update.type>3</oub:update.type>
+					<oub:quota.definition>
+                        <oub:quota.definition.sid>21830</oub:quota.definition.sid>
+                        <oub:quota.order.number.id>091528</oub:quota.order.number.id>
+                        <oub:validity.start.date>2023-01-01</oub:validity.start.date>
+                        <oub:validity.end.date>2023-12-31</oub:validity.end.date>
+                        <oub:quota.order.number.sid>2554</oub:quota.order.number.sid>
+                        <oub:volume>2550000</oub:volume>
+                        <oub:initial.volume>2550000</oub:initial.volume>
+                        <oub:measurement.unit.code>LTR</oub:measurement.unit.code>
+                        <oub:maximum.precision>3</oub:maximum.precision>
+                        <oub:critical.state>N</oub:critical.state>
+                        <oub:critical.threshold>90</oub:critical.threshold>
+                        <oub:description>Commission Implementation Regulation (EU) No 343/2011 - Opening and providing for the administration of Union tariff quotas for wines originating in Bosnia and Herzegovina
+                            L 96/12 of 9/04/2011
+                            Increase of volumes with COMMISSION IMPLEMENTING REGULATION (EU) 2017/822 of 15 May 2017 amending Implementing Regulation (EU) No 343/2011 opening and providing for the administration of Union tariff quotas for wines originating in Bosnia and Herzegovina (see OJ L 123/1)</oub:description>
+                    </oub:quota.definition>
+				</oub:record>
+			</oub:transmission>
+		</env:app.message>
+	</env:transaction>
+</env:envelope>

--- a/commodities/tests/test_forms.py
+++ b/commodities/tests/test_forms.py
@@ -62,3 +62,20 @@ def test_import_form_non_xml_file():
 
         assert not form.is_valid()
         assert "The selected file must be XML" in form.errors["taric_file"]
+
+
+# https://uktrade.atlassian.net/browse/TP2000-571
+def test_import_form_long_definition_description():
+    """Tests that form is valid when provided with QuotaDefinition description
+    longer than 500 characters."""
+    with open(f"{TEST_FILES_PATH}/quota_definition.xml", "rb") as upload_file:
+        file_data = {
+            "taric_file": SimpleUploadedFile(
+                upload_file.name,
+                upload_file.read(),
+                content_type="text/xml",
+            ),
+        }
+        form = forms.CommodityImportForm({}, file_data)
+
+    assert form.is_valid()

--- a/common/assets/envelope.xsd
+++ b/common/assets/envelope.xsd
@@ -41,7 +41,7 @@
             <xs:attribute name="id" use="required">
                 <xs:simpleType>
                     <xs:restriction base="xs:string">
-                        <xs:pattern value="[0-9]{6}"/>
+                        <xs:pattern value="[0-9]{5,6}"/>
                     </xs:restriction>
                 </xs:simpleType>
             </xs:attribute>

--- a/common/assets/taric3.xsd
+++ b/common/assets/taric3.xsd
@@ -577,7 +577,7 @@
     </xs:simpleType>
     <xs:simpleType name="ShortDescription">
         <xs:restriction base="xs:string">
-            <xs:maxLength value="500"/>
+            <xs:maxLength value="1000"/>
         </xs:restriction>
     </xs:simpleType>
     <xs:simpleType name="StoppedFlag">

--- a/importer/forms.py
+++ b/importer/forms.py
@@ -64,7 +64,7 @@ class ImportForm(forms.ModelForm):
                 capture_exception(e)
             raise ValidationError(generic_error_message)
 
-        with open(settings.PATH_XSD_COMMODITIES_TARIC) as xsd_file:
+        with open(self.xsd_file) as xsd_file:
             xmlschema = lxml.etree.XMLSchema(file=xsd_file)
 
         try:
@@ -93,6 +93,7 @@ class UploadTaricForm(ImportForm):
         required=False,
         initial=False,
     )
+    xsd_file = settings.PATH_XSD_TARIC
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/pii-ner-exclude.txt
+++ b/pii-ner-exclude.txt
@@ -1240,3 +1240,6 @@ run_business_rules_form
 f"empty
 Exit
 meth:`~workbaskets.models
+https://uktrade.atlassian.net/browse/TP2000-571
+validity.end.date>2023
+Implementing Regulation


### PR DESCRIPTION
# TP2000-571 Cannot import QuotaDefinition with description greater than 500 characters
<!---
 * Include the JIRA ticket number, eg TP-123, to automatically link.
 * Use 50 characters maximum.
 * Do not end with a full-stop.
--->

## Why
<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Use as many lines as you like.
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions or deliberately ignored edge-cases.
--->
Some files from the EU contain quota definitions with descriptions longer than 500 chars
## What
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Explain like I'm 5.
 * Use pictures if you can.
--->
- Increase the character limit from 500 to 1000 for both importers
- Ensure that two importers use different xsd files in validation
- Ensure that non-commodities importer accepts files with envelope ids of 5 or 6 digits
<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
## Checklist
- Requires migrations?
- Requires dependency updates?
--->

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
