### PR TITLE
Added ON4 business rule and updated ME6

### DIFF
--- a/common/business_rules.py
+++ b/common/business_rules.py
@@ -457,6 +457,20 @@ class MustExist(BusinessRule):
             raise self.violation(model)
 
 
+class MustExistNotNull(BusinessRule):
+    """Rule enforcing a referenced record exists, Null values raise
+    violation."""
+
+    reference_field_name: Optional[str] = None
+
+    def validate(self, model):
+        try:
+            if getattr(model, self.reference_field_name) is None:
+                raise self.violation(model)
+        except ObjectDoesNotExist:
+            raise self.violation(model)
+
+
 class ValidityStartDateRules(BusinessRule):
     """Repeated rule pattern for descriptions."""
 

--- a/measures/business_rules.py
+++ b/measures/business_rules.py
@@ -11,6 +11,7 @@ from common.business_rules import BusinessRule
 from common.business_rules import ExclusionMembership
 from common.business_rules import FootnoteApplicability
 from common.business_rules import MustExist
+from common.business_rules import MustExistNotNull
 from common.business_rules import PreventDeleteIfInUse
 from common.business_rules import UniqueIdentifyingFields
 from common.business_rules import ValidityPeriodContained
@@ -158,7 +159,7 @@ class ME5(ValidityPeriodContained):
     container_field_name = "geographical_area"
 
 
-class ME6(MustExist):
+class ME6(MustExistNotNull):
     """The goods code must exist."""
 
     reference_field_name = "goods_nomenclature"

--- a/measures/tests/test_business_rules.py
+++ b/measures/tests/test_business_rules.py
@@ -286,6 +286,22 @@ def test_ME6(reference_nonexistent_record):
             business_rules.ME6(measure.transaction).validate(measure)
 
 
+def test_ME6_happy(reference_nonexistent_record):
+    measure = factories.MeasureFactory.create()
+
+    assert business_rules.ME6(measure.transaction).validate(measure) is None
+
+
+def test_ME6_null_goods(reference_nonexistent_record):
+    measure = factories.MeasureFactory.create(
+        goods_nomenclature__suffix="00",
+        goods_nomenclature=None,
+    )
+
+    with pytest.raises(BusinessRuleViolation):
+        business_rules.ME6(measure.transaction).validate(measure)
+
+
 def test_ME7():
     """The goods nomenclature code must be a product code; that is, it may not
     be an intermediate line."""

--- a/quotas/business_rules.py
+++ b/quotas/business_rules.py
@@ -62,6 +62,19 @@ class ON2(BusinessRule):
             raise self.violation(order_number)
 
 
+class ON4(BusinessRule):
+    """The referenced geographical area must exist."""
+
+    def validate(self, order_number):
+        if (
+            order_number.origins.approved_up_to_transaction(
+                order_number.transaction,
+            ).count()
+            == 0
+        ):
+            raise self.violation(order_number)
+
+
 class ON5(BusinessRule):
     """There may be no overlap in time of two quota order number origins with
     the same quota order number SID and geographical area id."""

--- a/quotas/models.py
+++ b/quotas/models.py
@@ -66,6 +66,7 @@ class QuotaOrderNumber(TrackedModel, ValidityMixin):
     business_rules = (
         business_rules.ON1,
         business_rules.ON2,
+        business_rules.ON4,
         business_rules.ON9,
         business_rules.ON11,
         UniqueIdentifyingFields,

--- a/quotas/tests/test_business_rules.py
+++ b/quotas/tests/test_business_rules.py
@@ -54,6 +54,26 @@ def test_ON2(date_ranges, existing_range, new_range, ranges_overlap):
         business_rules.ON2(order_number.transaction).validate(order_number)
 
 
+def test_ON4_pass(date_ranges, approved_transaction, unapproved_transaction):
+    order_number = factories.QuotaOrderNumberFactory.create(
+        valid_between=date_ranges.normal,
+        transaction=unapproved_transaction,
+    )
+
+    assert business_rules.ON4(order_number.transaction).validate(order_number) is None
+
+
+def test_ON4_fail(date_ranges, approved_transaction, unapproved_transaction):
+    order_number = factories.QuotaOrderNumberFactory.create(
+        valid_between=date_ranges.normal,
+        transaction=approved_transaction,
+        origin=None,
+    )
+
+    with pytest.raises(BusinessRuleViolation):
+        business_rules.ON4(order_number.transaction).validate(order_number)
+
+
 def test_ON5(date_ranges, approved_transaction, unapproved_transaction):
     """There may be no overlap in time of two quota order number origins with
     the same quota order number SID and geographical area id."""


### PR DESCRIPTION
updated ME6 business rule to prevent nulls

# TP2000-558

## Why
ON4 was missing and has caused issues historically
ME6 (based on taric spec) A measure must be linked to a good id, but we have 300k of unlinked measures. This is an attempt to stop this happening going forward, then we can tidy up the historic issues

## What
Added ON4 business rule
updated ME6 business rule to prevent nulls

