### PR TITLE
Pull S3 creds from VCAP_SERVICES

### DIFF
--- a/publishing/storages.py
+++ b/publishing/storages.py
@@ -14,6 +14,7 @@ class EnvelopeStorage(S3Boto3Storage):
             access_key=settings.S3_ACCESS_KEY_ID,
             secret_key=settings.S3_SECRET_ACCESS_KEY,
             endpoint_url=settings.S3_ENDPOINT_URL,
+            region_name=settings.S3_REGION_NAME,
             default_acl="private",
         )
 
@@ -44,6 +45,7 @@ class LoadingReportStorage(S3Boto3Storage):
             access_key=settings.S3_ACCESS_KEY_ID,
             secret_key=settings.S3_SECRET_ACCESS_KEY,
             endpoint_url=settings.S3_ENDPOINT_URL,
+            region_name=settings.S3_REGION_NAME,
             default_acl="private",
         )
 

--- a/settings/common.py
+++ b/settings/common.py
@@ -323,7 +323,7 @@ if VCAP_SERVICES.get("aws-s3-bucket"):
     S3_SECRET_ACCESS_KEY = app_bucket_creds["aws_secret_access_key"]
     HMRC_PACKAGING_STORAGE_BUCKET_NAME = app_bucket_creds["bucket_name"]
 else:
-    S3_REGION_NAME = os.env.get("AWS_REGION", default="")
+    S3_REGION_NAME = os.environ.get("AWS_REGION")
     S3_ACCESS_KEY_ID = os.environ.get("S3_ACCESS_KEY_ID")
     S3_SECRET_ACCESS_KEY = os.environ.get("S3_SECRET_ACCESS_KEY")
     HMRC_PACKAGING_STORAGE_BUCKET_NAME = os.environ.get(

--- a/settings/common.py
+++ b/settings/common.py
@@ -313,18 +313,27 @@ HMRC_STORAGE_BUCKET_NAME = os.environ.get("HMRC_STORAGE_BUCKET_NAME", "hmrc")
 HMRC_STORAGE_DIRECTORY = os.environ.get("HMRC_STORAGE_DIRECTORY", "tohmrc/staging/")
 
 
-# S3 creds and endpoint.
-S3_ACCESS_KEY_ID = os.environ.get(
-    "S3_ACCESS_KEY_ID",
-    "",
-)
-S3_SECRET_ACCESS_KEY = os.environ.get(
-    "S3_SECRET_ACCESS_KEY",
-    "",
-)
+# S3 settings for packaging automation.
+
+if VCAP_SERVICES.get("aws-s3-bucket"):
+    app_bucket_creds = VCAP_SERVICES["aws-s3-bucket"][0]["credentials"]
+
+    S3_REGION_NAME = app_bucket_creds["aws_region"]
+    S3_ACCESS_KEY_ID = app_bucket_creds["aws_access_key_id"]
+    S3_SECRET_ACCESS_KEY = app_bucket_creds["aws_secret_access_key"]
+    HMRC_PACKAGING_STORAGE_BUCKET_NAME = app_bucket_creds["bucket_name"]
+else:
+    S3_REGION_NAME = os.env.get("AWS_REGION", default="")
+    S3_ACCESS_KEY_ID = os.environ.get("S3_ACCESS_KEY_ID")
+    S3_SECRET_ACCESS_KEY = os.environ.get("S3_SECRET_ACCESS_KEY")
+    HMRC_PACKAGING_STORAGE_BUCKET_NAME = os.environ.get(
+        "HMRC_PACKAGING_STORAGE_BUCKET_NAME",
+        "hmrc-packaging",
+    )
+
 S3_ENDPOINT_URL = os.environ.get(
     "S3_ENDPOINT_URL",
-    "https://test-url.local/",
+    "",
 )
 
 # Packaging automation.
@@ -333,10 +342,6 @@ HMRC_PACKAGING_SEED_ENVELOPE_ID = int(
         "HMRC_PACKAGING_SEED_ENVELOPE_ID",
         "0001",
     ),
-)
-HMRC_PACKAGING_STORAGE_BUCKET_NAME = os.environ.get(
-    "HMRC_PACKAGING_STORAGE_BUCKET_NAME",
-    "hmrc-packaging",
 )
 HMRC_ENVELOPE_STORAGE_DIRECTORY = os.environ.get(
     "HMRC_ENVELOPE_STORAGE_DIRECTORY",


### PR DESCRIPTION
# Pull S3 creds from VCAP_SERVICES
<!---
 * Include the JIRA ticket number, eg TP-123, to automatically link.
 * Use 50 characters maximum.
 * Do not end with a full-stop.
--->

## Why
<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Use as many lines as you like.
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions or deliberately ignored edge-cases.
--->
S3 credentials for envelope and loading report storage must be pulled from VCAP_SERVICES on PaaS.

## What
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Explain like I'm 5.
 * Use pictures if you can.
--->
This PR implements pulling S3 credentials for envelope and loading report storage from VCAP_SERVICES on PaaS.

<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
--->
## Checklist
- Requires migrations? No
- Requires dependency updates? No

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
