### PR TITLE
TP2000-664 Move Geographical Exclusions data in the Quota Order Number details tab

### DIFF
--- a/quotas/jinja2/includes/quotas/tabs/core_data.jinja
+++ b/quotas/jinja2/includes/quotas/tabs/core_data.jinja
@@ -22,6 +22,11 @@
                 "actions": {"items": []}
             },
             {
+                "key": {"text": "Geographical area exclusions"},
+                "value": {"text": object.geographical_exclusion_descriptions|join(", ") if object.geographical_exclusion_descriptions else "-"},
+                "actions": {"items": []}
+            },
+            {
                 "key": {"text": "Start date"},
                 "value": {"text":  "{:%d %b %Y}".format(object.valid_between.lower)},
                 "actions": {"items": []}
@@ -44,11 +49,6 @@
             {
                 "key": {"text": "Required certificates"},
                 "value": {"text": object.required_certificates.all()|join(", ") if object.is_origin_quota else "-"},
-                "actions": {"items": []}
-            },
-            {
-                "key": {"text": "Geographical area exclusions"},
-                "value": {"text": object.geographical_exclusion_descriptions|join(", ") if object.geographical_exclusion_descriptions else "-"},
                 "actions": {"items": []}
             },
             ]


### PR DESCRIPTION
# TP2000-664 Move Geographical Exclusions data in the Quota Order Number details tab

## Why
At the bottom of the Quota number details tab is the Geographical Area Exclusions field. This field ought to be moved to underneath the related Geographical Area field to make the look of the tab more consistent and make the exclusions easier to read.

## What
Repositions Geographical Area Exclusions underneath Geographical Area in the Quota number details tab

## Checklist
- Requires migrations? No
- Requires dependency updates? No

After:
<img width="1074" alt="Screenshot 2022-12-22 at 10 10 50" src="https://user-images.githubusercontent.com/118175145/209118130-96dc7436-e112-4322-aaaa-38a98b011800.png">

