### PR TITLE
TP2000-655 Create 500 error page

### DIFF
--- a/common/jinja2/common/500.jinja
+++ b/common/jinja2/common/500.jinja
@@ -1,0 +1,26 @@
+{% extends "layouts/layout.jinja" %}
+
+{% set page_title = "Sorry, there is a problem with this service" %}
+
+{% block breadcrumb %}{% endblock %}
+
+{% block content %}
+<div class="govuk-width-container">
+  <main class="govuk-main-wrapper govuk-main-wrapper--l" id="main-content" role="main">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <h1 class="govuk-heading-l">Sorry, there is a problem with this service</h1>
+        <p class="govuk-body">
+            <a class="govuk-link"
+              href="https://forms.office.com/Pages/DesignPageV2.aspx?subpage=design&FormId=7Beij6oz-0atlt_mgAa7hnv6Jn6EmylOnTuPOq1EO2NUMjBNRllURlk0R0dFS1FHQkVBMFhNWjROVi4u">
+              Contact the Tariff Application Platform (TAP) team
+            </a>
+            who will help to resolve this problem.
+        </p>
+        <p class="govuk-body">You will need to describe what you were doing before seeing this error message.</p>
+        <p class="govuk-body">The team will reply to you within two working days.</p>
+      </div>
+    </div>
+  </main>
+</div>
+{% endblock %}

--- a/common/tests/test_views.py
+++ b/common/tests/test_views.py
@@ -6,6 +6,7 @@ from common.tests import factories
 from common.util import xml_fromstring
 from common.views import HealthCheckResponse
 from common.views import handler403
+from common.views import handler500
 
 pytestmark = pytest.mark.django_db
 
@@ -103,3 +104,11 @@ def test_handler403(client):
 
     assert response.status_code == 403
     assert response.template_name == "common/403.jinja"
+
+
+def test_handler500(client):
+    request = client.get("/")
+    response = handler500(request)
+
+    assert response.status_code == 500
+    assert response.template_name == "common/500.jinja"

--- a/common/views.py
+++ b/common/views.py
@@ -311,3 +311,7 @@ class TrackedModelChangeView(
 
 def handler403(request, *args, **kwargs):
     return TemplateResponse(request=request, template="common/403.jinja", status=403)
+
+
+def handler500(request, *args, **kwargs):
+    return TemplateResponse(request=request, template="common/500.jinja", status=500)

--- a/pii-secret-exclude.txt
+++ b/pii-secret-exclude.txt
@@ -20,3 +20,4 @@ reports/jinja2/reports/report_chart.jinja
 reports/jinja2/reports/report_chart_timescale.jinja
 reports/tests/test_report_models.py
 common/jinja2/common/403.jinja
+common/jinja2/common/500.jinja

--- a/urls.py
+++ b/urls.py
@@ -19,6 +19,8 @@ from django.contrib import admin
 from django.urls import include
 from django.urls import path
 
+import common
+
 urlpatterns = [
     path("", include("common.urls")),
     path("", include("additional_codes.urls")),
@@ -38,6 +40,12 @@ urlpatterns = [
 
 handler403 = "common.views.handler403"
 handler500 = "common.views.handler500"
+
+if settings.DEBUG:
+    urlpatterns += [
+        path("403/", common.views.handler403, name="handler403"),
+        path("500/", common.views.handler500, name="handler500"),
+    ]
 
 if settings.SSO_ENABLED:
     urlpatterns = [

--- a/urls.py
+++ b/urls.py
@@ -37,6 +37,7 @@ urlpatterns = [
 ]
 
 handler403 = "common.views.handler403"
+handler500 = "common.views.handler500"
 
 if settings.SSO_ENABLED:
     urlpatterns = [


### PR DESCRIPTION
# TP2000-655 Create 500 error page

## Why
When a user encounters an unhandled server error, a generic server error (500) response is displayed without guidance on how to raise an issue.

## What
Adds custom server error 500 page with a link to a form where the user can raise an issue.

Maps error 500 and error 403 views to urls for viewing in debug mode only (thought it might be a convenient way to view the error templates but can remove)

## Checklist
- Requires migrations? No
- Requires dependency updates? No

Before:
<img width="561" alt="500-error-page-before" src="https://user-images.githubusercontent.com/118175145/208480712-2a2081d8-0c4a-4dc7-8f1a-9cd0ca0e20dd.png">

After:
<img width="1209" alt="500-error-page-after" src="https://user-images.githubusercontent.com/118175145/208480820-b37ae4fc-fbf4-4276-9803-5f7c7dc71950.png">

