### PR TITLE
fix for ON12 not allowing origin to be removed, even if no measures are attached

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,10 +1,10 @@
 repos:
   - repo: https://github.com/asottile/add-trailing-comma
-    rev: v2.2.3
+    rev: v2.3.0
     hooks:
       - id: add-trailing-comma
   - repo: https://github.com/myint/autoflake.git
-    rev: v1.4
+    rev: v1.7.7
     hooks:
       - id: autoflake
         args:
@@ -19,7 +19,7 @@ repos:
       - id: isort
         args: [--force-single-line-imports]
   - repo: https://github.com/myint/docformatter.git
-    rev: v1.4
+    rev: v1.5.0
     hooks:
       - id: docformatter
         args:
@@ -30,7 +30,7 @@ repos:
             "--pre-summary-newline",
           ]
   - repo: https://github.com/psf/black
-    rev: 22.3.0
+    rev: 22.10.0
     hooks:
       - id: black
   - repo: https://github.com/ikamensh/flynt/

--- a/Procfile
+++ b/Procfile
@@ -1,4 +1,3 @@
 web: gunicorn wsgi --bind 0.0.0.0:$PORT --timeout 1000 --worker-class=gevent --worker-connections=1000 --workers 9
 worker: celery -A common.celery worker -O fair -l info
 beat: celery -A common.celery beat
-flower: celery flower --basic_auth=$FLOWER_AUTH_USER:$FLOWER_AUTH_PASSWORD

--- a/additional_codes/tests/test_views.py
+++ b/additional_codes/tests/test_views.py
@@ -9,6 +9,7 @@ from additional_codes.models import AdditionalCode
 from additional_codes.views import AdditionalCodeList
 from common.tests import factories
 from common.tests.util import assert_model_view_renders
+from common.tests.util import assert_read_only_model_view_returns_list
 from common.tests.util import date_post_data
 from common.tests.util import get_class_based_view_urls_matching_url
 from common.tests.util import raises_if
@@ -93,3 +94,37 @@ def test_additional_codes_list_view(view, url_pattern, valid_user_client):
     """Verify that additional code list view is under the url additional_codes/
     and doesn't return an error."""
     assert_model_view_renders(view, url_pattern, valid_user_client)
+
+
+def test_additional_codes_api_list_view(valid_user_client, date_ranges):
+    selected_type = factories.AdditionalCodeTypeFactory.create()
+    expected_results = [
+        factories.AdditionalCodeFactory.create(
+            valid_between=date_ranges.normal,
+            type=selected_type,
+        ),
+        factories.AdditionalCodeFactory.create(
+            valid_between=date_ranges.earlier,
+            type=selected_type,
+        ),
+    ]
+    assert_read_only_model_view_returns_list(
+        "additionalcode",
+        "value",
+        "pk",
+        expected_results,
+        valid_user_client,
+    )
+
+
+def test_additional_code_type_api_list_view(valid_user_client):
+    expected_results = [
+        factories.AdditionalCodeTypeFactory.create(),
+    ]
+    assert_read_only_model_view_returns_list(
+        "additionalcodetype",
+        "sid",
+        "sid",
+        expected_results,
+        valid_user_client,
+    )

--- a/additional_codes/urls.py
+++ b/additional_codes/urls.py
@@ -11,7 +11,10 @@ api_router.register(
     views.AdditionalCodeViewSet,
     basename="additionalcode",
 )
-api_router.register(r"additional_code_types", views.AdditionalCodeTypeViewSet)
+api_router.register(
+    r"additional_code_types",
+    views.AdditionalCodeTypeViewSet,
+)
 
 detail = "<sid:sid>"
 description_detail = "<sid:described_additionalcode__sid>/description/<sid:sid>"

--- a/certificates/tests/test_views.py
+++ b/certificates/tests/test_views.py
@@ -9,6 +9,7 @@ from certificates.views import CertificateList
 from common.models.utils import override_current_transaction
 from common.tests import factories
 from common.tests.util import assert_model_view_renders
+from common.tests.util import assert_read_only_model_view_returns_list
 from common.tests.util import get_class_based_view_urls_matching_url
 from common.tests.util import view_is_subclass
 from common.tests.util import view_urlpattern_ids
@@ -134,3 +135,38 @@ def test_description_create_get_context_data(valid_user_api_client):
         described_certificate__sid=new_version.sid,
         described_certificate__certificate_type__sid=new_version.certificate_type.sid,
     ).exists()
+
+
+def test_certificate_api_list_view(valid_user_client, date_ranges):
+    selected_type = factories.CertificateTypeFactory.create()
+    expected_results = [
+        factories.CertificateFactory.create(
+            valid_between=date_ranges.normal,
+            certificate_type=selected_type,
+        ),
+        factories.CertificateFactory.create(
+            valid_between=date_ranges.earlier,
+            certificate_type=selected_type,
+        ),
+    ]
+    assert_read_only_model_view_returns_list(
+        "certificate",
+        "value",
+        "pk",
+        expected_results,
+        valid_user_client,
+    )
+
+
+def test_certificate_type_api_list_view(valid_user_client):
+    expected_results = [
+        factories.CertificateTypeFactory.create(),
+    ]
+
+    assert_read_only_model_view_returns_list(
+        "certificatetype",
+        "sid",
+        "sid",
+        expected_results,
+        valid_user_client,
+    )

--- a/certificates/urls.py
+++ b/certificates/urls.py
@@ -17,7 +17,10 @@ api_router.register(
     views.CertificatesViewSet,
     basename="certificate",
 )
-api_router.register(r"certificate_types", views.CertificateTypeViewSet)
+api_router.register(
+    r"certificate_types",
+    views.CertificateTypeViewSet,
+)
 
 detail = "<ctype_sid:certificate_type__sid><cert_sid:sid>"
 description_detail = "<ctype_sid:described_certificate__certificate_type__sid><cert_sid:described_certificate__sid>/description/<sid:sid>"

--- a/common/tests/util.py
+++ b/common/tests/util.py
@@ -1,5 +1,6 @@
 import contextlib
 import importlib
+import json
 from datetime import date
 from datetime import datetime
 from functools import lru_cache
@@ -435,6 +436,61 @@ def assert_model_view_renders(
     assert (
         response.status_code == 200
     ), f"View returned an error status: {response.status_code}"
+
+
+def assert_read_only_model_view_returns_list(
+    url_name,
+    result_attributes,
+    expected_attribute,
+    expected_results,
+    valid_user_client,
+    equals=False,
+):
+    """
+    Integration test to verify class based read only model views.
+
+    Given a class based view and a url_name -
+      - Lookup the url for a list function
+      - Fetch data from the a URL constructed using the just created data.
+      - Assert that a 200 status was returned.
+      - Assert that the expected data is in results or equal if equals flag true
+
+    :param url_name: url namespace for the view
+    :param result_attributes: attribute path for the result
+    :param expected_attribute: attribute path for the expected result
+    :param expected_results: expected result
+    :param valid_user_client:
+    :param equals=False: flag for equals check
+    :param valid_user_client:
+    """
+
+    def get_attribute_value(data, attributes):
+        for attribute in attributes.split("."):
+            data = data[attribute]
+        return data
+
+    def r_getattr(data, attributes):
+        for attribute in attributes.split("."):
+            data = getattr(data, attribute)
+        return data
+
+    url = reverse(f"{url_name}-list")
+    response = valid_user_client.get(url)
+
+    assert response.status_code == 200
+
+    results = json.loads(response.content)["results"]
+    actual_results = [
+        get_attribute_value(result, result_attributes) for result in results
+    ]
+
+    for index, expected_result in enumerate(expected_results):
+        if equals:
+            assert (
+                r_getattr(expected_result, expected_attribute) == actual_results[index]
+            )
+        else:
+            assert r_getattr(expected_result, expected_attribute) in actual_results
 
 
 def assert_records_match(

--- a/footnotes/tests/test_views.py
+++ b/footnotes/tests/test_views.py
@@ -3,6 +3,7 @@ from django.core.exceptions import ValidationError
 
 from common.tests import factories
 from common.tests.util import assert_model_view_renders
+from common.tests.util import assert_read_only_model_view_returns_list
 from common.tests.util import get_class_based_view_urls_matching_url
 from common.tests.util import raises_if
 from common.tests.util import valid_between_end_delta
@@ -128,3 +129,36 @@ def test_footnote_list_view(view, url_pattern, valid_user_client):
     """Verify that footnote list view is under the url footnotes/ and doesn't
     return an error."""
     assert_model_view_renders(view, url_pattern, valid_user_client)
+
+
+def test_footnote_api_list_view(valid_user_client, date_ranges):
+    selected_type = factories.FootnoteTypeFactory.create()
+    expected_results = [
+        factories.FootnoteFactory.create(
+            valid_between=date_ranges.normal,
+            footnote_type=selected_type,
+        ),
+        factories.FootnoteFactory.create(
+            valid_between=date_ranges.earlier,
+            footnote_type=selected_type,
+        ),
+    ]
+    assert_read_only_model_view_returns_list(
+        "footnote",
+        "value",
+        "pk",
+        expected_results,
+        valid_user_client,
+    )
+
+
+def test_footnote_type_api_list_view(valid_user_client):
+    expected_results = [factories.FootnoteTypeFactory.create()]
+
+    assert_read_only_model_view_returns_list(
+        "footnotetype",
+        "footnote_type_id",
+        "footnote_type_id",
+        expected_results,
+        valid_user_client,
+    )

--- a/footnotes/urls.py
+++ b/footnotes/urls.py
@@ -17,7 +17,10 @@ api_router.register(
     views.FootnoteViewSet,
     basename="footnote",
 )
-api_router.register(r"footnote_types", views.FootnoteTypeViewSet)
+api_router.register(
+    r"footnote_types",
+    views.FootnoteTypeViewSet,
+)
 
 detail = "<footnote_type_id:footnote_type__footnote_type_id><footnote_id:footnote_id>"
 description_detail = "<footnote_type_id:described_footnote__footnote_type__footnote_type_id><footnote_id:described_footnote__footnote_id>/description/<sid:sid>"

--- a/geo_areas/tests/test_views.py
+++ b/geo_areas/tests/test_views.py
@@ -5,6 +5,7 @@ from rest_framework.reverse import reverse
 from common.models.utils import override_current_transaction
 from common.tests import factories
 from common.tests.util import assert_model_view_renders
+from common.tests.util import assert_read_only_model_view_returns_list
 from common.tests.util import get_class_based_view_urls_matching_url
 from common.tests.util import view_is_subclass
 from common.tests.util import view_urlpattern_ids
@@ -103,3 +104,14 @@ def test_geographical_area_list_filter(search_terms, valid_user_client):
     )
 
     assert page.find("tbody").find("td", text="Greenland")
+
+
+def test_geo_area_api_list_view(valid_user_client):
+    expected_results = [factories.GeographicalAreaFactory.create()]
+    assert_read_only_model_view_returns_list(
+        "geo_area",
+        "value",
+        "pk",
+        expected_results,
+        valid_user_client,
+    )

--- a/measures/tests/test_views.py
+++ b/measures/tests/test_views.py
@@ -14,6 +14,7 @@ from common.models.transactions import Transaction
 from common.models.utils import override_current_transaction
 from common.tests import factories
 from common.tests.util import assert_model_view_renders
+from common.tests.util import assert_read_only_model_view_returns_list
 from common.tests.util import get_class_based_view_urls_matching_url
 from common.tests.util import raises_if
 from common.tests.util import view_is_subclass
@@ -1078,3 +1079,23 @@ def test_measure_form_creates_exclusions(
     assert not set(
         [e.excluded_geographical_area for e in measure.exclusions.all()],
     ).difference({excluded_country1, excluded_country2})
+
+
+def test_measuretype_api_list_view(valid_user_client):
+    expected_results = [
+        factories.MeasureTypeFactory.create(
+            description="1 test description",
+        ),
+        factories.MeasureTypeFactory.create(
+            description="2 test description",
+        ),
+    ]
+
+    assert_read_only_model_view_returns_list(
+        "measuretype",
+        "value",
+        "pk",
+        expected_results,
+        valid_user_client,
+        equals=True,
+    )

--- a/package-lock.json
+++ b/package-lock.json
@@ -1011,9 +1011,9 @@
       }
     },
     "node_modules/loader-utils": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.3.tgz",
-      "integrity": "sha512-THWqIsn8QRnvLl0shHYVBN9syumU8pYWEHPTmkiVGd+7K5eFNVSY6AJhRvgGF70gg1Dz+l/k8WicvFCxdEs60A==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
+      "integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
       "dependencies": {
         "big.js": "^5.2.2",
         "emojis-list": "^3.0.0",
@@ -2682,9 +2682,9 @@
       "integrity": "sha512-92+huvxMvYlMzMt0iIOukcwYBFpkYJdpl2xsZ7LrlayO7E8SOv+JJUEK17B/dJIHAOLMfh2dZZ/Y18WgmGtYNw=="
     },
     "loader-utils": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.3.tgz",
-      "integrity": "sha512-THWqIsn8QRnvLl0shHYVBN9syumU8pYWEHPTmkiVGd+7K5eFNVSY6AJhRvgGF70gg1Dz+l/k8WicvFCxdEs60A==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
+      "integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
       "requires": {
         "big.js": "^5.2.2",
         "emojis-list": "^3.0.0",

--- a/quotas/business_rules.py
+++ b/quotas/business_rules.py
@@ -11,6 +11,7 @@ from common.business_rules import PreventDeleteIfInUse
 from common.business_rules import UniqueIdentifyingFields
 from common.business_rules import ValidityPeriodContained
 from common.business_rules import only_applicable_after
+from common.business_rules import skip_when_not_deleted
 from common.models.utils import override_current_transaction
 from common.validators import UpdateType
 from geo_areas.validators import AreaCode
@@ -164,6 +165,7 @@ class ON11(PreventDeleteIfInUse):
 
 
 @only_applicable_after("2007-12-31")
+@skip_when_not_deleted
 class ON12(BusinessRule):
     """The quota order number origin cannot be deleted if it is used in a
     measure."""

--- a/quotas/business_rules.py
+++ b/quotas/business_rules.py
@@ -184,8 +184,8 @@ class ON12(BusinessRule):
             return
 
         order_numbers = measures.filter(
-            geographical_area_id=order_number_origin.geographical_area_id,
-            order_number_id=order_number_origin.order_number_id,
+            geographical_area__sid=order_number_origin.geographical_area.sid,
+            order_number__sid=order_number_origin.order_number.sid,
         )
 
         if order_numbers.exists():

--- a/quotas/business_rules.py
+++ b/quotas/business_rules.py
@@ -175,21 +175,18 @@ class ON12(BusinessRule):
         check that there are no measures linked to the origin .
         """
 
-        if (
-            type(on_origin.order_number.measure_set.first())
-            .objects.approved_up_to_transaction(on_origin.transaction)
-            .count()
-            == 0
-        ):
+        m_query = type(
+            on_origin.order_number.measure_set.first(),
+        ).objects.approved_up_to_transaction(
+            on_origin.transaction,
+        )
+
+        if not m_query.exists():
             return
 
-        on_query = (
-            type(on_origin.order_number.measure_set.first())
-            .objects.approved_up_to_transaction(on_origin.transaction)
-            .filter(
-                geographical_area_id=on_origin.geographical_area_id,
-                order_number_id=on_origin.order_number_id,
-            )
+        on_query = m_query.filter(
+            geographical_area_id=on_origin.geographical_area_id,
+            order_number_id=on_origin.order_number_id,
         )
 
         if on_query.exists():

--- a/quotas/business_rules.py
+++ b/quotas/business_rules.py
@@ -194,8 +194,8 @@ class ON12(BusinessRule):
             raise self.violation(
                 model=order_number_origin,
                 message=(
-                    "The quota order number origin cannot be deleted if it is used in a "
-                    "measure."
+                    "The quota order number origin cannot be deleted if it is used in a"
+                    " measure."
                     f"This order_number_origin is linked to {order_numbers.count()} measures currently."
                 ),
             )

--- a/quotas/business_rules.py
+++ b/quotas/business_rules.py
@@ -285,17 +285,26 @@ class OverlappingQuotaDefinition(BusinessRule):
     quota order number id."""
 
     def validate(self, quota_definition):
-        if (
+
+        potential_quota_definition_matches = (
             type(quota_definition)
-            .objects.approved_up_to_transaction(quota_definition.transaction)
+            .objects.approved_up_to_transaction(
+                quota_definition.transaction,
+            )
             .filter(
                 order_number=quota_definition.order_number,
                 valid_between__overlap=quota_definition.valid_between,
             )
             .exclude(sid=quota_definition.sid)
-            .exists()
-        ):
-            raise self.violation(quota_definition)
+        )
+
+        if potential_quota_definition_matches.exists():
+            for potential_quota_definition in potential_quota_definition_matches:
+                if (
+                    potential_quota_definition
+                    == potential_quota_definition.current_version
+                ):
+                    raise self.violation(quota_definition)
 
 
 class VolumeAndInitialVolumeMustMatch(BusinessRule):

--- a/quotas/business_rules.py
+++ b/quotas/business_rules.py
@@ -3,6 +3,7 @@ import datetime
 from datetime import date
 from decimal import Decimal
 
+import measures.models as measures_models
 from common.business_rules import BusinessRule
 from common.business_rules import ExclusionMembership
 from common.business_rules import MustExist
@@ -175,9 +176,7 @@ class ON12(BusinessRule):
         check that there are no measures linked to the origin .
         """
 
-        measures = type(
-            order_number_origin.order_number.measure_set.first(),
-        ).objects.approved_up_to_transaction(
+        measures = measures_models.Measure.objects.approved_up_to_transaction(
             order_number_origin.transaction,
         )
 

--- a/quotas/business_rules.py
+++ b/quotas/business_rules.py
@@ -175,18 +175,21 @@ class ON12(BusinessRule):
         check that there are no measures linked to the origin .
         """
 
-        m_query = type(
-            on_origin.order_number.measure_set.first(),
-        ).objects.approved_up_to_transaction(
-            on_origin.transaction,
-        )
-
-        if not m_query.exists():
+        if (
+            type(on_origin.order_number.measure_set.first())
+            .objects.approved_up_to_transaction(on_origin.transaction)
+            .count()
+            == 0
+        ):
             return
 
-        on_query = m_query.filter(
-            geographical_area_id=on_origin.geographical_area_id,
-            order_number_id=on_origin.order_number_id,
+        on_query = (
+            type(on_origin.order_number.measure_set.first())
+            .objects.approved_up_to_transaction(on_origin.transaction)
+            .filter(
+                geographical_area_id=on_origin.geographical_area_id,
+                order_number_id=on_origin.order_number_id,
+            )
         )
 
         if on_query.exists():

--- a/quotas/tests/test_business_rules.py
+++ b/quotas/tests/test_business_rules.py
@@ -516,6 +516,40 @@ def test_overlapping_quota_definition(date_ranges):
         ).validate(overlapping_definition)
 
 
+def test_overlapping_quota_definition_on_deleted_records(
+    date_ranges,
+    delete_record,
+    approved_transaction,
+):
+    order_number = factories.QuotaOrderNumberFactory.create()
+
+    old_quota_definition = factories.QuotaDefinitionFactory.create(
+        order_number=order_number,
+        valid_between=date_ranges.normal,
+    )
+
+    old_quota_definition.new_version(
+        update_type=UpdateType.DELETE,
+        transaction=approved_transaction,
+        workbasket=approved_transaction.workbasket,
+    )
+
+    overlapping_definition = factories.QuotaDefinitionFactory.create(
+        sid=5,
+        order_number=order_number,
+        valid_between=date_ranges.normal,
+    )
+
+    assert (
+        business_rules.OverlappingQuotaDefinition(
+            overlapping_definition.transaction,
+        ).validate(
+            overlapping_definition,
+        )
+        is None
+    )
+
+
 def test_volume_and_initial_volume_must_match(date_ranges):
     """Unless it is the main quota in a quota association, a definition's volume
     and initial_volume values should always be the same."""

--- a/quotas/tests/test_business_rules.py
+++ b/quotas/tests/test_business_rules.py
@@ -249,7 +249,7 @@ def test_ON12_does_not_raise(delete_record):
     # delete record
     deleted = delete_record(origin_without_measure)
 
-    assert business_rules.ON12(deleted.transaction).validate(deleted) is None
+    business_rules.ON12(deleted.transaction).validate(deleted)
 
 
 @pytest.mark.parametrize(

--- a/quotas/tests/test_business_rules.py
+++ b/quotas/tests/test_business_rules.py
@@ -231,6 +231,27 @@ def test_ON12(delete_record):
         business_rules.ON12(deleted.transaction).validate(deleted)
 
 
+def test_ON12_does_not_raise(delete_record):
+    """
+    The quota order number origin cannot be deleted if it is used in a measure.
+
+    This rule is only applicable for measure with start date after 31/12/2007.
+    """
+
+    # create measure, and quota order and origin
+    measure = factories.MeasureWithQuotaFactory.create()
+
+    # add another origin
+    origin_without_measure = factories.QuotaOrderNumberOriginFactory.create(
+        order_number=measure.order_number,
+    )
+
+    # delete record
+    deleted = delete_record(origin_without_measure)
+
+    assert business_rules.ON12(deleted.transaction).validate(deleted) is None
+
+
 @pytest.mark.parametrize(
     "area_code, expect_error",
     [

--- a/quotas/tests/test_views.py
+++ b/quotas/tests/test_views.py
@@ -2,6 +2,7 @@ import pytest
 
 from common.tests import factories
 from common.tests.util import assert_model_view_renders
+from common.tests.util import assert_read_only_model_view_returns_list
 from common.tests.util import get_class_based_view_urls_matching_url
 from common.tests.util import view_is_subclass
 from common.tests.util import view_urlpattern_ids
@@ -47,3 +48,135 @@ def test_quota_list_view(view, url_pattern, valid_user_client):
     """Verify that quota list view is under the url quotas/ and doesn't return
     an error."""
     assert_model_view_renders(view, url_pattern, valid_user_client)
+
+
+def test_quota_ordernumber_api_list_view(valid_user_client, date_ranges):
+    expected_results = [
+        factories.QuotaOrderNumberFactory.create(
+            valid_between=date_ranges.normal,
+        ),
+        factories.QuotaOrderNumberFactory.create(
+            valid_between=date_ranges.earlier,
+        ),
+    ]
+
+    assert_read_only_model_view_returns_list(
+        "quotaordernumber",
+        "value",
+        "pk",
+        expected_results,
+        valid_user_client,
+    )
+
+
+def test_quota_ordernumberorigin_api_list_view(valid_user_client, date_ranges):
+    order_number = factories.QuotaOrderNumberFactory.create()
+    expected_results = [
+        factories.QuotaOrderNumberOriginFactory.create(
+            valid_between=date_ranges.normal,
+            order_number=order_number,
+        ),
+        factories.QuotaOrderNumberOriginFactory.create(
+            valid_between=date_ranges.earlier,
+            order_number=order_number,
+        ),
+    ]
+
+    assert_read_only_model_view_returns_list(
+        "quotaordernumberorigin",
+        "sid",
+        "sid",
+        expected_results,
+        valid_user_client,
+    )
+
+
+def test_quota_ordernumberoriginexclusion_api_list_view(valid_user_client):
+    order_number_origin = factories.QuotaOrderNumberOriginFactory.create()
+    expected_results = [
+        factories.QuotaOrderNumberOriginExclusionFactory.create(
+            origin=order_number_origin,
+        ),
+        factories.QuotaOrderNumberOriginExclusionFactory.create(
+            origin=order_number_origin,
+        ),
+    ]
+
+    assert_read_only_model_view_returns_list(
+        "quotaordernumberoriginexclusion",
+        "origin.sid",
+        "origin.sid",
+        expected_results,
+        valid_user_client,
+    )
+
+
+def test_quota_definition_api_list_view(valid_user_client):
+    expected_results = [factories.QuotaDefinitionFactory.create()]
+
+    assert_read_only_model_view_returns_list(
+        "quotadefinition",
+        "sid",
+        "sid",
+        expected_results,
+        valid_user_client,
+    )
+
+
+def test_quota_association_api_list_view(valid_user_client):
+    main_quota = factories.QuotaDefinitionFactory.create()
+
+    expected_results = [
+        factories.QuotaAssociationFactory.create(
+            main_quota=main_quota,
+        ),
+    ]
+
+    assert_read_only_model_view_returns_list(
+        "quotaassociation",
+        "main_quota.sid",
+        "main_quota.sid",
+        expected_results,
+        valid_user_client,
+    )
+
+
+def test_quota_suspension_api_list_view(valid_user_client):
+    expected_results = [factories.QuotaSuspensionFactory.create()]
+
+    assert_read_only_model_view_returns_list(
+        "quotasuspension",
+        "sid",
+        "sid",
+        expected_results,
+        valid_user_client,
+    )
+
+
+def test_quota_blocking_api_list_view(valid_user_client):
+    expected_results = [factories.QuotaBlockingFactory.create()]
+
+    assert_read_only_model_view_returns_list(
+        "quotablocking",
+        "sid",
+        "sid",
+        expected_results,
+        valid_user_client,
+    )
+
+
+def test_quota_event_api_list_view(valid_user_client):
+    quota_definition = factories.QuotaDefinitionFactory.create()
+    expected_results = [
+        factories.QuotaEventFactory.create(
+            quota_definition=quota_definition,
+        ),
+    ]
+
+    assert_read_only_model_view_returns_list(
+        "quotaevent",
+        "quota_definition.sid",
+        "quota_definition.sid",
+        expected_results,
+        valid_user_client,
+    )

--- a/quotas/urls.py
+++ b/quotas/urls.py
@@ -11,16 +11,34 @@ api_router.register(
     views.QuotaOrderNumberViewset,
     basename="quotaordernumber",
 )
-api_router.register(r"quota_order_number_origins", views.QuotaOrderNumberOriginViewset)
+api_router.register(
+    r"quota_order_number_origins",
+    views.QuotaOrderNumberOriginViewset,
+)
 api_router.register(
     r"quota_order_number_origin_exclusions",
     views.QuotaOrderNumberOriginExclusionViewset,
 )
-api_router.register(r"quota_definitions", views.QuotaDefinitionViewset)
-api_router.register(r"quota_associations", views.QuotaAssociationViewset)
-api_router.register(r"quota_suspensions", views.QuotaSuspensionViewset)
-api_router.register(r"quota_blocking_periods", views.QuotaBlockingViewset)
-api_router.register(r"quota_events", views.QuotaEventViewset)
+api_router.register(
+    r"quota_definitions",
+    views.QuotaDefinitionViewset,
+)
+api_router.register(
+    r"quota_associations",
+    views.QuotaAssociationViewset,
+)
+api_router.register(
+    r"quota_suspensions",
+    views.QuotaSuspensionViewset,
+)
+api_router.register(
+    r"quota_blocking_periods",
+    views.QuotaBlockingViewset,
+)
+api_router.register(
+    r"quota_events",
+    views.QuotaEventViewset,
+)
 
 ui_patterns = get_ui_paths(views, "<sid:sid>")
 

--- a/regulations/tests/test_views.py
+++ b/regulations/tests/test_views.py
@@ -3,6 +3,7 @@ from django.core.exceptions import ValidationError
 
 from common.tests import factories
 from common.tests.util import assert_model_view_renders
+from common.tests.util import assert_read_only_model_view_returns_list
 from common.tests.util import get_class_based_view_urls_matching_url
 from common.tests.util import raises_if
 from common.tests.util import valid_between_start_delta
@@ -75,3 +76,25 @@ def test_regulation_list_view(
     """Verify that regulation list view is under the url regulations/ and
     doesn't return an error."""
     assert_model_view_renders(view, url_pattern, valid_user_client)
+
+
+def test_regulation_api_list_view(valid_user_client, date_ranges):
+    selected_group = factories.RegulationGroupFactory.create()
+    expected_results = [
+        factories.RegulationFactory.create(
+            valid_between=date_ranges.normal,
+            regulation_group=selected_group,
+        ),
+        factories.RegulationFactory.create(
+            valid_between=date_ranges.earlier,
+            regulation_group=selected_group,
+        ),
+    ]
+
+    assert_read_only_model_view_returns_list(
+        "regulation",
+        "value",
+        "pk",
+        expected_results,
+        valid_user_client,
+    )

--- a/workbaskets/tests/test_views.py
+++ b/workbaskets/tests/test_views.py
@@ -51,7 +51,10 @@ def test_workbasket_create_user_not_logged_in_dev_sso_disabled(client, settings)
     settings.ENV = "dev"
     settings.SSO_ENABLED = False
     settings.LOGIN_URL = reverse("login")
-    settings.MIDDLEWARE.remove("authbroker_client.middleware.ProtectAllViewsMiddleware")
+    if "authbroker_client.middleware.ProtectAllViewsMiddleware" in settings.MIDDLEWARE:
+        settings.MIDDLEWARE.remove(
+            "authbroker_client.middleware.ProtectAllViewsMiddleware",
+        )
     create_url = reverse("workbaskets:workbasket-ui-create")
     form_data = {
         "title": "My new workbasket",


### PR DESCRIPTION
# TOPS-824 - cant remove the required origin from order number, which has no measures attached. 

The rule states : The quota order number origin cannot be deleted if it is used in a measure.

## Why
 * Rule would reject removal if any measures existed on the order, without checking specific measures for the geographical area

## What
* Updated rule, added test

Links to relevant material
See: https://uktrade.atlassian.net/browse/TOPS-824
