### PR TITLE
TP2000-582 NIG11 not firing when it should

### DIFF
--- a/commodities/models/orm.py
+++ b/commodities/models/orm.py
@@ -91,6 +91,7 @@ class GoodsNomenclature(TrackedModel, ValidityMixin, DescribedMixin):
     business_rules = (
         business_rules.NIG1,
         business_rules.NIG5,
+        business_rules.NIG11,
         business_rules.NIG12,
         business_rules.NIG30,
         business_rules.NIG31,


### PR DESCRIPTION
# TP2000-582 NIG11 not firing when it should
<!---
 * Include the JIRA ticket number, eg TP-123, to automatically link.
 * Use 50 characters maximum.
 * Do not end with a full-stop.
--->

## Why
<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Use as many lines as you like.
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions or deliberately ignored edge-cases.
--->
Envelope 220243 passed business rules but failed at CDS with NIG11
## What
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Explain like I'm 5.
 * Use pictures if you can.
--->
Adds NIG11 to GoodsNomenclature.business_rules (currently only lives on GoodsNomenclatureIndent.indirect_business_rules) 
<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
## Checklist
- Requires migrations?
- Requires dependency updates?
--->

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
