### PR TITLE
TP2000-669 Changes to 'Create measure' Journey

### DIFF
--- a/common/jinja2/common/confirm_create.jinja
+++ b/common/jinja2/common/confirm_create.jinja
@@ -15,7 +15,7 @@
 {% block panel %}
   {{ govukPanel({
     "titleText": object._meta.verbose_name|title ~ " " ~ object|string ~ " has been created",
-    "text": "This new " ~ object._meta.verbose_name ~ " has been added to your tariff changes",
+    "text": "This new " ~ object._meta.verbose_name ~ " has been added to your workbasket",
     "classes": "govuk-!-margin-bottom-7"
   }) }}
 {% endblock %}

--- a/common/jinja2/common/confirm_create_description.jinja
+++ b/common/jinja2/common/confirm_create_description.jinja
@@ -22,7 +22,7 @@
     <div class="govuk-grid-column-two-thirds">
       {{ govukPanel({
         "titleText": "A new description of " ~ described_object._meta.verbose_name ~ " " ~ described_object|string ~ " has been created",
-        "text": "This new description has been added to your tariff changes",
+        "text": "This new description has been added to your workbasket",
         "classes": "govuk-!-margin-bottom-7"
       }) }}
 
@@ -30,16 +30,16 @@
       <p class="govuk-body">To complete your task you must publish your change. </p>
       {% if request.session.workbasket %}
       {{ govukButton({
-        "text": "Go to your tariff changes",
-        "href": url("workbaskets:edit-workbasket", args=[request.session.workbasket.id]),
+        "text": "Go to your workbasket summary",
+        "href": url("workbaskets:workbasket-ui-detail", args=[request.session.workbasket.id]),
         "classes": "govuk-button--secondary"
       }) }}
       {% endif %}
       <ul class="govuk-list govuk-list-spaced">
         <li><a class="govuk-link" href="{{ described_object.get_url() }}">View {{ described_object._meta.verbose_name }} {{ described_object|string }}</a></li>
-        <li><a class="govuk-link" href="{{ described_object.get_url("list") }}">Manage more {{ described_object._meta.verbose_name_plural }}</a></li>
+        <li><a class="govuk-link" href="{{ described_object.get_url("list") }}">Find and edit {{ described_object._meta.verbose_name_plural }}</a></li>
         {% if request.session.workbasket %}
-        <li><a class="govuk-link" href="{{ url('workbaskets:edit-workbasket', args=[request.session.workbasket.id]) }}">Return to main menu</a></li>
+        <li><a class="govuk-link" href="{{ url('workbaskets:edit-workbasket', args=[request.session.workbasket.id]) }}">Return to workbasket</a></li>
         {% endif %}
       </ul>
     </div>

--- a/common/jinja2/common/confirm_update.jinja
+++ b/common/jinja2/common/confirm_update.jinja
@@ -15,7 +15,7 @@
 {% block panel %}
   {{ govukPanel({
     "titleText": object._meta.verbose_name|capitalize ~ " " ~ object|string ~ " has been updated",
-    "text": "This change has been added to your tariff changes",
+    "text": "This change has been added to your workbasket",
     "classes": "govuk-!-margin-bottom-7"
   }) }}
 {% endblock %}

--- a/common/jinja2/common/confirm_update_description.jinja
+++ b/common/jinja2/common/confirm_update_description.jinja
@@ -22,7 +22,7 @@
     <div class="govuk-grid-column-two-thirds">
       {{ govukPanel({
         "titleText": "Description of " ~ described_object._meta.verbose_name ~ " " ~ described_object|string ~ " has been updated",
-        "text": "This change has been added to your tariff changes",
+        "text": "This change has been added to your workbasket",
         "classes": "govuk-!-margin-bottom-7"
       }) }}
 
@@ -30,16 +30,16 @@
       <p class="govuk-body">To complete your task you must publish your change. </p>
       {% if request.session.workbasket %}
       {{ govukButton({
-        "text": "Go to your tariff changes",
+        "text": "Go to your workbasket summary",
         "href": url("workbaskets:workbasket-ui-detail", args=[request.session.workbasket.id]),
         "classes": "govuk-button--secondary"
       }) }}
       {% endif %}
       <ul class="govuk-list govuk-list-spaced">
         <li><a class="govuk-link" href="{{ described_object.get_url() }}">View {{ described_object._meta.verbose_name }} {{ described_object|string }}</a></li>
-        <li><a class="govuk-link" href="{{ described_object.get_url("list") }}">Manage more {{ described_object._meta.verbose_name_plural }}</a></li>
+        <li><a class="govuk-link" href="{{ described_object.get_url("list") }}">Find and edit {{ described_object._meta.verbose_name_plural }}</a></li>
         {% if request.session.workbasket %}
-        <li><a class="govuk-link" href="{{ url('workbaskets:edit-workbasket', args=[request.session.workbasket.id]) }}">Return to main menu</a></li>
+        <li><a class="govuk-link" href="{{ url('workbaskets:edit-workbasket', args=[request.session.workbasket.id]) }}">Return to workbasket</a></li>
         {% endif %}
       </ul>
     </div>

--- a/common/jinja2/components/duty_help.jinja
+++ b/common/jinja2/components/duty_help.jinja
@@ -2,6 +2,6 @@
 
 {{ govukDetails({
         "summaryText": "Help with duties",
-        "text": "Enter the duty that applies to the " + component + ". This is expressed as a percentage (e.g. 4%), a specific duty (e.g. 33 GBP/100kg) or a compound duty (e.g. 3.5% + 11 GBP / 100 kg)."
+        "text": "Enter the duty that applies to the " + component + ". This is expressed as a percentage (for example, 4%), a specific duty (for example, 33 GBP/100kg) or a compound duty (for example, 3.5% + 11 GBP / 100 kg)."
     }) }}
     

--- a/common/jinja2/components/measure_condition_action_code/template.jinja
+++ b/common/jinja2/components/measure_condition_action_code/template.jinja
@@ -3,6 +3,7 @@
     <label for="id_{{ field.html_name }}" class="govuk-label">
         Action code
     </label>
+    <div id="action-code-hint" class="govuk-hint">Select the action code from the dropdown list</div>
     <select name="{{ field.html_name }}" class="govuk-select" id="id_{{ field.html_name }}"> 
         <option value="">-- Please select an action code --</option>
         {% for action in form.fields.action.queryset %}

--- a/common/jinja2/components/measure_condition_code/template.jinja
+++ b/common/jinja2/components/measure_condition_code/template.jinja
@@ -1,6 +1,7 @@
 <div id="div_id_{{ field.html_name }}" class="govuk-form-group">
+    <div id="condition-code-hint" class="govuk-hint">Select the condition code from the dropdown list</div>
     {% set selected_code = field.initial | int %}
-    <select name="{{ field.html_name }}" class="govuk-select" id="id_{{ field.html_name }}"> 
+    <select name="{{ field.html_name }}" class="govuk-select" id="id_{{ field.html_name }}">
         <option value="">-- Please select a condition code --</option>
         {% for condition in form.fields.condition_code.queryset %}
             <option 

--- a/common/jinja2/includes/common/main-menu-link.jinja
+++ b/common/jinja2/includes/common/main-menu-link.jinja
@@ -1,3 +1,3 @@
 {% if request.session.workbasket %}
-  <li><a href="{{ url('workbaskets:edit-workbasket', args=[request.session.workbasket.id]) }}">Return to main menu</a></li>
+  <li><a href="{{ url('workbaskets:edit-workbasket', args=[request.session.workbasket.id]) }}">Return to workbasket</a></li>
 {% endif %}

--- a/common/jinja2/layouts/confirm.jinja
+++ b/common/jinja2/layouts/confirm.jinja
@@ -20,14 +20,14 @@
       <p class="govuk-body">To complete your task you must publish your change. </p>
       {% if request.session.workbasket %}
       {{ govukButton({
-        "text": "Go to your tariff changes",
+        "text": "Go to your workbasket summary",
         "href": url("workbaskets:workbasket-ui-detail", args=[request.session.workbasket.id]),
         "classes": "govuk-button--secondary"
       }) }}
       {% endif %}
       <ul class="govuk-list govuk-list-spaced">
         <li><a class="govuk-link" href="{{ object.get_url() }}">View {{ object._meta.verbose_name }} {{ object|string }}</a></li>
-        <li><a href="{{ object.get_url("list") }}">Manage more {{ object._meta.verbose_name_plural }}</a></li>
+        <li><a href="{{ object.get_url("list") }}">Find and edit {{ object._meta.verbose_name_plural }}</a></li>
         {% include "includes/common/main-menu-link.jinja" %}
       </ul>
     </div>

--- a/measures/forms.py
+++ b/measures/forms.py
@@ -1010,7 +1010,11 @@ class MeasureAdditionalCodeForm(forms.ModelForm):
 class MeasureCommodityAndDutiesForm(forms.Form):
     commodity = AutoCompleteField(
         label="Commodity code",
-        help_text="Select the 10-digit commodity code to which the measure applies.",
+        help_text=(
+            "Search for a commodity code by typing in the code's number or a keyword. "
+            "After you've typed at least 3 numbers, a dropdown list will appear. "
+            "You can then select the correct quota from the dropdown list."
+        ),
         queryset=GoodsNomenclature.objects.all(),
         attrs={"min_length": 3},
     )

--- a/measures/forms.py
+++ b/measures/forms.py
@@ -814,7 +814,11 @@ class MeasureRegulationIdForm(forms.Form):
 
     generating_regulation = AutoCompleteField(
         label="Regulation ID",
-        help_text="Select the regulation which provides the legal basis for the measure.",
+        help_text=(
+            "Search for a regulation using its ID number or a keyword. "
+            "A dropdown list will appear after a few seconds. "
+            "You can then select the regulation from the dropdown list."
+        ),
         queryset=Regulation.objects.all(),
     )
 

--- a/measures/forms.py
+++ b/measures/forms.py
@@ -762,7 +762,11 @@ class MeasureDetailsForm(
 
     measure_type = AutoCompleteField(
         label="Measure type",
-        help_text="Select the appropriate measure type.",
+        help_text=(
+            "Search for a measure type using its ID number or a keyword. "
+            "A dropdown list will appear after a few seconds. "
+            "You can then select the measure type from the dropdown list."
+        ),
         queryset=models.MeasureType.objects.all(),
     )
 

--- a/measures/forms.py
+++ b/measures/forms.py
@@ -1077,6 +1077,10 @@ MeasureCommodityAndDutiesFormSet = formset_factory(
 class MeasureFootnotesForm(forms.Form):
     footnote = AutoCompleteField(
         label="",
+        help_text=(
+            "Search for a footnote by typing in the footnote's number or a keyword. "
+            "A dropdown list will appear after a few seconds. You can then select the correct footnote from the dropdown list."
+        ),
         queryset=Footnote.objects.all(),
     )
 

--- a/measures/forms.py
+++ b/measures/forms.py
@@ -483,7 +483,10 @@ class MeasureForm(ValidityPeriodForm, BindNestedFormMixin, forms.ModelForm):
     )
     additional_code = AutoCompleteField(
         label="Code and description",
-        help_text="If applicable, select the additional code to which the measure applies.",
+        help_text=(
+            "Search for an additional code by typing in the code's number or a keyword. "
+            "A dropdown list will appear after a few seconds. You can then select the correct code from the dropdown list."
+        ),
         queryset=AdditionalCode.objects.all(),
         required=False,
     )
@@ -987,7 +990,10 @@ class MeasureAdditionalCodeForm(forms.ModelForm):
 
     additional_code = AutoCompleteField(
         label="Additional code",
-        help_text="If applicable, select the additional code to which the measure applies.",
+        help_text=(
+            "Search for an additional code by typing in the code's number or a keyword. "
+            "A dropdown list will appear after a few seconds. You can then select the correct code from the dropdown list."
+        ),
         queryset=AdditionalCode.objects.all(),
         required=False,
     )

--- a/measures/forms.py
+++ b/measures/forms.py
@@ -882,6 +882,11 @@ class MeasureQuotaOrderNumberForm(forms.Form):
 class MeasureGeographicalAreaForm(BindNestedFormMixin, forms.Form):
     geo_area = RadioNested(
         label="",
+        help_text=(
+            "Choose the geographical area to which the measure applies. "
+            "This can be a specific country or a group of countries, and exclusions can be specified. "
+            "The measure will only apply to imports from or exports to the selected area."
+        ),
         choices=GeoAreaType.choices,
         nested_forms={
             GeoAreaType.ERGA_OMNES.value: [ErgaOmnesExclusionsFormSet],
@@ -920,14 +925,6 @@ class MeasureGeographicalAreaForm(BindNestedFormMixin, forms.Form):
         self.helper.legend_size = Size.SMALL
         self.helper.layout = Layout(
             "geo_area",
-            HTML.details(
-                "Help with geography",
-                (
-                    "Choose the geographical area to which the measure applies. This can be a specific country "
-                    "or a group of countries, and exclusions can be specified. The measure will only apply to imports "
-                    "from or exports to the selected area."
-                ),
-            ),
             Submit(
                 "submit",
                 "Continue",

--- a/measures/forms.py
+++ b/measures/forms.py
@@ -14,6 +14,7 @@ from django import forms
 from django.core.exceptions import ValidationError
 from django.db.models import TextChoices
 from django.template import loader
+from django.urls import reverse
 
 from additional_codes.models import AdditionalCode
 from certificates.models import Certificate
@@ -849,7 +850,8 @@ class MeasureQuotaOrderNumberForm(forms.Form):
     order_number = AutoCompleteField(
         label="Quota order number",
         help_text=(
-            "Select the quota order number if a quota measure type has been selected. "
+            "Search for a quota using its order number. "
+            "You can then select the correct quota from the dropdown list. "
             "Leave this field blank if the measure is not a quota."
         ),
         queryset=QuotaOrderNumber.objects.all(),
@@ -864,6 +866,10 @@ class MeasureQuotaOrderNumberForm(forms.Form):
         self.helper.legend_size = Size.SMALL
         self.helper.layout = Layout(
             "order_number",
+            HTML.details(
+                "I don't know what my quota ID number is",
+                f'You can search for the quota number by using <a href="{reverse("quota-ui-list")}" class="govuk-link">find and edit quotas</a>',
+            ),
             Submit(
                 "submit",
                 "Continue",

--- a/measures/jinja2/measures/confirm-create-multiple.jinja
+++ b/measures/jinja2/measures/confirm-create-multiple.jinja
@@ -13,9 +13,9 @@
 
 {% macro panel_subtitle(created_measures) %}
   {% if created_measures|length > 1 %}
-    These new measures have been added to your tariff changes
+    These new measures have been added to your workbasket
   {% else %}
-    This new measure has been added to your tariff changes
+    This new measure has been added to your workbasket
   {% endif %}
 {% endmacro %}
 
@@ -38,14 +38,14 @@
       <p class="govuk-body">To complete your task you must publish your change. </p>
       {% if request.session.workbasket %}
       {{ govukButton({
-        "text": "Go to your tariff changes",
-        "href": url("workbaskets:edit-workbasket", args=[request.session.workbasket.id]),
+        "text": "Go to your workbasket summary",
+        "href": url("workbaskets:workbasket-ui-detail", args=[request.session.workbasket.id]),
         "classes": "govuk-button--secondary"
       }) }}
       {% endif %}
       <ul class="govuk-list govuk-list-spaced">
         <li><a class="govuk-link" href="{{ created_measures.0.get_url('create') }}">Create a new measure</a></li>
-        <li><a href="{{ created_measures.0.get_url('list') }}">Manage more {{ created_measures.0._meta.verbose_name_plural }}</a></li>
+        <li><a href="{{ created_measures.0.get_url('list') }}">Find and edit {{ created_measures.0._meta.verbose_name_plural }}</a></li>
         {% include "includes/common/main-menu-link.jinja" %}
       </ul>
     </div>

--- a/measures/jinja2/measures/create-start.jinja
+++ b/measures/jinja2/measures/create-start.jinja
@@ -35,5 +35,5 @@
       "href": url("workbaskets:edit-workbasket", args=[request.session.workbasket.id]),
       "classes": "govuk-button--secondary"
     }) }}
-  </div
+  </div>
 {% endblock %}

--- a/measures/jinja2/measures/create-start.jinja
+++ b/measures/jinja2/measures/create-start.jinja
@@ -13,11 +13,7 @@
   </p>
 
   <p class="govuk-body">
-    You'll also need to use the 
-      <a class="govuk-link" href="{{ url("home") }}">
-        manage trade tariffs service  
-      </a>
-    to find or create details of the following:
+    You must also make sure you have details of the following:
     <ul class="govuk-list govuk-list--bullet">
       <li>the geographical area the measure applies to</li>
       <li>the regulation ID</li>
@@ -28,5 +24,16 @@
       <li>any footnotes</li>
     </ul>
   </p>
-  {{ govukButton({"text": "Start now", "isStartButton": True}) }}
+  
+  <p class="govuk-body">If you need to create or find these details, you can do so on the previous page.</p>
+  <p class="govuk-body">Your progress will be saved if you exit this service provided you remain on the same device.</p>
+  
+  <div class="govuk-button-group">
+    {{ govukButton({"text": "Start now", "isStartButton": True}) }}
+    {{ govukButton({
+      "text": "Back",
+      "href": url("workbaskets:edit-workbasket", args=[request.session.workbasket.id]),
+      "classes": "govuk-button--secondary"
+  }) }}
+  </div
 {% endblock %}

--- a/measures/jinja2/measures/create-start.jinja
+++ b/measures/jinja2/measures/create-start.jinja
@@ -34,6 +34,6 @@
       "text": "Back",
       "href": url("workbaskets:edit-workbasket", args=[request.session.workbasket.id]),
       "classes": "govuk-button--secondary"
-  }) }}
+    }) }}
   </div
 {% endblock %}

--- a/measures/jinja2/measures/create-wizard-step.jinja
+++ b/measures/jinja2/measures/create-wizard-step.jinja
@@ -2,7 +2,6 @@
 {% from "components/step-by-step-nav/macro.jinja" import step_by_step_nav %}
 
 {% set page_title = step_metadata[wizard.steps.current].title %}
-{% set page_subtitle = "Create a new measure" %}
 {% set info = "Create a new measure" %}
 
 {% block content %}

--- a/measures/views.py
+++ b/measures/views.py
@@ -208,11 +208,7 @@ class MeasureCreateWizard(
             "link_text": "Additional code",
         },
         CONDITIONS: {
-            "title": "Add any condition codes",
-            "info": (
-                "This section is optional. If there are no condition "
-                "codes, select continue."
-            ),
+            "title": "Add any condition codes (optional)",
             "link_text": "Conditions",
         },
         FOOTNOTES: {

--- a/measures/views.py
+++ b/measures/views.py
@@ -204,7 +204,7 @@ class MeasureCreateWizard(
             "link_text": "Commodities and duties",
         },
         ADDITIONAL_CODE: {
-            "title": "Assign an additional code",
+            "title": "Assign an additional code (optional)",
             "link_text": "Additional code",
         },
         CONDITIONS: {

--- a/measures/views.py
+++ b/measures/views.py
@@ -198,7 +198,6 @@ class MeasureCreateWizard(
         GEOGRAPHICAL_AREA: {
             "title": "Select the geographical area",
             "link_text": "Geographical areas",
-            "info": "The measure will only apply to imports from or exports to the selected area. You can specify exclusions.",
         },
         COMMODITIES: {
             "title": "Select commodities and enter the duties",

--- a/measures/views.py
+++ b/measures/views.py
@@ -212,11 +212,7 @@ class MeasureCreateWizard(
             "link_text": "Conditions",
         },
         FOOTNOTES: {
-            "title": "Add any footnotes",
-            "info": (
-                "This section is optional. If there are no footnotes, "
-                "select continue."
-            ),
+            "title": "Add any footnotes (optional)",
             "link_text": "Footnotes",
         },
         SUMMARY: {

--- a/workbaskets/jinja2/workbaskets/delete_changes_confirm.jinja
+++ b/workbaskets/jinja2/workbaskets/delete_changes_confirm.jinja
@@ -15,7 +15,7 @@
 
     {% if request.session.workbasket %}
     {{ govukButton({
-      "text": "Go to your tariff changes",
+      "text": "Go to your workbasket summary",
       "href": url("workbaskets:workbasket-ui-detail", args=[request.session.workbasket.id]),
       "classes": "govuk-button--secondary"
     }) }}


### PR DESCRIPTION
# TP2000-669 Changes to 'Create measure' Journey

## Why
The current 'Create measure' user journey requires content changes to better explain and reflect actions taken during creation.

## What

- Updates field help text across the forms to describe actual actions to take

- Updates first page content and adds back button

- Adds details component which includes a link to “find and edit quotas" to Quotas form

- Replaces “Help with Geography” dropdown on geo form with field help text

- Adds ‘(optional)’ to all sections that are optional, removing need for unnecessary help text 

- Changes confirmation screen so the buttons and text more accurately reflect where they lead and what has happened in creation


## Checklist
- Requires migrations? No
- Requires dependency updates? No

Examples:
<img width="450" alt="Screenshot 2022-12-23 at 13 24 32" src="https://user-images.githubusercontent.com/118175145/209343577-ff9f70ee-519e-4513-915f-01ce4524b789.png">

<img width="450" alt="Screenshot 2022-12-23 at 13 25 58" src="https://user-images.githubusercontent.com/118175145/209343580-bff15410-ee45-4274-a587-ee420de0fab2.png">

