### PR TITLE
TP2000-645 Add sub-quotas tab to Quota detail view

### DIFF
--- a/common/static/common/scss/_layout.scss
+++ b/common/static/common/scss/_layout.scss
@@ -68,3 +68,7 @@
     display: inline;
   }
 }
+
+ul.govuk-tabs__list[role=tablist] {
+  display: inline-flex;
+}

--- a/quotas/jinja2/includes/quotas/tabs/sub_quotas.jinja
+++ b/quotas/jinja2/includes/quotas/tabs/sub_quotas.jinja
@@ -1,7 +1,10 @@
 {% set table_rows = [] %}
 {% for quota_association in quota_associations %}
   {% set sub_quota_link %}
-    <a class="govuk-link govuk-!-font-weight-bold" href="{{ url('quota-ui-detail', args=[quota_association.sub_quota.order_number.sid]) }}">{{ quota_association.sub_quota.order_number }}</a>
+    <a class="govuk-link govuk-!-font-weight-bold"
+      href="{{ url('quota-ui-detail', args=[quota_association.sub_quota.order_number.sid]) }}">
+      {{ quota_association.sub_quota.order_number }}
+    </a>
   {% endset %}
   {{ table_rows.append([
     {"html": sub_quota_link},
@@ -28,3 +31,4 @@
     </div>
     {% include "includes/quotas/actions.jinja"%}
 </div>
+

--- a/quotas/jinja2/includes/quotas/tabs/sub_quotas.jinja
+++ b/quotas/jinja2/includes/quotas/tabs/sub_quotas.jinja
@@ -1,0 +1,30 @@
+{% set table_rows = [] %}
+{% for quota_association in quota_associations %}
+  {% set sub_quota_link %}
+    <a class="govuk-link govuk-!-font-weight-bold" href="{{ url('quota-ui-detail', args=[quota_association.sub_quota.order_number.sid]) }}">{{ quota_association.sub_quota.order_number }}</a>
+  {% endset %}
+  {{ table_rows.append([
+    {"html": sub_quota_link},
+    {"html": quota_association.sub_quota_relation_type},
+    {"text": quota_association.coefficient},
+  ]) or "" }}
+{% endfor %}
+
+<div class="quota__sub-quotas govuk-grid-row">
+    <div class="quota__sub-quotas__content govuk-grid-column-three-quarters">
+        <h2 class="govuk-heading-l">Details</h2>
+        {% if quota_associations %}
+        {{ govukTable({
+            "head": [
+                {"text": "Sub-quota order number"},
+                {"text": "Relation type"},
+                {"text": "Co-efficient"},
+            ],
+            "rows": table_rows
+            }) }}
+        {% else %}
+          <p class="govuk-body">No active sub-quotas.</p>
+        {% endif %}
+    </div>
+    {% include "includes/quotas/actions.jinja"%}
+</div>

--- a/quotas/jinja2/quotas/detail.jinja
+++ b/quotas/jinja2/quotas/detail.jinja
@@ -7,6 +7,7 @@
 
 {% set core_data_tab_html %}{% include "includes/quotas/tabs/core_data.jinja" %}{% endset %}
 {% set definition_details_html %}{% include "includes/quotas/tabs/definition_details.jinja" %}{% endset %}
+{% set sub_quotas_html %}{% include "includes/quotas/tabs/sub_quotas.jinja" %}{% endset %}
 {% set blocking_periods_html %}{% include "includes/quotas/tabs/blocking_periods.jinja" %}{% endset %}
 {% set suspension_periods_html %}{% include "includes/quotas/tabs/suspension_periods.jinja" %}{% endset %}
 {% set measures_html %}{% include "includes/quotas/tabs/measures.jinja" %}{% endset %}
@@ -26,6 +27,13 @@
         "id": "definition-details",
         "panel": {
           "html": definition_details_html
+        }
+      },
+      {
+        "label": "Sub-quotas",
+        "id": "sub-quotas",
+        "panel": {
+          "html": sub_quotas_html
         }
       },
       {

--- a/quotas/jinja2/quotas/detail.jinja
+++ b/quotas/jinja2/quotas/detail.jinja
@@ -18,9 +18,6 @@
       {
         "label": "Order number details",
         "id": "core-data",
-        "attributes": {
-          "style": "width: 11ch;",
-        },
         "panel": {
           "html": core_data_tab_html
         }
@@ -28,9 +25,6 @@
       {
         "label": "Definition details",
         "id": "definition-details",
-        "attributes": {
-          "style": "width: min-content;",
-        },
         "panel": {
           "html": definition_details_html
         }
@@ -38,9 +32,6 @@
       {
         "label": "Sub-quotas",
         "id": "sub-quotas",
-        "attributes": {
-          "style": "height: 50px;",
-        },
         "panel": {
           "html": sub_quotas_html
         }
@@ -48,9 +39,6 @@
       {
         "label": "Blocking periods",
         "id": "blocking-periods",
-        "attributes": {
-          "style": "width: min-content;",
-        },
         "panel": {
           "html": blocking_periods_html
         }
@@ -58,9 +46,6 @@
       {
         "label": "Suspension periods",
         "id": "suspension-periods",
-        "attributes": {
-          "style": "width: min-content;",
-        },
         "panel": {
           "html": suspension_periods_html
         }
@@ -68,9 +53,6 @@
       {
         "label": "Measures",
         "id": "measures",
-        "attributes": {
-          "style": "height: 50px;",
-        },
         "panel": {
           "html": measures_html
         }
@@ -78,9 +60,6 @@
       {
         "label": "Version control",
         "id": "versions",
-        "attributes": {
-          "style": "width: min-content;",
-        },
         "panel": {
           "html": version_control_tab_html
         }

--- a/quotas/jinja2/quotas/detail.jinja
+++ b/quotas/jinja2/quotas/detail.jinja
@@ -18,6 +18,9 @@
       {
         "label": "Order number details",
         "id": "core-data",
+        "attributes": {
+          "style": "width: 11ch;",
+        },
         "panel": {
           "html": core_data_tab_html
         }
@@ -25,6 +28,9 @@
       {
         "label": "Definition details",
         "id": "definition-details",
+        "attributes": {
+          "style": "width: min-content;",
+        },
         "panel": {
           "html": definition_details_html
         }
@@ -32,6 +38,9 @@
       {
         "label": "Sub-quotas",
         "id": "sub-quotas",
+        "attributes": {
+          "style": "height: 50px;",
+        },
         "panel": {
           "html": sub_quotas_html
         }
@@ -39,6 +48,9 @@
       {
         "label": "Blocking periods",
         "id": "blocking-periods",
+        "attributes": {
+          "style": "width: min-content;",
+        },
         "panel": {
           "html": blocking_periods_html
         }
@@ -46,6 +58,9 @@
       {
         "label": "Suspension periods",
         "id": "suspension-periods",
+        "attributes": {
+          "style": "width: min-content;",
+        },
         "panel": {
           "html": suspension_periods_html
         }
@@ -53,6 +68,9 @@
       {
         "label": "Measures",
         "id": "measures",
+        "attributes": {
+          "style": "height: 50px;",
+        },
         "panel": {
           "html": measures_html
         }
@@ -60,6 +78,9 @@
       {
         "label": "Version control",
         "id": "versions",
+        "attributes": {
+          "style": "width: min-content;",
+        },
         "panel": {
           "html": version_control_tab_html
         }

--- a/quotas/tests/test_views.py
+++ b/quotas/tests/test_views.py
@@ -447,7 +447,11 @@ def test_quota_detail_suspension_periods_tab(
         assert value in rows[i].text
 
 
-def test_quota_detail_sub_quota_tab(valid_user_client, date_ranges):
+def test_quota_detail_sub_quota_tab(
+    valid_user_client,
+    date_ranges,
+    mock_quota_api_no_data,
+):
     quota_order_number = factories.QuotaOrderNumberFactory()
     current_definition = factories.QuotaDefinitionFactory.create(
         order_number=quota_order_number,

--- a/quotas/views.py
+++ b/quotas/views.py
@@ -116,7 +116,9 @@ class QuotaDetail(QuotaMixin, TrackedModelDetailView, SortingMixin):
         current_definition = definitions.as_at_and_beyond(date.today()).first()
         context["current_definition"] = current_definition
 
-        context["quota_associations"] = QuotaAssociation.objects.filter(
+        context[
+            "quota_associations"
+        ] = QuotaAssociation.objects.latest_approved().filter(
             main_quota=current_definition,
         )
 

--- a/quotas/views.py
+++ b/quotas/views.py
@@ -18,6 +18,7 @@ from quotas import models
 from quotas import serializers
 from quotas.filters import OrderNumberFilterBackend
 from quotas.filters import QuotaFilter
+from quotas.models import QuotaAssociation
 from quotas.models import QuotaBlocking
 from quotas.models import QuotaSuspension
 from workbaskets.models import WorkBasket
@@ -103,6 +104,10 @@ class QuotaDetail(QuotaMixin, TrackedModelDetailView):
         definitions = self.object.definitions.current()
         current_definition = definitions.as_at_and_beyond(date.today()).first()
         context["current_definition"] = current_definition
+
+        context["quota_associations"] = QuotaAssociation.objects.filter(
+            main_quota=current_definition,
+        )
 
         context["blocking_period"] = (
             QuotaBlocking.objects.filter(quota_definition=current_definition)


### PR DESCRIPTION
# TP2000-645 Add sub-quotas tab to Quota detail view

## Why
Users are unable to view details of any sub-quota data for a given quota.

## What
Add sub-quotas tab to Quota detail view, showing details of any active sub-quotas. 

<img width="400" alt="Sub-quotas-tab-example" src="https://user-images.githubusercontent.com/118175145/213169020-b9a6c99d-dfe0-4c24-8ac3-2e7ae4488c19.png">

