### PR TITLE
TP2000-679 Add button to stop rule check

### DIFF
--- a/workbaskets/jinja2/workbaskets/summary-workbasket.jinja
+++ b/workbaskets/jinja2/workbaskets/summary-workbasket.jinja
@@ -25,9 +25,27 @@
   </form>
 {% endset %}
 
+{% set terminate_rule_check_form %}
+  <form
+    method="post"
+    class="govuk-!-display-inline-block govuk-!-margin-left-5"
+  >
+    <input type="hidden" name="csrfmiddlewaretoken" value="{{ csrf_token }}">
+    <input type="hidden" name="workbasket_id" value="{{ workbasket.id }}">
+    {{ govukButton({
+        "text": "Stop rule check",
+        "classes": "govuk-button--warning govuk-!-margin-0",
+        "name": "form-action",
+        "value": "terminate-rule-check",
+        "preventDoubleClick": true,
+    }) }}
+  </form>
+{% endset %}
+
 {% set rule_check_status %}
   {% if rule_check_in_progress %}
       : rule check in progress. Checking {{ workbasket.tracked_models.count() }} objects in basket. Come back later or refresh to see results.
+      {{ terminate_rule_check_form }}
   {% elif workbasket.tracked_model_check_errors.exists() %}
        ({{ "{:%d %b %Y %H:%M}".format(localtime(workbasket.tracked_model_checks.order_by("created_at").last().created_at)) }}): failing business rules.
     {{ run_business_rules_form }}

--- a/workbaskets/views/ui.py
+++ b/workbaskets/views/ui.py
@@ -267,6 +267,7 @@ class WorkBasketDetail(TemplateResponseMixin, FormMixin, View):
     # Form action mappings to URL names.
     action_success_url_names = {
         "run-business-rules": "workbaskets:workbasket-ui-detail",
+        "terminate-rule-check": "workbaskets:workbasket-ui-detail",
         "remove-selected": "workbaskets:workbasket-ui-delete-changes",
         "page-prev": "workbaskets:workbasket-ui-detail",
         "page-next": "workbaskets:workbasket-ui-detail",
@@ -355,6 +356,15 @@ class WorkBasketDetail(TemplateResponseMixin, FormMixin, View):
             )
         elif form_action == "run-business-rules":
             self.run_business_rules()
+            return self._append_url_page_param(
+                reverse(
+                    self.action_success_url_names[form_action],
+                    kwargs={"pk": self.workbasket.pk},
+                ),
+                form_action,
+            )
+        elif form_action == "terminate-rule-check":
+            self.workbasket.terminate_rule_check()
             return self._append_url_page_param(
                 reverse(
                     self.action_success_url_names[form_action],


### PR DESCRIPTION
# TP2000-679 Add button to stop rule check

## Why
In some circumstances, business rules are shown to be running on a workbasket when in fact they’re not. When this happens, users ask a member of the DDaT team to terminate these "ghost" rule checks on their behalf.

## What
Adds a button to allow users themselves to stop a rule check.

<img width="500" alt="stop-rule-check-button" src="https://user-images.githubusercontent.com/118175145/213466045-12365712-d7be-4489-a013-567a43317a6e.png">

