### PR TITLE
Remove unused Notify template variable.

### DIFF
--- a/publishing/models/packaged_workbasket.py
+++ b/publishing/models/packaged_workbasket.py
@@ -571,7 +571,6 @@ class PackagedWorkBasket(TimestampedMixin):
         personalisation = {
             "envelope_id": self.envelope.envelope_id,
             "transaction_count": self.workbasket.transactions.count(),
-            "link_to_file": "",  # TODO: Remove link_to_file after deployment.
             "loading_report_message": loading_report_message,
             "comments": self.loading_report.comments,
         }


### PR DESCRIPTION
# TP2000-695 Part B
<!---
 * Include the JIRA ticket number, eg TP-123, to automatically link.
 * Use 50 characters maximum.
 * Do not end with a full-stop.
--->

## Why
<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Use as many lines as you like.
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions or deliberately ignored edge-cases.
--->
One of TAP's Notify template personalisation variables, link_to_file, requires removal as part of the second stage of a deployment. See the description on [PR #810](https://github.com/uktrade/tamato/pull/810) for details.

## What
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Explain like I'm 5.
 * Use pictures if you can.
--->
Remove the template personalisation variable 'link_to_file`.

Note that [TP2000-695 S3 loading reports integration](https://github.com/uktrade/tamato/pull/810) must be merged and deployed before this PR is deployed.


<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
--->
## Checklist
- Requires migrations? No
- Requires dependency updates? No

<!---
--->
Links to relevant material
See: [TP2000-695 S3 loading reports integration](https://github.com/uktrade/tamato/pull/810)
