### PR TITLE
Correctly start envelope creation.

### DIFF
--- a/publishing/models.py
+++ b/publishing/models.py
@@ -238,7 +238,8 @@ def create_envelope_on_completed_processing(func):
 
     def inner(self, *args, **kwargs):
         result = func(self, *args, **kwargs)
-        PackagedWorkBasket.create_envelope_for_top()
+        if not PackagedWorkBasket.objects.currently_processing():
+            PackagedWorkBasket.create_envelope_for_top()
         return result
 
     return inner


### PR DESCRIPTION
# Envelope creation corrections
<!---
 * Include the JIRA ticket number, eg TP-123, to automatically link.
 * Use 50 characters maximum.
 * Do not end with a full-stop.
--->

## Why
<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Use as many lines as you like.
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions or deliberately ignored edge-cases.
--->

Envelopes were being created by `pop_top()` for a packaged workbasket at position 1 before the top packaged workbasket's envelope had been processed by HMRC. This was due to `pop_top()` being called from within the `begin_processing` transition when the top instance's `processing_state` had not yet settled to `CURRENTLY_PROCESSING`.

Envelopes were not being generated for next queued instances upon completing processing of the top instance (i.e. upon `processing_succeeded` and `processing_failed`)


## What
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Explain like I'm 5.
 * Use pictures if you can.
--->

Move the call to `pop_top' into a decorator that wraps the `begin_processing` transition, allowing `processing_state` to arrive at its final state - it then calls `pop_top`.

Add decorator to start generating the next envelope upon `processing_succeeded` and `processing_failed` transitions completing.


<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:

--->
## Checklist
- Requires migrations? No
- Requires dependency updates? No


<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
