### PR TITLE
TP2000-673 Sort by commodity code in Quota measures tab

### DIFF
--- a/common/jinja2/components/sort_by.jinja
+++ b/common/jinja2/components/sort_by.jinja
@@ -1,12 +1,12 @@
 
-{% macro sort_by(request, sort_by, title, base_url) %}
+{% macro sort_by(request, sort_by, title, base_url, anchor="") %}
 
   {% if request.GET.sort_by == sort_by and request.GET.order == "desc" %}
-    <a class="govuk-link govuk-link--no-visited-state sort-icon--down" href="{{ base_url }}?sort_by={{ sort_by }}&order=asc">
+    <a class="govuk-link govuk-link--no-visited-state sort-icon--down" href="{{ base_url }}?sort_by={{ sort_by }}&order=asc{{ anchor }}">
       {{ title }} <img src="{{ static('common/images/sort_icon.svg') }}" alt="">
     </a>
   {% else %}
-    <a class="govuk-link govuk-link--no-visited-state sort-icon--up" href="{{ base_url }}?sort_by={{ sort_by }}&order=desc">
+    <a class="govuk-link govuk-link--no-visited-state sort-icon--up" href="{{ base_url }}?sort_by={{ sort_by }}&order=desc{{ anchor }}">
       {{ title }} <img src="{{ static('common/images/sort_icon.svg') }}" alt="">
     </a>
   {% endif %}

--- a/quotas/jinja2/includes/quotas/tabs/measures.jinja
+++ b/quotas/jinja2/includes/quotas/tabs/measures.jinja
@@ -1,11 +1,13 @@
+{% from "components/sort_by.jinja" import sort_by %}
+
 {% set table_rows = [] %}
 {% for object in measures %}
-  {% set measure_link -%}
+  {% set measure_link %}
     <a class="govuk-link govuk-!-font-weight-bold" href="{{ url('measure-ui-detail', args=[object.sid]) }}">{{ object.sid }}</a>
-  {%- endset %}
-  {% set commodity_link -%}
+  {% endset %}
+  {% set commodity_link %}
     <a class="govuk-link govuk-!-font-weight-bold" href="{{ url('commodity-ui-detail', args=[object.goods_nomenclature.sid]) }}">{{ object.goods_nomenclature.item_id|wordwrap(2) }}</a>
-  {%- endset %}
+  {% endset %}
   {{ table_rows.append([
     {"html": measure_link},
     {"html": commodity_link},
@@ -14,6 +16,11 @@
   ]) or "" }}
 {% endfor %}
 
+{% set base_url = url('quota-ui-detail', args=[object.sid]) %}
+
+{% set commodity_code %}
+  {{ sort_by(request, "goods_nomenclature", "Commodity code", base_url, "#measures") }}
+{% endset %}
 
 <div class="quota__measures govuk-grid-row">
     <div class="quota__measures__content govuk-grid-column-three-quarters">
@@ -23,7 +30,7 @@
         {{ govukTable({
             "head": [
                 {"text": "Measure SID"},
-                {"text": "Commodity code"},
+                {"text": commodity_code},
                 {"text": "Start date"},
                 {"text": "End date"},
             ],

--- a/quotas/views.py
+++ b/quotas/views.py
@@ -94,8 +94,9 @@ class QuotaList(QuotaMixin, TamatoListView):
     filterset_class = QuotaFilter
 
 
-class QuotaDetail(QuotaMixin, TrackedModelDetailView):
+class QuotaDetail(QuotaMixin, TrackedModelDetailView, SortingMixin):
     template_name = "quotas/detail.jinja"
+    sort_by_fields = ["goods_nomenclature"]
 
     def get_context_data(self, *args, **kwargs):
         context = super().get_context_data(*args, **kwargs)
@@ -116,8 +117,14 @@ class QuotaDetail(QuotaMixin, TrackedModelDetailView):
             .first()
         )
 
-        context["measures"] = Measure.objects.filter(order_number=self.object).as_at(
-            date.today(),
+        order = self.get_ordering()
+        if not order:
+            order = "goods_nomenclature"
+
+        context["measures"] = (
+            Measure.objects.filter(order_number=self.object)
+            .as_at(date.today())
+            .order_by(order)
         )
         url_params = urlencode({"order_number": self.object.pk})
         context["measures_url"] = f"{reverse('measure-ui-list')}?{url_params}"


### PR DESCRIPTION
# TP2000-673 Make commodity codes sortable in Quota measures tab

## Why

- Tariff Managers have indicated that the ability to sort by commodity code would help them to compare the list of commodity codes attached against other data easier.

## What

- Make commodity code list sortable (in ascending or descending order) by user.

Before:
<img width="400" alt="quota-measures-list-before" src="https://user-images.githubusercontent.com/118175145/212713163-47780016-1ee3-498a-b2cc-6e51fd5221a2.png">

After:
<img width="400" alt="sortable-comm-codes-quota-measures-tab" src="https://user-images.githubusercontent.com/118175145/212713181-cca71d70-ba95-44e9-aed1-2c5d1767577d.png">
