### PR TITLE
TP2000-756  Fix version control activity dates

### DIFF
--- a/common/jinja2/includes/common/tabs/version_control.jinja
+++ b/common/jinja2/includes/common/tabs/version_control.jinja
@@ -5,7 +5,7 @@
 {% for object in object.version_group.versions.all() %}
   {{ table_rows.append([
     {"text": object.get_update_type_display()},
-    {"text": "{:%d %b %Y}".format(object.version_group.created_at)},
+    {"text": "{:%d %b %Y}".format(object.transaction.updated_at)},
     {"text": object.transaction.workbasket.get_status_display()},
     {"text": "{:%d %b %Y}".format(object.valid_between.lower)},
     {"text": "{:%d %b %Y}".format(object.valid_between.upper) if object.valid_between.upper else "-"},

--- a/common/static/common/scss/_layout.scss
+++ b/common/static/common/scss/_layout.scss
@@ -70,5 +70,5 @@
 }
 
 ul.govuk-tabs__list[role=tablist] {
-  display: inline-flex;
+  display: flex;
 }

--- a/measures/jinja2/includes/measures/tabs/version_control.jinja
+++ b/measures/jinja2/includes/measures/tabs/version_control.jinja
@@ -3,7 +3,7 @@
 {% for object in object.version_group.versions.all() %}
   {{ table_rows.append([
     {"text": object.get_update_type_display()},
-    {"text": "{:%d %b %Y}".format(object.version_group.created_at)},
+    {"text": "{:%d %b %Y}".format(object.transaction.updated_at)},
     {"text": object.transaction.workbasket.get_status_display()},
     {"text": "{:%d %b %Y}".format(object.valid_between.lower)},
     {"text": "{:%d %b %Y}".format(object.effective_end_date) if object.effective_end_date else "-"},

--- a/measures/tests/test_views.py
+++ b/measures/tests/test_views.py
@@ -378,26 +378,34 @@ def test_measure_detail_quota_order_number(client, valid_user):
     assert str(quota_order_number) in items
 
 
-def test_measure_detail_version_control(client, valid_user):
+def test_measure_detail_version_control(valid_user_client):
     measure = factories.MeasureFactory.create()
     measure.new_version(measure.transaction.workbasket)
     measure.new_version(measure.transaction.workbasket)
 
     url = reverse("measure-ui-detail", kwargs={"sid": measure.sid}) + "#versions"
-    client.force_login(valid_user)
-    response = client.get(url)
+    response = valid_user_client.get(url)
+    assert response.status_code == 200
+
     soup = BeautifulSoup(
         response.content.decode(response.charset),
         "html.parser",
     )
-    rows = soup.select("#versions table > tbody > tr")
-    assert len(rows) == 3
+    rows = len(soup.select("#versions table > tbody > tr"))
+    assert rows == 3
 
     update_types = {
         cell.text
         for cell in soup.select("#versions table > tbody > tr > td:first-child")
     }
     assert update_types == {"Create", "Update"}
+
+    activity_dates = [
+        date.text
+        for date in soup.select("#versions table > tbody > tr > td:nth-of-type(2)")
+    ]
+    expected_dates = [f"{measure.transaction.updated_at:%d %b %Y}"] * rows
+    assert activity_dates == expected_dates
 
 
 @pytest.mark.parametrize(

--- a/measures/tests/test_views.py
+++ b/measures/tests/test_views.py
@@ -391,8 +391,8 @@ def test_measure_detail_version_control(valid_user_client):
         response.content.decode(response.charset),
         "html.parser",
     )
-    rows = len(soup.select("#versions table > tbody > tr"))
-    assert rows == 3
+    num_rows = len(soup.select("#versions table > tbody > tr"))
+    assert num_rows == 3
 
     update_types = {
         cell.text
@@ -404,7 +404,7 @@ def test_measure_detail_version_control(valid_user_client):
         date.text
         for date in soup.select("#versions table > tbody > tr > td:nth-of-type(2)")
     ]
-    expected_dates = [f"{measure.transaction.updated_at:%d %b %Y}"] * rows
+    expected_dates = [f"{measure.transaction.updated_at:%d %b %Y}"] * num_rows
     assert activity_dates == expected_dates
 
 

--- a/quotas/jinja2/includes/quotas/tabs/version_control.jinja
+++ b/quotas/jinja2/includes/quotas/tabs/version_control.jinja
@@ -5,7 +5,7 @@
 {% for object in object.version_group.versions.all() %}
   {{ table_rows.append([
     {"text": object.get_update_type_display()},
-    {"text": "{:%d %b %Y}".format(object.version_group.created_at)},
+    {"text": "{:%d %b %Y}".format(object.transaction.updated_at)},
     {"text": object.transaction.workbasket.get_status_display()},
     {"text": "{:%d %b %Y}".format(object.valid_between.lower)},
     {"text": "{:%d %b %Y}".format(object.valid_between.upper) if object.valid_between.upper else "-"},

--- a/regulations/jinja2/includes/regulations/tabs/version_control.jinja
+++ b/regulations/jinja2/includes/regulations/tabs/version_control.jinja
@@ -5,7 +5,7 @@
 {% for object in object.version_group.versions.all() %}
   {{ table_rows.append([
     {"text": object.get_update_type_display()},
-    {"text": "{:%d %b %Y}".format(object.version_group.created_at)},
+    {"text": "{:%d %b %Y}".format(object.transaction.updated_at)},
     {"text": object.transaction.workbasket.get_status_display()},
     {"text": "{:%d %b %Y}".format(object.valid_between.lower)},
     {"text": "{:%d %b %Y}".format(object.valid_between.upper) if object.valid_between.upper else "-"},


### PR DESCRIPTION
# TP2000-756  Fix version control activity dates

## Why
The version control tab always shows the same activity date for multiple versions

## What
- Uses the latest timestamp for an object's transaction instead of its version group creation date
- Updates unit test
- Fixes tab visual bug

Before:
<img width="500" alt="Screenshot 2023-02-16 at 15 34 26" src="https://user-images.githubusercontent.com/118175145/219414208-5af04d33-2f65-4e2b-8da0-21f2b45707a6.png">

After:
<img width="500" alt="Screenshot 2023-02-16 at 15 37 14" src="https://user-images.githubusercontent.com/118175145/219414364-11bb5fa7-d638-4dc5-817b-a67ce41b3bd8.png">

Linked issue: TP2000-403