### PR TITLE
Create regulation ID using the current year.

### DIFF
--- a/regulations/tests/test_forms.py
+++ b/regulations/tests/test_forms.py
@@ -1,4 +1,5 @@
 import pytest
+from django.utils import timezone
 
 from common.tests import factories
 from regulations import forms
@@ -57,7 +58,8 @@ def test_regulation_create_form_unapproved_and_not_draft(date_ranges, session_re
 def test_regulation_create_form_invalid_part_value(date_ranges, session_request):
     """Test that RegulationCreateForm excepts an IndexError when looking for an
     alphanumeric character after Z and raises a ValidationError."""
-    factories.RegulationFactory.create(regulation_id="C220001Z")
+    year = timezone.now().strftime("%y")
+    factories.RegulationFactory.create(regulation_id=f"C{year}0001Z")
     group = factories.RegulationGroupFactory.create()
     data = {
         "regulation_group": group.pk,


### PR DESCRIPTION
# TP2000-671 - Year-sensitive Regulation unit test broken
<!---
 * Include the JIRA ticket number, eg TP-123, to automatically link.
 * Use 50 characters maximum.
 * Do not end with a full-stop.
--->

## Why
<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Use as many lines as you like.
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions or deliberately ignored edge-cases.
--->
The unit test test_regulation_create_form_invalid_part_value has a hard-coded date dependency, causing a test failure when the year differs to hard coded value.

## What
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Explain like I'm 5.
 * Use pictures if you can.
--->
Make the test use the current year as per the other parts of the test.

<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
--->
## Checklist
- Requires migrations? No
- Requires dependency updates? No

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
