### PR TITLE
TP2000-576 App info page showing running checks

### DIFF
--- a/common/jinja2/common/app_info.jinja
+++ b/common/jinja2/common/app_info.jinja
@@ -30,8 +30,14 @@
     Active business rule checks
   </h2>
 
+  {% set table_head = [
+      {"text": "Workbasket ID"},
+      {"text": "Time started"},
+      {"text": "Celery task ID"},
+  ] %}
+  {% set table_rows = [] %}
+
   {% if active_checks %}
-    {% set table_rows = [] %}
     {% for check in active_checks %}
       {{ table_rows.append([
           {"text": check.workbasket_id},
@@ -39,16 +45,18 @@
           {"text": check.task_id},
       ]) or "" }}
     {% endfor %}
-    {{ govukTable({
-        "head": [
-            {"text": "Workbasket ID"},
-            {"text": "Time started"},
-            {"text": "Celery task ID"},
-        ],
-        "rows": table_rows
-    }) }}
   {% else %}
-    No active checks
+    {{ table_rows.append([
+      {
+        "text": "No active checks",
+        "colspan": 3,
+      }
+    ]) or "" }}
   {% endif %}
+
+  {{ govukTable({
+      "head": table_head,
+      "rows": table_rows
+  }) }}
 
 {% endblock %}

--- a/common/jinja2/common/app_info.jinja
+++ b/common/jinja2/common/app_info.jinja
@@ -37,21 +37,30 @@
   ] %}
   {% set table_rows = [] %}
 
-  {% if active_checks %}
-    {% for check in active_checks %}
+  {% if celery_healthy %}
+    {% if active_checks %}
+      {% for check in active_checks %}
+        {{ table_rows.append([
+            {"text": check.workbasket_id},
+            {"text": check.date_time_start},
+            {"text": check.task_id},
+        ]) or "" }}
+      {% endfor %}
+    {% else %}
       {{ table_rows.append([
-          {"text": check.workbasket_id},
-          {"text": check.date_time_start},
-          {"text": check.task_id},
+        {
+          "text": "No active checks.",
+          "colspan": 3,
+        }
       ]) or "" }}
-    {% endfor %}
+    {% endif %}
   {% else %}
-    {{ table_rows.append([
-      {
-        "text": "No active checks",
-        "colspan": 3,
-      }
-    ]) or "" }}
+      {{ table_rows.append([
+        {
+          "text": "Business rule check details are currently unavailable.",
+          "colspan": 3,
+        }
+      ]) or "" }}
   {% endif %}
 
   {{ govukTable({

--- a/common/jinja2/common/app_info.jinja
+++ b/common/jinja2/common/app_info.jinja
@@ -1,0 +1,54 @@
+{% extends "layouts/layout.jinja" %}
+
+{% from "components/inset-text/macro.njk" import govukInsetText %}
+{% from "components/table/macro.njk" import govukTable %}
+
+
+{% set page_title = "Application information" %}
+
+{% block breadcrumb %}
+  <div class="govuk-breadcrumbs">
+    <ol class="govuk-breadcrumbs__list">
+      <li class="govuk-breadcrumbs__list-item">
+        <a class="govuk-breadcrumbs__link" href="{{ url('home') }}">Home</a>
+      </li>
+      <li class="govuk-breadcrumbs__list-item">
+        {{ page_title }}
+      </li>
+    </ol>
+  </div>
+{% endblock %}
+
+{% block content %}
+  <h1 class="govuk-heading-xl">
+    {% block page_title %}
+      {{ page_title }}
+    {% endblock %}
+  </h1>
+
+  <h2 class="govuk-heading-m">
+    Active business rule checks
+  </h2>
+
+  {% if active_checks %}
+    {% set table_rows = [] %}
+    {% for check in active_checks %}
+      {{ table_rows.append([
+          {"text": check.workbasket_id},
+          {"text": check.date_time_start},
+          {"text": check.task_id},
+      ]) or "" }}
+    {% endfor %}
+    {{ govukTable({
+        "head": [
+            {"text": "Workbasket ID"},
+            {"text": "Time started"},
+            {"text": "Celery task ID"},
+        ],
+        "rows": table_rows
+    }) }}
+  {% else %}
+    No active checks
+  {% endif %}
+
+{% endblock %}

--- a/common/tests/test_views.py
+++ b/common/tests/test_views.py
@@ -62,3 +62,12 @@ def test_healthcheck_response(response, status_code, status):
     assert payload[0].tag == "status"
     assert payload[0].text == status
     assert payload[1].tag == "response_time"
+
+
+def test_app_info(valid_user_client):
+    response = valid_user_client.get(reverse("app-info"))
+
+    assert response.status_code == 200
+
+    page = BeautifulSoup(str(response.content), "html.parser")
+    assert "Active business rule checks" in page.select("h2")[0].text

--- a/common/urls.py
+++ b/common/urls.py
@@ -16,6 +16,7 @@ register_converter(NumericSIDConverter, "sid")
 urlpatterns = [
     path("", views.HomeView.as_view(), name="home"),
     path("healthcheck", views.healthcheck, name="healthcheck"),
+    path("app-info", views.AppInfoView.as_view(), name="app-info"),
     path("login", views.LoginView.as_view(), name="login"),
     path("logout", views.LogoutView.as_view(), name="logout"),
     path("api-auth/", include("rest_framework.urls")),

--- a/common/views.py
+++ b/common/views.py
@@ -6,6 +6,7 @@ from typing import Tuple
 from typing import Type
 
 import django.contrib.auth.views
+import kombu.exceptions
 from django.conf import settings
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.contrib.auth.mixins import PermissionRequiredMixin
@@ -111,7 +112,6 @@ class AppInfoView(
     def active_checks(self):
         results = []
         inspect = app.control.inspect()
-
         if not inspect:
             return results
 
@@ -142,7 +142,12 @@ class AppInfoView(
 
     def get_context_data(self, **kwargs):
         data = super().get_context_data(**kwargs)
-        data["active_checks"] = self.active_checks()
+        try:
+            data["active_checks"] = self.active_checks()
+            data["celery_healthy"] = True
+        except kombu.exceptions.OperationalError as oe:
+            data["celery_healthy"] = False
+
         return data
 
 

--- a/common/views.py
+++ b/common/views.py
@@ -1,11 +1,13 @@
 """Common views."""
 import time
+from datetime import datetime
 from typing import Optional
 from typing import Tuple
 from typing import Type
 
 import django.contrib.auth.views
 from django.conf import settings
+from django.contrib.auth.mixins import LoginRequiredMixin
 from django.contrib.auth.mixins import PermissionRequiredMixin
 from django.contrib.auth.mixins import UserPassesTestMixin
 from django.core.cache import cache
@@ -19,8 +21,10 @@ from django.http import Http404
 from django.http import HttpResponse
 from django.shortcuts import redirect
 from django.urls import reverse
+from django.utils.timezone import make_aware
 from django.views import generic
 from django.views.generic import FormView
+from django.views.generic import TemplateView
 from django.views.generic.base import View
 from django.views.generic.edit import FormMixin
 from django_filters.views import FilterView
@@ -29,6 +33,7 @@ from redis.exceptions import TimeoutError as RedisTimeoutError
 from common import forms
 from common.business_rules import BusinessRule
 from common.business_rules import BusinessRuleViolation
+from common.celery import app
 from common.models import TrackedModel
 from common.pagination import build_pagination_list
 from common.validators import UpdateType
@@ -95,6 +100,50 @@ def healthcheck(request):
         return response.fail("Redis missing")
 
     return response
+
+
+class AppInfoView(
+    LoginRequiredMixin,
+    TemplateView,
+):
+    template_name = "common/app_info.jinja"
+
+    def active_checks(self):
+        results = []
+        inspect = app.control.inspect()
+
+        if not inspect:
+            return results
+
+        active_tasks = inspect.active()
+        if not active_tasks:
+            return results
+
+        for _, task_info_list in active_tasks.items():
+            for task_info in task_info_list:
+                if (
+                    task_info.get("name")
+                    == "workbaskets.tasks.call_check_workbasket_sync"
+                ):
+                    date_time_start = make_aware(
+                        datetime.fromtimestamp(
+                            task_info.get("time_start"),
+                        ),
+                    ).strftime("%Y-%m-%d, %H:%M:%S")
+                    results.append(
+                        {
+                            "task_id": task_info.get("id"),
+                            "workbasket_id": task_info.get("args", [""])[0],
+                            "date_time_start": date_time_start,
+                        },
+                    )
+
+        return results
+
+    def get_context_data(self, **kwargs):
+        data = super().get_context_data(**kwargs)
+        data["active_checks"] = self.active_checks()
+        return data
 
 
 class LoginView(django.contrib.auth.views.LoginView):

--- a/pii-ner-exclude.txt
+++ b/pii-ner-exclude.txt
@@ -1244,3 +1244,4 @@ https://uktrade.atlassian.net/browse/TP2000-571
 validity.end.date>2023
 Implementing RegulationY-%m-%d
 date_time_start
+Y-%m-%d

--- a/pii-ner-exclude.txt
+++ b/pii-ner-exclude.txt
@@ -1242,4 +1242,5 @@ Exit
 meth:`~workbaskets.models
 https://uktrade.atlassian.net/browse/TP2000-571
 validity.end.date>2023
-Implementing Regulation
+Implementing RegulationY-%m-%d
+date_time_start


### PR DESCRIPTION
# TP2000-576 App info page showing running checks
<!---
 * Include the JIRA ticket number, eg TP-123, to automatically link.
 * Use 50 characters maximum.
 * Do not end with a full-stop.
--->

## Why
<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Use as many lines as you like.
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions or deliberately ignored edge-cases.
--->
Business rule checks are currently only visible from the workbasket running a specific check - whether in the main UI or the Django admin site. Users currently get the information via an unreliable out-of-band means - usually asking in a Teams channel if anyone is running rules checks.

## What
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Explain like I'm 5.
 * Use pictures if you can.
--->
This PR provides an application-wide view of which workbaskets currently have actively executing business rules checks. Information present on the view:

- WorkBasket ID.
- Rule check start time.
- Celery task ID (used to run the check - useful for debug and investigation).

The view is available on the system-wide route path, `/app-info`, and is restricted to logged in users only.

No checks running:
![image](https://user-images.githubusercontent.com/85895113/198307073-bc0dc8ed-bf7a-4951-98ba-48fd187c741a.png)

One active check executing:
![image](https://user-images.githubusercontent.com/85895113/198306607-3d3eb987-22f4-4018-a248-fa4b35ae180a.png)

<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
--->
## Checklist
- Requires migrations? No
- Requires dependency updates? No

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
