### PR TITLE
Update Notify template variables.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
       - id: isort
         args: [--force-single-line-imports]
   - repo: https://github.com/myint/docformatter.git
-    rev: v1.6.0.rc1
+    rev: v1.5.1
     hooks:
       - id: docformatter
         args:

--- a/publishing/models/packaged_workbasket.py
+++ b/publishing/models/packaged_workbasket.py
@@ -534,7 +534,7 @@ class PackagedWorkBasket(TimestampedMixin):
         """
         eif = "Immediately"
         if self.eif:
-            eif = self.eif.strftime("%d:%m:%Y")
+            eif = self.eif.strftime("%d/%m/%Y")
 
         personalisation = {
             "envelope_id": self.envelope.envelope_id,
@@ -561,17 +561,13 @@ class PackagedWorkBasket(TimestampedMixin):
         `template_id` should be the ID of the Notify email template of either
         the successfully processed email or failed processing.
         """
-        loading_report_message = "No loading report was provided."
+        loading_report_message = "Loading report: No loading report was provided."
         if self.loading_report.file:
-            loading_report_message = (
-                f'The loading report "{self.loading_report.file_name}" was '
-                "uploaded and is available to download from TAP."
-            )
+            loading_report_message = f"Loading report: {self.loading_report.file_name}"
 
         personalisation = {
             "envelope_id": self.envelope.envelope_id,
             "transaction_count": self.workbasket.transactions.count(),
-            "link_to_file": "",  # TODO: Remove link_to_file after deployment.
             "loading_report_message": loading_report_message,
             "comments": self.loading_report.comments,
         }


### PR DESCRIPTION
# TP2000-695 Part B + Notify variable changes
<!---
 * Include the JIRA ticket number, eg TP-123, to automatically link.
 * Use 50 characters maximum.
 * Do not end with a full-stop.
--->

## Why
<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Use as many lines as you like.
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions or deliberately ignored edge-cases.
--->
One of TAP's Notify template personalisation variables, link_to_file, requires removal as part of the second stage of a deployment. See the description on https://github.com/uktrade/tamato/pull/810 for details.

Also, copy changes are required:

- Date format in the envelope ready notification emails uses colons instead of the correct slash notation.
- Envelope processing completed emails for accept and reject should only show the loading report filename if one was added.

## What
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Explain like I'm 5.
 * Use pictures if you can.
--->
Remove the template personalisation variable 'link_to_file`.

Correctly format dates in Notification emails to use slash notation.

Show loading report filename in confirmation notification emails when a loading report is provided during the accept and reject stages of envelope processing.

<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
--->
## Checklist
- Requires migrations? No
- Requires dependency updates? No

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
