### PR TITLE
TP2000-604 Newly created Commodity Codes imported into a workbasket are not visible in the Measures journey

### DIFF
--- a/commodities/tests/test_views.py
+++ b/commodities/tests/test_views.py
@@ -1,3 +1,4 @@
+import json
 from os import path
 from unittest.mock import patch
 
@@ -145,3 +146,26 @@ def test_commodities_detail_views(
     don't return an error."""
 
     assert_model_view_renders(view, url_pattern, valid_user_client)
+
+
+def test_goods_nomenclature(valid_user_client, date_ranges):
+    past_good = factories.GoodsNomenclatureFactory.create(
+        valid_between=date_ranges.earlier,
+    )
+    present_good = factories.GoodsNomenclatureFactory.create(
+        valid_between=date_ranges.normal,
+    )
+    future_good = factories.GoodsNomenclatureFactory.create(
+        valid_between=date_ranges.later,
+    )
+    url = reverse("goodsnomenclature-list")
+    response = valid_user_client.get(url)
+
+    assert response.status_code == 200
+
+    goods = json.loads(response.content)["results"]
+    pks = [good["value"] for good in goods]
+
+    assert past_good.pk not in pks
+    assert present_good.pk in pks
+    assert future_good.pk in pks

--- a/commodities/views.py
+++ b/commodities/views.py
@@ -38,7 +38,7 @@ class GoodsNomenclatureViewset(viewsets.ReadOnlyModelViewSet):
                 tx,
             )
             .prefetch_related("descriptions")
-            .as_at(date.today())
+            .as_at_and_beyond(date.today())
             .filter(suffix=80)
         )
 

--- a/common/querysets.py
+++ b/common/querysets.py
@@ -96,6 +96,13 @@ class ValidityQuerySet(QuerySet):
         """
         return self.as_at(date.today())
 
+    def as_at_and_beyond(self, date) -> QuerySet:
+        """Return the instances of the model that are respresented at the
+        current date as well as any future instances."""
+        return self.filter(
+            Q(valid_between__contains=date) | Q(valid_between__startswith__gt=date),
+        )
+
 
 class TransactionPartitionQuerySet(QuerySet):
     @classmethod


### PR DESCRIPTION
# TP2000-604 Newly created Commodity Codes imported into a workbasket are not visible in the Measures journey
<!---
 * Include the JIRA ticket number, eg TP-123, to automatically link.
 * Use 50 characters maximum.
 * Do not end with a full-stop.
--->

## Why
<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Use as many lines as you like.
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions or deliberately ignored edge-cases.
--->
The commodities dropdown in the measure create wizard doesn't show commodities with a start date in the future.
## What
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Explain like I'm 5.
 * Use pictures if you can.
--->
Adds a `as_at_and_beyond` queryset method and uses this instead of `as_at` in `GoodsNomenclatureViewset`
<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
## Checklist
- Requires migrations?
- Requires dependency updates?
--->

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
