### PR TITLE
TP2000-675 Fix version control tab template paths

### DIFF
--- a/workbaskets/jinja2/workbaskets/macros/detail_tabs.jinja
+++ b/workbaskets/jinja2/workbaskets/macros/detail_tabs.jinja
@@ -10,7 +10,7 @@
   #}
   {% set core_data_tab_html %}{% include "includes/additional_codes/tabs/core_data.jinja" %}{% endset %}
   {% set description_tab_html %}{% include "includes/common/tabs/descriptions.jinja" %}{% endset %}
-  {% set version_control_tab_html %}{% include "includes/additional_codes/tabs/version_control.jinja" %}{% endset %}
+  {% set version_control_tab_html %}{% include "includes/common/tabs/version_control.jinja" %}{% endset %}
   {{ govukTabs({
     "items": [
       {
@@ -48,7 +48,7 @@
   #}
   {% set core_data_tab_html %}{% include "includes/footnotes/tabs/core_data.jinja" %}{% endset %}
   {% set description_tab_html %}{% include "includes/common/tabs/descriptions.jinja" %}{% endset %}
-  {% set version_control_tab_html %}{% include "includes/footnotes/tabs/version_control.jinja" %}{% endset %}
+  {% set version_control_tab_html %}{% include "includes/common/tabs/version_control.jinja" %}{% endset %}
   {{ govukTabs({
     "items": [
       {

--- a/workbaskets/tests/test_views.py
+++ b/workbaskets/tests/test_views.py
@@ -562,7 +562,21 @@ def setup(session_workbasket, valid_user_client):
         good = GoodsNomenclatureFactory.create(transaction=transaction)
         measure = MeasureFactory.create(transaction=transaction)
         geo_area = GeographicalAreaFactory.create(transaction=transaction)
-        objects = [good, measure, geo_area]
+        regulation = factories.RegulationFactory.create(transaction=transaction)
+        additional_code = factories.AdditionalCodeFactory.create(
+            transaction=transaction,
+        )
+        certificate = factories.CertificateFactory.create(transaction=transaction)
+        footnote = factories.FootnoteFactory.create(transaction=transaction)
+        objects = [
+            good,
+            measure,
+            geo_area,
+            regulation,
+            additional_code,
+            certificate,
+            footnote,
+        ]
         for obj in objects:
             TrackedModelCheckFactory.create(
                 transaction_check__transaction=transaction,
@@ -681,3 +695,17 @@ def test_violation_list_page_sorting_ignores_invalid_params(
     response = valid_user_client.get(f"{url}?sort_by=foo&order=bar")
 
     assert response.status_code == 200
+
+
+def test_workbasket_changes_view(setup, valid_user_client, session_workbasket):
+    url = reverse(
+        "workbaskets:workbasket-ui-changes",
+        kwargs={"pk": session_workbasket.pk},
+    )
+
+    response = valid_user_client.get(url)
+    assert response.status_code == 200
+
+    soup = BeautifulSoup(str(response.content), "html.parser")
+    version_control_tabs = soup.select('a[href="#version-control"]')
+    assert len(version_control_tabs) == 2


### PR DESCRIPTION
# TP2000-675 Fix version control tab template paths

## Why
There occurs a 500-series error owing to missing version control templates on WorkBasket changes view.

## What
Amends incorrect version control template path to use common template
Adds test for WorkBasket Changes view

<img width="400" alt="Screenshot 2023-01-11 at 09 50 48" src="https://user-images.githubusercontent.com/118175145/211774472-097b09ae-b765-4f33-a0ed-043e542f76be.png">
