### PR TITLE
TP2000-648 Add measures tab

### DIFF
--- a/quotas/jinja2/includes/quotas/actions.jinja
+++ b/quotas/jinja2/includes/quotas/actions.jinja
@@ -2,10 +2,11 @@
   <div class="app-related-items" role="complementary">
       <h2 class="govuk-heading-s" id="subsection-title">Actions</h2>
       <ul class="govuk-list govuk-!-font-size-16">
-              <li><a class="govuk-link" href="{{ url('quota-definitions', args=[object.sid]) }}">View definition periods</a></li>
+            <li><a class="govuk-link" href="{{ url('quota-definitions', args=[object.sid]) }}">View definition periods</a></li>
+            <li><a class="govuk-link" href="{{ measures_url }}">View all measures</a></li>
           {% set delete_url = object.get_url('delete') %}
           {% if delete_url %}
-              <li><a class="govuk-link" href="{{ delete_url }}">Delete this {{object._meta.verbose_name}}</a></li>
+            <li><a class="govuk-link" href="{{ delete_url }}">Delete this {{object._meta.verbose_name}}</a></li>
           {% endif %}
       </ul>
   </div>

--- a/quotas/jinja2/includes/quotas/tabs/definition_details.jinja
+++ b/quotas/jinja2/includes/quotas/tabs/definition_details.jinja
@@ -26,12 +26,12 @@
                 },
                 {
                     "key": {"text": "Initial volume"},
-                    "value": {"text": current_definition.initial_volume },
+                    "value": {"text": intcomma(current_definition.initial_volume) },
                     "actions": {"items": []}
                 },
                 {
                     "key": {"text": "Volume"},
-                    "value": {"text": current_definition.volume },
+                    "value": {"text": intcomma(current_definition.volume) },
                     "actions": {"items": []}
                 },
                 {

--- a/quotas/jinja2/includes/quotas/tabs/measures.jinja
+++ b/quotas/jinja2/includes/quotas/tabs/measures.jinja
@@ -1,0 +1,38 @@
+
+{% set table_rows = [] %}
+{% for object in measures %}
+  {% set measure_link -%}
+    <a class="govuk-link govuk-!-font-weight-bold" href="{{ url('measure-ui-detail', args=[object.sid]) }}">{{ object.sid }}</a>
+  {%- endset %}
+  {% set commodity_link -%}
+    <a class="govuk-link govuk-!-font-weight-bold" href="{{ url('commodity-ui-detail', args=[object.goods_nomenclature.sid]) }}">{{ object.goods_nomenclature.item_id|wordwrap(2) }}</a>
+  {%- endset %}
+  {{ table_rows.append([
+    {"html": measure_link},
+    {"html": commodity_link},
+    {"text": "{:%d %b %Y}".format(object.valid_between.lower)},
+    {"text": "{:%d %b %Y}".format(object.valid_between.upper) if object.valid_between.upper else "-"},
+  ]) or "" }}
+{% endfor %}
+
+
+<div class="quota__core-data govuk-grid-row">
+    <div class="quota__core-data__content govuk-grid-column-three-quarters">
+        <h2 class="govuk-heading-l">Details</h2>
+        <p class="govuk-body">Showing currently active measures.</p>
+        {% if measures %}
+        {{ govukTable({
+            "head": [
+                {"text": "Measure SID"},
+                {"text": "Commodity code"},
+                {"text": "Start date"},
+                {"text": "End date"},
+            ],
+            "rows": table_rows
+            }) }}
+    {% else %}
+        <p class="govuk-body">No active measures.</p>
+    {% endif %}
+    </div>
+    {% include "includes/quotas/actions.jinja"%}
+</div>

--- a/quotas/jinja2/quotas/detail.jinja
+++ b/quotas/jinja2/quotas/detail.jinja
@@ -7,6 +7,7 @@
 
 {% set core_data_tab_html %}{% include "includes/quotas/tabs/core_data.jinja" %}{% endset %}
 {% set definition_details_html %}{% include "includes/quotas/tabs/definition_details.jinja" %}{% endset %}
+{% set measures_html %}{% include "includes/quotas/tabs/measures.jinja" %}{% endset %}
 {% set version_control_tab_html %}{% include "includes/quotas/tabs/version_control.jinja" %}{% endset %}
 
 {% set tabs = {
@@ -23,6 +24,13 @@
         "id": "definition-details",
         "panel": {
           "html": definition_details_html
+        }
+      },
+      {
+        "label": "Measures",
+        "id": "measures",
+        "panel": {
+          "html": measures_html
         }
       },
       {

--- a/quotas/tests/test_views.py
+++ b/quotas/tests/test_views.py
@@ -264,3 +264,30 @@ def test_quota_definitions_list_current_versions(
         soup.select("table tr > td:first-child > details > summary > span"),
     )
     assert num_definitions == 1
+
+
+def test_quota_definitions_list_current_measures(
+    valid_user_client,
+    date_ranges,
+):
+    quota_order_number = factories.QuotaOrderNumberFactory()
+    old_measures = factories.MeasureFactory.create_batch(
+        5,
+        valid_between=date_ranges.adjacent_earlier_big,
+        order_number=quota_order_number,
+    )
+    current_measures = factories.MeasureFactory.create_batch(
+        4,
+        valid_between=date_ranges.normal,
+        order_number=quota_order_number,
+    )
+
+    url = reverse("quota-ui-detail", kwargs={"sid": quota_order_number.sid})
+
+    response = valid_user_client.get(url)
+
+    soup = BeautifulSoup(response.content.decode(response.charset), "html.parser")
+    num_measures = len(
+        soup.select("#measures table tbody > tr > td:first-child"),
+    )
+    assert num_measures == 4

--- a/quotas/views.py
+++ b/quotas/views.py
@@ -1,5 +1,7 @@
 from datetime import date
+from urllib.parse import urlencode
 
+from django.urls import reverse
 from django.views.generic.list import ListView
 from rest_framework import permissions
 from rest_framework import viewsets
@@ -9,6 +11,7 @@ from common.views import SortingMixin
 from common.views import TamatoListView
 from common.views import TrackedModelDetailMixin
 from common.views import TrackedModelDetailView
+from measures.models import Measure
 from quotas import business_rules
 from quotas import forms
 from quotas import models
@@ -94,11 +97,18 @@ class QuotaDetail(QuotaMixin, TrackedModelDetailView):
 
     def get_context_data(self, *args, **kwargs):
         definitions = self.object.definitions.current()
+        measures = Measure.objects.filter(order_number=self.object).as_at(date.today())
+        url_params = urlencode({"order_number": self.object.pk})
+        measures_url = f"{reverse('measure-ui-list')}?{url_params}"
         current_definition = definitions.as_at(date.today()).first()
         if not current_definition:
             current_definition = definitions.not_yet_in_effect(date.today()).first()
         return super().get_context_data(
-            current_definition=current_definition, *args, **kwargs
+            current_definition=current_definition,
+            measures=measures,
+            measures_url=measures_url,
+            *args,
+            **kwargs,
         )
 
 


### PR DESCRIPTION
# TP2000-648 Add measures tab
<!---
 * Include the JIRA ticket number, eg TP-123, to automatically link.
 * Use 50 characters maximum.
 * Do not end with a full-stop.
--->

## Why
<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Use as many lines as you like.
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions or deliberately ignored edge-cases.
--->
* Users need to be able to find measures related to a quota order number

## What
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Explain like I'm 5.
 * Use pictures if you can.
--->
* Adds a measures tab to the quota order number detail page that shows currently active measures
* Adds a link to the find and edit measures page that filters by the quota order number

<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
## Checklist
- Requires migrations?
- Requires dependency updates?
--->

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
<img width="1093" alt="Screenshot 2022-12-21 at 15 34 45" src="https://user-images.githubusercontent.com/25905279/208943398-1f5a4ac8-5af7-48c1-a2ef-3474c172b7b8.png">
