### PR TITLE
Added active and total quotas to dashboard

### DIFF
--- a/common/tests/test_views.py
+++ b/common/tests/test_views.py
@@ -117,11 +117,20 @@ def test_handler500(client):
 def test_display_dashboard_overview(valid_user_client):
     factories.MeasureFactory.create()
     factories.MeasureFactory.create()
+    factories.QuotaOrderNumberFactory.create()
+    factories.QuotaOrderNumberFactory.create()
+    factories.QuotaOrderNumberFactory.create()
     response = valid_user_client.get(reverse("overview"))
 
     assert response.status_code == 200
 
     page = BeautifulSoup(str(response.content), "html.parser")
-    counts = page.find_all("p", attrs={"class": "govuk-number"})
+    counts = page.find_all("p", attrs={"class": "govuk-heading-xl"})
 
+    assert len(counts) == 6
     assert counts[0].text == '2'
+    assert counts[1].text == '2'
+    assert counts[2].text == '4'
+    assert counts[3].text == '4'
+    assert counts[4].text == '3'
+    assert counts[5].text == '3'

--- a/common/views.py
+++ b/common/views.py
@@ -42,6 +42,7 @@ from common.models import TrackedModel
 from common.pagination import build_pagination_list
 from common.validators import UpdateType
 from measures.models import Measure
+from quotas.models import QuotaOrderNumber
 from workbaskets.views.mixins import WithCurrentWorkBasket
 
 
@@ -72,10 +73,18 @@ class DashboardView(TemplateView):
     @property
     def commodities_total_count(self):
         return GoodsNomenclature.objects.values("sid").count()
-
+    
     @property
     def commodities_active_count(self):
         return GoodsNomenclature.objects.values("sid").as_at_today().count()
+
+    @property
+    def quotas_total_count(self):
+        return QuotaOrderNumber.objects.values("sid").count()
+
+    @property
+    def quotas_active_count(self):
+        return QuotaOrderNumber.objects.values("sid").as_at_today().count()
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
@@ -94,6 +103,13 @@ class DashboardView(TemplateView):
                     {"title": "Active", "value": self.commodities_active_count},
                 ],
             },
+            {
+                "heading": "Quotas",
+                "counts": [
+                    {"title": "Total ", "value": self.quotas_total_count},
+                    {"title": "Active ", "value": self.quotas_active_count},
+                ],
+            }
         ]
         return context
 


### PR DESCRIPTION
# Added active and total quotas to dashboard page

## Why
Added Total and Active Quota counts to the dashboard so this data can be viewable by tariff managers


<img width="552" alt="image" src="https://user-images.githubusercontent.com/16708670/211275056-f3af718b-f431-45d2-8cc8-0b9c54cecdf3.png">
