### PR TITLE
Remove unnecessary H1s on confirmation pages

### DIFF
--- a/common/jinja2/common/confirm_create_description.jinja
+++ b/common/jinja2/common/confirm_create_description.jinja
@@ -20,9 +20,6 @@
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <span class="govuk-caption-l">Confirmation</span>
-      <h1 class="govuk-heading-xl">{{ page_title }}</h1>
-
       {{ govukPanel({
         "titleText": "A new description of " ~ described_object._meta.verbose_name ~ " " ~ described_object|string ~ " has been created",
         "text": "This new description has been added to your tariff changes",

--- a/common/jinja2/common/confirm_update_description.jinja
+++ b/common/jinja2/common/confirm_update_description.jinja
@@ -20,9 +20,6 @@
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <span class="govuk-caption-l">Confirmation</span>
-      <h1 class="govuk-heading-xl">{{ page_title }}</h1>
-
       {{ govukPanel({
         "titleText": "Description of " ~ described_object._meta.verbose_name ~ " " ~ described_object|string ~ " has been updated",
         "text": "This change has been added to your tariff changes",

--- a/common/jinja2/layouts/confirm.jinja
+++ b/common/jinja2/layouts/confirm.jinja
@@ -15,8 +15,6 @@
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <span class="govuk-caption-l">Confirmation</span>
-      <h1 class="govuk-heading-xl">{{ page_title }}</h1>
       {% block panel %}{% endblock%}
       <h2 class="govuk-heading-m">Next steps</h2>
       <p class="govuk-body">To complete your task you must publish your change. </p>

--- a/measures/jinja2/measures/confirm-create-multiple.jinja
+++ b/measures/jinja2/measures/confirm-create-multiple.jinja
@@ -29,8 +29,6 @@
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <span class="govuk-caption-l">Confirmation</span>
-      <h1 class="govuk-heading-xl">{{ page_title }}</h1>
       {{ govukPanel({
         "titleText": panel_title(created_measures),
         "text": panel_subtitle(created_measures),

--- a/workbaskets/jinja2/workbaskets/delete_changes_confirm.jinja
+++ b/workbaskets/jinja2/workbaskets/delete_changes_confirm.jinja
@@ -6,16 +6,6 @@
 {% set page_title = "Remove tariff changes" %}
 
 {% block content %}
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <span class="govuk-caption-l">Confirmation</span>
-    <h1 class="govuk-heading-xl">
-      Remove tariff changes
-      <span class="govuk-caption-xl"></span>
-    </h1>
-  </div>
-</div>
-
 <div class="govuk-grid-row govuk-!-margin-bottom-3">
   <div class="govuk-grid-column-two-thirds">
     {{ govukPanel({


### PR DESCRIPTION
# TP2000-385 Multiple H1s on confirm create pages

## Why
Several confirmation pages contain multiple H1 tags. Such pages should only contain one, that being the title within a panel component confirming an action has been successfully completed. 

## What
Removes unnecessary H1 page title and confirmation span.

## Checklist
- Requires migrations? No
- Requires dependency updates? No


<img width="450" alt="Screenshot 2022-11-28 at 10 00 57" src="https://user-images.githubusercontent.com/118175145/204262324-645a48bf-1bd6-4010-9ca8-19b9f192a986.png">
