### PR TITLE
TP2000-608 Unit tests for api list views

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,10 +1,10 @@
 repos:
   - repo: https://github.com/asottile/add-trailing-comma
-    rev: v2.2.3
+    rev: v2.3.0
     hooks:
       - id: add-trailing-comma
   - repo: https://github.com/myint/autoflake.git
-    rev: v1.4
+    rev: v1.7.7
     hooks:
       - id: autoflake
         args:
@@ -19,7 +19,7 @@ repos:
       - id: isort
         args: [--force-single-line-imports]
   - repo: https://github.com/myint/docformatter.git
-    rev: v1.4
+    rev: v1.5.0
     hooks:
       - id: docformatter
         args:
@@ -30,7 +30,7 @@ repos:
             "--pre-summary-newline",
           ]
   - repo: https://github.com/psf/black
-    rev: 22.3.0
+    rev: 22.10.0
     hooks:
       - id: black
   - repo: https://github.com/ikamensh/flynt/

--- a/additional_codes/tests/test_views.py
+++ b/additional_codes/tests/test_views.py
@@ -9,6 +9,7 @@ from additional_codes.models import AdditionalCode
 from additional_codes.views import AdditionalCodeList
 from common.tests import factories
 from common.tests.util import assert_model_view_renders
+from common.tests.util import assert_read_only_model_view_returns_list
 from common.tests.util import date_post_data
 from common.tests.util import get_class_based_view_urls_matching_url
 from common.tests.util import raises_if
@@ -93,3 +94,37 @@ def test_additional_codes_list_view(view, url_pattern, valid_user_client):
     """Verify that additional code list view is under the url additional_codes/
     and doesn't return an error."""
     assert_model_view_renders(view, url_pattern, valid_user_client)
+
+
+def test_additional_codes_api_list_view(valid_user_client, date_ranges):
+    selected_type = factories.AdditionalCodeTypeFactory.create()
+    expected_results = [
+        factories.AdditionalCodeFactory.create(
+            valid_between=date_ranges.normal,
+            type=selected_type,
+        ),
+        factories.AdditionalCodeFactory.create(
+            valid_between=date_ranges.earlier,
+            type=selected_type,
+        ),
+    ]
+    assert_read_only_model_view_returns_list(
+        "additionalcode",
+        "value",
+        "pk",
+        expected_results,
+        valid_user_client,
+    )
+
+
+def test_additional_code_type_api_list_view(valid_user_client):
+    expected_results = [
+        factories.AdditionalCodeTypeFactory.create(),
+    ]
+    assert_read_only_model_view_returns_list(
+        "additionalcodetype",
+        "sid",
+        "sid",
+        expected_results,
+        valid_user_client,
+    )

--- a/additional_codes/urls.py
+++ b/additional_codes/urls.py
@@ -14,7 +14,6 @@ api_router.register(
 api_router.register(
     r"additional_code_types",
     views.AdditionalCodeTypeViewSet,
-    basename="additionalcodetype",
 )
 
 detail = "<sid:sid>"

--- a/additional_codes/urls.py
+++ b/additional_codes/urls.py
@@ -11,7 +11,11 @@ api_router.register(
     views.AdditionalCodeViewSet,
     basename="additionalcode",
 )
-api_router.register(r"additional_code_types", views.AdditionalCodeTypeViewSet)
+api_router.register(
+    r"additional_code_types",
+    views.AdditionalCodeTypeViewSet,
+    basename="additionalcodetype",
+)
 
 detail = "<sid:sid>"
 description_detail = "<sid:described_additionalcode__sid>/description/<sid:sid>"

--- a/certificates/tests/test_views.py
+++ b/certificates/tests/test_views.py
@@ -9,6 +9,7 @@ from certificates.views import CertificateList
 from common.models.utils import override_current_transaction
 from common.tests import factories
 from common.tests.util import assert_model_view_renders
+from common.tests.util import assert_read_only_model_view_returns_list
 from common.tests.util import get_class_based_view_urls_matching_url
 from common.tests.util import view_is_subclass
 from common.tests.util import view_urlpattern_ids
@@ -134,3 +135,38 @@ def test_description_create_get_context_data(valid_user_api_client):
         described_certificate__sid=new_version.sid,
         described_certificate__certificate_type__sid=new_version.certificate_type.sid,
     ).exists()
+
+
+def test_certificate_api_list_view(valid_user_client, date_ranges):
+    selected_type = factories.CertificateTypeFactory.create()
+    expected_results = [
+        factories.CertificateFactory.create(
+            valid_between=date_ranges.normal,
+            certificate_type=selected_type,
+        ),
+        factories.CertificateFactory.create(
+            valid_between=date_ranges.earlier,
+            certificate_type=selected_type,
+        ),
+    ]
+    assert_read_only_model_view_returns_list(
+        "certificate",
+        "value",
+        "pk",
+        expected_results,
+        valid_user_client,
+    )
+
+
+def test_certificate_type_api_list_view(valid_user_client):
+    expected_results = [
+        factories.CertificateTypeFactory.create(),
+    ]
+
+    assert_read_only_model_view_returns_list(
+        "certificatetype",
+        "sid",
+        "sid",
+        expected_results,
+        valid_user_client,
+    )

--- a/certificates/urls.py
+++ b/certificates/urls.py
@@ -20,7 +20,6 @@ api_router.register(
 api_router.register(
     r"certificate_types",
     views.CertificateTypeViewSet,
-    basename="certificatetype",
 )
 
 detail = "<ctype_sid:certificate_type__sid><cert_sid:sid>"

--- a/certificates/urls.py
+++ b/certificates/urls.py
@@ -17,7 +17,11 @@ api_router.register(
     views.CertificatesViewSet,
     basename="certificate",
 )
-api_router.register(r"certificate_types", views.CertificateTypeViewSet)
+api_router.register(
+    r"certificate_types",
+    views.CertificateTypeViewSet,
+    basename="certificatetype",
+)
 
 detail = "<ctype_sid:certificate_type__sid><cert_sid:sid>"
 description_detail = "<ctype_sid:described_certificate__certificate_type__sid><cert_sid:described_certificate__sid>/description/<sid:sid>"

--- a/common/tests/util.py
+++ b/common/tests/util.py
@@ -446,6 +446,23 @@ def assert_read_only_model_view_returns_list(
     valid_user_client,
     equals=False,
 ):
+    """
+    Integration test to verify class based read only model views.
+
+    Given a class based view and a url_name -
+      - Lookup the url for a list function
+      - Fetch data from the a URL constructed using the just created data.
+      - Assert that a 200 status was returned.
+      - Assert that the expected data is in results or equal if equals flag true
+
+    :param url_name: url namespace for the view
+    :param result_attributes: attribute path for the result
+    :param expected_attribute: attribute path for the expected result
+    :param expected_results: expected result
+    :param valid_user_client:
+    :param equals=False: flag for equals check
+    :param valid_user_client:
+    """
     def get_attribute_value(data, attributes):
         for attribute in attributes.split("."):
             data = data[attribute]

--- a/common/tests/util.py
+++ b/common/tests/util.py
@@ -463,6 +463,7 @@ def assert_read_only_model_view_returns_list(
     :param equals=False: flag for equals check
     :param valid_user_client:
     """
+
     def get_attribute_value(data, attributes):
         for attribute in attributes.split("."):
             data = data[attribute]

--- a/footnotes/tests/test_views.py
+++ b/footnotes/tests/test_views.py
@@ -3,6 +3,7 @@ from django.core.exceptions import ValidationError
 
 from common.tests import factories
 from common.tests.util import assert_model_view_renders
+from common.tests.util import assert_read_only_model_view_returns_list
 from common.tests.util import get_class_based_view_urls_matching_url
 from common.tests.util import raises_if
 from common.tests.util import valid_between_end_delta
@@ -128,3 +129,36 @@ def test_footnote_list_view(view, url_pattern, valid_user_client):
     """Verify that footnote list view is under the url footnotes/ and doesn't
     return an error."""
     assert_model_view_renders(view, url_pattern, valid_user_client)
+
+
+def test_footnote_api_list_view(valid_user_client, date_ranges):
+    selected_type = factories.FootnoteTypeFactory.create()
+    expected_results = [
+        factories.FootnoteFactory.create(
+            valid_between=date_ranges.normal,
+            footnote_type=selected_type,
+        ),
+        factories.FootnoteFactory.create(
+            valid_between=date_ranges.earlier,
+            footnote_type=selected_type,
+        ),
+    ]
+    assert_read_only_model_view_returns_list(
+        "footnote",
+        "value",
+        "pk",
+        expected_results,
+        valid_user_client,
+    )
+
+
+def test_footnote_type_api_list_view(valid_user_client):
+    expected_results = [factories.FootnoteTypeFactory.create()]
+
+    assert_read_only_model_view_returns_list(
+        "footnotetype",
+        "footnote_type_id",
+        "footnote_type_id",
+        expected_results,
+        valid_user_client,
+    )

--- a/footnotes/urls.py
+++ b/footnotes/urls.py
@@ -20,7 +20,6 @@ api_router.register(
 api_router.register(
     r"footnote_types",
     views.FootnoteTypeViewSet,
-    basename="footnotetype",
 )
 
 detail = "<footnote_type_id:footnote_type__footnote_type_id><footnote_id:footnote_id>"

--- a/footnotes/urls.py
+++ b/footnotes/urls.py
@@ -17,7 +17,11 @@ api_router.register(
     views.FootnoteViewSet,
     basename="footnote",
 )
-api_router.register(r"footnote_types", views.FootnoteTypeViewSet)
+api_router.register(
+    r"footnote_types",
+    views.FootnoteTypeViewSet,
+    basename="footnotetype",
+)
 
 detail = "<footnote_type_id:footnote_type__footnote_type_id><footnote_id:footnote_id>"
 description_detail = "<footnote_type_id:described_footnote__footnote_type__footnote_type_id><footnote_id:described_footnote__footnote_id>/description/<sid:sid>"

--- a/geo_areas/tests/test_views.py
+++ b/geo_areas/tests/test_views.py
@@ -5,6 +5,7 @@ from rest_framework.reverse import reverse
 from common.models.utils import override_current_transaction
 from common.tests import factories
 from common.tests.util import assert_model_view_renders
+from common.tests.util import assert_read_only_model_view_returns_list
 from common.tests.util import get_class_based_view_urls_matching_url
 from common.tests.util import view_is_subclass
 from common.tests.util import view_urlpattern_ids
@@ -103,3 +104,14 @@ def test_geographical_area_list_filter(search_terms, valid_user_client):
     )
 
     assert page.find("tbody").find("td", text="Greenland")
+
+
+def test_geo_area_api_list_view(valid_user_client):
+    expected_results = [factories.GeographicalAreaFactory.create()]
+    assert_read_only_model_view_returns_list(
+        "geo_area",
+        "value",
+        "pk",
+        expected_results,
+        valid_user_client,
+    )

--- a/measures/tests/test_views.py
+++ b/measures/tests/test_views.py
@@ -14,6 +14,7 @@ from common.models.transactions import Transaction
 from common.models.utils import override_current_transaction
 from common.tests import factories
 from common.tests.util import assert_model_view_renders
+from common.tests.util import assert_read_only_model_view_returns_list
 from common.tests.util import get_class_based_view_urls_matching_url
 from common.tests.util import raises_if
 from common.tests.util import view_is_subclass
@@ -1078,3 +1079,23 @@ def test_measure_form_creates_exclusions(
     assert not set(
         [e.excluded_geographical_area for e in measure.exclusions.all()],
     ).difference({excluded_country1, excluded_country2})
+
+
+def test_measuretype_api_list_view(valid_user_client):
+    expected_results = [
+        factories.MeasureTypeFactory.create(
+            description="1 test description",
+        ),
+        factories.MeasureTypeFactory.create(
+            description="2 test description",
+        ),
+    ]
+
+    assert_read_only_model_view_returns_list(
+        "measuretype",
+        "value",
+        "pk",
+        expected_results,
+        valid_user_client,
+        equals=True,
+    )

--- a/quotas/tests/test_views.py
+++ b/quotas/tests/test_views.py
@@ -157,7 +157,7 @@ def test_quota_blocking_api_list_view(valid_user_client):
     expected_results = [factories.QuotaBlockingFactory.create()]
 
     assert_read_only_model_view_returns_list(
-        "quotablockingperiod",
+        "quotablocking",
         "sid",
         "sid",
         expected_results,

--- a/quotas/tests/test_views.py
+++ b/quotas/tests/test_views.py
@@ -2,6 +2,7 @@ import pytest
 
 from common.tests import factories
 from common.tests.util import assert_model_view_renders
+from common.tests.util import assert_read_only_model_view_returns_list
 from common.tests.util import get_class_based_view_urls_matching_url
 from common.tests.util import view_is_subclass
 from common.tests.util import view_urlpattern_ids
@@ -47,3 +48,135 @@ def test_quota_list_view(view, url_pattern, valid_user_client):
     """Verify that quota list view is under the url quotas/ and doesn't return
     an error."""
     assert_model_view_renders(view, url_pattern, valid_user_client)
+
+
+def test_quota_ordernumber_api_list_view(valid_user_client, date_ranges):
+    expected_results = [
+        factories.QuotaOrderNumberFactory.create(
+            valid_between=date_ranges.normal,
+        ),
+        factories.QuotaOrderNumberFactory.create(
+            valid_between=date_ranges.earlier,
+        ),
+    ]
+
+    assert_read_only_model_view_returns_list(
+        "quotaordernumber",
+        "value",
+        "pk",
+        expected_results,
+        valid_user_client,
+    )
+
+
+def test_quota_ordernumberorigin_api_list_view(valid_user_client, date_ranges):
+    order_number = factories.QuotaOrderNumberFactory.create()
+    expected_results = [
+        factories.QuotaOrderNumberOriginFactory.create(
+            valid_between=date_ranges.normal,
+            order_number=order_number,
+        ),
+        factories.QuotaOrderNumberOriginFactory.create(
+            valid_between=date_ranges.earlier,
+            order_number=order_number,
+        ),
+    ]
+
+    assert_read_only_model_view_returns_list(
+        "quotaordernumberorigin",
+        "sid",
+        "sid",
+        expected_results,
+        valid_user_client,
+    )
+
+
+def test_quota_ordernumberoriginexclusion_api_list_view(valid_user_client):
+    order_number_origin = factories.QuotaOrderNumberOriginFactory.create()
+    expected_results = [
+        factories.QuotaOrderNumberOriginExclusionFactory.create(
+            origin=order_number_origin,
+        ),
+        factories.QuotaOrderNumberOriginExclusionFactory.create(
+            origin=order_number_origin,
+        ),
+    ]
+
+    assert_read_only_model_view_returns_list(
+        "quotaordernumberoriginexclusion",
+        "origin.sid",
+        "origin.sid",
+        expected_results,
+        valid_user_client,
+    )
+
+
+def test_quota_definition_api_list_view(valid_user_client):
+    expected_results = [factories.QuotaDefinitionFactory.create()]
+
+    assert_read_only_model_view_returns_list(
+        "quotadefinition",
+        "sid",
+        "sid",
+        expected_results,
+        valid_user_client,
+    )
+
+
+def test_quota_association_api_list_view(valid_user_client):
+    main_quota = factories.QuotaDefinitionFactory.create()
+
+    expected_results = [
+        factories.QuotaAssociationFactory.create(
+            main_quota=main_quota,
+        ),
+    ]
+
+    assert_read_only_model_view_returns_list(
+        "quotaassociation",
+        "main_quota.sid",
+        "main_quota.sid",
+        expected_results,
+        valid_user_client,
+    )
+
+
+def test_quota_suspension_api_list_view(valid_user_client):
+    expected_results = [factories.QuotaSuspensionFactory.create()]
+
+    assert_read_only_model_view_returns_list(
+        "quotasuspension",
+        "sid",
+        "sid",
+        expected_results,
+        valid_user_client,
+    )
+
+
+def test_quota_blocking_api_list_view(valid_user_client):
+    expected_results = [factories.QuotaBlockingFactory.create()]
+
+    assert_read_only_model_view_returns_list(
+        "quotablockingperiod",
+        "sid",
+        "sid",
+        expected_results,
+        valid_user_client,
+    )
+
+
+def test_quota_event_api_list_view(valid_user_client):
+    quota_definition = factories.QuotaDefinitionFactory.create()
+    expected_results = [
+        factories.QuotaEventFactory.create(
+            quota_definition=quota_definition,
+        ),
+    ]
+
+    assert_read_only_model_view_returns_list(
+        "quotaevent",
+        "quota_definition.sid",
+        "quota_definition.sid",
+        expected_results,
+        valid_user_client,
+    )

--- a/quotas/urls.py
+++ b/quotas/urls.py
@@ -11,16 +11,41 @@ api_router.register(
     views.QuotaOrderNumberViewset,
     basename="quotaordernumber",
 )
-api_router.register(r"quota_order_number_origins", views.QuotaOrderNumberOriginViewset)
+api_router.register(
+    r"quota_order_number_origins",
+    views.QuotaOrderNumberOriginViewset,
+    basename="quotaordernumberorigin",
+)
 api_router.register(
     r"quota_order_number_origin_exclusions",
     views.QuotaOrderNumberOriginExclusionViewset,
+    basename="quotaordernumberoriginexclusion",
 )
-api_router.register(r"quota_definitions", views.QuotaDefinitionViewset)
-api_router.register(r"quota_associations", views.QuotaAssociationViewset)
-api_router.register(r"quota_suspensions", views.QuotaSuspensionViewset)
-api_router.register(r"quota_blocking_periods", views.QuotaBlockingViewset)
-api_router.register(r"quota_events", views.QuotaEventViewset)
+api_router.register(
+    r"quota_definitions",
+    views.QuotaDefinitionViewset,
+    basename="quotadefinition",
+)
+api_router.register(
+    r"quota_associations",
+    views.QuotaAssociationViewset,
+    basename="quotaassociation",
+)
+api_router.register(
+    r"quota_suspensions",
+    views.QuotaSuspensionViewset,
+    basename="quotasuspension",
+)
+api_router.register(
+    r"quota_blocking_periods",
+    views.QuotaBlockingViewset,
+    basename="quotablockingperiod",
+)
+api_router.register(
+    r"quota_events",
+    views.QuotaEventViewset,
+    basename="quotaevent",
+)
 
 ui_patterns = get_ui_paths(views, "<sid:sid>")
 

--- a/quotas/urls.py
+++ b/quotas/urls.py
@@ -14,37 +14,30 @@ api_router.register(
 api_router.register(
     r"quota_order_number_origins",
     views.QuotaOrderNumberOriginViewset,
-    basename="quotaordernumberorigin",
 )
 api_router.register(
     r"quota_order_number_origin_exclusions",
     views.QuotaOrderNumberOriginExclusionViewset,
-    basename="quotaordernumberoriginexclusion",
 )
 api_router.register(
     r"quota_definitions",
     views.QuotaDefinitionViewset,
-    basename="quotadefinition",
 )
 api_router.register(
     r"quota_associations",
     views.QuotaAssociationViewset,
-    basename="quotaassociation",
 )
 api_router.register(
     r"quota_suspensions",
     views.QuotaSuspensionViewset,
-    basename="quotasuspension",
 )
 api_router.register(
     r"quota_blocking_periods",
     views.QuotaBlockingViewset,
-    basename="quotablockingperiod",
 )
 api_router.register(
     r"quota_events",
     views.QuotaEventViewset,
-    basename="quotaevent",
 )
 
 ui_patterns = get_ui_paths(views, "<sid:sid>")

--- a/regulations/tests/test_views.py
+++ b/regulations/tests/test_views.py
@@ -3,6 +3,7 @@ from django.core.exceptions import ValidationError
 
 from common.tests import factories
 from common.tests.util import assert_model_view_renders
+from common.tests.util import assert_read_only_model_view_returns_list
 from common.tests.util import get_class_based_view_urls_matching_url
 from common.tests.util import raises_if
 from common.tests.util import valid_between_start_delta
@@ -75,3 +76,25 @@ def test_regulation_list_view(
     """Verify that regulation list view is under the url regulations/ and
     doesn't return an error."""
     assert_model_view_renders(view, url_pattern, valid_user_client)
+
+
+def test_regulation_api_list_view(valid_user_client, date_ranges):
+    selected_group = factories.RegulationGroupFactory.create()
+    expected_results = [
+        factories.RegulationFactory.create(
+            valid_between=date_ranges.normal,
+            regulation_group=selected_group,
+        ),
+        factories.RegulationFactory.create(
+            valid_between=date_ranges.earlier,
+            regulation_group=selected_group,
+        ),
+    ]
+
+    assert_read_only_model_view_returns_list(
+        "regulation",
+        "value",
+        "pk",
+        expected_results,
+        valid_user_client,
+    )

--- a/workbaskets/tests/test_views.py
+++ b/workbaskets/tests/test_views.py
@@ -51,7 +51,10 @@ def test_workbasket_create_user_not_logged_in_dev_sso_disabled(client, settings)
     settings.ENV = "dev"
     settings.SSO_ENABLED = False
     settings.LOGIN_URL = reverse("login")
-    settings.MIDDLEWARE.remove("authbroker_client.middleware.ProtectAllViewsMiddleware")
+    if "authbroker_client.middleware.ProtectAllViewsMiddleware" in settings.MIDDLEWARE:
+        settings.MIDDLEWARE.remove(
+            "authbroker_client.middleware.ProtectAllViewsMiddleware",
+        )
     create_url = reverse("workbaskets:workbasket-ui-create")
     form_data = {
         "title": "My new workbasket",


### PR DESCRIPTION
# TP2000-608  Unit tests for api list views

## Why
Previously the ReadOnlyModelViewSet views did not have any units tests, this story ensures that this coverage has been addressed

## What
Unit testing API view sets
