### PR TITLE
TP2000-665 Corrects data fields on commodities details view

### DIFF
--- a/commodities/jinja2/includes/commodities/tabs/core_data.jinja
+++ b/commodities/jinja2/includes/commodities/tabs/core_data.jinja
@@ -73,12 +73,12 @@
                 "actions": {"items": []}
             },
             {
-                "key": {"text": "Parent comodity Code"},
+                "key": {"text": "Parent commodity Code"},
                 "value": {"text": parent_code if object.origins.all() else "-"},
                 "actions": {"items": []}
             },
             {
-                "key": {"text": "Parent comodity suffix"},
+                "key": {"text": "Parent commodity suffix"},
                 "value": {"text": parent_suffix if object.origins.all() else "-"},
                 "actions": {"items": []}
             },

--- a/commodities/jinja2/includes/commodities/tabs/core_data.jinja
+++ b/commodities/jinja2/includes/commodities/tabs/core_data.jinja
@@ -1,23 +1,7 @@
-{% set parent_sid %}
-    <ul class="govuk-table-list">
-        {% for origin in object.origins.all() %}
-            <li>{{origin.sid}}</li>
-        {% endfor %}
-    </ul>
-{% endset %}
 {% set parent_code %}
-    <ul class="govuk-table-list">
-        {% for origin in object.origins.all() %}
-            <a class="govuk-link govuk-!-font-weight-bold" href="{{ url("commodity-ui-detail", kwargs={"sid": origin.sid}) }}">{{ origin.code }}</a>
-        {% endfor %}
-    </ul>
-{% endset %}
-{% set parent_suffix %}
-    <ul class="govuk-table-list">
-        {% for origin in object.origins.all() %}
-            <li>{{origin.suffix}}</li>
-        {% endfor %}
-    </ul>
+    {% if parent %}
+        <a class="govuk-link govuk-!-font-weight-bold" href="{{ url("commodity-ui-detail", kwargs={"sid": parent.sid}) }}">{{ parent.code }}</a>
+    {% endif %}
 {% endset %}
 {% set indent %}
     <ul class="govuk-table-list">
@@ -37,7 +21,7 @@
                 "actions": {"items": []}
             },
             {
-                "key": {"text": "Commodity Code"},
+                "key": {"text": "Commodity code"},
                 "value": {"text": object.code},
                 "actions": {"items": []}
             },
@@ -53,7 +37,7 @@
                 "actions": {"items": []}
             },
             {
-                "key": {"text": "Commodity Description"},
+                "key": {"text": "Commodity description"},
                 "value": {"text": object.get_description().description},
                 "actions": {"items": []}
             },
@@ -69,17 +53,17 @@
             },
             {
                 "key": {"text": "Parent commodity SID"},
-                "value": {"text": parent_sid if object.origins.all() else "-"},
+                "value": {"text": parent.sid if parent else "-"},
                 "actions": {"items": []}
             },
             {
-                "key": {"text": "Parent commodity Code"},
-                "value": {"text": parent_code if object.origins.all() else "-"},
+                "key": {"text": "Parent commodity code"},
+                "value": {"text": parent_code if parent else "-"},
                 "actions": {"items": []}
             },
             {
                 "key": {"text": "Parent commodity suffix"},
-                "value": {"text": parent_suffix if object.origins.all() else "-"},
+                "value": {"text": parent.suffix if parent else "-"},
                 "actions": {"items": []}
             },
             ]

--- a/commodities/jinja2/includes/commodities/tabs/core_data.jinja
+++ b/commodities/jinja2/includes/commodities/tabs/core_data.jinja
@@ -3,13 +3,7 @@
         <a class="govuk-link govuk-!-font-weight-bold" href="{{ url("commodity-ui-detail", kwargs={"sid": parent.sid}) }}">{{ parent.code }}</a>
     {% endif %}
 {% endset %}
-{% set indent %}
-    <ul class="govuk-table-list">
-        {% for indent in object.indents.all() %}
-            <li>{{indent.indent}}</li>
-        {% endfor %}
-    </ul>
-{% endset %}
+
 <div class="quota__core-data">
     <div class="quota__core-data__content">
         <h2 class="govuk-heading-l">Details</h2>
@@ -32,8 +26,7 @@
             },
             {
                 "key": {"text": "Indent number"},
-                "value": {"text": object.indents.all()},
-                "value": {"text": indent if object.origins.all() else "-"},
+                "value": {"text": object.indents.all().last().indent},
                 "actions": {"items": []}
             },
             {

--- a/commodities/views.py
+++ b/commodities/views.py
@@ -11,6 +11,7 @@ from commodities.filters import CommodityFilter
 from commodities.filters import GoodsNomenclatureFilterBackend
 from commodities.forms import CommodityImportForm
 from commodities.models import GoodsNomenclature
+from commodities.models.dc import get_chapter_collection
 from common.serializers import AutoCompleteSerializer
 from common.views import TrackedModelDetailView
 from common.views import WithPaginationListView
@@ -75,3 +76,17 @@ class CommodityList(CommodityMixin, WithPaginationListView):
 
 class CommodityDetail(CommodityMixin, TrackedModelDetailView):
     template_name = "commodities/detail.jinja"
+
+    def get_context_data(self, *args, **kwargs):
+        collection = get_chapter_collection(self.object)
+        tx = WorkBasket.get_current_transaction(self.request)
+        date = self.object.valid_between.upper
+        snapshot = collection.get_snapshot(tx, date)
+        commodity = snapshot.get_commodity(self.object, self.object.suffix)
+        parent = snapshot.get_parent(commodity)
+
+        return super().get_context_data(
+            parent=parent,
+            *args,
+            **kwargs,
+        )

--- a/commodities/views.py
+++ b/commodities/views.py
@@ -78,15 +78,13 @@ class CommodityDetail(CommodityMixin, TrackedModelDetailView):
     template_name = "commodities/detail.jinja"
 
     def get_context_data(self, *args, **kwargs):
+        context = super().get_context_data(*args, **kwargs)
+
         collection = get_chapter_collection(self.object)
         tx = WorkBasket.get_current_transaction(self.request)
         date = self.object.valid_between.upper
         snapshot = collection.get_snapshot(tx, date)
         commodity = snapshot.get_commodity(self.object, self.object.suffix)
-        parent = snapshot.get_parent(commodity)
+        context["parent"] = snapshot.get_parent(commodity)
 
-        return super().get_context_data(
-            parent=parent,
-            *args,
-            **kwargs,
-        )
+        return context


### PR DESCRIPTION
# TP2000-665 Corrects data fields on commodities details view

## Why

- Commodities details view incorrectly displays commodity origin data as parent commodity data. 
- Commodities details view displays outdated indent values (TP2000-528).
- Data fields contain spelling errors.

## What

- Fixes parent commodity data.
- Shows only current indent value.
- Corrects spelling errors.

Before:
<img width="400" alt="Screenshot 2023-01-09 at 14 25 16" src="https://user-images.githubusercontent.com/118175145/211330746-0cf89d32-9f1f-4044-8cd4-18a615de6442.png">


After:
<img width="400" alt="Screenshot 2023-01-09 at 14 10 54" src="https://user-images.githubusercontent.com/118175145/211330531-db20947f-340f-48a5-af61-940ec14ba473.png">