### PR TITLE
TP2000-602: Get Trade Tariff API quota data

### DIFF
--- a/common/tariffs_api.py
+++ b/common/tariffs_api.py
@@ -1,0 +1,69 @@
+import asyncio
+from urllib.parse import urlencode
+
+import aiohttp
+import requests
+
+BASE_URL = "https://www.trade-tariff.service.gov.uk/api/v2/"
+QUOTAS = f"{BASE_URL}quotas/search"
+
+
+def get_quota_data(order_number):
+    params = urlencode({"order_number": order_number})
+    response = requests.get(f"{QUOTAS}?{params}")
+    if response.status_code == 200:
+        return response.json()
+    else:
+        return None
+
+
+async def async_get(url, session):
+    async with session.get(url=url) as response:
+        try:
+            assert response.status == 200
+        except AssertionError:
+            return None
+        return await response.json()
+
+
+async def async_get_all(urls):
+    async with aiohttp.ClientSession() as session:
+        return await asyncio.gather(*[async_get(url, session) for url in urls])
+
+
+def get_quota_definitions_data(order_number, object_list):
+    """
+    Since the API does not return all definition periods past and future from
+    one endpoint we need to make multiple requests with different params.
+
+    We use the quota order number and start date of each of its definition
+    periods to build urls to get the data for all of them.
+    """
+
+    definition_params = [
+        {
+            "order_number": order_number,
+            "year": d.valid_between.lower.year,
+            "month": d.valid_between.lower.month,
+            "day": d.valid_between.lower.day,
+        }
+        for d in object_list
+    ]
+
+    urls = [f"{QUOTAS}?{urlencode(params)}" for params in definition_params]
+
+    data = asyncio.run(async_get_all(urls))
+
+    json_data = [
+        json["data"][0]["attributes"] for json in data if json and json["data"]
+    ]
+
+    serialized = {
+        json["quota_definition_sid"]: {
+            "status": json["status"],
+            "balance": json["balance"],
+        }
+        for json in json_data
+    }
+
+    return serialized

--- a/common/tests/factories.py
+++ b/common/tests/factories.py
@@ -782,8 +782,8 @@ class QuotaDefinitionFactory(TrackedModelMixin, ValidityFactoryMixin):
         QuotaOrderNumberFactory,
         valid_between=factory.SelfAttribute("..valid_between"),
     )
-    volume = 0
-    initial_volume = 0
+    volume = Decimal("0.000")
+    initial_volume = Decimal("0.000")
     monetary_unit = None
     measurement_unit = None
     measurement_unit_qualifier = None

--- a/common/tests/test_models.py
+++ b/common/tests/test_models.py
@@ -387,7 +387,11 @@ def test_get_description_dates(description_factory, date_ranges):
     assert future == future_description
 
 
-def test_trackedmodel_get_url(trackedmodel_factory, valid_user_client):
+def test_trackedmodel_get_url(
+    trackedmodel_factory,
+    valid_user_client,
+    mock_quota_api_no_data,
+):
     """Verify get_url() returns something sensible and doesn't crash."""
     instance = trackedmodel_factory.create()
     url = instance.get_url()

--- a/common/tests/test_tariffs_api.py
+++ b/common/tests/test_tariffs_api.py
@@ -1,0 +1,195 @@
+import pytest
+
+from common.tariffs_api import QUOTAS
+from common.tariffs_api import async_get_all
+from common.tariffs_api import build_urls
+from common.tariffs_api import get_quota_data
+from common.tariffs_api import serialize_quota_data
+from common.tests import factories
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def quota_definitions(quota_order_number):
+    return factories.QuotaDefinitionFactory.create_batch(
+        5,
+        order_number=quota_order_number,
+    )
+
+
+def test_get_quota_data_error(quota_order_number, requests_mock):
+    requests_mock.get(url=QUOTAS, status_code=400)
+    data = get_quota_data(quota_order_number.id)
+    assert data is None
+
+
+async def test_get_quota_data_ok(quota_order_number, requests_mock, quotas_json):
+    requests_mock.get(url=QUOTAS, json=quotas_json, status_code=200)
+    data = get_quota_data(quota_order_number.id)
+    assert data == quotas_json
+
+
+@pytest.mark.asyncio
+async def test_async_get_all(
+    mock_aioresponse,
+    quota_order_number,
+    quota_definitions,
+    quotas_json,
+):
+    urls = build_urls(quota_order_number.order_number, quota_definitions)
+    for url in urls:
+        mock_aioresponse.get(url, status=200, payload=quotas_json)
+    data = await async_get_all(urls)
+    assert data
+    for d in data:
+        assert d == quotas_json
+
+
+@pytest.mark.asyncio
+async def test_async_get_all_failure(
+    mock_aioresponse,
+    quota_order_number,
+    quota_definitions,
+    quotas_json,
+):
+    urls = build_urls(quota_order_number.order_number, quota_definitions)
+    for url in urls:
+        mock_aioresponse.get(url, status=400, payload=quotas_json)
+    data = await async_get_all(urls)
+    assert data
+    for d in data:
+        assert d == None
+
+
+def test_build_urls(quota_order_number, quota_definitions):
+    urls = build_urls(quota_order_number.order_number, quota_definitions)
+    assert len(urls) == 5
+    for i, url in enumerate(urls):
+        assert QUOTAS in url
+        assert str(quota_definitions[i].valid_between.lower.year) in url
+        assert str(quota_definitions[i].valid_between.lower.month) in url
+        assert str(quota_definitions[i].valid_between.lower.day) in url
+
+
+def test_serialize_quota_data():
+    data = [
+        {
+            "data": [
+                {
+                    "id": "23098",
+                    "type": "definition",
+                    "attributes": {
+                        "quota_definition_sid": "1111",
+                        "quota_order_number_id": "058007",
+                        "initial_volume": "80601000.0",
+                        "validity_start_date": "2022-07-01T00:00:00.000Z",
+                        "validity_end_date": "2022-09-30T23:59:59.000Z",
+                        "status": "Open",
+                        "description": None,
+                        "balance": "80601000.0",
+                        "measurement_unit": "Kilogram (kg)",
+                        "monetary_unit": None,
+                        "measurement_unit_qualifier": None,
+                        "last_allocation_date": None,
+                        "suspension_period_start_date": None,
+                        "suspension_period_end_date": None,
+                        "blocking_period_start_date": None,
+                        "blocking_period_end_date": None,
+                    },
+                    "relationships": {
+                        "incoming_quota_closed_and_transferred_event": {"data": None},
+                        "order_number": {
+                            "data": {"id": "058007", "type": "order_number"},
+                        },
+                        "measures": {"data": []},
+                        "quota_balance_events": {},
+                    },
+                },
+            ],
+            "included": [],
+            "meta": {"pagination": {"page": 1, "per_page": 5, "total_count": 1}},
+        },
+        {
+            "data": [
+                {
+                    "id": "23099",
+                    "type": "definition",
+                    "attributes": {
+                        "quota_definition_sid": "2222",
+                        "quota_order_number_id": "058007",
+                        "initial_volume": "80601000.0",
+                        "validity_start_date": "2022-10-01T00:00:00.000Z",
+                        "validity_end_date": "2022-12-31T23:59:59.000Z",
+                        "status": "Open",
+                        "description": None,
+                        "balance": "23401000.0",
+                        "measurement_unit": "Kilogram (kg)",
+                        "monetary_unit": None,
+                        "measurement_unit_qualifier": None,
+                        "last_allocation_date": None,
+                        "suspension_period_start_date": None,
+                        "suspension_period_end_date": None,
+                        "blocking_period_start_date": None,
+                        "blocking_period_end_date": None,
+                    },
+                    "relationships": {
+                        "incoming_quota_closed_and_transferred_event": {"data": None},
+                        "order_number": {
+                            "data": {"id": "058007", "type": "order_number"},
+                        },
+                        "measures": {"data": []},
+                        "quota_balance_events": {},
+                    },
+                },
+            ],
+            "included": [],
+            "meta": {"pagination": {"page": 1, "per_page": 5, "total_count": 1}},
+        },
+        {
+            "data": [
+                {
+                    "id": "23100",
+                    "type": "definition",
+                    "attributes": {
+                        "quota_definition_sid": "3333",
+                        "quota_order_number_id": "058007",
+                        "initial_volume": "78849000.0",
+                        "validity_start_date": "2023-01-01T00:00:00.000Z",
+                        "validity_end_date": "2023-03-31T23:59:59.000Z",
+                        "status": "Open",
+                        "description": None,
+                        "balance": "78849000.0",
+                        "measurement_unit": "Kilogram (kg)",
+                        "monetary_unit": None,
+                        "measurement_unit_qualifier": None,
+                        "last_allocation_date": None,
+                        "suspension_period_start_date": None,
+                        "suspension_period_end_date": None,
+                        "blocking_period_start_date": None,
+                        "blocking_period_end_date": None,
+                    },
+                    "relationships": {
+                        "incoming_quota_closed_and_transferred_event": {"data": None},
+                        "order_number": {
+                            "data": {"id": "058007", "type": "order_number"},
+                        },
+                        "measures": {"data": []},
+                        "quota_balance_events": {},
+                    },
+                },
+            ],
+            "included": [],
+            "meta": {"pagination": {"page": 1, "per_page": 5, "total_count": 1}},
+        },
+        None,
+    ]
+    serialized = serialize_quota_data(data)
+    assert len(serialized) == 3
+    assert not set(serialized.keys()).difference({"1111", "2222", "3333"})
+    assert serialized["1111"]["status"] == "Open"
+    assert serialized["1111"]["balance"] == "80601000.0"
+    assert serialized["2222"]["status"] == "Open"
+    assert serialized["2222"]["balance"] == "23401000.0"
+    assert serialized["3333"]["status"] == "Open"
+    assert serialized["3333"]["balance"] == "78849000.0"

--- a/conftest.py
+++ b/conftest.py
@@ -13,6 +13,7 @@ from unittest.mock import patch
 
 import boto3
 import pytest
+from aioresponses import aioresponses
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Group
@@ -1360,3 +1361,9 @@ def quotas_json():
         ],
         "meta": {"pagination": {"page": 1, "per_page": 5, "total_count": 1}},
     }
+
+
+@pytest.fixture
+def mock_aioresponse():
+    with aioresponses() as m:
+        yield m

--- a/conftest.py
+++ b/conftest.py
@@ -39,6 +39,7 @@ from common.models.transactions import Transaction
 from common.models.transactions import TransactionPartition
 from common.models.utils import override_current_transaction
 from common.serializers import TrackedModelSerializer
+from common.tariffs_api import QUOTAS
 from common.tests import factories
 from common.tests.models import model_with_history
 from common.tests.util import Dates
@@ -1313,3 +1314,8 @@ def pytest_collection_modifyitems(config, items):
 @pytest.fixture()
 def quota_order_number():
     return factories.QuotaOrderNumberFactory()
+
+
+@pytest.fixture
+def mock_quota_api_no_data(requests_mock):
+    yield requests_mock.get(url=QUOTAS, json={})

--- a/conftest.py
+++ b/conftest.py
@@ -1319,3 +1319,44 @@ def quota_order_number():
 @pytest.fixture
 def mock_quota_api_no_data(requests_mock):
     yield requests_mock.get(url=QUOTAS, json={})
+
+
+@pytest.fixture
+def quotas_json():
+    return {
+        "data": [
+            {
+                "id": "12345",
+                "type": "definition",
+                "attributes": {
+                    "quota_definition_sid": "12345",
+                    "quota_order_number_id": "12345",
+                    "initial_volume": "78849000.0",
+                    "validity_start_date": "2023-01-01T00:00:00.000Z",
+                    "validity_end_date": "2023-03-31T23:59:59.000Z",
+                    "status": "Open",
+                    "description": None,
+                    "balance": "76766532.891",
+                    "measurement_unit": "Kilogram (kg)",
+                    "monetary_unit": None,
+                    "measurement_unit_qualifier": None,
+                    "last_allocation_date": "2023-01-10T00:00:00Z",
+                    "suspension_period_start_date": None,
+                    "suspension_period_end_date": None,
+                    "blocking_period_start_date": None,
+                    "blocking_period_end_date": None,
+                },
+                "relationships": {
+                    "incoming_quota_closed_and_transferred_event": {"data": None},
+                    "order_number": {"data": {"id": "1234", "type": "order_number"}},
+                    "measures": {
+                        "data": [
+                            {"id": "1234", "type": "measure"},
+                        ],
+                    },
+                    "quota_balance_events": {},
+                },
+            },
+        ],
+        "meta": {"pagination": {"page": 1, "per_page": 5, "total_count": 1}},
+    }

--- a/quotas/jinja2/includes/quotas/actions.jinja
+++ b/quotas/jinja2/includes/quotas/actions.jinja
@@ -8,6 +8,8 @@
           {% if delete_url %}
             <li><a class="govuk-link" href="{{ delete_url }}">Delete this {{object._meta.verbose_name}}</a></li>
           {% endif %}
+          <br><br>
+          <li><a class="govuk-link" href="https://www.trade-tariff.service.gov.uk/quota_search?order_number={{ object.order_number }}" target="_blank" noopener noreferrer>View this quota on the UK Integrated Online Tariff </a></li>
       </ul>
   </div>
 </div>

--- a/quotas/jinja2/includes/quotas/tabs/definition_details.jinja
+++ b/quotas/jinja2/includes/quotas/tabs/definition_details.jinja
@@ -6,7 +6,7 @@
                 "rows": [
                     {
                         "key": {"text": "Quota definition SID"},
-                        "value": {"text": object.sid},
+                        "value": {"text": current_definition.sid},
                         "actions": {"items": []}
                     },
                     {

--- a/quotas/jinja2/includes/quotas/tabs/definition_details.jinja
+++ b/quotas/jinja2/includes/quotas/tabs/definition_details.jinja
@@ -6,12 +6,17 @@
                 "rows": [
                     {
                         "key": {"text": "Quota definition SID"},
-                        "value": {"text": current_definition.sid},
+                        "value": {"text": object.sid},
                         "actions": {"items": []}
                     },
                     {
                         "key": {"text": "Quota definition description"},
                         "value": {"text": current_definition.description if current_definition.description else "-"},
+                        "actions": {"items": []}
+                    },
+                    {
+                        "key": {"text": "Definition period status"},
+                        "value": {"text": quota_data.attributes.status if quota_data else "-" },
                         "actions": {"items": []}
                     },
                     {
@@ -32,6 +37,11 @@
                     {
                         "key": {"text": "Volume"},
                         "value": {"text": intcomma(current_definition.volume) },
+                        "actions": {"items": []}
+                    },
+                    {
+                        "key": {"text": "Remaining balance"},
+                        "value": {"text": intcomma(quota_data.attributes.balance) if quota_data else "-" },
                         "actions": {"items": []}
                     },
                     {
@@ -56,9 +66,9 @@
                     },
                 ]
             })}}
-        {% else %}
-            <p class="govuk-body">No active or upcoming quota definition.</p>
-        {% endif %}
+    {% else %}
+        <p class="govuk-body">No active or upcoming quota definition.</p>
+    {% endif %}
     </div>
     {% include "includes/quotas/actions.jinja"%}
 </div>

--- a/quotas/jinja2/quotas/definitions.jinja
+++ b/quotas/jinja2/quotas/definitions.jinja
@@ -64,13 +64,13 @@
 
     {{ table_rows.append([
       {"text": object_details },
-      {"text": "-" },
+      {"text": quota_data[object.sid].status if quota_data[object.sid] else "-" },
       {"text": "{:%d %b %Y}".format(object.valid_between.lower) },
       {"text": "{:%d %b %Y}".format(object.valid_between.upper) if object.valid_between.upper else "-"},
       {"text": intcomma(object.initial_volume) },
       {"text": intcomma(object.volume) },
+      {"text": intcomma(quota_data[object.sid].balance) if quota_data[object.sid] else "-" },
       {"text": object.measurement_unit.abbreviation|title},
-      {"text": "-" },
     ]) or "" }}
   {% endfor %}
 
@@ -94,8 +94,8 @@
     {"text": "End date"},
     {"text": "Initial volume"},
     {"text": "Volume"},
+    {"text": "Balance"},
     {"text": "Measurement unit"},
-    {"text": "Balance"}
   ],
   "rows": table_rows
 }) }}

--- a/quotas/tests/test_views.py
+++ b/quotas/tests/test_views.py
@@ -413,7 +413,11 @@ def test_quota_detail_blocking_periods_tab(
         assert value in rows[i].text
 
 
-def test_quota_detail_suspension_periods_tab(valid_user_client, date_ranges):
+def test_quota_detail_suspension_periods_tab(
+    valid_user_client,
+    date_ranges,
+    mock_quota_api_no_data,
+):
     quota_order_number = factories.QuotaOrderNumberFactory()
     current_definition = factories.QuotaDefinitionFactory.create(
         order_number=quota_order_number,

--- a/quotas/tests/test_views.py
+++ b/quotas/tests/test_views.py
@@ -151,8 +151,8 @@ def test_quota_detail_api_response_has_results(
     assert rows_content[2] == data["attributes"]["status"]
     assert rows_content[3] == f"{quota_definition.valid_between.lower:%d %b %Y}"
     assert rows_content[4] == f"{quota_definition.valid_between.upper:%d %b %Y}"
-    assert rows_content[5] == "0.000"
-    assert rows_content[6] == "0.000"
+    assert rows_content[5] == intcomma(float(quota_definition.initial_volume))
+    assert rows_content[6] == intcomma(float(quota_definition.volume))
     assert rows_content[7] == intcomma(float(data["attributes"]["balance"]))
     assert rows_content[8] == (quota_definition.measurement_unit.abbreviation).title()
     assert rows_content[9] == f"{quota_definition.quota_critical_threshold}%"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 aiohttp==3.8.3
+aioresponses==0.7.4
 allure-pytest-bdd==2.8.40
 api-client==1.3.0
 apsw-wheels==3.36.*
@@ -48,6 +49,7 @@ parsec==3.8
 psycopg2-binary==2.9.*
 pygments>=2.8
 pytest==7.1.2
+pytest-asyncio==0.20.3
 pytest-bdd==4.1.0
 pytest-celery==0.0.0
 pytest-cov==3.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+aiohttp==3.8.3
 allure-pytest-bdd==2.8.40
 api-client==1.3.0
 apsw-wheels==3.36.*

--- a/requirements.txt
+++ b/requirements.txt
@@ -57,6 +57,7 @@ pytest-responses==0.5.0
 pytest-xdist==2.5.0
 python-magic==0.4.25
 requests-oauthlib==1.3.0
+requests-mock==1.10.0
 responses==0.12.1
 sentry-sdk==0.20.2
 Sphinx==4.2.0


### PR DESCRIPTION
# TP2000-602: Get tariffs API quota data
<!---
 * Include the JIRA ticket number, eg TP-123, to automatically link.
 * Use 50 characters maximum.
 * Do not end with a full-stop.
--->

## Why
<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Use as many lines as you like.
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions or deliberately ignored edge-cases.
--->
* Some data on quotas is not held in TAP so we get this data from the [Trade Tariff API](https://api.trade-tariff.service.gov.uk/reference.html#trade-tariff-public-api-v2)

## What
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Explain like I'm 5.
 * Use pictures if you can.
--->
* Adds status and balance data for quotas and definition periods
* If the API is unreachable we omit this data from the page
* Adds a link to the quota on the Trade Tariff API in the sidebar
* Adds support for testing async functions with pytest

## Checklist
- Requires migrations? ❌ 
- Requires dependency updates? ✅ 


<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
<img width="1128" alt="Screenshot 2023-01-17 at 11 51 11" src="https://user-images.githubusercontent.com/25905279/212893087-809c3ae1-5d58-4550-90c3-e3898d9274a7.png">

<img width="1118" alt="Screenshot 2023-01-17 at 11 50 18" src="https://user-images.githubusercontent.com/25905279/212893104-033bc979-2fd2-4ace-9b66-89dbd166cae2.png">

