### PR TITLE
Firebreak   Data overview link

### DIFF
--- a/common/forms.py
+++ b/common/forms.py
@@ -163,6 +163,7 @@ class HomeForm(forms.Form):
             "EDIT",
             "Edit an existing workbasket",
         )
+        OVERVIEW = "OVERVIEW", "View tariff overview"
 
     workbasket_action = forms.ChoiceField(
         label="",

--- a/common/jinja2/common/dashboard_overview.jinja
+++ b/common/jinja2/common/dashboard_overview.jinja
@@ -14,8 +14,23 @@
 {% endblock %}
 
 {% macro dashboard_block(context) %}
+  {% set detail_text = context.details ~ "<a href='" ~ context.link ~ 
+  "' class='govuk-link' rel='noreferrer noopener' target='_blank'>" ~ 
+  context.summary ~ "</a>" %}
   <div class="govuk-grid-column-two-thirds">
     <h2 class="govuk-heading-m">{{ context.heading }}</h2>
+    <details class="govuk-details" data-module="govuk-details">
+      <summary class="govuk-details__summary">
+        <span class="govuk-details__summary-text">
+          {{ context.summary }}
+        </span>
+      </summary>
+      <div class="govuk-details__text">
+        {{ context.details }} 
+        <a href="{{context.link}}" class="govuk-link" rel="noreferrer noopener"
+         target="_blank">{{context.summary}}</a>
+      </div>
+    </details>
     <div class="govuk-grid-row">
       {% for count in context.counts %}
         <div class="govuk-grid-column-one-half">
@@ -37,6 +52,8 @@
     {% endfor %}
   </div>
 {% endblock %}
+
+
 
 
 

--- a/common/jinja2/common/dashboard_overview.jinja
+++ b/common/jinja2/common/dashboard_overview.jinja
@@ -2,7 +2,7 @@
 
 {% from "components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
 
-{% set page_title = "Tariff management dashboard overview" %}
+{% set page_title = "Tariff overview" %}
 
 {% block breadcrumb %}
   {{ govukBreadcrumbs({
@@ -13,50 +13,97 @@
   }}
 {% endblock %}
 
-{% macro dashboard_block(context) %}
-  {% set detail_text = context.details ~ "<a href='" ~ context.link ~ 
-  "' class='govuk-link' rel='noreferrer noopener' target='_blank'>" ~ 
-  context.summary ~ "</a>" %}
-  <div class="govuk-grid-column-two-thirds">
-    <h2 class="govuk-heading-m">{{ context.heading }}</h2>
-    <details class="govuk-details" data-module="govuk-details">
-      <summary class="govuk-details__summary">
-        <span class="govuk-details__summary-text">
-          {{ context.summary }}
-        </span>
-      </summary>
-      <div class="govuk-details__text">
-        {{ context.details }} 
-        <a href="{{context.link}}" class="govuk-link" rel="noreferrer noopener"
-         target="_blank">{{context.summary}}</a>
-      </div>
-    </details>
-    <div class="govuk-grid-row">
-      {% for count in context.counts %}
-        <div class="govuk-grid-column-one-half">
-          <h2 class="govuk-heading-s">{{ count.title }}</h2>
-          <p class="govuk-heading-xl">{{ intcomma(count.value) }}</p>
-        </div>
-      {% endfor %}
-    </div>
-  </div>
+{% macro dashboard_block(title, value, heading) %}
+<div class="govuk-grid-column-one-half">
+  <{{heading or "h3"}} class="govuk-heading-s">{{ title }}</{{heading or "h3"}}>
+  <p class="govuk-heading-xl">{{ intcomma(value) }}</p>
+</div>
 {% endmacro %}
+
+{% macro dashboard_details(object, details, link) %}
+  <details class="govuk-details" data-module="govuk-details">
+    <summary class="govuk-details__summary">
+      <span class="govuk-details__summary-text">
+        What are {{ object }}?
+      </span>
+    </summary>
+    <div class="govuk-details__text">
+      {{ details }} 
+      <a href="{{link}}" class="govuk-link" rel="noreferrer noopener"
+      target="_blank">More information on {{ object }}</a>
+    </div>
+  </details>
+{% endmacro %}
+
 
 {% block content %}
   <span class="govuk-caption-m govuk-!-margin-bottom-3">Dashboard</span>
   <h1 class="govuk-heading-l govuk-!-margin-bottom-9">{{ page_title }}</h1>
 
+  <h2 class="govuk-heading-l">Regulations</h2>
+  {{ dashboard_details(
+    "regulations",
+    "The legal basis for a measure/tariff. A regulation can apply to many measures.",
+    "https://uktrade.github.io/tariff-data-manual/documentation/data-structures/regulations.html#regulations"
+    )}}  
   <div class="govuk-grid-row">
-    {% for content in dashboard_contents %}
-      {{ dashboard_block(content) }}
-    {% endfor %}
+    {{ dashboard_block("Total regulations", view.regulations_total_count) }}
+    {{ dashboard_block("Active regulations", view.regulations_active_count) }}
+  </div>
+
+  <h2 class="govuk-heading-l">Measures</h2>
+  {{ dashboard_details(
+    "measures",
+    "A measure provides information about a commodity code 
+    and conditions for its use. They are based on law and are the 
+    building blocks of any trade tariff.",
+    "https://uktrade.github.io/tariff-data-manual/documentation/data-structures/measures.html#what-measures-are"
+    )}} 
+  <div class="govuk-grid-row">
+    {{ dashboard_block("Total measures", view.measures_total_count) }}
+    {{ dashboard_block("Active measures", view.measures_active_count) }}
+  </div>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-one-half">
+      <h3 class="govuk-heading-m">Commodities</h3>
+      {{ dashboard_details(
+        "commodity codes",
+        "A commodity code is a unique 10-digit number used 
+        to classify a good for import and export.",
+        "https://uktrade.github.io/tariff-data-manual/documentation/data-structures/commodity-codes.html#commodity-codes"
+        )}} 
+      <div class="govuk-grid-row">
+        {{ dashboard_block("Total commodities", view.commodities_total_count, "h4") }}
+        {{ dashboard_block("Active commodities", view.commodities_active_count, "h4") }}
+      </div>
+    </div>
+
+    <div class="govuk-grid-column-one-half">
+      <h3 class="govuk-heading-m">Quotas</h3>
+      {{ dashboard_details(
+        "quotas",
+        "Lower tariff rates on importing a good up to a 
+        specific quantity.",
+        "https://uktrade.github.io/tariff-data-manual/documentation/data-structures/quotas.html#quotas"
+        )}} 
+      <div class="govuk-grid-row">
+        {{ dashboard_block("Total quotas", view.quotas_total_count, "h4") }}
+        {{ dashboard_block("Active quotas", view.quotas_active_count, "h4") }}
+      </div>
+    </div>
+
+    <div class="govuk-grid-column-one-half">
+      <h3 class="govuk-heading-m">Certificates</h3>
+      {{ dashboard_details(
+        "certificates",
+        "Certificates, licenses, and non-paper conditions are sometimes required to bring goods through customs.",
+        "https://uktrade.github.io/tariff-data-manual/documentation/data-structures/certificates.html#certificates"
+        )}}
+      <div class="govuk-grid-row">
+        {{ dashboard_block("Total certificates", view.certificates_total_count, "h4") }}
+        {{ dashboard_block("Active certificates", view.certificates_active_count, "h4") }}
+      </div>
+    </div>
   </div>
 {% endblock %}
-
-
-
-
-
-
-
-

--- a/common/tests/test_views.py
+++ b/common/tests/test_views.py
@@ -37,6 +37,12 @@ def test_index_displays_workbasket_action_form(valid_user_client):
             },
             "workbaskets:workbasket-ui-create",
         ),
+        (
+            {
+                "workbasket_action": "OVERVIEW",
+            },
+            "overview",
+        ),
     ),
 )
 def test_workbasket_action_form_response_redirects_user(
@@ -120,6 +126,7 @@ def test_display_dashboard_overview(valid_user_client):
     factories.QuotaOrderNumberFactory.create()
     factories.QuotaOrderNumberFactory.create()
     factories.QuotaOrderNumberFactory.create()
+    factories.CertificateFactory.create()
     response = valid_user_client.get(reverse("overview"))
 
     assert response.status_code == 200
@@ -127,10 +134,22 @@ def test_display_dashboard_overview(valid_user_client):
     page = BeautifulSoup(str(response.content), "html.parser")
     counts = page.find_all("p", attrs={"class": "govuk-heading-xl"})
 
-    assert len(counts) == 6
-    assert counts[0].text == '2'
-    assert counts[1].text == '2'
-    assert counts[2].text == '4'
-    assert counts[3].text == '4'
-    assert counts[4].text == '3'
-    assert counts[5].text == '3'
+    assert len(counts) == 10
+    assert counts[0].text == "2"
+    assert counts[1].text == "2"
+    assert counts[2].text == "2"
+    assert counts[3].text == "2"
+    assert counts[4].text == "4"
+    assert counts[5].text == "4"
+    assert counts[6].text == "3"
+    assert counts[7].text == "3"
+    assert counts[8].text == "1"
+    assert counts[9].text == "1"
+
+
+def test_dashboard_overiew_403(client):
+    request = client.get("/overview")
+    response = handler403(request)
+
+    assert response.status_code == 403
+    assert response.template_name == "common/403.jinja"

--- a/common/urls.py
+++ b/common/urls.py
@@ -16,7 +16,7 @@ register_converter(NumericSIDConverter, "sid")
 urlpatterns = [
     path("", views.HomeView.as_view(), name="home"),
     path("healthcheck", views.healthcheck, name="healthcheck"),
-    path("overview/", views.DashboardView.as_view(), name="overview"),
+    path("overview", views.DashboardView.as_view(), name="overview"),
     path("app-info", views.AppInfoView.as_view(), name="app-info"),
     path("login", views.LoginView.as_view(), name="login"),
     path("logout", views.LogoutView.as_view(), name="logout"),

--- a/common/views.py
+++ b/common/views.py
@@ -88,9 +88,15 @@ class DashboardView(TemplateView):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
+        #<a href="#" class="govuk-link govuk-link--no-visited-state">link text (with no visited state)</a>
         context["dashboard_contents"] = [
             {
                 "heading": "Measures",
+                "summary": "What are measures?",
+                "details": """A measure provides information about a commodity code 
+                and conditions for its use. They are based on law and are the 
+                building blocks of any trade tariff.""",
+                "link": "https://uktrade.github.io/tariff-data-manual/documentation/data-structures/measures.html#what-measures-are",
                 "counts": [
                     {"title": "Total ", "value": self.measure_total_count},
                     {"title": "Active ", "value": self.measure_active_count},
@@ -98,6 +104,10 @@ class DashboardView(TemplateView):
             },
             {
                 "heading": "Commodity codes",
+                "summary": "What are Commodity codes?",
+                "details": """A commodity code is a unique 10-digit number used 
+                to classify a good for import and export.""",
+                "link": "https://uktrade.github.io/tariff-data-manual/documentation/data-structures/commodity-codes.html#commodity-codes",
                 "counts": [
                     {"title": "Total", "value": self.commodities_total_count},
                     {"title": "Active", "value": self.commodities_active_count},
@@ -105,6 +115,10 @@ class DashboardView(TemplateView):
             },
             {
                 "heading": "Quotas",
+                "summary": "What are Quotas?",
+                "details": """Lower tariff rates on importing a good up to a 
+                specific quantity.""",
+                "link": "https://uktrade.github.io/tariff-data-manual/documentation/data-structures/quotas.html#quotas",
                 "counts": [
                     {"title": "Total ", "value": self.quotas_total_count},
                     {"title": "Active ", "value": self.quotas_active_count},

--- a/common/views.py
+++ b/common/views.py
@@ -33,6 +33,7 @@ from django_filters.views import FilterView
 from redis.exceptions import TimeoutError as RedisTimeoutError
 from rest_framework import permissions
 
+from certificates.models import Certificate
 from commodities.models import GoodsNomenclature
 from common import forms
 from common.business_rules import BusinessRule
@@ -43,6 +44,7 @@ from common.pagination import build_pagination_list
 from common.validators import UpdateType
 from measures.models import Measure
 from quotas.models import QuotaOrderNumber
+from regulations.models import Regulation
 from workbaskets.views.mixins import WithCurrentWorkBasket
 
 
@@ -55,6 +57,8 @@ class HomeView(FormView, View):
             return redirect(reverse("workbaskets:workbasket-ui-list"))
         elif form.cleaned_data["workbasket_action"] == "CREATE":
             return redirect(reverse("workbaskets:workbasket-ui-create"))
+        elif form.cleaned_data["workbasket_action"] == "OVERVIEW":
+            return redirect("overview")
 
 
 class DashboardView(TemplateView):
@@ -63,69 +67,48 @@ class DashboardView(TemplateView):
     template_name = "common/dashboard_overview.jinja"
 
     @property
-    def measure_total_count(self):
-        return Measure.objects.values("sid").count()
+    def measures_total_count(self):
+        return Measure.objects.count()
+
+    @property
+    def measures_active_count(self):
+        return Measure.objects.as_at_today().count()
 
     @property
     def measure_active_count(self):
-        return Measure.objects.values("sid").as_at_today().count()
+        return Measure.objects.as_at_today().count()
 
     @property
     def commodities_total_count(self):
-        return GoodsNomenclature.objects.values("sid").count()
-    
+        return GoodsNomenclature.objects.count()
+
     @property
     def commodities_active_count(self):
-        return GoodsNomenclature.objects.values("sid").as_at_today().count()
+        return GoodsNomenclature.objects.as_at_today().count()
+
+    @property
+    def regulations_total_count(self):
+        return Regulation.objects.count()
+
+    @property
+    def regulations_active_count(self):
+        return Regulation.objects.as_at_today().count()
 
     @property
     def quotas_total_count(self):
-        return QuotaOrderNumber.objects.values("sid").count()
+        return QuotaOrderNumber.objects.count()
 
     @property
     def quotas_active_count(self):
-        return QuotaOrderNumber.objects.values("sid").as_at_today().count()
+        return QuotaOrderNumber.objects.as_at_today().count()
 
-    def get_context_data(self, **kwargs):
-        context = super().get_context_data(**kwargs)
-        #<a href="#" class="govuk-link govuk-link--no-visited-state">link text (with no visited state)</a>
-        context["dashboard_contents"] = [
-            {
-                "heading": "Measures",
-                "summary": "What are measures?",
-                "details": """A measure provides information about a commodity code 
-                and conditions for its use. They are based on law and are the 
-                building blocks of any trade tariff.""",
-                "link": "https://uktrade.github.io/tariff-data-manual/documentation/data-structures/measures.html#what-measures-are",
-                "counts": [
-                    {"title": "Total ", "value": self.measure_total_count},
-                    {"title": "Active ", "value": self.measure_active_count},
-                ],
-            },
-            {
-                "heading": "Commodity codes",
-                "summary": "What are Commodity codes?",
-                "details": """A commodity code is a unique 10-digit number used 
-                to classify a good for import and export.""",
-                "link": "https://uktrade.github.io/tariff-data-manual/documentation/data-structures/commodity-codes.html#commodity-codes",
-                "counts": [
-                    {"title": "Total", "value": self.commodities_total_count},
-                    {"title": "Active", "value": self.commodities_active_count},
-                ],
-            },
-            {
-                "heading": "Quotas",
-                "summary": "What are Quotas?",
-                "details": """Lower tariff rates on importing a good up to a 
-                specific quantity.""",
-                "link": "https://uktrade.github.io/tariff-data-manual/documentation/data-structures/quotas.html#quotas",
-                "counts": [
-                    {"title": "Total ", "value": self.quotas_total_count},
-                    {"title": "Active ", "value": self.quotas_active_count},
-                ],
-            }
-        ]
-        return context
+    @property
+    def certificates_total_count(self):
+        return Certificate.objects.count()
+
+    @property
+    def certificates_active_count(self):
+        return Certificate.objects.as_at_today().count()
 
 
 class HealthCheckResponse(HttpResponse):


### PR DESCRIPTION
# Data overview link

## Why
the overview dashboard can only be accessed via the url

## What

a link on the home page to the overview dashboard 

<img width="947" alt="image" src="https://user-images.githubusercontent.com/16708670/211556264-86a894cc-fe56-4e2a-ba72-9a843e4d8fe9.png">


See: [Trello Ticket](https://trello.com/c/sHZ2HMgi/18-link-to-overview-page)

