### PR TITLE
change test so it passes all the time

### DIFF
--- a/checks/tests/test_querysets.py
+++ b/checks/tests/test_querysets.py
@@ -49,7 +49,7 @@ def test_current_queryset_returns_correct_results(
             approved=True,
             order=head_order + 1,
         )
-    assert Transaction.objects.all().approved.last() == latest
+    assert Transaction.objects.all().approved().last() == latest
 
     assert_current(check, expect_current)
 

--- a/checks/tests/test_querysets.py
+++ b/checks/tests/test_querysets.py
@@ -47,9 +47,9 @@ def test_current_queryset_returns_correct_results(
     else:
         latest = common_factories.TransactionFactory.create(
             approved=True,
-            order=head_order + 1,
+            order=head_order + 2,
         )
-    assert Transaction.objects.all().approved().last() == latest
+    assert Transaction.approved.last() == latest
 
     assert_current(check, expect_current)
 

--- a/checks/tests/test_querysets.py
+++ b/checks/tests/test_querysets.py
@@ -49,7 +49,7 @@ def test_current_queryset_returns_correct_results(
             approved=True,
             order=head_order + 1,
         )
-    assert Transaction.approved.last() == latest
+    assert Transaction.objects.all().approved.last() == latest
 
     assert_current(check, expect_current)
 

--- a/quotas/business_rules.py
+++ b/quotas/business_rules.py
@@ -194,8 +194,8 @@ class ON12(BusinessRule):
             raise self.violation(
                 model=order_number_origin,
                 message=(
-                    "The quota order number origin cannot be deleted if it is used in a"
-                    " measure."
+                    "The quota order number origin cannot be deleted if it is used in a "
+                    "measure. "
                     f"This order_number_origin is linked to {order_numbers.count()} measures currently."
                 ),
             )


### PR DESCRIPTION
# No Ticket, small PR to fix test: 

## Why
checks/tests/test_querysets.py::test_current_queryset_returns_correct_results[check of approved transaction with greater approved check transaction] will intermittently fail, roughly 50% of the time. 

## What
* The test would fail 50% of the time (and has presumably for all of its existence) since the parameterised test would set up 2 transactions with the same order number. Incrementing the order number of the second created transaction in the test fixes the issue and the increate in coverage indicates here is additional code that is now being covered that was not before. 

## Checklist
Requires migrations? no
Requires dependency updates? no
