### PR TITLE
update ME32 rule violation message to include violating measures

### DIFF
--- a/measures/business_rules.py
+++ b/measures/business_rules.py
@@ -361,15 +361,13 @@ class ME32(BusinessRule):
         if measure.goods_nomenclature is None:
             return
 
-        if self.clashing_measures(measure).exists():
-            message = (
-                "There may be no overlap in time with other measure occurrences with a goods code in the same "
-                "nomenclature hierarchy which references the same measure type, geo area, order number, "
-                "additional code and reduction indicator."
-            )
+        clashing_measures = self.clashing_measures(measure)
 
-            for clashing_measure in self.clashing_measures(measure):
-                message += f"Overlap detected with Measure SID {clashing_measure.sid}. "
+        if clashing_measures.exists():
+            message = self.violation(measure).default_message() + " \n"
+
+            for clashing_measure in clashing_measures:
+                message += f"\nClash with Measure SID {clashing_measure.sid}. "
 
             raise self.violation(measure, message)
 

--- a/measures/business_rules.py
+++ b/measures/business_rules.py
@@ -362,7 +362,16 @@ class ME32(BusinessRule):
             return
 
         if self.clashing_measures(measure).exists():
-            raise self.violation(measure)
+            message = (
+                "There may be no overlap in time with other measure occurrences with a goods code in the same "
+                "nomenclature hierarchy which references the same measure type, geo area, order number, "
+                "additional code and reduction indicator."
+            )
+
+            for clashing_measure in self.clashing_measures(measure):
+                message += f"Overlap detected with Measure SID {clashing_measure.sid}. "
+
+            raise self.violation(measure, message)
 
 
 # -- Ceiling/quota definition existence


### PR DESCRIPTION
# TOPS-839
* I can only imagine how frustrating it is for a TM to have to ask a DE / Dev to find out which measure is overlapping when faced with an ME32 message but no other information. 

## Why
 * All errors should give enough information for a TM to process and update the workbasket in order to resolve a rule violation. This is the first attempt to expose key information that will make TMs work more autonomous 

## What
 * Really simple change, adding the measure SIDs to the end of the violation message
 * Example : There may be no overlap in time with other measure occurrences with a goods code in the same nomenclature hierarchy which references the same measure type, geo area, order number, additional code and reduction indicator. Clash with Measure SID 20198035. 

## Checklist
- Requires migrations? No
- Requires dependency updates? No 


Links to relevant material
Ticket : TOPS-839 (https://uktrade.atlassian.net/browse/TOPS-839)

