### PR TITLE
minor change to ON12 validation error message text.

### DIFF
--- a/quotas/business_rules.py
+++ b/quotas/business_rules.py
@@ -194,8 +194,8 @@ class ON12(BusinessRule):
             raise self.violation(
                 model=order_number_origin,
                 message=(
-                    "The quota order number origin cannot be deleted if it is used in a"
-                    " measure."
+                    "The quota order number origin cannot be deleted if it is used in a "
+                    "measure. "
                     f"This order_number_origin is linked to {order_numbers.count()} measures currently."
                 ),
             )


### PR DESCRIPTION
# TOPS-842

## Why
 * ON12 violation error text was missing a space before a new sentence

## What
 * Fix missing space

## Checklist
- Requires migrations? No
- Requires dependency updates? No
