### PR TITLE
TP2000-583 me40 gives false positives (pt. 2)

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1192,3 +1192,31 @@ def model2_with_history(date_ranges):
         version_group=factories.VersionGroupFactory.create(),
         custom_sid=1,
     )
+
+
+# As per this open issue with pytest https://github.com/pytest-dev/pytest/issues/5997,
+# some tests can only be run with global capturing disabled. Until we find a way
+# to disable capturing from within the test itself we can mark tests that should be skipped
+# unless global capturing is disabled via the "-s" flag.
+
+# TODO https://uktrade.atlassian.net/browse/TP2000-591
+
+# See pytest docs for implementation below
+# https://docs.pytest.org/en/7.1.x/example/simple.html#control-skipping-of-tests-according-to-command-line-option
+
+
+def pytest_configure(config):
+    config.addinivalue_line(
+        "markers",
+        "s: mark test as needing global capturing disabled to run",
+    )
+
+
+def pytest_collection_modifyitems(config, items):
+    if config.getoption("-s") == "no":
+        # -s given in cli: do not skip s tests
+        return
+    skip_s = pytest.mark.skip(reason="need -s option to run")
+    for item in items:
+        if "s" in item.keywords:
+            item.add_marker(skip_s)

--- a/measures/business_rules.py
+++ b/measures/business_rules.py
@@ -449,6 +449,7 @@ class ME117(BusinessRule):
         raise self.violation(measure)
 
 
+@skip_when_deleted
 @only_applicable_after("2007-12-31")
 class ME119(ValidityPeriodContained):
     """When a quota order number is used in a measure then the validity period

--- a/measures/business_rules.py
+++ b/measures/business_rules.py
@@ -715,6 +715,7 @@ class ME34(BusinessRule):
 # -- Measure component
 
 
+@skip_when_deleted
 class ME40(BusinessRule):
     """
     If the flag "duty expression" on measure type is "mandatory" then at least

--- a/measures/tests/test_business_rules.py
+++ b/measures/tests/test_business_rules.py
@@ -779,6 +779,14 @@ def test_ME119_multiple_valid_origins():
     business_rules.ME119(later_measure.transaction).validate(later_measure)
 
 
+@pytest.mark.s
+def test_ME119_skipped_when_deleted(capfd):
+    measure = factories.MeasureFactory.create(update_type=UpdateType.DELETE)
+    business_rules.ME119(measure.transaction).validate(measure)
+
+    assert "Skipping ME119: update_type is 2" in capfd.readouterr().err
+
+
 def test_quota_origin_matching_area():
     origin = factories.QuotaOrderNumberOriginFactory.create(
         geographical_area__sid="666",
@@ -1187,6 +1195,14 @@ def test_ME40(applicability_code, component, condition_component, error_expected
         business_rules.ME40(
             (condition_component or component or measure).transaction,
         ).validate(measure)
+
+
+@pytest.mark.s
+def test_ME40_skipped_when_deleted(capfd):
+    measure = factories.MeasureFactory.create(update_type=UpdateType.DELETE)
+    business_rules.ME40(measure.transaction).validate(measure)
+
+    assert "Skipping ME40: update_type is 2" in capfd.readouterr().err
 
 
 def test_ME41(reference_nonexistent_record):

--- a/pii-ner-exclude.txt
+++ b/pii-ner-exclude.txt
@@ -1245,3 +1245,4 @@ validity.end.date>2023
 Implementing RegulationY-%m-%d
 date_time_start
 Y-%m-%d
+Skipping ME119: update_type


### PR DESCRIPTION
# TP2000-583 me40 gives false positives (pt. 2)
<!---
 * Include the JIRA ticket number, eg TP-123, to automatically link.
 * Use 50 characters maximum.
 * Do not end with a full-stop.
--->

## Why
<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Use as many lines as you like.
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions or deliberately ignored edge-cases.
--->
ME119 is now giving false positives
## What
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Explain like I'm 5.
 * Use pictures if you can.
--->
Adds `skip_when_deleted` decorator to ME119 and adds some tests for that decorator and `skip_when_not_deleted`
<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
## Checklist
- Requires migrations?
- Requires dependency updates?
--->

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
The tests are not an ideal solution, but I spent quite a bit of time trying different things without success, so created this ticket to refactor at some point https://uktrade.atlassian.net/browse/TP2000-591