### PR TITLE
TP2000-508 multiple measures delete

### DIFF
--- a/measures/jinja2/includes/measures/list.jinja
+++ b/measures/jinja2/includes/measures/list.jinja
@@ -1,41 +1,92 @@
 {% from 'macros/create_link.jinja' import create_link %} 
 {% from "includes/measures/conditions.jinja" import conditions_list %}
+{% from "components/button/macro.njk" import govukButton %}
 
-{% set table_rows = [] %}
-{% for measure in object_list %}
-  {% set measure_link -%}
-    <a class="govuk-link govuk-!-font-weight-bold" href="{{ measure.get_url() }}">{{measure.sid}}</a>
-  {%- endset %}
-  {% set footnotes %}
-    {% for footnote in measure.footnotes.all() %}
-        {{ create_link(footnote.get_url(), footnote|string) }}{{ ", " if not loop.last else "" }}
-    {% endfor %}
-  {% endset %}
-  {{ table_rows.append([
-    {"html": measure_link},
-    {"text": measure.measure_type.sid ~ " - " ~ measure.measure_type.description},
-    {"text": measure.goods_nomenclature.item_id|wordwrap(2)|replace("\n", " ") if measure.goods_nomenclature else '-', "classes": "govuk-!-width-one-eighth"},
-    {"text": measure.duty_sentence if measure.duty_sentence else '-'},
-    {"html": create_link(url("additional_code-ui-detail", kwargs={"sid": measure.additional_code.sid}), measure.additional_code.type.sid ~ measure.additional_code.code) if measure.additional_code else '-'},
-    {"html": create_link(url("geo_area-ui-detail", kwargs={"sid": measure.geographical_area.sid}), measure.geographical_area.area_id ~ " - " ~ measure.geographical_area.get_description().description) if measure.geographical_area else '-'},
-    {"text": create_link(measure.order_number.get_url(), measure.order_number.order_number) if measure.order_number else '-'},
-    {"text": footnotes if measure.footnotes.all() else '-'},
-    {"text": conditions_list(measure) if measure.conditions.latest_approved() else "-", "classes": "govuk-!-width-one-quarter"},
-  ]) or "" }}
-{% endfor %}
+{# Sets out checkbox #}
+{% macro checkbox_item(field) -%}
+  {% set id = field.id_for_label %}
+  {% set name = field.name %}
+  {% set checked = "checked" if field.value() else "" %}
+  <div class="govuk-form-group">
+    <fieldset class="govuk-fieldset">
+      <div class="govuk-checkboxes govuk-checkboxes--small" data-module="govuk-checkboxes">
+        <div class="govuk-checkboxes__item">
+          <input class="govuk-checkboxes__input" id="{{ id }}" name="{{ name }}" type="checkbox" {{ checked }} data-check-trackedmodel>
+          <label class="govuk-label govuk-checkboxes__label" for="{{ id }}"></label>
+        </div>
+      </div>
+    </fieldset>
+  </div>
+{%- endmacro %}
 
-{{ govukTable({
-  "head": [
-    {"text": "ID"},
-    {"text": "Type"},
-    {"text": "Commodity code"},
-    {"text": "Duties"},
-    {"text": "Additional code"},
-    {"text": "Geographical area"},
-    {"text": "Quota"},
-    {"text": "Footnote"},
-    {"text": "Conditions"},
-  ],
-  "rows": table_rows,
-  "classes": "govuk-table-m"
-}) }}
+{# Sets out checking all checkbox #}
+{% set checkbox_check_all -%}
+  <div class="govuk-form-group">
+    <fieldset class="govuk-fieldset">
+      <div class="govuk-checkboxes govuk-checkboxes--small">
+        <div class="govuk-checkboxes__item">
+          <input class="govuk-checkboxes__input" id="select-all" name="select-all" type="checkbox" data-check-all="data-check-trackedmodel">
+          <label class="govuk-label govuk-checkboxes__label govuk-!-padding-right-0" for="selected"></label>
+        </div>
+      </div>
+    </fieldset>
+  </div>
+{%- endset %}
+
+{# sets out form #}
+<form method="post">
+  <input type="hidden" name="csrfmiddlewaretoken" value="{{ csrf_token }}">
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+      {% if form.fields %}
+        {% set table_rows = [] %}
+        {% for field in form %}
+          {% set checkbox = checkbox_item(field) %}
+          {% set measure = field.field.obj %}
+            {% set measure_link -%}
+              <a class="govuk-link govuk-!-font-weight-bold" href="{{ measure.get_url() }}">{{measure.sid}}</a>
+            {%- endset %}
+            {% set footnotes %}
+              {% for footnote in measure.footnotes.all() %}
+                  {{ create_link(footnote.get_url(), footnote|string) }}{{ ", " if not loop.last else "" }}
+              {% endfor %}
+            {% endset %}
+            {{ table_rows.append([
+              {"html": checkbox},
+              {"html": measure_link},
+              {"text": measure.measure_type.sid ~ " - " ~ measure.measure_type.description},
+              {"text": measure.goods_nomenclature.item_id|wordwrap(2)|replace("\n", " ") if measure.goods_nomenclature else '-', "classes": "govuk-!-width-one-eighth"},
+              {"text": "{:%d %b %Y}".format(measure.effective_valid_between.lower)},
+              {"text": "{:%d %b %Y}".format(measure.effective_valid_between.upper)},
+              {"text": measure.duty_sentence if measure.duty_sentence else '-'},
+              {"html": create_link(url("additional_code-ui-detail", kwargs={"sid": measure.additional_code.sid}), measure.additional_code.type.sid ~ measure.additional_code.code) if measure.additional_code else '-'},
+              {"html": create_link(url("geo_area-ui-detail", kwargs={"sid": measure.geographical_area.sid}), measure.geographical_area.area_id ~ " - " ~ measure.geographical_area.get_description().description) if measure.geographical_area else '-'},
+              {"text": create_link(measure.order_number.get_url(), measure.order_number.order_number) if measure.order_number else '-'},
+              {"text": footnotes if measure.footnotes.all() else '-'},
+              {"text": conditions_list(measure) if measure.conditions.latest_approved() else "-", "classes": "govuk-!-width-one-quarter"},
+            ]) or "" }}
+        {% endfor %}
+        {{ govukTable({
+          "head": [
+            {"html": checkbox_check_all},
+            {"text": "ID"},
+            {"text": "Type"},
+            {"text": "Commodity code"},
+            {"text": "Start date"},
+            {"text": "End date"},
+            {"text": "Duties"},
+            {"text": "Additional code"},
+            {"text": "Geographical area"},
+            {"text": "Quota"},
+            {"text": "Footnote"},
+            {"text": "Conditions"},
+          ],
+          "rows": table_rows,
+          "classes": "govuk-table-m"
+        }) }}
+      {% endif %}
+    </div>
+  </div>
+  <button value="remove-selected" name="form-action" class="govuk-button govuk-button--secondary" data-module="govuk-button">Delete selected measures </button>
+</form>

--- a/measures/jinja2/includes/measures/list.jinja
+++ b/measures/jinja2/includes/measures/list.jinja
@@ -52,22 +52,20 @@
                   {{ create_link(footnote.get_url(), footnote|string) }}{{ ", " if not loop.last else "" }}
               {% endfor %}
             {% endset %}
-            {%if table_rows%}
               {{ table_rows.append([
                 {"html": checkbox},
                 {"html": measure_link},
                 {"text": measure.measure_type.sid ~ " - " ~ measure.measure_type.description},
                 {"text": measure.goods_nomenclature.item_id|wordwrap(2)|replace("\n", " ") if measure.goods_nomenclature else '-', "classes": "govuk-!-width-one-eighth"},
-                {"text": "{:%d %b %Y}".format(measure.effective_valid_between.lower)},
-                {"text": "{:%d %b %Y}".format(measure.effective_valid_between.upper)},
+                {"text": "{:%d %b %Y}".format(measure.effective_valid_between.lower) if measure.effective_valid_between.lower else '-' },
+                {"text": "{:%d %b %Y}".format(measure.effective_valid_between.upper) if measure.effective_valid_between.upper else '-' },
                 {"text": measure.duty_sentence if measure.duty_sentence else '-'},
                 {"html": create_link(url("additional_code-ui-detail", kwargs={"sid": measure.additional_code.sid}), measure.additional_code.type.sid ~ measure.additional_code.code) if measure.additional_code else '-'},
                 {"html": create_link(url("geo_area-ui-detail", kwargs={"sid": measure.geographical_area.sid}), measure.geographical_area.area_id ~ " - " ~ measure.geographical_area.get_description().description) if measure.geographical_area else '-'},
                 {"text": create_link(measure.order_number.get_url(), measure.order_number.order_number) if measure.order_number else '-'},
                 {"text": footnotes if measure.footnotes.all() else '-'},
                 {"text": conditions_list(measure) if measure.conditions.latest_approved() else "-", "classes": "govuk-!-width-one-quarter"},
-              ]) or "" }}
-            {% endif %}  
+              ]) or "" }} 
           {% endfor %}
         {{ govukTable({
           "head": [

--- a/measures/jinja2/includes/measures/list.jinja
+++ b/measures/jinja2/includes/measures/list.jinja
@@ -52,21 +52,23 @@
                   {{ create_link(footnote.get_url(), footnote|string) }}{{ ", " if not loop.last else "" }}
               {% endfor %}
             {% endset %}
-            {{ table_rows.append([
-              {"html": checkbox},
-              {"html": measure_link},
-              {"text": measure.measure_type.sid ~ " - " ~ measure.measure_type.description},
-              {"text": measure.goods_nomenclature.item_id|wordwrap(2)|replace("\n", " ") if measure.goods_nomenclature else '-', "classes": "govuk-!-width-one-eighth"},
-              {"text": "{:%d %b %Y}".format(measure.effective_valid_between.lower)},
-              {"text": "{:%d %b %Y}".format(measure.effective_valid_between.upper)},
-              {"text": measure.duty_sentence if measure.duty_sentence else '-'},
-              {"html": create_link(url("additional_code-ui-detail", kwargs={"sid": measure.additional_code.sid}), measure.additional_code.type.sid ~ measure.additional_code.code) if measure.additional_code else '-'},
-              {"html": create_link(url("geo_area-ui-detail", kwargs={"sid": measure.geographical_area.sid}), measure.geographical_area.area_id ~ " - " ~ measure.geographical_area.get_description().description) if measure.geographical_area else '-'},
-              {"text": create_link(measure.order_number.get_url(), measure.order_number.order_number) if measure.order_number else '-'},
-              {"text": footnotes if measure.footnotes.all() else '-'},
-              {"text": conditions_list(measure) if measure.conditions.latest_approved() else "-", "classes": "govuk-!-width-one-quarter"},
-            ]) or "" }}
-        {% endfor %}
+            {%if table_rows%}
+              {{ table_rows.append([
+                {"html": checkbox},
+                {"html": measure_link},
+                {"text": measure.measure_type.sid ~ " - " ~ measure.measure_type.description},
+                {"text": measure.goods_nomenclature.item_id|wordwrap(2)|replace("\n", " ") if measure.goods_nomenclature else '-', "classes": "govuk-!-width-one-eighth"},
+                {"text": "{:%d %b %Y}".format(measure.effective_valid_between.lower)},
+                {"text": "{:%d %b %Y}".format(measure.effective_valid_between.upper)},
+                {"text": measure.duty_sentence if measure.duty_sentence else '-'},
+                {"html": create_link(url("additional_code-ui-detail", kwargs={"sid": measure.additional_code.sid}), measure.additional_code.type.sid ~ measure.additional_code.code) if measure.additional_code else '-'},
+                {"html": create_link(url("geo_area-ui-detail", kwargs={"sid": measure.geographical_area.sid}), measure.geographical_area.area_id ~ " - " ~ measure.geographical_area.get_description().description) if measure.geographical_area else '-'},
+                {"text": create_link(measure.order_number.get_url(), measure.order_number.order_number) if measure.order_number else '-'},
+                {"text": footnotes if measure.footnotes.all() else '-'},
+                {"text": conditions_list(measure) if measure.conditions.latest_approved() else "-", "classes": "govuk-!-width-one-quarter"},
+              ]) or "" }}
+            {% endif %}  
+          {% endfor %}
         {{ govukTable({
           "head": [
             {"html": checkbox_check_all},

--- a/measures/jinja2/measures/delete-multiple-measures.jinja
+++ b/measures/jinja2/measures/delete-multiple-measures.jinja
@@ -3,12 +3,23 @@
 {% from "components/button/macro.njk" import govukButton %}
 {% from "components/warning-text/macro.njk" import govukWarningText %}
 {% from "components/inset-text/macro.njk" import govukInsetText %}
+{% from "components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
 
 {% from 'macros/create_link.jinja' import create_link %} 
 {% from "includes/measures/conditions.jinja" import conditions_list %}
 {% from "components/table/macro.njk" import govukTable %}
 
 {% set page_title = "Delete measures" %}
+
+{% block breadcrumb %}
+  {{ govukBreadcrumbs({
+    "items": [
+      {"text": "Home", "href": url("home")},
+      {"text": "Find and edit measures", "href": url("measure-ui-list")},
+      {"text": page_title}
+    ]
+  }) }}
+{% endblock %}
 
 {% block content %}
   <div class="govuk-grid-row">

--- a/measures/jinja2/measures/delete-multiple-measures.jinja
+++ b/measures/jinja2/measures/delete-multiple-measures.jinja
@@ -40,10 +40,8 @@
       }) }}
       <p class="govuk-body govuk-!-font-weight-bold" style="padding-left: 45px;">Check your selected measures meet this criteria before pressing "Delete Measures" as it could prevent the correct measure from being used.</p>
       <div class="govuk-inset-text">
-        Your deleted measures will be added to your work basket as items.
-        <br>
-        <br>
-        If you need to undo your deletions later, you will need to remove the items from the workbasket.
+        <p>Your deleted measures will be added to your work basket as items.</p>
+        <p>If you need to undo your deletions later, you will need to remove the items from the workbasket.</p>
       </div>
 
       <form method="post">

--- a/measures/jinja2/measures/delete-multiple-measures.jinja
+++ b/measures/jinja2/measures/delete-multiple-measures.jinja
@@ -1,0 +1,129 @@
+{% extends "layouts/layout.jinja" %}
+
+{% from "components/button/macro.njk" import govukButton %}
+{% from "components/warning-text/macro.njk" import govukWarningText %}
+{% from "components/inset-text/macro.njk" import govukInsetText %}
+
+{% from 'macros/create_link.jinja' import create_link %} 
+{% from "includes/measures/conditions.jinja" import conditions_list %}
+{% from "components/table/macro.njk" import govukTable %}
+
+{% set page_title = "Delete measures" %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-xl">
+        Delete measures
+        <span class="govuk-caption-xl"></span>
+      </h1>
+    </div>
+  </div>
+
+  <div class="govuk-grid-row govuk-!-margin-bottom-5">
+    <div class="govuk-grid-column-two-thirds">
+      <p class="govuk-body"> You are about to delete your selected measures.</p>
+      {{ govukWarningText({
+        "text": "You should only delete a measure if end dating the measure isn't appropriate.",
+        "iconFallbackText": "Warning"
+      }) }}
+      <p class="govuk-body govuk-!-font-weight-bold" style="padding-left: 45px;">Check your selected measures meet this criteria before pressing "Delete Measures" as it could prevent the correct measure from being used.</p>
+      <div class="govuk-inset-text">
+        Your deleted measures will be added to your work basket as items.
+        <br>
+        <br>
+        If you need to undo your deletions later, you will need to remove the items from the workbasket.
+      </div>
+
+      <form method="post">
+        <input type="hidden" name="csrfmiddlewaretoken" value="{{ csrf_token }}">
+
+        <div class="govuk-button-group">
+           {{ govukButton({
+            "text": "Back",
+            "classes": "govuk-button--secondary",
+            "name": "action",
+            "value": "cancel",
+            "href": url("measure-ui-list")
+          }) }}
+          {% if object_list %}
+            {{ govukButton({
+              "text": "Delete measures",
+              "classes": "govuk-button--warning",
+              "name": "action",
+              "value": "delete"
+            }) }}
+          
+          {% else %}
+            {{ govukButton({
+              "text": "Delete measures",
+              "classes": "govuk-button--warning",
+              "name": "action",
+              "value": "delete",
+              "disabled": "true"
+            }) }}
+          {% endif %}
+        </div>
+      </form>
+    </div>
+  </div>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full"></div>
+      <details class="govuk-details" data-module="govuk-details">
+        <summary class="govuk-details__summary">
+          <span class="govuk-details__summary-text">
+            View all selected measures
+          </span>
+        </summary>
+        <div class="govuk-details__text">
+          {% if object_list %}
+
+            {% set table_rows = [] %}
+            {% for measure in object_list %}
+                {% set measure_link -%}
+                  <a class="govuk-link govuk-!-font-weight-bold" href="{{ measure.get_url() }}">{{measure.sid}}</a>
+                {%- endset %}
+                {% set footnotes %}
+                  {% for footnote in measure.footnotes.all() %}
+                      {{ create_link(footnote.get_url(), footnote|string) }}{{ ", " if not loop.last else "" }}
+                  {% endfor %}
+                {% endset %}
+
+                {{ table_rows.append([
+                  {"html": measure_link},
+                  {"text": measure.measure_type.sid ~ " - " ~ measure.measure_type.description},
+                  {"text": measure.goods_nomenclature.item_id|wordwrap(2)|replace("\n", " ") if measure.goods_nomenclature else '-', "classes": "govuk-!-width-one-eighth"},
+                  {"text": "{:%d %b %Y}".format(measure.effective_valid_between.lower)},
+                  {"text": "{:%d %b %Y}".format(measure.effective_valid_between.upper)},
+                  {"text": measure.duty_sentence if measure.duty_sentence else '-'},
+                  {"html": create_link(url("additional_code-ui-detail", kwargs={"sid": measure.additional_code.sid}), measure.additional_code.type.sid ~ measure.additional_code.code) if measure.additional_code else '-'},
+                  {"html": create_link(url("geo_area-ui-detail", kwargs={"sid": measure.geographical_area.sid}), measure.geographical_area.area_id ~ " - " ~ measure.geographical_area.get_description().description) if measure.geographical_area else '-'},
+                  {"text": create_link(measure.order_number.get_url(), measure.order_number.order_number) if measure.order_number else '-'},
+                  {"text": footnotes if measure.footnotes.all() else '-'},
+                ]) or "" }}
+            {% endfor %}
+            {{ govukTable({
+              "head": [
+                {"text": "ID"},
+                {"text": "Type"},
+                {"text": "Commodity code"},
+                {"text": "Start date"},
+                {"text": "End date"},
+                {"text": "Duties"},
+                {"text": "Additional code"},
+                {"text": "Geographical area"},
+                {"text": "Quota"},
+                {"text": "Footnote"},
+              ],
+              "rows": table_rows,
+              "classes": "govuk-table-m"
+            }) }}
+
+          {% endif %}
+        </div>
+      </details>
+    </div>
+  </div>
+
+{% endblock %}

--- a/measures/jinja2/measures/delete-multiple-measures.jinja
+++ b/measures/jinja2/measures/delete-multiple-measures.jinja
@@ -78,7 +78,6 @@
         </summary>
         <div class="govuk-details__text">
           {% if object_list %}
-
             {% set table_rows = [] %}
             {% for measure in object_list %}
                 {% set measure_link -%}
@@ -89,13 +88,12 @@
                       {{ create_link(footnote.get_url(), footnote|string) }}{{ ", " if not loop.last else "" }}
                   {% endfor %}
                 {% endset %}
-
                 {{ table_rows.append([
                   {"html": measure_link},
                   {"text": measure.measure_type.sid ~ " - " ~ measure.measure_type.description},
                   {"text": measure.goods_nomenclature.item_id|wordwrap(2)|replace("\n", " ") if measure.goods_nomenclature else '-', "classes": "govuk-!-width-one-eighth"},
-                  {"text": "{:%d %b %Y}".format(measure.effective_valid_between.lower)},
-                  {"text": "{:%d %b %Y}".format(measure.effective_valid_between.upper)},
+                  {"text": "{:%d %b %Y}".format(measure.effective_valid_between.lower) if measure.effective_valid_between.lower else '-'},
+                  {"text": "{:%d %b %Y}".format(measure.effective_valid_between.upper) if measure.effective_valid_between.upper else '-'},
                   {"text": measure.duty_sentence if measure.duty_sentence else '-'},
                   {"html": create_link(url("additional_code-ui-detail", kwargs={"sid": measure.additional_code.sid}), measure.additional_code.type.sid ~ measure.additional_code.code) if measure.additional_code else '-'},
                   {"html": create_link(url("geo_area-ui-detail", kwargs={"sid": measure.geographical_area.sid}), measure.geographical_area.area_id ~ " - " ~ measure.geographical_area.get_description().description) if measure.geographical_area else '-'},

--- a/measures/tests/test_views.py
+++ b/measures/tests/test_views.py
@@ -194,7 +194,7 @@ def test_multiple_measure_delete_template(client, valid_user, session_workbasket
 
     # grab the whole measure objects for our pk's we've got in the session, so we can compare attributes.
     selected_measures = Measure.objects.filter(
-        pk__in=[key for key in session["DELETE_MEASURE_SELECTIONS"].items()],
+        pk__in=session["DELETE_MEASURE_SELECTIONS"].keys(),
     )
 
     # Get the measure ids that are being shown in the table in the template.

--- a/measures/tests/test_views.py
+++ b/measures/tests/test_views.py
@@ -114,8 +114,8 @@ def test_measure_delete(use_delete_form):
     use_delete_form(factories.MeasureFactory())
 
 
-def test_multiple_measure_delete(client, valid_user, session_workbasket):
-    """Tests that MultipleMeasureDelete view's Post function takes a list of
+def test_multiple_measure_delete_functionality(client, valid_user, session_workbasket):
+    """Tests that MeasureMultipleDelete view's Post function takes a list of
     measures, and sets their update type to delete, clearing the session once
     completed."""
     measure_1 = factories.MeasureFactory.create()
@@ -153,6 +153,73 @@ def test_multiple_measure_delete(client, valid_user, session_workbasket):
     for measure in workbasket_measures:
         # check that the update type is delete which is 2
         assert measure.update_type == 2
+
+
+def test_multiple_measure_delete_template(client, valid_user, session_workbasket):
+    """Test that valid user receives a 200 on GET for MultipleMeasureDelete and
+    correct measures display in html table."""
+    # Make a bunch of measures
+    measure_1 = factories.MeasureFactory.create()
+    measure_2 = factories.MeasureFactory.create()
+    measure_3 = factories.MeasureFactory.create()
+    measure_4 = factories.MeasureFactory.create()
+    measure_5 = factories.MeasureFactory.create()
+
+    url = reverse("measure-ui-delete-multiple")
+    client.force_login(valid_user)
+    session = client.session
+    session["workbasket"] = {
+        "id": session_workbasket.pk,
+        "status": session_workbasket.status,
+        "title": session_workbasket.title,
+    }
+    # Add some of those measures to the session to replicate them being selected on list page.
+    session.update(
+        {
+            "DELETE_MEASURE_SELECTIONS": {
+                measure_1.pk: True,
+                measure_2.pk: True,
+                measure_3.pk: True,
+            },
+        },
+    )
+    session.save()
+    url = reverse("measure-ui-delete-multiple")
+    response = client.get(url)
+
+    assert response.status_code == 200
+
+    soup = BeautifulSoup(str(response.content), "html.parser")
+
+    # grab the whole measure objects for our pk's we've got in the session, so we can compare attributes.
+    selected_measures = Measure.objects.filter(
+        pk__in=[key for key in session["DELETE_MEASURE_SELECTIONS"].items()],
+    )
+
+    # Get the measure ids that are being shown in the table in the template.
+    measure_ids_in_table = [e.text for e in soup.select("table tr td:first-child")]
+
+    # Get the sids for the measures we selected, as these are what are shown in the template.
+    selected_measures_ids = [str(measure.sid) for measure in selected_measures]
+
+    assert measure_ids_in_table == selected_measures_ids
+    assert set(measure_ids_in_table).difference([measure_4.sid, measure_5.sid])
+
+    # 4th column is start date
+    start_dates_in_table = {e.text for e in soup.select("table tr td:nth-child(4)")}
+    measure_start_dates = {
+        f"{m.valid_between.lower:%d %b %Y}" for m in selected_measures
+    }
+    assert not measure_start_dates.difference(start_dates_in_table)
+
+    # 5th column is end date
+    end_dates_in_table = {e.text for e in soup.select("table tr td:nth-child(5)")}
+    measure_end_dates = {
+        f"{m.effective_end_date:%d %b %Y}"
+        for m in selected_measures
+        if m.effective_end_date
+    }
+    assert not measure_end_dates.difference(end_dates_in_table)
 
 
 @pytest.mark.parametrize(

--- a/measures/tests/test_views.py
+++ b/measures/tests/test_views.py
@@ -163,22 +163,18 @@ def test_multiple_measure_delete_template(client, valid_user, session_workbasket
     url = reverse("measure-ui-delete-multiple")
     client.force_login(valid_user)
     session = client.session
+    # Add a workbasket to the session, and add some selected measures to it.
     session["workbasket"] = {
         "id": session_workbasket.pk,
         "status": session_workbasket.status,
         "title": session_workbasket.title,
-    }
-    # Add some of those measures to the session to replicate them being selected on list page.
-    session.update(
-        {
-            "DELETE_MEASURE_SELECTIONS": {
-                measure_1.pk: True,
-                measure_2.pk: True,
-                measure_3.pk: True,
-            },
+        "DELETE_MEASURE_SELECTIONS": {
+            measure_1.pk: True,
+            measure_2.pk: True,
+            measure_3.pk: True,
         },
-    )
-    session.save()
+    }
+
     url = reverse("measure-ui-delete-multiple")
     response = client.get(url)
 

--- a/measures/tests/test_views.py
+++ b/measures/tests/test_views.py
@@ -125,16 +125,21 @@ def test_multiple_measure_delete_functionality(client, valid_user, session_workb
     url = reverse("measure-ui-delete-multiple")
     client.force_login(valid_user)
     session = client.session
-    session["workbasket"] = {
-        "id": session_workbasket.pk,
-        "status": session_workbasket.status,
-        "title": session_workbasket.title,
-        "DELETE_MEASURE_SELECTIONS": {
-            measure_1.pk: True,
-            measure_2.pk: True,
-            measure_3.pk: True,
+    session.update(
+        {
+            "workbasket": {
+                "id": session_workbasket.pk,
+                "status": session_workbasket.status,
+                "title": session_workbasket.title,
+            },
+            "DELETE_MEASURE_SELECTIONS": {
+                measure_1.pk: True,
+                measure_2.pk: True,
+                measure_3.pk: True,
+            },
         },
-    }
+    )
+    session.save()
     post_data = {"action": "delete"}
     response = client.post(url, data=post_data)
 
@@ -164,16 +169,21 @@ def test_multiple_measure_delete_template(client, valid_user, session_workbasket
     client.force_login(valid_user)
     session = client.session
     # Add a workbasket to the session, and add some selected measures to it.
-    session["workbasket"] = {
-        "id": session_workbasket.pk,
-        "status": session_workbasket.status,
-        "title": session_workbasket.title,
-        "DELETE_MEASURE_SELECTIONS": {
-            measure_1.pk: True,
-            measure_2.pk: True,
-            measure_3.pk: True,
+    session.update(
+        {
+            "workbasket": {
+                "id": session_workbasket.pk,
+                "status": session_workbasket.status,
+                "title": session_workbasket.title,
+            },
+            "DELETE_MEASURE_SELECTIONS": {
+                measure_1.pk: True,
+                measure_2.pk: True,
+                measure_3.pk: True,
+            },
         },
-    }
+    )
+    session.save()
 
     url = reverse("measure-ui-delete-multiple")
     response = client.get(url)

--- a/measures/tests/test_views.py
+++ b/measures/tests/test_views.py
@@ -129,17 +129,12 @@ def test_multiple_measure_delete_functionality(client, valid_user, session_workb
         "id": session_workbasket.pk,
         "status": session_workbasket.status,
         "title": session_workbasket.title,
-    }
-    session.update(
-        {
-            "DELETE_MEASURE_SELECTIONS": {
-                measure_1.pk: True,
-                measure_2.pk: True,
-                measure_3.pk: True,
-            },
+        "DELETE_MEASURE_SELECTIONS": {
+            measure_1.pk: True,
+            measure_2.pk: True,
+            measure_3.pk: True,
         },
-    )
-    session.save()
+    }
     post_data = {"action": "delete"}
     response = client.post(url, data=post_data)
 

--- a/measures/urls.py
+++ b/measures/urls.py
@@ -20,6 +20,11 @@ ui_patterns = [
         name="measure-ui-create",
     ),
     path(
+        "delete-multiple-measures/",
+        views.MeasureMultipleDelete.as_view(),
+        name="measure-ui-delete-multiple",
+    ),
+    path(
         "create/<step>/",
         views.MeasureCreateWizard.as_view(
             url_name="measure-ui-create",

--- a/measures/views.py
+++ b/measures/views.py
@@ -584,16 +584,6 @@ class MeasureMultipleDelete(TemplateView, ListView):
 
     template_name = "measures/delete-multiple-measures.jinja"
 
-    def _workbasket(self):
-        """Get the current workbasket that is in session."""
-
-        try:
-            session_workbasket = self.request.session._session["workbasket"]
-            workbasket = WorkBasket.objects.get(pk=session_workbasket["id"])
-        except WorkBasket.DoesNotExist:
-            workbasket = WorkBasket.objects.none()
-        return workbasket
-
     def _session_store(self):
         """Get the session store to store the measures that will be deleted."""
 
@@ -619,17 +609,12 @@ class MeasureMultipleDelete(TemplateView, ListView):
             # The user has cancelled out of the deletion process.
             return redirect("home")
 
-        # By reverse ordering on record_code + subrecord_code we're able to
-        # delete child entities first, avoiding protected foreign key
-        # violations.
         object_list = self.get_queryset()
-        # To do - figure out how to get record_ordering and reverse to work when added to this chain. Quotaset error.
-        # .record_ordering().reverse()
 
         for obj in object_list:
             # make a new version of the object with an update type of delete.
             obj.new_version(
-                workbasket=self._workbasket(),
+                workbasket=WorkBasket.current(),
                 update_type=UpdateType.DELETE,
             )
         session_store = self._session_store()

--- a/measures/views.py
+++ b/measures/views.py
@@ -8,9 +8,13 @@ from django.db.transaction import atomic
 from django.http import HttpRequest
 from django.http import HttpResponse
 from django.http import HttpResponseRedirect
+from django.shortcuts import redirect
 from django.shortcuts import render
 from django.utils.decorators import method_decorator
 from django.views import View
+from django.views.generic.base import TemplateView
+from django.views.generic.edit import FormView
+from django.views.generic.list import ListView
 from formtools.wizard.views import NamedUrlSessionWizardView
 from rest_framework import viewsets
 from rest_framework.reverse import reverse
@@ -31,7 +35,9 @@ from measures.models import MeasureType
 from measures.pagination import MeasurePaginator
 from measures.parsers import DutySentenceParser
 from measures.patterns import MeasureCreationPattern
+from workbaskets.forms import SelectableObjectsForm
 from workbaskets.models import WorkBasket
+from workbaskets.session_store import SessionStore
 from workbaskets.views.decorators import require_current_workbasket
 from workbaskets.views.generic import CreateTaricDeleteView
 from workbaskets.views.generic import CreateTaricUpdateView
@@ -59,12 +65,46 @@ class MeasureMixin:
         return Measure.objects.approved_up_to_transaction(tx)
 
 
-class MeasureList(MeasureMixin, TamatoListView):
+class MeasureList(MeasureMixin, FormView, TamatoListView):
     """UI endpoint for viewing and filtering Measures."""
 
-    paginator_class = MeasurePaginator
     template_name = "measures/list.jinja"
     filterset_class = MeasureFilter
+    form_class = SelectableObjectsForm
+
+    def get_form_kwargs(self):
+        kwargs = super().get_form_kwargs()
+        page = self.paginator.get_page(self.request.GET.get("page", 1))
+        kwargs["objects"] = page.object_list
+        return kwargs
+
+    @property
+    def paginator(self):
+        filterset_class = self.get_filterset_class()
+        self.filterset = self.get_filterset(filterset_class)
+        return MeasurePaginator(self.filterset.qs, per_page=10)
+
+    def form_valid(self, form):
+        store = SessionStore(
+            self.request,
+            "DELETE_MEASURE_SELECTIONS",
+        )
+        # clear the store here before adding items
+        # in case there was a previous form in progress that was abandoned
+        store.clear()
+        # If the user selects all, adds all the measures to the store
+        select_all = self.request.POST.get("select-all-pages")
+        if select_all:
+            object_pks = {key: True for key, value in form.fields if value}
+            store.add_items(object_pks)
+        else:
+            object_pks = {
+                key: True for key, value in form.cleaned_data_no_prefix.items() if value
+            }
+            store.add_items(object_pks)
+
+        url = reverse("measure-ui-delete-multiple")
+        return HttpResponseRedirect(url)
 
 
 class MeasureDetail(MeasureMixin, TrackedModelDetailView):
@@ -537,3 +577,62 @@ class MeasureDelete(
 ):
     form_class = forms.MeasureDeleteForm
     success_path = "list"
+
+
+class MeasureMultipleDelete(TemplateView, ListView):
+    """UI for user review and deletion of multiple Measures."""
+
+    template_name = "measures/delete-multiple-measures.jinja"
+
+    def _workbasket(self):
+        """Get the current workbasket that is in session."""
+
+        try:
+            session_workbasket = self.request.session._session["workbasket"]
+            workbasket = WorkBasket.objects.get(pk=session_workbasket["id"])
+        except WorkBasket.DoesNotExist:
+            workbasket = WorkBasket.objects.none()
+        return workbasket
+
+    def _session_store(self):
+        """Get the session store to store the measures that will be deleted."""
+
+        return SessionStore(
+            self.request,
+            "DELETE_MEASURE_SELECTIONS",
+        )
+
+    def get_queryset(self):
+        """Get the measures that are candidates for deletion."""
+        store = self._session_store()
+        return Measure.objects.filter(pk__in=store.data.keys())
+
+    def get_context_data(self, **kwargs):
+        store_objects = self.get_queryset()
+        self.object_list = store_objects
+        context = super().get_context_data(**kwargs)
+
+        return context
+
+    def post(self, request):
+        if request.POST.get("action", None) != "delete":
+            # The user has cancelled out of the deletion process.
+            return redirect("home")
+
+        # By reverse ordering on record_code + subrecord_code we're able to
+        # delete child entities first, avoiding protected foreign key
+        # violations.
+        object_list = self.get_queryset()
+        # To do - figure out how to get record_ordering and reverse to work when added to this chain. Quotaset error.
+        # .record_ordering().reverse()
+
+        for obj in object_list:
+            # make a new version of the object with an update type of delete.
+            obj.new_version(
+                workbasket=self._workbasket(),
+                update_type=UpdateType.DELETE,
+            )
+        session_store = self._session_store()
+        session_store.clear()
+
+        return redirect(reverse("measure-ui-list"))

--- a/measures/views.py
+++ b/measures/views.py
@@ -82,7 +82,7 @@ class MeasureList(MeasureMixin, FormView, TamatoListView):
     def paginator(self):
         filterset_class = self.get_filterset_class()
         self.filterset = self.get_filterset(filterset_class)
-        return MeasurePaginator(self.filterset.qs, per_page=10)
+        return MeasurePaginator(self.filterset.qs, per_page=20)
 
     def form_valid(self, form):
         store = SessionStore(

--- a/measures/views.py
+++ b/measures/views.py
@@ -614,7 +614,7 @@ class MeasureMultipleDelete(TemplateView, ListView):
         for obj in object_list:
             # make a new version of the object with an update type of delete.
             obj.new_version(
-                workbasket=WorkBasket.current(),
+                workbasket=WorkBasket.current(request),
                 update_type=UpdateType.DELETE,
             )
         session_store = self._session_store()

--- a/pii-ner-exclude.txt
+++ b/pii-ner-exclude.txt
@@ -1,0 +1,1251 @@
+membership.valid_between.upper
+membership.other(object).area_id}
+area.</p
+replaced_goods_nomenclature__sid
+BaseGoodsNomenclatureDescriptionHandler
+sid
+indented_goods_nomenclature_id
+geographical_area_1002
+A ``Checker``
+A ``Checker`` that
+BusinessRule
+Checker
+TrackedModel
+User Group
+VersionGroup
+f"https://legislation.gov.uk/uksi/2021/{n
+UI
+FIXME
+Measure SID
+AdditionalCode
+MeasurementUnit
+rotate(180deg
+model&d
+sort_by(sort_by
+MonetaryUnit
+check_name&d
+f"{c.transaction_check.transaction.created_at:%d
+"Generate a URL to a representation of the model in the webapp
+NM
+kwargs={'wb_pk
+description:</h3
+wb_pk"
+target.quota.definition.sid
+MeasureType
+ImportBatch
+f"{url}?page=2
+f"<pk>/edit/
+BatchDependencies
+Jira
+MeasureActions
+do?{%
+MeasureAction
+Quota
+url('my
+SID
+the Euro ISO
+the Euro Definition
+QAM
+Quota Definitions
+sub_quota
+Ensure a Quota Definition
+KGM
+First Come First Served
+Erga Omnes
+MIT
+Department for International Trade
+https://uktrade.github.io/tamato/docs/
+AssertionError
+DLL
+var/
+PyInstaller
+# Installer
+pip-delete-this-directory.txt
+local_settings.py
+Scrapy
+Sphinx
+PyBuilder
+Jupyter Notebook
+#
+PEP 582
+Celery
+env/
+ENV/
+# Rope
+dmypy.json
+Pyre
+npm-debug.log
+PyCharm
+Y}".format(object.version_group.created_at
+id="id
+name=
+X000
+" BaseHandler Metaclass
+Handler
+ModelSerializer
+The Base
+DependentModelAHandler(BaseHandler
+LinkToModelB
+kargs
+model.identifying_fields
+" Load a given link for a handler
+WorkBasket
+Envelope
+Streaming EnvelopeSerializer
+Transaction Write
+RenderedTransaction
+XSD
+RenderedTransactions
+RenderedEnvelope
+Envelope Too Big: {rendered_envelope.envelope_id
+33 GBP/100kg
+NC000
+000
+IntegerField
+Value
+kwargs["output_field
+current_workbasket_id = Value(transaction.workbasket.id
+CurrentWorkBasketId
+Max
+False) & ~Q(latest
+ModelChoiceField(queryset
+PL/SQL
+nearform
+govukButton
+Queryset
+"Infer the partition of Transactions to REVISION if they are not in the first workbasket
+"Infer the partition of Transactions to DRAFT
+Workbasket
+Create Partition
+SEED / REVISION
+Draft Transactions
+Mixins
+~ described_object._meta.verbose_name ~
+geographical.area.group.sid
+record.taric_template
+Footnote
+li><a
+the Code of Conduct
+the `Contributor Covenant
+XXX
+goods.nomenclature.item.id>
+f'<a class="govuk
+ADR 13
+Assert
+NIG34
+DELETE
+NIG30 / NIG31
+ME88
+Transaction and Workbasket
+SEED_FILE
+TransactionPartition
+TRANSACTION_PARTITION_SCHEMES
+TransactionPartitionScheme
+REVISION
+Withdraw
+CDS S3
+Mark
+-pk
+footnote_detail_tabs
+measure_detail_tabs
+additionalcode
+# Footnote
+Measure
+# Regulation
+checkbox
+the Django Session
+POST
+updated_at
+"Manage POST
+Healthcheck
+URLconf
+ECONOMIC
+ATOMIC
+Economic/Coal
+GSP
+MFN
+EU
+the European Court of Justice
+U' Unilateral
+Import and Export
+the Official Journal
+r"IYY\d{5
+0xA0
+Revision
+TARIC3
+QA3
+B.
+https://uktrade.atlassian.net/browse/TP-851
+TN001
+The Tariff Management Tool
+Guernsey
+a TARIC 3 Full Extraction of the UK
+TARIC3 Differential Extractions
+Jinja2
+HMRC
+HTTP
+API
+DB
+Returns a
+CommodityCode
+chapter 99
+"Returns True
+GoodsNomenclature
+certificate_X000
+Commodity
+HS22 2
+Bootstrapping Implementation ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+CommodityCollection
+CommodityChange
+YY
+Transactions
+New Envelope
+100 kg
+measure_type_series
+export_refund_sid
+name="footnote.description.period.sid
+footnote.description.period.sid
+ADR
+ORM
+Column        | Type                    | Description
+FK
+NULL
+Column      | Type                     | Description
+Boolean
+Object
+Transaction
+WorkBaskets
+TrackedModels
+WorkBasket TrackedModels
+GROUP -%
+description_tab_html
+version_control_tab_html
+measurement_unit_qualifier
+tracked_model_count
+https://www.sphinx-doc.org/en/master/usage/configuration.html
+Tariff Management Tool
+SVG
+GitHub
+Alpha
+Agile
+builtin
+ALTER COLUMN TYPE USING
+Range
+NIG
+Retruns
+ref - https://docs.cloudfoundry.org/devguide/deploy-apps/deploy-app.html
+mkdir -p ~/logs
+FINISHED
+certificates.views
+NIG1
+NIG2
+all_closed_and_span"
+NIG3
+2000000010"
+Export
+r"^[A-Z0-9]$
+r"^[A-Z0-9][A-Z0-9][A-Z0-9]$
+min_length
+goods_nomenclature__item_id
+certificate.description.period.sid
+r"^[A-Z0-9]{3}$
+r"^[A-Z]{3}$
+Harmonised System Chapter
+Harmonised System Heading
+Harmonised System Subheading
+Import/Export
+GA1
+GA3
+"Geographic Areas
+Edit
+Generate incrementing
+Generate iterating DIT
+wb+
+Task to Task
+GUI
+Upload
+MIT License
+Software
+IMPLIED
+DAMAGES
+LIABILITY
+ApplicabilityCode
+NumericSID
+origin__sid
+excluded_geographical_area__sid
+main_quota__sid
+quota_definition__sid
+max_count
+D017
+D018
+XEM
+MIL
+1.230 EUR / kg
+simple_ad_valorem
+Provides
+TTag
+40010
+the XML Schema
+TaricSchemaTags
+condition__sid
+Measure ID"},
+object.measure_type.sid
+Upload Envelope
+s3
+Create Envelope
+EnvelopeTransaction
+x)\n
+regulation_extends_+
+Suspension
+^[A-Z0-9]{2}$|^[A-Z0-9]{4}$
+" Ensure Quota Events of all types output appropriate XML
+Quota Events
+SQLite
+common/common.rst
+footnote.get_description().description|default
+footnote.footnote_type.footnote_type_id
+^12.1.0
+^3.0.0
+^1.1.0
+@types
+0.0.50
+https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.11.1.tgz
+https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.11.1.tgz
+bin
+https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz
+3.5.2
+3.1.2
+node_modules/big.js
+https://registry.npmjs.org/braces/-/braces-3.0.2.tgz
+cli.js
+1.0.30001301
+~4.0.1
+https://registry.npmjs.org/commander/-/commander-2.20.3.tgz
+https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz
+^3.1.0
+fffYD8qWbInZrD0S9ccI6vZclF3DsHE7njGlLtaHbhg==
+https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.8.3.tgz
+https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz
+^4.0.0
+darwin
+^8.16.0 || ^10.6.0 || >=11.0.0
+3.14.0
+https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz
+b5GsnG330uUNgRpu1PA==
+4.0.3
+https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz
+7.0.0
+node_modules/klona
+nanoid
+bin/nanoid.cjs"
+sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==
+^1.0.7
+1.49.0
+klona
+^1.3.0
+a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==
+node_modules/shebang-command
+node_modules/shebang-regex
+https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz
+8.1.1
+^2.20.0
+hDY
+4.9.2
+kMTcxWHcZFPrw/eQuY4Df1TxvIWfWM2x7mRqBQCqKEd96oCUa9jkapLBaFfRce33eGDb4Pr7YQ==
+@discoveryjs
+^5.7.3
+geU/gLr1wDjOhQ+Q==
+https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.3.tgz
+aria-label="Goto Page
+AutocompleteWidget
+Convert
+MeasureCondition
+KeyError
+" Returns True
+" Generate a URL to a representation of the model in the webapp
+param
+"Creates a new TrackedModel
+CDS
+Trade Tariff Management
+TTM
+Metadata
+TaMato
+Find and Edit Measures
+Paginator
+LIMITED_PAGINATOR_MAX_COUNT
+Full Temporary Stop
+Partial Temporary Stop
+Complete Abrogation
+FTS
+TransactionQueryset
+class="button
+workbaskets</button>
+goodsnomenclature_origins_+
+Signed Out" %
+remove_button -%
+name="remove
+quota.suspension.period.sid
+replaced.regulation.role
+record.measure_type_id
+Bird
+Eye View
+HM Government's
+Customs Declaration Services
+border systems
+Caesar and GEMS
+DIT
+Data Workspace
+the European Union
+TARif Intégré Communautaire
+Integrated Tariff
+the European Communities
+ValidityStartMixin`
+Domain Modules
+a Django App
+mod:`quotas
+English
+European
+Framework
+errors.data
+CE2
+^[A-Z0-9]{3}$
+^[A-Z0-9]{1}$
+url_start
+Tamato
+cutoff:%Y-%m-%d
+Construct a POST
+MultiValueWidget
+r"^[A-Z0-9]{2}$|^[A-Z0-9]{4}$
+Geographical Area Group
+described_geographicalarea__sid>/description/<sid
+certificate_type__sid
+EnvelopeSerializer
+FootnoteFactory
+FootnoteType
+Serializer
+type__sid
+Meursing Heading"
+r"[A-Z0-9]{2}[A
+RUN npm install && npm
+ENV
+tamato && \
+Export Refunds
+reference_price
+JS
+f"instance_footnotes_{sid
+MeasureForm
+GDS
+MeasureUpdate
+the submit button's
+Alice
+Regulation Number
+ElementParser
+prefix="ns
+" Handle the start of an XML tag
+The Python
+FM99999999999999999999
+Writable
+justification.regulation.role
+export.refund.nomenclature.sid
+self.dependent_batch
+commodities.business_rules
+APPROVED  Approved
+CDS systems
+LR
+BDD
+TAP
+Gherkin
+USE_IMPORTER_CACHE
+WTO
+SAD
+Preference
+323
+KON
+ValidityMixin
+Box 36
+SignedIntSID
+PreferenceCode
+BoolField
+ME120
+MeasureFactory
+measure.goods_nomenclature.item_id
+f"{n}.00%
+measure.generating_regulation.regulation_id
+Most Favoured Nation
+Tariff
+@notebook
+Jupyter
+MeasureCreationPattern
+Publication Date
+" The "Regulation Approved Flag
+Regulation Approved Flag
+TP-
+https://github.com/myint/autoflake.git
+https://github.com/myint/docformatter.git
+https://github.com/ikamensh/flynt/
+0.76
+ner_output_file.txt
+CI
+# Set
+npm
+Github Pages
+invalid_type.txt
+https://uktrade.github.io/tariff-data-manual/documentation/trade-policies/most-favoured-nation-duties.html
+the `Tariff Management Tool
+r"[A-Z0-9]{1
+rf"^{CERTIFICATE_TYPE_SID_REGEX}$
+r"[A-Z0-9]{3
+SENTRY_DSN=
+AWS_ACCESS_KEY_ID=
+Minio
+SSO OAuth2
+non-Meursing
+Export Refund for Processed Agricultural Goods
+Export Refund for Processed '
+Agricultural Goods
+Validations
+Builds on govuk_frontend_jinja.templates
+govuk_frontend_jinja
+r"(for attribute
+"Override the govuk_frontend_jinja Environment
+r"([^\w]+
+" Set up the Jinja
+foo|bar|baz
+foo;bar;baz"
+about 1 language
+additional_code__sid
+href="https://www.gov.uk">a
+Runner
+create/<step>/
+Import Batches
+Footnote Types
+^^^^^^^
+the TARIC3 Interface Data Specification
+a Statutory Instrument
+WorkBasket``\
+Workbasket``
+MTI
+Model Schema|
+ChildModel
+SQL
+ON commodity.trackedmodel_ptr_id = trackedmodel.id
+ON footnotetype.trackedmodel_ptr_id
+ON trackedmodel.polymorphic_ctype_id
+max_length=3
+Django-Polymorphic
+kwargs={"sid
+^[A-Z][A-Z
+^[A-Z]{3}$
+MeasureExcludedGeographicalArea
+Tests for browse regulations behaviours
+f"{regulation_C2000000.regulation_id} - {
+record.subrecord_code
+" Client for HMRC Secure Data Exchange Notifications API
+Gov-Client-Local-IPs
+00%3A00%3A00%3A00%3A00%3A00"
+Gov-Client-Multi-Factor
+Docker
+Gov-Vendor-License
+Gov-Vendor-Version
+The Generalised System of Preferences
+Search and Filter
+100.0 + kg
+m2
+m3
+monetary.unit.code m4
+D-008
+TNE c5
+False m2
+TNE c5:
+D-018
+m3>\S+)(?:\s|$))?(?:(?P
+m1"
+m4
+WebPDB
+IPD
+Pyston
+common_event_fields(record
+"Edit Footnote
+EU Taric
+Exercise HMRCStorage
+Bucket
+Group
+@media
+Secure Data Exchange Service
+"Returns the HS
+HS
+CA001
+Footnote Type
+monetary.unit.code>
+measure.condition.sid
+format(record.duty_expression.sid
+tracked_qs
+TARIC3 xml
+conditions_tab_html
+measure.type.combination
+210
+FM00
+name="export.refund.nomenclature.sid
+name="duty.amount
+type="DutyAmount
+Where Webpack
+// c.f
+FilterSet for Additional Codes
+The ``checks` subsystem
+metadata
+The Exporter Management Commands
+importer.tasks.find_and_run_next_batch_chunks
+MSA
+NULLIF
+a Common Table Expression
+^[A-Z0-9][A-Z0-9][A-Z0-9]$
+^[A-Z0-9]$
+Bob
+Additional Codes
+a RESTful API
+DRF
+TastyPie
+Use Django REST Framework
+Enable Django
+ENABLE_DJANGO_DEBUG_TOOLBAR
+whitenoise.runserver_nostatic
+VersionsPanel
+debug_toolbar.panels.timer
+TimerPanel
+TemplatesPanel
+~ described_object._meta.verbose_name  ~
+a Tracked Model
+Y}".format(version.valid_between.lower
+li class="gem-c
+contents.href.startswith("http
+href.startswith("http") %
+add_url_params("http://example.com?q
+url.split
+CertificateType
+Install Python
+shell
+Generate
+measure_detail_tabs(object
+Carol
+maxdepth
+node_modules/
+ISO
+kilogram
+f"If
+modified_measure__sid
+record.enacting_regulation.official_journal_page
+approved.flag>
+" Metaclass for all BusinessRules
+version_at
+" Decorate BusinessRules
+Union[date
+UpdateTypes
+" Return True
+Subclass
+version='1.0
+http://www.w3.org/1999/xhtml
+href="http://www.w3.org/XML/1998
+href="http://www.w3.org/TR/REC-xml
+Working
+Notes</h4
+href="http://www.w3.org/TR/xmlbase/">http://www.w3.org/TR/xmlbase/</a>
+href="http://www.w3.org/TR/xml-id/">http://www.w3.org/TR/xml-id/</a
+attributeGroup name="specialAttrs
+ref="xml
+Jon Bosak
+Working Group
+XML
+h2><a
+&lt;import namespace="http://www.w3.org
+http://www.w3.org/2009/01/xml.xsd</a
+Commission
+the Commission
+main.quota.definition.sid
+name="certificate.description.period.sid
+A Geographical Area
+A Geographical Membership
+member__sid
+Goods Nomenclature
+MeasureCreationWizard
+Michael
+Michael Nygard's
+Nat Pryce's
+Michael Nygard
+approver_id
+Caches
+Workbasket</h2
+Electronic Data Interchange For Administration
+ERN
+International Standards Organisation
+Official Journal
+Partial Temporary Stop Regulation
+UTF
+excluded.geographical.area.sid
+excluded.geographical.area.sid>
+pbkdf2_sha256$180000$wA6tcwwDYV3W$ev5KnHn+Hb+nJHFCnZGKmWk/wJJITjl3QREfnxU0x9M=
+is_superuser
+Accept
+Streaming Envelope
+Framework Serializer
+f"Max
+"Return True If total_size bytes would fit inside a single Envelope
+"Render TrackedModels
+DocumentInvalid
+Raise AssertionError
+Excel
+latest_tracked_model
+duties_html
+geographical_area_html
+fetches OAuth2
+https://uktrade.atlassian.net/browse/TP2000-144
+measures.forms.MeasureForm.save
+40 GBP/100kg
+MeasureWizard
+2 GBP/100kg
+MeasureComponents
+SelectorFormat
+@extend
+name="officialjournal.page
+type="RegulationId
+name="approved.flag
+modification.regulation.role
+type="RegulationId"/
+fts_action
+stopped.regulation.role
+name="replacing.regulation.id
+// Based
+ConnectionError
+SentinelError
+0101010101
+ABCDEFGHIJ
+" Loops in the parent
+UNION ALL SELECT
+ga.trackedmodel_ptr_id
+ON hierarchy.descendant_id
+params.display_class
+params.min_length
+QuotaAssociation
+"Defines a blocking period for a (
+sub-)quota
+@mixin
+chevron
+min-width
+calc(100
+% - #
+100px
+xml="http://www.w3.org/XML/1998/
+namespace="http://www.w3.org/XML/1998/
+below</xs
+value="\d\d"/
+ref="abstract.record"/
+name="Date
+value="\d{4}-\d{2}-\d{2}"/
+name="LanguageId
+value="\d{1,3}"/
+xmlns="taric-format">AAA</format
+name="OfficialJournalNumber
+name="QuotaBlockedStateCode
+03/08/2013 CUST
+name="TableLineSequenceNumber
+name="additional.code.description.period.sid
+type="DutyAmountApplicabilityCode"/>
+name="abrogation.date
+name="export.refund.nomenclature.indents.sid
+name="meursing.table.plan.id
+type="RegulationRoleTypeId"/>
+name="goods.nomenclature.indent.sid
+type="ConditionCode"/
+type="MeasurementUnitCode"/>
+name="meursing.additional.code.sid
+name="monetary.exchange.period.sid
+type="ExchangeRate"/>
+name="prorogation.regulation.id
+name="publication.sigle
+name="quota.order.number.sid
+name="quota.order.number.origin.sid
+name="main.quota.definition.sid
+name="quota.blocking.period.sid
+name="quota.suspension.period.sid
+type="QuotaBlockedStateCode"/>
+name="target.quota.definition.sid
+Minimal
+BUILDDIR
+Makefile
+Tariff Managers
+https://www.manage-trade-tariffs.trade.gov.uk/
+sudo su
+requirements-dev.txt
+Compile SCSS and Javascripts
+superuser
+VAT
+UUID
+HMRC S3
+Jenkins
+CLI
+record.priority_code
+html
+FILE
+N990
+Measure {} end date
+Provides an Excel
+additional.code.description.period.sid
+this.button.classList.remove('js-hidden'
+this.button.addEventListener('click
+button.classList.add('govuk-button'
+nodeListForEach(modules
+PYTHONPATH
+pluralize(change_count
+LazyValue
+Proxy
+Middleware
+custom_sid
+f"{prefix}transaction__workbasket__id
+/requirements.txt
+TransactionMiddleware
+Subrecord
+I.e
+Foreign Keys
+Version Group
+Iterate all TrackedModel
+XPath
+UserTransactionPartitionScheme get_partition
+OPQ.</li>
+SPG.</li
+FTA
+PRF
+View.queryset
+PYTHON
+\
+wait_for_db && $
+{PYTHON
+@sphinx
+@for FILE
+BASH
+docs && sphinx
+CT1
+The Meursing
+ME115
+Description Periods
+celery[redis]>=5.2.2
+django-extensions==3.1.1
+django-filter==2.4.0
+django-formtools==2.3
+django-storages==1.11.1
+freezegun==1.1.0
+gunicorn==20.0.4
+moto==2.1.0
+openpyxl==3.0.7
+pytest-xdist==2.3.0
+sphinx-gherkindoc==3.6.2
+MeasureConditions
+Django AppConfig
+name="header
+minLength
+minOccurs="0
+name="business.ref
+NMTOKEN
+object.valid_between
+WIP
+Detail
+Screenshots
+Slack/Teams
+ELASTIC_TOKEN
+SERVICE_NAME
+CertificatesConfig
+GeoAreasConfig
+measures.apps
+MeasuresConfig
+QuotasConfig
+ExporterConfig
+crispy_forms_gds
+WhiteNoiseMiddleware
+DIRS
+OPTIONS
+DjangoTemplates
+ALLOW_PAAS_URIS
+the X-XSS-Protection
+the X-Content-Type-Options
+-- Running Django
+WSGI
+-- Debug
+-- Cache
+DJANGO_CACHE"
+HMRC_STORAGE_BUCKET_NAME
+SQLITE_S3_ACCESS_KEY_ID
+DMZ
+name)s
+message)s
+StreamHandler
+GIT_COMMIT
+REST Framework
+DEFAULT_PERMISSION_CLASSES
+https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/secure-data-exchange-notifications/1.0
+HMRC_API_BASE_URL
+-vv
+ME1
+Duplicate of ME116"
+-- Export Refund for
+"Export Refund for Processed Agricultural Goods
+an Export Refund
+the Export Refund for Processed Agricultural Goods
+DO
+TNE
+Condition
+ConditionCodes
+MeasureSnapshot
+DescriptionMixin
+GoodsNomenclatureDescription
+SET prefix='+'
+SET prefix='+ AC'
+SET prefix='+ AC
+SET prefix='MIN'
+SET prefix='+ SD'
+SET prefix='+ SD
+SET prefix='+ FD'
+SET prefix='+ FD
+GRT
+KAC
+KMT
+KCL
+MGM
+MCG
+MWH
+SET abbreviation='kg'
+SET abbreviation='1,000 kg'
+SET abbreviation='kg N'
+KNI
+SET abbreviation='kg
+KMA
+LPA
+MTK
+SET abbreviation='hl'
+HLT
+SET abbreviation='kg U'
+KUR
+NCL
+SET abbreviation='pa'
+KPO
+SET abbreviation='kg KOH'
+KSD
+HMT
+SET abbreviation='g'
+CTM
+SET abbreviation='ct/l'
+KPP
+SET abbreviation='kg H2O2'
+SET abbreviation='kg NaOH'
+KSH
+LTR
+SET abbreviation='raw
+1.0 EUR / kg
+MAR
+JUL
+172.200 GBP DTN Z
+geographicalarea_memberships_+
+Convert EUR
+The Northern Ireland
+NIP
+C3
+ChangeTimeSpan
+C3 -- C3
+NIG18
+a Goods Nomenclature or Indent"]
+Successor
+True
+param overall_range DateRange
+param contained_range DateRange
+relations.keys()!r
+param field str
+ACCESS SHARE
+" Decorator for PostgreSQL's table-level lock functionality
+LOCK Documentation
+id_field Field
+TO_CHAR
+r"(?!^)([A-Z]+
+Convert TrackedModel
+kwargs={"pk
+common.change_trackedmodel
+RoleType
+Title"
+QuotaDefinition
+QuotaEvent
+d.
+order_number__sid
+" A Quota Definition
+The Quota Definition
+"A Quota Association
+"A Quota Suspension
+"A Quota Blocking Period
+UpdateType
+EDIFACT
+United Nations Trade Data Elements Directory
+UNB
+UNH
+UNZ
+UNTDED
+UTF-8
+byte sequence
+quota.blocking.period.sid
+blocking.end.date
+Generate the
+50 megabytes
+no_overlap
+Policy
+use_create_form
+Contents
+Provide
+MustExist
+CREATE
+Hacky
+antidumping.regulation.role
+complete.abrogation.regulation.id
+the Tariff Management Tool
+CDS
+AWAITING_CDS_UPLOAD_EDIT
+AWAITING_CDS_UPLOAD_DELETE
+tracked_model_workbasket_schema_updated.png
+AbortController
+Activity Stream
+ActivityStream
+depends_on
+Serialize to JSON
+document.querySelectorAll
+Manage Trade Tariffs" %}
+assert
+future_measure.sid
+POSTGRES_HOST_AUTH_METHOD
+f"Leave
+"Returns a Form
+f"{self.prefix}-
+A ``TransactionCheck`` is considered "current"
+A ``TransactionCheck`` is considered "fresh" if the transaction
+A ``TransactionCheck`` is considered "
+A ``TransactionCheck`` requires
+VersionGroups
+Replacements
+RadioNested
+components__component_measurement__measurement_unit
+Parsers for TARIC
+Parser
+" Save the Record
+transaction_id
+f"Data Import
+start_ns
+Start Date"
+Measure Type Description"
+Order Number
+measure__additional_code__code
+commodity__code
+measure__regulation__id
+MaD
+MaD.
+NA
+goods.nomenclature.description.period.sid
+ME33
+diagram
+ENVELOPE
+TextElement
+Record(ElementParser
+Tag("record
+Nursery
+The Object Handler
+Y}".format(geo_area.valid_between.upper
+SQLite Export =
+RelatedManager
+Home 2
+Home.as_view
+exporter.urls
+@ECHO
+REM Command
+PATH
+goto
+C123456
+IYY0
+C990001A
+Z2021AAA
+V2022ZZZ
+IYY12345
+measure.sid}}</a
+measure.additional_code.sid
+measure.additional_code.code
+measure.additional_code
+condition.measurement.unit.code>
+DutySentenceParser
+CONCAT
+db_effective_end_date
+upload_workbasket_envelopes
+keys[2
+the Envelopes Upload
+EnvelopeTransactions
+TestModelDescription1
+self.__class__.__name
+Install Node
+" Basic Filter for API views
+" Basic Filter for UI
+filter_active_state
+Chapter
+Chunk
+" Finds the next
+model_data, field
+StepNav
+this.element.classList.remove('js-hidden'
+d="M19.5 10C19.5
+0.500001
+d="M6.32617
+0.499997
+stroke="#1D70B8"/>' +
+this.addAriaControlsAttrForShowHideAllButton
+this.bindToggleShowHideAllButton(stepNavTracker
+span.appendChild(commaSpan
+addAriaControlsAttrForShowHideAllButton
+this.element.querySelector('.js-panel').getAttribute('id'
+StepView(step
+StepView(thisel
+(this.rememberShownStep && data.indexOf(id
+stepView.toggle
+event.currentTarget.parentNode.hasAttribute('data
+bindComponentLinkClicks(stepNavTracker
+thisel.querySelector('.js-link').getAttribute('data-position').toString(
+this.titleButton
+IE8
+isShown
+trackClick
+dimension28
+trackingLabel
+this.target.classList.contains('js-toggle
+Google Analytics
+GOVUK
+GOVUK && window.GOVUK.analytics &&
+options.dimension27
+^[A-Z0-9]{2}[A-Z0-9
+ABC
+A12
+aaa
+f"{self.footnote_type.footnote_type_id}{self.footnote_id
+"Returns the the commodity code
+CommodityTree
+SnapshotMoments
+FootnoteAssociation
+Update
+Returns a CommodityCollection
+item_id
+ConfirmCreate
+app
+Sort Commodity
+goods.nomenclature.item.id
+" Write a given transaction to the relevant chunk
+b"xmlns
+Returns None
+ModelBackend
+OAuth2
+Quotas
+0009_add_abbrev_to_unit_qualifier_with_code_n
+0.0.0.34
+LazyString
+TrackedModelCheck
+f"Error
+TransactionCheck
+Restart
+MeasureFootnoteAssociation
+CELERY_TASK_ALWAYS_EAGER"
+sid A01
+checker_cache
+Cache of Business
+CheckResult
+Checkers
+self.linked_model
+"Attach BusinessRules
+WorkBasketOutputFormat
+param kwargs:
+Enum
+QuotaOrderNumberOrigin
+QuotaOrderNumber
+ME119
+TestRule
+schemaLocation="commodities_envelope.xsd"/
+7930d36f
+*** measure_qs = <
+CharField\n
+OuterRef\n
+django.db.models.functions.comparison
+Cast\n
+django.db.models.functions.text
+measure_sid = 20185730\n
+measure_qs
+measure_qs}\")\n
+kernelspec
+*** measure_qs.count
+*** components_qs
+components_qs}\")\n
+measure_qs)\n
+MeasureComponent
+Components
+TP2000-452
+xmlbomb.xml
+xmlbomb2.xml
+self.xml_bomb
+self.xml_external
+self.xml_bomb
+DTD
+https://github.com/tiran/defusedxml/blob/main/defusedxml/lxml.pyg
+commodity_1_kwargs
+goods_nomenclature_indent.xml
+ElementTree
+403s
+importer.forms.UploadTaricForm.save
+role="alert
+Item
+FootnoteForm
+AreaCode
+erga omnes data
+IndexError
+USERNAME
+django.core.cache
+Split
+Args
+Split Transactions
+Retrospective ADR
+WorkbasketStatus
+Clears the cache
+dumped_cache.pkl
+WorkBasketOutputFormat Enum
+TestHandlerChild1
+f"TestHandler
+TestSerializer
+BaseHandler
+AttributeError
+XZX
+BaseEngine
+TARGET_COMMAND
+https://github.com/tiran/defusedxml/blob/main/defusedxml/lxml.py
+importer.forms.UploadTaricForm.save
+Commodity Code
+Commodity Description
+Comodity Code
+Comodity Description"
+f"/commodities/{commodity2.sid}/
+f"{first_line_of(workbasket.reason
+WorkBasketOutputFormat Enum
+0004_archive_field
+Europe
+Enter the Regulation ID
+Enter the Quota Order Number
+tranxs #
+WorkBasket Contents
+MEASURE_SID
+Merge
+indent=0
+0005_workbasket_rule_check_task_id
+run_business_rules_form
+f"empty
+Exit
+meth:`~workbaskets.models
+https://uktrade.atlassian.net/browse/TP2000-571
+validity.end.date>2023
+Implementing RegulationY-%m-%d
+date_time_start
+Y-%m-%d
+Skipping ME119: update_type
+Implementing Regulation
+measure.effective_valid_between.upper
+Tests that MeasureMultipleDelete

--- a/workbaskets/tests/test_forms.py
+++ b/workbaskets/tests/test_forms.py
@@ -71,20 +71,23 @@ def test_selectable_objects_form():
     assert len(form.fields) == 5
     # Check that the ids added to the end of the field names, match the measure pks.
     assert form_fields_keys == measure_pks
-    # Check that the field name class method returns the right name.
+
     for item in measures:
+        # Check that the field name class method returns the right name.
         assert (
             SelectableObjectsForm.field_name_for_object(measures[measures.index(item)])
             == f"selectableobject_{item.pk}"
         )
-    # Check that the id class method returns the right id.
-    for item in measures:
+        # Check that the id class method returns the right id.
         assert (
             SelectableObjectsForm.object_id_from_field_name(
                 list(form.fields.keys())[measures.index(item)],
             )
             == measure_pks[measures.index(item)]
         )
+        # Check that the fields are of SelectableObjectField type
+        assert type(form.fields[f"selectableobject_{item.pk}"]) is SelectableObjectField
+
     # Check that the cleaned_data_no_prefix property returns a list of the data with no prefixes.
     form.cleaned_data = {
         f"selectableobject_{measure_pks[0]}": True,

--- a/workbaskets/tests/test_forms.py
+++ b/workbaskets/tests/test_forms.py
@@ -1,5 +1,8 @@
 import pytest
 
+from common.tests import factories
+from workbaskets.forms import SelectableObjectField
+from workbaskets.forms import SelectableObjectsForm
 from workbaskets.forms import WorkbasketCreateForm
 
 pytestmark = pytest.mark.django_db
@@ -51,3 +54,54 @@ def test_workbasket_create_form_invalid_data():
     assert not form.is_valid()
     assert "This field is required." in form.errors["title"]
     assert "This field is required." in form.errors["reason"]
+
+
+def test_selectable_objects_form():
+    """Test that the SelectableObjectsForm creates a SelectableObjectField for
+    each item passed to it, and the class methods and properties provide the
+    expected data for the item."""
+    measures = factories.MeasureFactory.create_batch(5)
+    form = SelectableObjectsForm(initial={}, prefix=None, objects=measures)
+    # grab a list of the ids tacked on to the end of the field name, as this
+    # should be the pk of the measure.
+    form_fields_keys = [str.partition("_")[2] for str in form.fields.keys()]
+    measure_pks = [str(measure.pk) for measure in measures]
+
+    # Check that the fields in the form has the same length as the measures we made.
+    assert len(form.fields) == 5
+    # Check that the ids added to the end of the field names, match the measure pks.
+    assert form_fields_keys == measure_pks
+    # Check that the field name class method returns the right name.
+    for item in measures:
+        assert (
+            SelectableObjectsForm.field_name_for_object(measures[measures.index(item)])
+            == f"selectableobject_{item.pk}"
+        )
+    # Check that the id class method returns the right id.
+    for item in measures:
+        assert (
+            SelectableObjectsForm.object_id_from_field_name(
+                list(form.fields.keys())[measures.index(item)],
+            )
+            == measure_pks[measures.index(item)]
+        )
+    # Check that the cleaned_data_no_prefix property returns a list of the data with no prefixes.
+    form.cleaned_data = {
+        f"selectableobject_{measure_pks[0]}": True,
+        f"selectableobject_{measure_pks[1]}": True,
+        f"selectableobject_{measure_pks[2]}": True,
+        f"selectableobject_{measure_pks[3]}": False,
+        f"selectableobject_{measure_pks[4]}": False,
+    }
+    # The cleaned_data_no_prefix property is created using cleaned_data, so providing cleaned_data should
+    # create the object for us, so we just need to check it matches what we expect.
+    assert form.cleaned_data_no_prefix == {
+        measure_pks[0]: True,
+        measure_pks[1]: True,
+        measure_pks[2]: True,
+        measure_pks[3]: False,
+        measure_pks[4]: False,
+    }
+    # Check that the fields are of SelectableObjectField type
+    for item in measures:
+        assert type(form.fields[f"selectableobject_{item.pk}"]) is SelectableObjectField


### PR DESCRIPTION
# TP-2000-508 Multiple Measures Delete 


## Why

In order for TM's to delete multiple measures in one go, I have added the functionality and templates to allow TM's to select the measures they wish to delete from the list view, confirm that they want to delete these measures and delete them.


## What
- Amend the List page to show checkboxes next to each item, make them selectable, and show their start and end dates. 
- Create a MultipleMeasuresDelete view which is responsible for showing the measures the users have chosen on a review page, and deleting those measures. 
- Added templates to accommodate the designs. 
- Added tests for the SelectableObjectsForm as it was missing them.


<img width="1680" alt="Screenshot 2022-11-25 at 14 33 43" src="https://user-images.githubusercontent.com/46787754/204006402-aca78c14-395c-445f-9178-a63c61b9eb6c.png">
Added checkboxes to each item, along with start and end dates for the measures on the list page. 



<img width="1680" alt="Screenshot 2022-11-25 at 14 34 51" src="https://user-images.githubusercontent.com/46787754/204006595-039f6769-1c79-495e-ad3c-725f6227763f.png">
Added Delete multiple measures "review" page, where users can see which measures they've selected to mass delete in the Details component and delete functionality to remove the measures. 


Wider issues noted that are to be separate tickets: 
- No measures should be shown on the page without being filtered first. We should add a new page with just the filter on, which redirects to a new page showing the filtered list (considered the easiest approach with how the filtering is set up) 
- Confirmation of deletion pages should be added to all




## Checklist
- Requires migrations? - No
- Requires dependency updates? - No

