### PR TITLE
TP2000-570 ERRORED shouldn't be a final state for WorkBasket

### DIFF
--- a/workbaskets/models.py
+++ b/workbaskets/models.py
@@ -457,6 +457,16 @@ class WorkBasket(TimestampedMixin):
                 version_group.current_version = versions.first()
             version_group.save()
 
+    @transition(
+        field=status,
+        source=WorkflowStatus.ERRORED,
+        target=WorkflowStatus.EDITING,
+        custom={"label": "Restore for further editing."},
+    )
+    def restore(self):
+        """WorkBasket is ready to be worked on again after being rejected by
+        CDS."""
+
     def save_to_session(self, session):
         session["workbasket"] = {
             "id": self.pk,


### PR DESCRIPTION
# TP2000-570 ERRORED shouldn't be a final state for WorkBasket
<!---
 * Include the JIRA ticket number, eg TP-123, to automatically link.
 * Use 50 characters maximum.
 * Do not end with a full-stop.
--->

## Why
<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Use as many lines as you like.
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions or deliberately ignored edge-cases.
--->
We should start using ERRORED state to make it clear that a workbasket approved by tariff managers has been rejected for some reason by CDS. To do this, we need a way of restoring a workbasket to EDITING state, so that fixes can be made.
## What
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Explain like I'm 5.
 * Use pictures if you can.
--->
Adds a `restore` transition method to `WorkBasket` and unit tests existing transition methods
<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
## Checklist
- Requires migrations?
- Requires dependency updates?
--->

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
