### PR TITLE
TP2000-647  Add suspension periods tab to Quota detail view

### DIFF
--- a/quotas/jinja2/includes/quotas/tabs/suspension_periods.jinja
+++ b/quotas/jinja2/includes/quotas/tabs/suspension_periods.jinja
@@ -1,0 +1,34 @@
+<div class="quota__suspension-periods govuk-grid-row">
+    <div class="quota__suspension-periods__content govuk-grid-column-three-quarters">
+        <h2 class="govuk-heading-l">Details</h2>
+        {% if suspension_period %}
+            {{ govukSummaryList({
+                "rows": [
+                    {
+                        "key": {"text": "Quota suspension period SID"},
+                        "value": {"text": suspension_period.sid},
+                        "actions": {"items": []}
+                    },
+                    {
+                        "key": {"text": "Suspension start date"},
+                        "value": {"text": "{:%d %b %Y}".format(suspension_period.valid_between.lower)},
+                        "actions": {"items": []}
+                    },
+                    {
+                        "key": {"text": "Suspension end date"},
+                        "value": {"text": "{:%d %b %Y}".format(suspension_period.valid_between.upper)},
+                        "actions": {"items": []}
+                    },
+                    {
+                        "key": {"text": "Description"},
+                        "value": {"text": suspension_period.description if suspension_period.description else "-"},
+                        "actions": {"items": []}
+                    },
+                ]
+            })}}
+        {% else %}
+            <p class="govuk-body">No active or upcoming suspension period.</p>
+        {% endif %}
+    </div>
+    {% include "includes/quotas/actions.jinja"%}
+</div>

--- a/quotas/jinja2/quotas/detail.jinja
+++ b/quotas/jinja2/quotas/detail.jinja
@@ -8,6 +8,7 @@
 {% set core_data_tab_html %}{% include "includes/quotas/tabs/core_data.jinja" %}{% endset %}
 {% set definition_details_html %}{% include "includes/quotas/tabs/definition_details.jinja" %}{% endset %}
 {% set blocking_periods_html %}{% include "includes/quotas/tabs/blocking_periods.jinja" %}{% endset %}
+{% set suspension_periods_html %}{% include "includes/quotas/tabs/suspension_periods.jinja" %}{% endset %}
 {% set measures_html %}{% include "includes/quotas/tabs/measures.jinja" %}{% endset %}
 {% set version_control_tab_html %}{% include "includes/quotas/tabs/version_control.jinja" %}{% endset %}
 
@@ -32,6 +33,13 @@
         "id": "blocking-periods",
         "panel": {
           "html": blocking_periods_html
+        }
+      },
+      {
+        "label": "Suspension periods",
+        "id": "suspension-periods",
+        "panel": {
+          "html": suspension_periods_html
         }
       },
       {

--- a/quotas/tests/test_views.py
+++ b/quotas/tests/test_views.py
@@ -322,3 +322,33 @@ def test_quota_detail_blocking_periods_tab(valid_user_client, date_ranges):
 
     for i, value in enumerate(expected_data.values()):
         assert value in rows[i].text
+
+
+def test_quota_detail_suspension_periods_tab(valid_user_client, date_ranges):
+    quota_order_number = factories.QuotaOrderNumberFactory()
+    current_definition = factories.QuotaDefinitionFactory.create(
+        order_number=quota_order_number,
+        valid_between=date_ranges.normal,
+    )
+    suspension_period = factories.QuotaSuspensionFactory.create(
+        quota_definition=current_definition,
+        description="Test description",
+        valid_between=date_ranges.normal,
+    )
+
+    expected_data = {
+        "Quota Suspension period SID": str(suspension_period.sid),
+        "Suspension start date": f"{suspension_period.valid_between.lower:%d %b %Y}",
+        "Suspension end date": f"{suspension_period.valid_between.upper:%d %b %Y}",
+        "Description": suspension_period.description,
+    }
+
+    url = reverse("quota-ui-detail", args=[quota_order_number.sid])
+    response = valid_user_client.get(url)
+
+    soup = BeautifulSoup(response.content.decode(response.charset), "html.parser")
+    rows = soup.select(".quota__suspension-periods__content > dl > div > dd")
+    assert len(rows) == 4
+
+    for i, value in enumerate(expected_data.values()):
+        assert value in rows[i].text

--- a/quotas/views.py
+++ b/quotas/views.py
@@ -19,6 +19,7 @@ from quotas import serializers
 from quotas.filters import OrderNumberFilterBackend
 from quotas.filters import QuotaFilter
 from quotas.models import QuotaBlocking
+from quotas.models import QuotaSuspension
 from workbaskets.models import WorkBasket
 from workbaskets.views.generic import CreateTaricDeleteView
 
@@ -109,6 +110,13 @@ class QuotaDetail(QuotaMixin, TrackedModelDetailView):
             )
         else:
             blocking_period = None
+
+        suspension_period = (
+            QuotaSuspension.objects.filter(quota_definition=current_definition)
+            .as_at_and_beyond(date.today())
+            .first()
+        )
+
         measures = Measure.objects.filter(order_number=self.object).as_at(date.today())
         url_params = urlencode({"order_number": self.object.pk})
         measures_url = f"{reverse('measure-ui-list')}?{url_params}"
@@ -116,6 +124,7 @@ class QuotaDetail(QuotaMixin, TrackedModelDetailView):
         return super().get_context_data(
             current_definition=current_definition,
             blocking_period=blocking_period,
+            suspension_period=suspension_period,
             measures=measures,
             measures_url=measures_url,
             *args,

--- a/quotas/views.py
+++ b/quotas/views.py
@@ -116,7 +116,9 @@ class QuotaDetail(QuotaMixin, TrackedModelDetailView):
             .first()
         )
 
-        context["measures"] = Measure.objects.filter(order_number=self.object).as_at(date.today())
+        context["measures"] = Measure.objects.filter(order_number=self.object).as_at(
+            date.today(),
+        )
         url_params = urlencode({"order_number": self.object.pk})
         context["measures_url"] = f"{reverse('measure-ui-list')}?{url_params}"
 


### PR DESCRIPTION
# TP2000-647  Add suspension periods tab to Quota detail view

## Why

- Users are unable to view details of any suspension periods in place for a quota.

## What

- Adds suspension periods tab, showing active or upcoming suspension period.
- Adds unit test for suspension periods tab.

Example:
<img width="450" alt="quota-suspension-periods-tab-example" src="https://user-images.githubusercontent.com/118175145/212095183-925850c4-f5c9-4d77-a90d-3a59157e5334.png">

