### PR TITLE
TP2000-621 Content improvement for the create a workbasket page

### DIFF
--- a/workbaskets/forms.py
+++ b/workbaskets/forms.py
@@ -14,6 +14,11 @@ class WorkbasketCreateForm(forms.ModelForm):
 
     title = forms.CharField(
         label="Tops/Jira number",
+        help_text=(
+            "Your Tops/Jira number is needed to associate your workbasket with your Jira ticket. "
+            "You can find this number at the end of the web address for your Jira ticket. "
+            "Your workbasket will be given a unique number that may be different to your Tops/Jira number. "
+        ),
         widget=forms.TextInput,
         required=True,
     )

--- a/workbaskets/forms.py
+++ b/workbaskets/forms.py
@@ -7,6 +7,7 @@ from django import forms
 
 from common.forms import DescriptionHelpBox
 from workbaskets import models
+from workbaskets import validators
 
 
 class WorkbasketCreateForm(forms.ModelForm):
@@ -20,6 +21,7 @@ class WorkbasketCreateForm(forms.ModelForm):
             "Your workbasket will be given a unique number that may be different to your Tops/Jira number. "
         ),
         widget=forms.TextInput,
+        validators=[validators.tops_jira_number_validator],
         required=True,
     )
 

--- a/workbaskets/tests/test_forms.py
+++ b/workbaskets/tests/test_forms.py
@@ -1,30 +1,22 @@
 import pytest
-from django import forms
 
 from workbaskets.forms import WorkbasketCreateForm
 
 pytestmark = pytest.mark.django_db
 
 
-class WorkBasketForm(forms.Form):
-    title = forms.CharField()
-    reason = forms.CharField()
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
-
 def test_workbasket_form_validation():
-    form = WorkBasketForm(
+    form = WorkbasketCreateForm(
         {
             "title": "some title",
             "reason": "",
         },
     )
     assert not form.is_valid()
+    assert "title" in form.errors
     assert "reason" in form.errors
 
-    form = WorkBasketForm(
+    form = WorkbasketCreateForm(
         {
             "title": "",
             "reason": "some reason",
@@ -33,28 +25,19 @@ def test_workbasket_form_validation():
     assert not form.is_valid()
     assert "title" in form.errors
 
-    form = WorkBasketForm(
-        {
-            "title": "",
-            "reason": "",
-        },
-    )
-    assert not form.is_valid()
-    assert "title" in form.errors
-    assert "reason" in form.errors
-
-    form = WorkBasketForm(
+    form = WorkbasketCreateForm(
         {
             "title": "some title",
             "reason": "some reason",
         },
     )
-    assert form.is_valid()
+    assert not form.is_valid()
+    assert "title" in form.errors
 
 
 def test_workbasket_create_form_valid_data():
     """Test that WorkbasketCreateForm is valid when required fields in data."""
-    data = {"title": "test basket", "reason": "testing testing"}
+    data = {"title": "123", "reason": "testing testing"}
     form = WorkbasketCreateForm(data=data)
 
     assert form.is_valid()

--- a/workbaskets/tests/test_views.py
+++ b/workbaskets/tests/test_views.py
@@ -30,7 +30,7 @@ def test_workbasket_create_form_creates_workbasket_object(
     create_url = reverse("workbaskets:workbasket-ui-create")
 
     form_data = {
-        "title": "My new workbasket",
+        "title": "1234567890",
         "reason": "Making a new workbasket",
     }
 
@@ -57,7 +57,7 @@ def test_workbasket_create_user_not_logged_in_dev_sso_disabled(client, settings)
         )
     create_url = reverse("workbaskets:workbasket-ui-create")
     form_data = {
-        "title": "My new workbasket",
+        "title": "1234567890",
         "reason": "Making a new workbasket",
     }
     response = client.post(create_url, form_data)
@@ -71,7 +71,7 @@ def test_workbasket_create_without_permission(client):
     permission."""
     create_url = reverse("workbaskets:workbasket-ui-create")
     form_data = {
-        "title": "My new workbasket",
+        "title": "1234567890",
         "reason": "Making a new workbasket",
     }
     user = factories.UserFactory.create()

--- a/workbaskets/validators.py
+++ b/workbaskets/validators.py
@@ -1,4 +1,10 @@
+from django.core.validators import RegexValidator
 from django.db import models
+
+tops_jira_number_validator = RegexValidator(
+    r"^[0-9]+$",
+    message="Your TOPS/Jira number must only include numbers. You do not need to add ‘TOPS’ or ‘Jira’ in front of the number.",
+)
 
 
 class WorkflowStatus(models.TextChoices):


### PR DESCRIPTION
# TP2000-621 Content improvement for the create a workbasket page

## Why
Currently the 'Tops/Jira number' field on the create a workbasket page does not provide the user with guidance on where to find this number or in what format it must be inputted. The field also does not validate the input, allowing alphanumeric characters as well as special characters.

## What
Adds help text to the field, explaining where this number can be found and providing other important context.

Adds a numerical-only input validator on the field to prevent invalid input (i.e alphabet and special characters).

Updates workbasket create form tests to reflect addition of numerical-only input validator.

## Checklist
- Requires migrations? No
- Requires dependency updates? No


<img width="500" alt="Screenshot 2022-11-30 at 12 40 42" src="https://user-images.githubusercontent.com/118175145/204802036-dac0c2f7-4169-4632-8adb-792d474917ea.png">
