### PR TITLE
update setup content types to be full fixture, and only load available apps

### DIFF
--- a/commodities/tests/test_migrations.py
+++ b/commodities/tests/test_migrations.py
@@ -73,7 +73,7 @@ def test_main_migration_works(migrator):
         "GoodsNomenclatureDescription",
     )
     current_version_id = GoodsNomenclatureDescription.objects.get(
-        trackedmodel_ptr_id=10008934
+        trackedmodel_ptr_id=10008934,
     ).version_group.current_version_id
     assert GoodsNomenclatureDescription.objects.get(
         trackedmodel_ptr_id=current_version_id,

--- a/conftest.py
+++ b/conftest.py
@@ -129,19 +129,29 @@ def spanning_dates(request, date_ranges):
     )
 
 
-def setup_content_types(apps):
+@pytest.fixture
+def setup_content_types():
     """This fixture is used to set-up content types, needed for migration
     testing, when a clean new database and the content types have not been
     populated yet."""
 
-    tamato_apps = settings.DOMAIN_APPS + settings.TAMATO_APPS
+    def _method(apps):
+        tamato_apps = settings.DOMAIN_APPS + settings.TAMATO_APPS
 
-    for app_name in tamato_apps:
-        app_label = app_name.split(".")[0]
-        app_config = apps.get_app_config(app_label)
-        app_config.models_module = True
+        app_labels = []
 
-        create_contenttypes(app_config)
+        for app in apps.get_app_configs():
+            app_labels.append(app.label)
+
+        for app_name in tamato_apps:
+            app_label = app_name.split(".")[0]
+            if app_label in app_labels:
+                app_config = apps.get_app_config(app_label)
+                app_config.models_module = True
+
+                create_contenttypes(app_config)
+
+    return _method
 
 
 @pytest.fixture

--- a/measures/tests/test_migrations.py
+++ b/measures/tests/test_migrations.py
@@ -4,7 +4,6 @@ from datetime import timedelta
 import pytest
 from psycopg2._range import DateTimeTZRange
 
-import conftest
 from common.tests.factories import ApprovedWorkBasketFactory
 from common.tests.factories import DutyExpressionFactory
 from common.tests.factories import GeographicalAreaFactory
@@ -15,7 +14,7 @@ from common.tests.factories import RegulationGroupFactory
 
 
 @pytest.mark.django_db()
-def test_add_back_deleted_measures(migrator):
+def test_add_back_deleted_measures(migrator, setup_content_types):
     from common.models.transactions import TransactionPartition
 
     """Ensures that the initial migration works."""
@@ -26,7 +25,7 @@ def test_add_back_deleted_measures(migrator):
         ),
     )
 
-    conftest.setup_content_types(old_state.apps)
+    setup_content_types(old_state.apps)
 
     # setup
     target_workbasket_id = 545
@@ -114,7 +113,10 @@ def test_add_back_deleted_measures(migrator):
 
 
 @pytest.mark.django_db()
-def test_add_back_deleted_measures_fails_silently_if_data_not_present(migrator):
+def test_add_back_deleted_measures_fails_silently_if_data_not_present(
+    migrator,
+    setup_content_types,
+):
     """Ensures that the initial migration works when no data to create measures
     are present, for local dev etc."""
 
@@ -125,7 +127,7 @@ def test_add_back_deleted_measures_fails_silently_if_data_not_present(migrator):
         ),
     )
 
-    conftest.setup_content_types(old_state.apps)
+    setup_content_types(old_state.apps)
 
     measurement_class = old_state.apps.get_model("measures", "Measure")
 

--- a/reports/views.py
+++ b/reports/views.py
@@ -9,7 +9,6 @@ import reports.utils as utils
 
 @permission_required("app.view_report_index")
 def index(request):
-
     context = {
         "report": index_model.IndexTable(),
     }
@@ -19,7 +18,6 @@ def index(request):
 
 @permission_required("app.view_report")
 def report(request):
-
     # find the report based on the request
     report_class = utils.get_report_by_slug(request.resolver_match.url_name)
 


### PR DESCRIPTION
Updates to conftest fixture setup_content_types to be a full fixture. Also update to only load available apps and not fail

# TP2000-660

## Why
previous work I created setup_content_types but issues have occurred since relating to this work, so have updated the fixture to be an actual fixture and added a check to verify apps are available before loading them. 

## What
improvements to fixture setup_content_types

## Checklist
- Requires migrations? No
- Requires dependency updates? No


See: [[Description](https://example.com/...)](https://uktrade.atlassian.net/browse/TP2000-660)
