### PR TITLE
Add certificates counts

### DIFF
--- a/common/jinja2/common/dashboard_overview.jinja
+++ b/common/jinja2/common/dashboard_overview.jinja
@@ -92,5 +92,18 @@
         {{ dashboard_block("Active quotas", view.quotas_active_count, "h4") }}
       </div>
     </div>
+
+    <div class="govuk-grid-column-one-half">
+      <h3 class="govuk-heading-m">Certificates</h3>
+      {{ dashboard_details(
+        "certificates",
+        "Certificates, licenses, and non-paper conditions are sometimes required to bring goods through customs.",
+        "https://uktrade.github.io/tariff-data-manual/documentation/data-structures/certificates.html#certificates"
+        )}}
+      <div class="govuk-grid-row">
+        {{ dashboard_block("Total certificates", view.certificates_total_count, "h4") }}
+        {{ dashboard_block("Active certificates", view.certificates_active_count, "h4") }}
+      </div>
+    </div>
   </div>
 {% endblock %}

--- a/common/tests/test_views.py
+++ b/common/tests/test_views.py
@@ -120,6 +120,7 @@ def test_display_dashboard_overview(valid_user_client):
     factories.QuotaOrderNumberFactory.create()
     factories.QuotaOrderNumberFactory.create()
     factories.QuotaOrderNumberFactory.create()
+    factories.CertificateFactory.create()
     response = valid_user_client.get(reverse("overview"))
 
     assert response.status_code == 200
@@ -127,10 +128,14 @@ def test_display_dashboard_overview(valid_user_client):
     page = BeautifulSoup(str(response.content), "html.parser")
     counts = page.find_all("p", attrs={"class": "govuk-heading-xl"})
 
-    assert len(counts) == 6
-    assert counts[0].text == '2'
-    assert counts[1].text == '2'
-    assert counts[2].text == '4'
-    assert counts[3].text == '4'
-    assert counts[4].text == '3'
-    assert counts[5].text == '3'
+    assert len(counts) == 10
+    assert counts[0].text == "2"
+    assert counts[1].text == "2"
+    assert counts[2].text == "2"
+    assert counts[3].text == "2"
+    assert counts[4].text == "4"
+    assert counts[5].text == "4"
+    assert counts[6].text == "3"
+    assert counts[7].text == "3"
+    assert counts[8].text == "1"
+    assert counts[9].text == "1"

--- a/common/views.py
+++ b/common/views.py
@@ -33,6 +33,7 @@ from django_filters.views import FilterView
 from redis.exceptions import TimeoutError as RedisTimeoutError
 from rest_framework import permissions
 
+from certificates.models import Certificate
 from commodities.models import GoodsNomenclature
 from common import forms
 from common.business_rules import BusinessRule
@@ -98,6 +99,14 @@ class DashboardView(TemplateView):
     @property
     def quotas_active_count(self):
         return QuotaOrderNumber.objects.as_at_today().count()
+
+    @property
+    def certificates_total_count(self):
+        return Certificate.objects.count()
+
+    @property
+    def certificates_active_count(self):
+        return Certificate.objects.as_at_today().count()
 
 
 class HealthCheckResponse(HttpResponse):


### PR DESCRIPTION
# Firebreak: Add certificates counts

## Why
Dashboard overview is missing total and active counts for certificates.

## What
Adds counts for certificates

<img width="571" alt="Screenshot 2023-01-10 at 10 35 23" src="https://user-images.githubusercontent.com/118175145/211533012-ec4f4089-e05c-4102-a603-57701dff8ec1.png">

