### PR TITLE
TP2000-672 Add multiple measures edit end date form

### DIFF
--- a/measures/forms.py
+++ b/measures/forms.py
@@ -21,6 +21,7 @@ from certificates.models import Certificate
 from commodities.models import GoodsNomenclature
 from common.fields import AutoCompleteField
 from common.forms import BindNestedFormMixin
+from common.forms import DateInputFieldFixed
 from common.forms import FormSet
 from common.forms import RadioNested
 from common.forms import ValidityPeriodForm
@@ -1135,3 +1136,25 @@ class MeasureReviewForm(forms.Form):
 
 
 MeasureDeleteForm = delete_form_for(models.Measure)
+
+
+class MeasureEndDateForm(forms.Form):
+    end_date = DateInputFieldFixed(
+        label="End date",
+    )
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self.helper = FormHelper(self)
+        self.helper.label_size = Size.SMALL
+        self.helper.legend_size = Size.SMALL
+        self.helper.layout = Layout(
+            "end_date",
+            Submit(
+                "submit",
+                "Save measure end dates",
+                data_module="govuk-button",
+                data_prevent_double_click="true",
+            ),
+        )

--- a/measures/forms.py
+++ b/measures/forms.py
@@ -1174,9 +1174,11 @@ class MeasureEndDateForm(forms.Form):
                 lower = measure.valid_between.lower
                 upper = datetime.date(year, month, day)
                 if lower > upper:
+                    formatted_lower = lower.strftime("%d/%m/%Y")
+                    formatted_upper = upper.strftime("%d/%m/%Y")
                     raise ValidationError(
                         f"The end date cannot be before the start date: "
-                        f"{lower} does not start before {upper}",
+                        f"Start date {formatted_lower} does not start before {formatted_upper}",
                     )
 
         return cleaned_data

--- a/measures/forms.py
+++ b/measures/forms.py
@@ -1,3 +1,4 @@
+import datetime
 import logging
 
 from crispy_forms_gds.helper import FormHelper
@@ -1145,6 +1146,7 @@ class MeasureEndDateForm(forms.Form):
     )
 
     def __init__(self, *args, **kwargs):
+        self.selected_measures = kwargs.pop("selected_measures", None)
         super().__init__(*args, **kwargs)
 
         self.helper = FormHelper(self)
@@ -1159,3 +1161,22 @@ class MeasureEndDateForm(forms.Form):
                 data_prevent_double_click="true",
             ),
         )
+
+    def clean(self):
+        cleaned_data = super().clean()
+
+        if "end_date" in cleaned_data:
+            for measure in self.selected_measures:
+                year = int(cleaned_data["end_date"].year)
+                month = int(cleaned_data["end_date"].month)
+                day = int(cleaned_data["end_date"].day)
+
+                lower = measure.valid_between.lower
+                upper = datetime.date(year, month, day)
+                if lower > upper:
+                    raise ValidationError(
+                        f"The end date cannot be before the start date: "
+                        f"{lower} does not start before {upper}",
+                    )
+
+        return cleaned_data

--- a/measures/forms.py
+++ b/measures/forms.py
@@ -1140,7 +1140,7 @@ MeasureDeleteForm = delete_form_for(models.Measure)
 
 class MeasureEndDateForm(forms.Form):
     end_date = DateInputFieldFixed(
-        label="EIF date",
+        label="End date",
         help_text="For example, 27 3 2008",
     )
 

--- a/measures/forms.py
+++ b/measures/forms.py
@@ -1140,7 +1140,8 @@ MeasureDeleteForm = delete_form_for(models.Measure)
 
 class MeasureEndDateForm(forms.Form):
     end_date = DateInputFieldFixed(
-        label="End date",
+        label="EIF date",
+        help_text="For example, 27 3 2008",
     )
 
     def __init__(self, *args, **kwargs):

--- a/measures/jinja2/includes/measures/list.jinja
+++ b/measures/jinja2/includes/measures/list.jinja
@@ -88,6 +88,6 @@
       {% endif %}
     </div>
   </div>
-  <button value="remove-selected" name="form-action" class="govuk-button govuk-button--secondary" data-module="govuk-button">Delete selected measures </button>
   <button value="edit-selected" name="form-action" class="govuk-button govuk-button--secondary" data-module="govuk-button">Edit selected measures </button>
+  <button value="remove-selected" name="form-action" class="govuk-button govuk-button--secondary" data-module="govuk-button">Delete selected measures </button>
 </form>

--- a/measures/jinja2/includes/measures/list.jinja
+++ b/measures/jinja2/includes/measures/list.jinja
@@ -89,4 +89,5 @@
     </div>
   </div>
   <button value="remove-selected" name="form-action" class="govuk-button govuk-button--secondary" data-module="govuk-button">Delete selected measures </button>
+  <button value="edit-selected" name="form-action" class="govuk-button govuk-button--secondary" data-module="govuk-button">Edit selected measures </button>
 </form>

--- a/measures/jinja2/measures/edit-multiple-measures-enddates.jinja
+++ b/measures/jinja2/measures/edit-multiple-measures-enddates.jinja
@@ -1,0 +1,116 @@
+{% extends "layouts/form.jinja" %}
+
+{% from "components/button/macro.njk" import govukButton %}
+{% from "components/warning-text/macro.njk" import govukWarningText %}
+{% from "components/inset-text/macro.njk" import govukInsetText %}
+{% from "components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
+
+{% from 'macros/create_link.jinja' import create_link %} 
+{% from "includes/measures/conditions.jinja" import conditions_list %}
+{% from "components/table/macro.njk" import govukTable %}
+
+{% set page_title = "Edit measure end dates" %}
+
+{% block breadcrumb %}
+  {{ govukBreadcrumbs({
+    "items": [
+      {"text": "Home", "href": url("home")},
+      {"text": "Find and edit measures", "href": url("measure-ui-list")},
+      {"text": page_title}
+    ]
+  }) }}
+{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-xl">
+        Edit measures
+        <span class="govuk-caption-xl"></span>
+      </h1>
+    </div>
+  </div>
+
+  <div class="govuk-grid-row govuk-!-margin-bottom-5">
+    <div class="govuk-grid-column-two-thirds">
+      <p class="govuk-body"> You are about to edit the end date of your selected measures.</p>
+      {{ govukWarningText({
+        "text": "You are currently only able to change the end dates of multiple measures.",
+        "iconFallbackText": "Warning"
+      }) }}
+    
+      <div class="govuk-inset-text">
+        <p>Your edited measures will be added to your work basket as items.</p>
+        <p>If you need to undo your edits later, you will need to remove the items from the workbasket.</p>
+      </div>
+
+      {% block form %}
+        <div class="govuk-grid-row">
+            <div class="govuk-grid-column-two-thirds">
+            {% call django_form() %}
+                {{ crispy(form) }}
+            {% endcall %}
+            </div>
+        </div>
+      {% endblock %}
+    
+    </div>
+  </div>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full"></div>
+      <details class="govuk-details" data-module="govuk-details">
+        <summary class="govuk-details__summary">
+          <span class="govuk-details__summary-text">
+            View all selected measures
+          </span>
+        </summary>
+        <div class="govuk-details__text">
+          {% if object_list %}
+            {% set table_rows = [] %}
+            {% for measure in object_list %}
+                {% set measure_link -%}
+                  <a class="govuk-link govuk-!-font-weight-bold" href="{{ measure.get_url() }}">{{measure.sid}}</a>
+                {%- endset %}
+                {% set footnotes %}
+                  {% for footnote in measure.footnotes.all() %}
+                      {{ create_link(footnote.get_url(), footnote|string) }}{{ ", " if not loop.last else "" }}
+                  {% endfor %}
+                {% endset %}
+                {{ table_rows.append([
+                  {"html": measure_link},
+                  {"text": measure.measure_type.sid ~ " - " ~ measure.measure_type.description},
+                  {"text": measure.goods_nomenclature.item_id|wordwrap(2)|replace("\n", " ") if measure.goods_nomenclature else '-', "classes": "govuk-!-width-one-eighth"},
+                  {"text": "{:%d %b %Y}".format(measure.effective_valid_between.lower) if measure.effective_valid_between.lower else '-'},
+                  {"text": "{:%d %b %Y}".format(measure.effective_valid_between.upper) if measure.effective_valid_between.upper else '-'},
+                  {"text": measure.duty_sentence if measure.duty_sentence else '-'},
+                  {"html": create_link(url("additional_code-ui-detail", kwargs={"sid": measure.additional_code.sid}), measure.additional_code.type.sid ~ measure.additional_code.code) if measure.additional_code else '-'},
+                  {"html": create_link(url("geo_area-ui-detail", kwargs={"sid": measure.geographical_area.sid}), measure.geographical_area.area_id ~ " - " ~ measure.geographical_area.get_description().description) if measure.geographical_area else '-'},
+                  {"text": create_link(measure.order_number.get_url(), measure.order_number.order_number) if measure.order_number else '-'},
+                  {"text": footnotes if measure.footnotes.all() else '-'},
+                ]) or "" }}
+            {% endfor %}
+            {{ govukTable({
+              "head": [
+                {"text": "ID"},
+                {"text": "Type"},
+                {"text": "Commodity code"},
+                {"text": "Start date"},
+                {"text": "End date"},
+                {"text": "Duties"},
+                {"text": "Additional code"},
+                {"text": "Geographical area"},
+                {"text": "Quota"},
+                {"text": "Footnote"},
+              ],
+              "rows": table_rows,
+              "classes": "govuk-table-m"
+            }) }}
+
+          {% endif %}
+        </div>
+      </details>
+    </div>
+  </div>
+
+{% endblock %}

--- a/measures/jinja2/measures/edit-multiple-measures-enddates.jinja
+++ b/measures/jinja2/measures/edit-multiple-measures-enddates.jinja
@@ -33,14 +33,14 @@
 
   <div class="govuk-grid-row govuk-!-margin-bottom-5">
     <div class="govuk-grid-column-two-thirds">
-      <p class="govuk-body"> You are about to edit the end date of your selected measures.</p>
+      <p class="govuk-body"> You are about to edit the end dates of your selected measures.</p>
       {{ govukWarningText({
         "text": "You are currently only able to change the end dates of multiple measures.",
         "iconFallbackText": "Warning"
       }) }}
     
       <div class="govuk-inset-text">
-        <p>Your edited measures will be added to your work basket as items.</p>
+        <p>Your edited measures will be added to your workbasket as items.</p>
         <p>If you need to undo your edits later, you will need to remove the items from the workbasket.</p>
       </div>
 

--- a/measures/jinja2/measures/edit.jinja
+++ b/measures/jinja2/measures/edit.jinja
@@ -10,7 +10,7 @@
 {% from "components/breadcrumbs.jinja" import breadcrumbs %}
 
 
-{% set page_title = "Edit " ~ object._meta.verbose_name ~ " details" %}
+{% set page_title = "Edit" ~ object._meta.verbose_name ~ " details" %}
 
 {% block breadcrumb %}
   {{ breadcrumbs(request, [

--- a/measures/jinja2/measures/edit.jinja
+++ b/measures/jinja2/measures/edit.jinja
@@ -10,7 +10,7 @@
 {% from "components/breadcrumbs.jinja" import breadcrumbs %}
 
 
-{% set page_title = "Edit" ~ object._meta.verbose_name ~ " details" %}
+{% set page_title = "Edit " ~ object._meta.verbose_name ~ " details" %}
 
 {% block breadcrumb %}
   {{ breadcrumbs(request, [

--- a/measures/tests/test_views.py
+++ b/measures/tests/test_views.py
@@ -132,7 +132,7 @@ def test_multiple_measure_delete_functionality(client, valid_user, session_workb
                 "status": session_workbasket.status,
                 "title": session_workbasket.title,
             },
-            "DELETE_MEASURE_SELECTIONS": {
+            "MULTIPLE_MEASURE_SELECTIONS": {
                 measure_1.pk: True,
                 measure_2.pk: True,
                 measure_3.pk: True,
@@ -149,7 +149,7 @@ def test_multiple_measure_delete_functionality(client, valid_user, session_workb
 
     # on success, the page redirects to the list page
     assert response.status_code == 302
-    assert client.session["DELETE_MEASURE_SELECTIONS"] == {}
+    assert client.session["MULTIPLE_MEASURE_SELECTIONS"] == {}
     for measure in workbasket_measures:
         # check that the update type is delete which is 2
         assert measure.update_type == 2
@@ -176,7 +176,7 @@ def test_multiple_measure_delete_template(client, valid_user, session_workbasket
                 "status": session_workbasket.status,
                 "title": session_workbasket.title,
             },
-            "DELETE_MEASURE_SELECTIONS": {
+            "MULTIPLE_MEASURE_SELECTIONS": {
                 measure_1.pk: True,
                 measure_2.pk: True,
                 measure_3.pk: True,
@@ -194,7 +194,7 @@ def test_multiple_measure_delete_template(client, valid_user, session_workbasket
 
     # grab the whole measure objects for our pk's we've got in the session, so we can compare attributes.
     selected_measures = Measure.objects.filter(
-        pk__in=session["DELETE_MEASURE_SELECTIONS"].keys(),
+        pk__in=session["MULTIPLE_MEASURE_SELECTIONS"].keys(),
     )
 
     # Get the measure ids that are being shown in the table in the template.

--- a/measures/tests/test_views.py
+++ b/measures/tests/test_views.py
@@ -1,3 +1,4 @@
+import datetime
 import unittest
 from datetime import date
 from decimal import Decimal
@@ -19,6 +20,7 @@ from common.tests.util import get_class_based_view_urls_matching_url
 from common.tests.util import raises_if
 from common.tests.util import view_is_subclass
 from common.tests.util import view_urlpattern_ids
+from common.util import TaricDateRange
 from common.validators import UpdateType
 from common.views import TamatoListView
 from common.views import TrackedModelDetailMixin
@@ -1208,3 +1210,132 @@ def test_measuretype_api_list_view(valid_user_client):
         valid_user_client,
         equals=True,
     )
+
+
+def test_multiple_measure_end_date_edit_functionality(
+    client,
+    valid_user,
+    session_workbasket,
+):
+    """Tests that MeasureMultipleEndDateEdit view's Post function takes a list
+    of measures, and sets their update type to update, updates their end dates,
+    and clears the session once completed."""
+    measure_1 = factories.MeasureFactory.create()
+    measure_2 = factories.MeasureFactory.create()
+    measure_3 = factories.MeasureFactory.create()
+
+    measure_3.valid_between = (
+        TaricDateRange(
+            lower=datetime.date(2023, 10, 30),
+        ),
+    )
+
+    url = reverse("measure-ui-edit-multiple-end-date")
+    client.force_login(valid_user)
+    session = client.session
+    session.update(
+        {
+            "workbasket": {
+                "id": session_workbasket.pk,
+                "status": session_workbasket.status,
+                "title": session_workbasket.title,
+            },
+            "MULTIPLE_MEASURE_SELECTIONS": {
+                measure_1.pk: True,
+                measure_2.pk: True,
+                measure_3.pk: True,
+            },
+        },
+    )
+    session.save()
+    post_data = {
+        "submit": "Save measure end dates",
+        "end_date_0": "25",
+        "end_date_1": "10",
+        "end_date_2": "2023",
+    }
+    response = client.post(url, data=post_data)
+
+    workbasket_measures = Measure.objects.filter(
+        trackedmodel_ptr__transaction__workbasket_id=session_workbasket.id,
+    ).order_by("sid")
+
+    # on success, the page redirects to the list page
+    assert response.status_code == 302
+    assert client.session["MULTIPLE_MEASURE_SELECTIONS"] == {}
+    for measure in workbasket_measures:
+        # check that the update type is update which is 2
+        assert measure.update_type == 1
+        # Check that if the start date is invalid, there's no end date applied
+        if measure.valid_between.lower == datetime.date(2023, 10, 30):
+            assert measure.valid_between.upper == None
+        else:
+            # Check the end dates have been applied
+            assert measure.effective_end_date == datetime.date(2023, 10, 25)
+
+
+def test_multiple_measure_delete_template(client, valid_user, session_workbasket):
+    """Test that valid user receives a 200 on GET for MeasureMultipleEndDateEdit
+    and correct measures display in html table."""
+    # Make a bunch of measures
+    measure_1 = factories.MeasureFactory.create()
+    measure_2 = factories.MeasureFactory.create()
+    measure_3 = factories.MeasureFactory.create()
+    measure_4 = factories.MeasureFactory.create()
+    measure_5 = factories.MeasureFactory.create()
+
+    client.force_login(valid_user)
+    session = client.session
+    # Add a workbasket to the session, and add some selected measures to it.
+    session.update(
+        {
+            "workbasket": {
+                "id": session_workbasket.pk,
+                "status": session_workbasket.status,
+                "title": session_workbasket.title,
+            },
+            "MULTIPLE_MEASURE_SELECTIONS": {
+                measure_1.pk: True,
+                measure_2.pk: True,
+                measure_3.pk: True,
+            },
+        },
+    )
+    session.save()
+
+    url = reverse("measure-ui-edit-multiple-end-date")
+    response = client.get(url)
+
+    assert response.status_code == 200
+
+    soup = BeautifulSoup(str(response.content), "html.parser")
+
+    # grab the whole measure objects for our pk's we've got in the session, so we can compare attributes.
+    selected_measures = Measure.objects.filter(
+        pk__in=session["MULTIPLE_MEASURE_SELECTIONS"].keys(),
+    )
+
+    # Get the measure ids that are being shown in the table in the template.
+    measure_ids_in_table = [e.text for e in soup.select("table tr td:first-child")]
+
+    # Get the sids for the measures we selected, as these are what are shown in the template.
+    selected_measures_ids = [str(measure.sid) for measure in selected_measures]
+
+    assert measure_ids_in_table == selected_measures_ids
+    assert set(measure_ids_in_table).difference([measure_4.sid, measure_5.sid])
+
+    # 4th column is start date
+    start_dates_in_table = {e.text for e in soup.select("table tr td:nth-child(4)")}
+    measure_start_dates = {
+        f"{m.valid_between.lower:%d %b %Y}" for m in selected_measures
+    }
+    assert not measure_start_dates.difference(start_dates_in_table)
+
+    # 5th column is end date
+    end_dates_in_table = {e.text for e in soup.select("table tr td:nth-child(5)")}
+    measure_end_dates = {
+        f"{m.effective_end_date:%d %b %Y}"
+        for m in selected_measures
+        if m.effective_end_date
+    }
+    assert not measure_end_dates.difference(end_dates_in_table)

--- a/measures/urls.py
+++ b/measures/urls.py
@@ -25,6 +25,11 @@ ui_patterns = [
         name="measure-ui-delete-multiple",
     ),
     path(
+        "edit-multiple-measures-end-dates/",
+        views.MeasureMultipleEndDateEdit.as_view(),
+        name="measure-ui-edit-multiple-end-date",
+    ),
+    path(
         "create/<step>/",
         views.MeasureCreateWizard.as_view(
             url_name="measure-ui-create",

--- a/measures/views.py
+++ b/measures/views.py
@@ -676,33 +676,3 @@ class MeasureMultipleEndDateEdit(FormView, ListView):
             session_store.clear()
 
         return redirect(reverse("measure-ui-list"))
-
-    # def post(self, request):
-    #     if request.POST.get("submit", None) != "Save measure end dates":
-    #         # The user has cancelled out of the editing process.
-    #         return redirect("home")
-
-    #     object_list = self.get_queryset()
-
-    #     for obj in object_list:
-    #         # make a new version of the object with an update type of update, pass in the new end date.
-    #         end_year = int(request.POST["end_date_2"])
-    #         end_month = int(request.POST["end_date_1"])
-    #         end_day = int(request.POST["end_date_0"])
-
-    #         lower = obj.valid_between.lower
-    #         upper = datetime.date(end_year, end_month, end_day)
-
-    #         if upper >= lower:
-    #             obj.new_version(
-    #                 workbasket=WorkBasket.current(request),
-    #                 update_type=UpdateType.UPDATE,
-    #                 valid_between=TaricDateRange(
-    #                     lower=obj.valid_between.lower,
-    #                     upper=datetime.date(end_year, end_month, end_day),
-    #                 ),
-    #             )
-    #     session_store = self._session_store()
-    #     session_store.clear()
-
-    #     return redirect(reverse("measure-ui-list"))

--- a/measures/views.py
+++ b/measures/views.py
@@ -648,32 +648,61 @@ class MeasureMultipleEndDateEdit(FormView, ListView):
 
         return context
 
-    def post(self, request):
-        if request.POST.get("submit", None) != "Save measure end dates":
+    def get_form_kwargs(self):
+        kwargs = super().get_form_kwargs()
+        kwargs["selected_measures"] = self.get_queryset()
+        return kwargs
+
+    def form_valid(self, form):
+        if self.request.POST.get("submit", None) != "Save measure end dates":
             # The user has cancelled out of the editing process.
             return redirect("home")
 
-        object_list = self.get_queryset()
-
-        for obj in object_list:
-            # make a new version of the object with an update type of update, pass in the new end date.
-            end_year = int(request.POST["end_date_2"])
-            end_month = int(request.POST["end_date_1"])
-            end_day = int(request.POST["end_date_0"])
-
-            lower = obj.valid_between.lower
-            upper = datetime.date(end_year, end_month, end_day)
-
-            if upper >= lower:
-                obj.new_version(
-                    workbasket=WorkBasket.current(request),
-                    update_type=UpdateType.UPDATE,
-                    valid_between=TaricDateRange(
-                        lower=obj.valid_between.lower,
-                        upper=datetime.date(end_year, end_month, end_day),
+        selected_measures = self.get_queryset()
+        for measure in selected_measures:
+            measure.new_version(
+                workbasket=WorkBasket.current(self.request),
+                update_type=UpdateType.UPDATE,
+                valid_between=TaricDateRange(
+                    lower=measure.valid_between.lower,
+                    upper=datetime.date(
+                        form.cleaned_data["end_date"].year,
+                        form.cleaned_data["end_date"].month,
+                        form.cleaned_data["end_date"].day,
                     ),
-                )
-        session_store = self._session_store()
-        session_store.clear()
+                ),
+            )
+            session_store = self._session_store()
+            session_store.clear()
 
         return redirect(reverse("measure-ui-list"))
+
+    # def post(self, request):
+    #     if request.POST.get("submit", None) != "Save measure end dates":
+    #         # The user has cancelled out of the editing process.
+    #         return redirect("home")
+
+    #     object_list = self.get_queryset()
+
+    #     for obj in object_list:
+    #         # make a new version of the object with an update type of update, pass in the new end date.
+    #         end_year = int(request.POST["end_date_2"])
+    #         end_month = int(request.POST["end_date_1"])
+    #         end_day = int(request.POST["end_date_0"])
+
+    #         lower = obj.valid_between.lower
+    #         upper = datetime.date(end_year, end_month, end_day)
+
+    #         if upper >= lower:
+    #             obj.new_version(
+    #                 workbasket=WorkBasket.current(request),
+    #                 update_type=UpdateType.UPDATE,
+    #                 valid_between=TaricDateRange(
+    #                     lower=obj.valid_between.lower,
+    #                     upper=datetime.date(end_year, end_month, end_day),
+    #                 ),
+    #             )
+    #     session_store = self._session_store()
+    #     session_store.clear()
+
+    #     return redirect(reverse("measure-ui-list"))

--- a/measures/views.py
+++ b/measures/views.py
@@ -1,3 +1,4 @@
+import datetime
 from itertools import groupby
 from operator import attrgetter
 from typing import Any
@@ -21,6 +22,7 @@ from rest_framework.reverse import reverse
 
 from common.models import TrackedModel
 from common.serializers import AutoCompleteSerializer
+from common.util import TaricDateRange
 from common.validators import UpdateType
 from common.views import TamatoListView
 from common.views import TrackedModelDetailMixin
@@ -87,7 +89,7 @@ class MeasureList(MeasureMixin, FormView, TamatoListView):
     def form_valid(self, form):
         store = SessionStore(
             self.request,
-            "DELETE_MEASURE_SELECTIONS",
+            "MULTIPLE_MEASURE_SELECTIONS",
         )
         # clear the store here before adding items
         # in case there was a previous form in progress that was abandoned
@@ -103,7 +105,13 @@ class MeasureList(MeasureMixin, FormView, TamatoListView):
             }
             store.add_items(object_pks)
 
-        url = reverse("measure-ui-delete-multiple")
+        if form.data["form-action"] == "remove-selected":
+            url = reverse("measure-ui-delete-multiple")
+        elif form.data["form-action"] == "edit-selected":
+            url = reverse("measure-ui-edit-multiple-end-date")
+        else:
+            url = reverse("measure-ui-list")
+
         return HttpResponseRedirect(url)
 
 
@@ -580,7 +588,7 @@ class MeasureMultipleDelete(TemplateView, ListView):
 
         return SessionStore(
             self.request,
-            "DELETE_MEASURE_SELECTIONS",
+            "MULTIPLE_MEASURE_SELECTIONS",
         )
 
     def get_queryset(self):
@@ -608,6 +616,63 @@ class MeasureMultipleDelete(TemplateView, ListView):
                 workbasket=WorkBasket.current(request),
                 update_type=UpdateType.DELETE,
             )
+        session_store = self._session_store()
+        session_store.clear()
+
+        return redirect(reverse("measure-ui-list"))
+
+
+class MeasureMultipleEndDateEdit(FormView, ListView):
+    """UI for user edit and review of multiple measure end dates."""
+
+    template_name = "measures/edit-multiple-measures-enddates.jinja"
+    form_class = forms.MeasureEndDateForm
+
+    def _session_store(self):
+        """Get the session store to store the measures that will be edited."""
+
+        return SessionStore(
+            self.request,
+            "MULTIPLE_MEASURE_SELECTIONS",
+        )
+
+    def get_queryset(self):
+        """Get the measures that are candidates for editing."""
+        store = self._session_store()
+        return Measure.objects.filter(pk__in=store.data.keys())
+
+    def get_context_data(self, **kwargs):
+        store_objects = self.get_queryset()
+        self.object_list = store_objects
+        context = super().get_context_data(**kwargs)
+
+        return context
+
+    def post(self, request):
+        if request.POST.get("submit", None) != "Save measure end dates":
+            # The user has cancelled out of the editing process.
+            return redirect("home")
+
+        object_list = self.get_queryset()
+
+        for obj in object_list:
+            # make a new version of the object with an update type of update, pass in the new end date.
+            end_year = int(request.POST["end_date_2"])
+            end_month = int(request.POST["end_date_1"])
+            end_day = int(request.POST["end_date_0"])
+
+            lower = obj.valid_between.lower
+            upper = datetime.date(end_year, end_month, end_day)
+
+            if upper >= lower:
+                obj.new_version(
+                    workbasket=WorkBasket.current(request),
+                    update_type=UpdateType.UPDATE,
+                    valid_between=TaricDateRange(
+                        lower=obj.valid_between.lower,
+                        upper=datetime.date(end_year, end_month, end_day),
+                    ),
+                )
         session_store = self._session_store()
         session_store.clear()
 


### PR DESCRIPTION
# TP2000-672 Add multiple measures edit end date form

## Why
Due to the create measures form having some quirks, it's not a bright idea to make a multiple measures edit form based on it. We've decided as a team that it needs some extra thought and planning, along with some time spent polishing up the create form. As an interim, we've got this 'MVP' version allowing TM's to edit the end dates of multiple measures cause that would be a lifesaver as a minimum. 

## What
This is only an interim change, that's been implemented until the polished article can come out. This PR adds a button to the MeasureList page, next to the delete button to edit the end dates. This takes you to a new page, similar to the multiple delete review page, except it has an end date form on it. This form has no visible validation on it, as that's coming later in a separate ticket as we need to think about how we show errors to the users when making multiple edits at once. The code, however, has a little clause in it that will stop any measure from being altered if the start date is after the proposed end date. 


Here's the new button on the measures list page... 
![Screenshot 2023-01-13 at 17 56 58](https://user-images.githubusercontent.com/46787754/212387960-82f3a169-2aa1-4b62-afe9-3a7ee638c8d9.png)


And here's the edit multiple measures end dates page ...
![Screenshot 2023-01-13 at 17 54 13](https://user-images.githubusercontent.com/46787754/212387440-b3bbfe7b-0734-49d7-a08b-d7bb8275fda0.png)


## Checklist
- Requires migrations? - no
- Requires dependency updates? - no


