### PR TITLE
TP2000-736 Add permission check workbasket finder

### DIFF
--- a/workbaskets/views/ui.py
+++ b/workbaskets/views/ui.py
@@ -435,10 +435,11 @@ class WorkBasketDetail(TemplateResponseMixin, FormMixin, View):
         return super().form_valid(form)
 
 
-class WorkBasketList(WithPaginationListView):
+class WorkBasketList(PermissionRequiredMixin, WithPaginationListView):
     """UI endpoint for viewing and filtering workbaskets."""
 
     template_name = "workbaskets/list.jinja"
+    permission_required = "workbaskets.change_workbasket"
     filterset_class = WorkBasketFilter
     search_fields = [
         "title",


### PR DESCRIPTION
# TP2000-736 Add permission check workbasket finder


## Why
The workbasket list all view is accessible to all user groups. This page should only be viewable to users who have permission to select, edit and create workbaskets.

## What
- Adds `PermissionRequiredMixin` to `WorkBasketList` view

