### PR TITLE
Tops 681 update to OverlappingQuotaDefinition Rule

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1011,9 +1011,9 @@
       }
     },
     "node_modules/loader-utils": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.3.tgz",
-      "integrity": "sha512-THWqIsn8QRnvLl0shHYVBN9syumU8pYWEHPTmkiVGd+7K5eFNVSY6AJhRvgGF70gg1Dz+l/k8WicvFCxdEs60A==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
+      "integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
       "dependencies": {
         "big.js": "^5.2.2",
         "emojis-list": "^3.0.0",
@@ -2682,9 +2682,9 @@
       "integrity": "sha512-92+huvxMvYlMzMt0iIOukcwYBFpkYJdpl2xsZ7LrlayO7E8SOv+JJUEK17B/dJIHAOLMfh2dZZ/Y18WgmGtYNw=="
     },
     "loader-utils": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.3.tgz",
-      "integrity": "sha512-THWqIsn8QRnvLl0shHYVBN9syumU8pYWEHPTmkiVGd+7K5eFNVSY6AJhRvgGF70gg1Dz+l/k8WicvFCxdEs60A==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
+      "integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
       "requires": {
         "big.js": "^5.2.2",
         "emojis-list": "^3.0.0",

--- a/quotas/business_rules.py
+++ b/quotas/business_rules.py
@@ -292,7 +292,12 @@ class OverlappingQuotaDefinition(BusinessRule):
                 order_number=quota_definition.order_number,
                 valid_between__overlap=quota_definition.valid_between,
             )
-            .exclude(sid=quota_definition.sid)
+            .exclude(
+                sid=quota_definition.sid,
+                update_type=2,
+                trackedmodel_ptr_id=quota_definition.trackedmodel_ptr_id,
+            )
+            .exclude(update_type=2)
             .exists()
         ):
             raise self.violation(quota_definition)

--- a/quotas/tests/test_business_rules.py
+++ b/quotas/tests/test_business_rules.py
@@ -516,7 +516,11 @@ def test_overlapping_quota_definition(date_ranges):
         ).validate(overlapping_definition)
 
 
-def test_overlapping_quota_definition_on_deleted_records(date_ranges, delete_record):
+def test_overlapping_quota_definition_on_deleted_records(
+    date_ranges,
+    delete_record,
+    approved_transaction,
+):
     order_number = factories.QuotaOrderNumberFactory.create()
 
     old_quota_definition = factories.QuotaDefinitionFactory.create(
@@ -526,9 +530,12 @@ def test_overlapping_quota_definition_on_deleted_records(date_ranges, delete_rec
 
     old_quota_definition.new_version(
         update_type=UpdateType.DELETE,
+        transaction=approved_transaction,
+        workbasket=approved_transaction.workbasket,
     )
 
     overlapping_definition = factories.QuotaDefinitionFactory.create(
+        sid=5,
         order_number=order_number,
         valid_between=date_ranges.normal,
     )

--- a/quotas/tests/test_business_rules.py
+++ b/quotas/tests/test_business_rules.py
@@ -516,6 +516,33 @@ def test_overlapping_quota_definition(date_ranges):
         ).validate(overlapping_definition)
 
 
+def test_overlapping_quota_definition_on_deleted_records(date_ranges, delete_record):
+    order_number = factories.QuotaOrderNumberFactory.create()
+
+    old_quota_definition = factories.QuotaDefinitionFactory.create(
+        order_number=order_number,
+        valid_between=date_ranges.normal,
+    )
+
+    old_quota_definition.new_version(
+        update_type=UpdateType.DELETE,
+    )
+
+    overlapping_definition = factories.QuotaDefinitionFactory.create(
+        order_number=order_number,
+        valid_between=date_ranges.normal,
+    )
+
+    assert (
+        business_rules.OverlappingQuotaDefinition(
+            overlapping_definition.transaction,
+        ).validate(
+            overlapping_definition,
+        )
+        is None
+    )
+
+
 def test_volume_and_initial_volume_must_match(date_ranges):
     """Unless it is the main quota in a quota association, a definition's volume
     and initial_volume values should always be the same."""


### PR DESCRIPTION
# TOPS-681

## Why
 * OverlappingQuotaDefinition correctly filtered deleted models, but did not check latest version of model was current.
 * No test to verify if a Quota definition previously deleted would pass through the rule check 
 * A production update example caused this issue to prevent an update

## What
 * Updates the OverlappingQuotaDefinition business rule to check only current version of model

## Checklist
- Requires migrations? NO
- Requires dependency updates? NO

Links to relevant material
See: This change will unblock this ticket : https://uktrade.atlassian.net/browse/TOPS-831
See : Original request that identified the issue : https://uktrade.atlassian.net/browse/TOPS-681
