### PR TITLE
TP2000-696 Content amendments packaging automation UI

### DIFF
--- a/publishing/forms.py
+++ b/publishing/forms.py
@@ -29,7 +29,7 @@ class LoadingReportForm(ModelForm):
         self.helper.layout = Layout(
             Field("file"),
             Field.textarea("comments", rows=5),
-            HTML.warning("Submitting this form sends a notification email to users."),
+            HTML.warning("Upon submission, DIT and HMRC will be notified."),
             Submit(
                 "submit",
                 "Submit",

--- a/publishing/forms.py
+++ b/publishing/forms.py
@@ -102,7 +102,7 @@ class PackagedWorkBasketCreateForm(forms.ModelForm):
                 HTML(
                     '<strong class="govuk-warning-text__text">'
                     '<span class="govuk-warning-text__assistive">Warning</span>'
-                    "The workbasket will be added to the queue ready to send to CDS."
+                    "The workbasket will be added to the packaging queue to send to CDS."
                     "</strong>",
                 ),
                 css_class="govuk-warning-text",

--- a/publishing/jinja2/includes/queue-unpaused.jinja
+++ b/publishing/jinja2/includes/queue-unpaused.jinja
@@ -8,11 +8,15 @@
 
 <div class="govuk-grid-column-three-quarters">
   {{ govukDetails({
-    "summaryText": "What does pausing and unpausing CDS queue mean?",
+    "summaryText": "What does pausing and unpausing the CDS queue mean?",
     "html": (
-      "<p>Pausing the CDS queue prevents any envelopes that are waiting in "
-      "this queue from being downloaded by HMRC users.</p>"
-      "<p>Unpausing allows downloads to commence again.</p>"
+      "<p>It is essentially a way to temporarily stop the automatic sending of envelopes to CDS. "
+      "You can manually pause the queue if you want to temporarily stop the automatic process "
+      "of sending envelopes to CDS. The CDS queue will be paused automatically when "
+      "an envelope is rejected by CDS.</p>"
+      "<p>It is important to check the reason why the processing queue was initially paused "
+      "before restarting the process, as the first file in the queue will be "
+      "automatically sent to CDS once you resume.</p>"
     ),
     "classes": "govuk-!-margin-bottom-0",
   }) }}

--- a/publishing/jinja2/includes/warning_help.jinja
+++ b/publishing/jinja2/includes/warning_help.jinja
@@ -1,6 +1,6 @@
 {% from "components/warning-text/macro.njk" import govukWarningText %}
 
 {{ govukWarningText({
-  "text": "The workbasket will be added to the queue ready to send to CDS.",
+  "text": "The workbasket will be added to the packaging queue to send to CDS.",
   "iconFallbackText": "Warning"
 }) }}

--- a/publishing/jinja2/publishing/complete-envelope-processing-confirm.jinja
+++ b/publishing/jinja2/publishing/complete-envelope-processing-confirm.jinja
@@ -19,7 +19,7 @@
   }) }}
 {% endblock %}
 
-{% macro notified_message() %}
+{% set notified_message %}
   {% if page_title == "Accept envelope confirmation" %}
     Email was sent to inform DIT.
   {% else %}
@@ -32,7 +32,7 @@
     <div class="govuk-grid-column-two-thirds">
         {{ govukPanel({
           "titleText": message,
-          "text": notified_message(),
+          "text": notified_message,
           "classes": "govuk-!-margin-bottom-7"
         }) }}
     </div>

--- a/publishing/jinja2/publishing/complete-envelope-processing-confirm.jinja
+++ b/publishing/jinja2/publishing/complete-envelope-processing-confirm.jinja
@@ -19,14 +19,22 @@
   }) }}
 {% endblock %}
 
+{% macro notified_message() %}
+  {% if page_title == "Accept envelope confirmation" %}
+    Email was sent to inform DIT.
+  {% else %}
+    The DIT team has been notified of the rejection. Once the envelope has been corrected, new envelopes will be available for download.
+  {% endif %}
+{% endmacro %}
+
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      {{ govukPanel({
-        "titleText": message,
-        "text": "Email was sent to inform DIT",
-        "classes": "govuk-!-margin-bottom-7"
-      }) }}
+        {{ govukPanel({
+          "titleText": message,
+          "text": notified_message(),
+          "classes": "govuk-!-margin-bottom-7"
+        }) }}
     </div>
   </div>
 

--- a/publishing/jinja2/publishing/complete-envelope-processing-confirm.jinja
+++ b/publishing/jinja2/publishing/complete-envelope-processing-confirm.jinja
@@ -25,7 +25,7 @@
   {% else %}
     The DIT team has been notified of the rejection. Once the envelope has been corrected, new envelopes will be available for download.
   {% endif %}
-{% endmacro %}
+{% endset %}
 
 {% block content %}
   <div class="govuk-grid-row">

--- a/publishing/jinja2/publishing/envelope_queue.jinja
+++ b/publishing/jinja2/publishing/envelope_queue.jinja
@@ -31,17 +31,15 @@
         }) }}
       {% else %}
         {{ govukDetails({
-          "summaryText": "What happens when an envelope is downloaded?",
+          "summaryText": "How to process an envelope?",
           "html": (
-            "<p>Downloading an envelope 'locks' the associated workbasket, "
-            "preventing it from being removed from or reordered in the queue by "
-            "DIT staff.</p>"
-
-            "<p>After downloading, you should process the envelope and then "
-            "choose to either <em>Accept</em> or <em>Reject</em> it, depending "
-            "upon the processing results. This will unlock the workbasket, "
-            "remove it from the queue, and make the next envelope available for "
-            "downloading.</p>"
+            "<p>To begin, simply click on the \"Process envelope\" link "
+            "to alert DIT that you are currently processing this file. "
+            "Click the \"Download envelope\" link to download the envelope "
+            "in XML format. Once you ingest the envelope into CDS, you can "
+            "use the options on the interface to accept or reject it. "
+            "After accepting or rejecting, the next available envelope will be "
+            "ready for download.</p>"
           ),
         }) }}
 

--- a/publishing/jinja2/publishing/envelope_queue.jinja
+++ b/publishing/jinja2/publishing/envelope_queue.jinja
@@ -31,7 +31,7 @@
         }) }}
       {% else %}
         {{ govukDetails({
-          "summaryText": "How to process an envelope?",
+          "summaryText": "How to process an envelope",
           "html": (
             "<p>To begin, simply click on the \"Process envelope\" link "
             "to alert DIT that you are currently processing this file. "

--- a/publishing/views.py
+++ b/publishing/views.py
@@ -321,9 +321,7 @@ class RejectEnvelopeConfirmView(EnvelopeActionConfirmView):
         envelope = packaged_workbasket.envelope
 
         data["page_title"] = "Reject envelope confirmation"
-        data[
-            "message"
-        ] = f"Envelope ID {envelope.envelope_id} was rejected and queue was paused."
+        data["message"] = f"Envelope ID {envelope.envelope_id} has been rejected."
         return data
 
 


### PR DESCRIPTION
# TP2000-696 Content amendments packaging automation UI

## Why
Small content amendments could be made to improve users' understanding of actions taken throughout the packaging automation journey. 

## What
Amends the following content:
- 'Add to queue' warning text
- 'Pausing and unpausing' dropdown detail text
- 'How to process an envelope' dropdown detail text
- Accept or reject envelope warning text
- Envelope rejection confirmation text

<img width="400" alt="add-to-queue-warning-text" src="https://user-images.githubusercontent.com/118175145/216291476-9d5fcd03-bd61-464d-ab73-6c68813fe3e6.png">
<img width="400" alt="Pause-and-unpause-explanation" src="https://user-images.githubusercontent.com/118175145/216288772-c4c82be5-f114-42b3-96b9-57776755eacd.png">
<img width="400" alt="how-to-process-an-envelope" src="https://user-images.githubusercontent.com/118175145/216288760-f6c805b5-aa12-4ac0-9c69-3d3f911da424.png">
<img width="400" alt="accept-envelope-amend-warning" src="https://user-images.githubusercontent.com/118175145/216288996-5bf4729d-61cf-4a7d-aac2-46fbe06fc57a.png">

