### PR TITLE
TP2000-654 Create 403 error page

### DIFF
--- a/common/jinja2/common/403.jinja
+++ b/common/jinja2/common/403.jinja
@@ -1,6 +1,6 @@
 {% extends "layouts/layout.jinja" %}
 
-{% set page_title = "Sorry, there is a problem with access to the service" %}
+{% set page_title = "You do not have access to this part of the service" %}
 
 {% block breadcrumb %}{% endblock %}
 
@@ -9,12 +9,12 @@
   <main class="govuk-main-wrapper govuk-main-wrapper--l" id="main-content" role="main">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
-        <h1 class="govuk-heading-l">Sorry, there is a problem with access to the service</h1>
+        <h1 class="govuk-heading-l">You do not have access to this part of the service</h1>
         <p class="govuk-body">
-          <a class="govuk-link" href="https://forms.office.com/Pages/DesignPageV2.aspx?subpage=design&FormId=7Beij6oz-0atlt_mgAa7hnv6Jn6EmylOnTuPOq1EO2NUMjBNRllURlk0R0dFS1FHQkVBMFhNWjROVi4u">Contact the TAP team</a> to change your access rights.
+          <a class="govuk-link" href="https://forms.office.com/Pages/DesignPageV2.aspx?subpage=design&FormId=7Beij6oz-0atlt_mgAa7hnv6Jn6EmylOnTuPOq1EO2NUMjBNRllURlk0R0dFS1FHQkVBMFhNWjROVi4u">Contact the Tariff Application Platform (TAP) team</a> to change your access rights.
         </p>
-        <p class="govuk-body">Please describe what you were doing before seeing this error message.</p>
-        <p class="govuk-body">You can expect a reply within two working days.</p>
+        <p class="govuk-body">You will need to describe what you were doing before seeing this error message.</p>
+        <p class="govuk-body">The team will reply to you within two working days.</p>
       </div>
     </div>
   </main>

--- a/common/jinja2/common/403.jinja
+++ b/common/jinja2/common/403.jinja
@@ -11,7 +11,7 @@
       <div class="govuk-grid-column-two-thirds">
         <h1 class="govuk-heading-l">Sorry, there is a problem with access to the service</h1>
         <p class="govuk-body">
-          <a class="govuk-link" href="https://forms.office.com/Pages/DesignPageV2.aspx?subpage=design&FormId=7Beij6oz-0atlt_mgAa7hnv6Jn6EmylOnTuPOq1EO2NUMjBNRllURlk0R0dFS1FHQkVBMFhNWjROVi4u&Token=3e454d078ea64c8fbbfcf336325d0427">Contact the TAP team</a> to change your access rights.
+          <a class="govuk-link" href="https://forms.office.com/Pages/DesignPageV2.aspx?subpage=design&FormId=7Beij6oz-0atlt_mgAa7hnv6Jn6EmylOnTuPOq1EO2NUMjBNRllURlk0R0dFS1FHQkVBMFhNWjROVi4u">Contact the TAP team</a> to change your access rights.
         </p>
         <p class="govuk-body">Please describe what you were doing before seeing this error message.</p>
         <p class="govuk-body">You can expect a reply within two working days.</p>

--- a/common/jinja2/common/403.jinja
+++ b/common/jinja2/common/403.jinja
@@ -1,0 +1,22 @@
+{% extends "layouts/layout.jinja" %}
+
+{% set page_title = "Sorry, there is a problem with access to the service" %}
+
+{% block breadcrumb %}{% endblock %}
+
+{% block content %}
+<div class="govuk-width-container">
+  <main class="govuk-main-wrapper govuk-main-wrapper--l" id="main-content" role="main">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <h1 class="govuk-heading-l">Sorry, there is a problem with access to the service</h1>
+        <p class="govuk-body">
+          <a class="govuk-link" href="https://forms.office.com/Pages/DesignPageV2.aspx?subpage=design&FormId=7Beij6oz-0atlt_mgAa7hnv6Jn6EmylOnTuPOq1EO2NUMjBNRllURlk0R0dFS1FHQkVBMFhNWjROVi4u&Token=3e454d078ea64c8fbbfcf336325d0427">Contact the TAP team</a> to change your access rights.
+        </p>
+        <p class="govuk-body">Please describe what you were doing before seeing this error message.</p>
+        <p class="govuk-body">You can expect a reply within two working days.</p>
+      </div>
+    </div>
+  </main>
+</div>
+{% endblock %}

--- a/common/tests/test_views.py
+++ b/common/tests/test_views.py
@@ -2,6 +2,7 @@ import pytest
 from bs4 import BeautifulSoup
 from django.urls import reverse
 
+from common.tests import factories
 from common.util import xml_fromstring
 from common.views import HealthCheckResponse
 from common.views import handler403
@@ -92,6 +93,13 @@ def test_index_displays_footer_links(valid_user_client):
 def test_handler403(client):
     request = client.get("/")
     response = handler403(request)
+
+    assert response.status_code == 403
+    assert response.template_name == "common/403.jinja"
+
+    user = factories.UserFactory.create()
+    client.force_login(user)
+    response = client.get(reverse("workbaskets:workbasket-ui-list"))
 
     assert response.status_code == 403
     assert response.template_name == "common/403.jinja"

--- a/common/tests/test_views.py
+++ b/common/tests/test_views.py
@@ -4,6 +4,7 @@ from django.urls import reverse
 
 from common.util import xml_fromstring
 from common.views import HealthCheckResponse
+from common.views import handler403
 
 pytestmark = pytest.mark.django_db
 
@@ -86,3 +87,11 @@ def test_index_displays_footer_links(valid_user_client):
         a_tags[0].attrs["href"]
         == "https://workspace.trade.gov.uk/working-at-dit/policies-and-guidance/policies/tariff-application-privacy-policy/"
     )
+
+
+def test_handler403(client):
+    request = client.get("/")
+    response = handler403(request)
+
+    assert response.status_code == 403
+    assert response.template_name == "common/403.jinja"

--- a/common/views.py
+++ b/common/views.py
@@ -21,6 +21,7 @@ from django.db.models import QuerySet
 from django.http import Http404
 from django.http import HttpResponse
 from django.shortcuts import redirect
+from django.template.response import TemplateResponse
 from django.urls import reverse
 from django.utils.timezone import make_aware
 from django.views import generic
@@ -306,3 +307,7 @@ class TrackedModelChangeView(
             return self.form_invalid(form)
 
         return FormMixin.form_valid(self, form)
+
+
+def handler403(request, *args, **kwargs):
+    return TemplateResponse(request=request, template="common/403.jinja", status=403)

--- a/pii-secret-exclude.txt
+++ b/pii-secret-exclude.txt
@@ -19,3 +19,4 @@ common/static/common/js/chart.js
 reports/jinja2/reports/report_chart.jinja
 reports/jinja2/reports/report_chart_timescale.jinja
 reports/tests/test_report_models.py
+common/jinja2/common/403.jinja

--- a/urls.py
+++ b/urls.py
@@ -36,6 +36,8 @@ urlpatterns = [
     path("admin/", admin.site.urls),
 ]
 
+handler403 = "common.views.handler403"
+
 if settings.SSO_ENABLED:
     urlpatterns = [
         path(


### PR DESCRIPTION
# TP2000-654 Create 403 error page

## Why
When a user attempts to access a part of the service to which they don't have the required access rights, a generic 403 error response is displayed without guidance on how to rectify the problem or raise an issue. 

## What
Adds custom 403 error page with a link to a form where the user can request access or raise an issue. 

## Checklist
- Requires migrations? No
- Requires dependency updates? No

Before:
<img width="450" alt="Screenshot 2022-12-15 at 17 47 51" src="https://user-images.githubusercontent.com/118175145/207931950-ad21dad9-b4ce-474e-b38d-1cba45c2621c.png">

After:
<img width="1200" alt="Screenshot 2022-12-16 at 12 10 31" src="https://user-images.githubusercontent.com/118175145/208096249-866f32a5-0acc-4542-939f-3ea3ba14ac7a.png">
