### PR TITLE
TP2000-726 Content and UI amendments packaging queue view

### DIFF
--- a/publishing/jinja2/includes/packaged-workbasket-queue.jinja
+++ b/publishing/jinja2/includes/packaged-workbasket-queue.jinja
@@ -130,7 +130,7 @@
         name="promote_to_top_position"
         value="{{ obj.pk }}"
       >
-        Move to top to notify CDS
+        Move to top
       </button>
     {% endif %}
   {% endset -%}
@@ -143,7 +143,7 @@
         name="remove_from_queue"
         value="{{ obj.pk }}"
       >
-        Remove from queue
+        Remove
       </button>
     {% endif %}
   {% endset -%}

--- a/publishing/static/publishing/scss/_publishing.scss
+++ b/publishing/static/publishing/scss/_publishing.scss
@@ -23,6 +23,7 @@ table.packaged-workbaskets .icon-progress {
   display: inline-block;
   vertical-align: middle;
   width: 5.6rem;
+  display: none;
 }
 table.queued-envelopes .down-arrow,
 table.queued-envelopes .right-arrow {
@@ -41,4 +42,8 @@ table.queued-envelopes .disabled-action {
 }
 table.queued-envelopes .icon-begin-processing {
     vertical-align: middle;
+}
+
+button.pause-queue-button {
+  float: right;
 }

--- a/publishing/static/publishing/scss/_publishing.scss
+++ b/publishing/static/publishing/scss/_publishing.scss
@@ -44,6 +44,6 @@ table.queued-envelopes .icon-begin-processing {
     vertical-align: middle;
 }
 
-button.pause-queue-button {
+button.pause-queue-button, button.unpause-queue-button{
   float: right;
 }


### PR DESCRIPTION
# TP2000-726 Content and UI amendments packaging queue view

## Why
Small amendments could be made to improve the packaging queue UI.

## What
- Aligns 'Pause/Unpause CDS queue' button with table edge. 
- Amends 'Move' and 'Remove' text
- Removes 3 'step process' icons

Before:
<img width="1200" alt="Screenshot 2023-02-02 at 10 20 57" src="https://user-images.githubusercontent.com/118175145/216298399-0d59c8d3-8a7b-41d3-8b2d-f565885828c0.png">


After:
<img width="1200" alt="Screenshot 2023-02-02 at 10 18 02" src="https://user-images.githubusercontent.com/118175145/216298071-6c8b6e60-8de1-44ad-9097-2cd76d8351ac.png">


