### PR TITLE
TP2000-574 correctly format workbasket removal confirmation page next actions

### DIFF
--- a/workbaskets/jinja2/workbaskets/delete_changes_confirm.jinja
+++ b/workbaskets/jinja2/workbaskets/delete_changes_confirm.jinja
@@ -1,6 +1,7 @@
 {% extends "layouts/layout.jinja" %}
 
 {% from "components/panel/macro.njk" import govukPanel %}
+{% from "components/button/macro.njk" import govukButton %}
 
 {% set page_title = "Remove tariff changes" %}
 
@@ -22,9 +23,16 @@
       "classes": "govuk-!-margin-bottom-7"
     }) }}
 
-    <p class="govuk-body">
+    {% if request.session.workbasket %}
+    {{ govukButton({
+      "text": "Go to your tariff changes",
+      "href": url("workbaskets:workbasket-ui-detail", args=[request.session.workbasket.id]),
+      "classes": "govuk-button--secondary"
+    }) }}
+    {% endif %}
+    <ul class="govuk-list govuk-list-spaced">
       {% include "includes/common/main-menu-link.jinja" %}
-    </p>
+    </ul>
   </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
# TP2000-574 format confirmation next actions
<!---
 * Include the JIRA ticket number, eg TP-123, to automatically link.
 * Use 50 characters maximum.
 * Do not end with a full-stop.
--->

## Why
<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Use as many lines as you like.
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions or deliberately ignored edge-cases.
--->
Next Actions at the bottom of the confirmation page (displayed after removing items from a workbasket) isn't complete or formatted correctly.
![image](https://user-images.githubusercontent.com/85895113/198013208-b0284fbe-78a5-43a4-9f43-f75dc41ed710.png)

## What
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Explain like I'm 5.
 * Use pictures if you can.
--->
Make next actions consistent with other parts of the application.
![image](https://user-images.githubusercontent.com/85895113/198013518-df1c4f6d-cf2b-49f5-a224-983da81f753f.png)

<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
--->
## Checklist
- Requires migrations? No
- Requires dependency updates? No

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
