### PR TITLE
TP2000-694 Add list of selected measures

### DIFF
--- a/measures/jinja2/includes/measures/list.jinja
+++ b/measures/jinja2/includes/measures/list.jinja
@@ -102,3 +102,33 @@
     </div>
   </div>
 </form>
+
+<details class="govuk-details" data-module="govuk-details">
+  <summary class="govuk-details__summary">
+    <span class="govuk-details__summary-text">
+      View all selected measures
+    </span>
+  </summary>
+  <div class="govuk-details__text">
+  {% if measure_selections %}
+    {% set table_rows = [] %}
+      {% for measure in measure_selections %}
+        {% set measure_link %}
+          <a class="govuk-link govuk-!-font-weight-bold" href="{{measure.get_url()}}">{{measure.sid}}</a>
+        {% endset %}
+        {{ table_rows.append([
+          {"html": measure_link},
+          ]) or "" }}
+      {% endfor %}
+      {{ govukTable({
+        "head": [
+        {"text": "ID"},
+      ],
+      "rows": table_rows,
+      "classes": "govuk-table-m"
+      }) }}
+  {% else %}
+    No measures selected.
+  {% endif %}
+  </div>
+</details>

--- a/measures/views.py
+++ b/measures/views.py
@@ -101,10 +101,15 @@ class MeasureList(MeasureMixin, FormView, TamatoListView):
         return [*self.session_store.data]
 
     def get_context_data(self, **kwargs):
-        return super().get_context_data(
-            measure_selections=self.measure_selections,
-            **kwargs,
+        context = super().get_context_data(**kwargs)
+        measure_selections = [
+            SelectableObjectsForm.object_id_from_field_name(name)
+            for name in self.measure_selections
+        ]
+        context["measure_selections"] = Measure.objects.filter(
+            pk__in=measure_selections,
         )
+        return context
 
     def get_initial(self):
         return {**self.session_store.data}


### PR DESCRIPTION
# TP2000-694 Add list of selected measures

## Why
Now that users can select measures across multiple pages #809, it would be useful for them to see a running list of their selections.

## What
- Adds a dropdown detail component to show a running list of a user's measure selections

<img width="750" alt="Screenshot 2023-02-14 at 17 39 25" src="https://user-images.githubusercontent.com/118175145/218817638-f0c9f090-33b1-4a07-895a-14f717d1379c.png">

