### PR TITLE
TP2000-693 Fix duplication in Quota measures tab

### DIFF
--- a/quotas/views.py
+++ b/quotas/views.py
@@ -122,7 +122,8 @@ class QuotaDetail(QuotaMixin, TrackedModelDetailView, SortingMixin):
             order = "goods_nomenclature"
 
         context["measures"] = (
-            Measure.objects.filter(order_number=self.object)
+            Measure.objects.latest_approved()
+            .filter(order_number=self.object)
             .as_at(date.today())
             .order_by(order)
         )


### PR DESCRIPTION
# TP2000-693 Fix duplication in Quota measures tab

## Why
The measures queryset used in the measures tab on a quota detail view returns duplicated data for some quotas.

## What
Adds latest_approved() to the query to return only the current version of an object and not its historical updates.

Before:
<img width="400" alt="before" src="https://user-images.githubusercontent.com/118175145/213132707-5d622e06-9680-4e4c-9f10-b5ca28acdf5b.png">

After:
<img width="400" alt="after" src="https://user-images.githubusercontent.com/118175145/213132739-00e7c1ec-63f0-47f7-8758-3de9fa54e2e4.png">