### PR TITLE
TP2000-682 Amend weak password policy

### DIFF
--- a/settings/common.py
+++ b/settings/common.py
@@ -23,6 +23,11 @@ SSO_ENABLED = is_truthy(os.environ.get("SSO_ENABLED", "true"))
 VCAP_SERVICES = json.loads(os.environ.get("VCAP_SERVICES", "{}"))
 VCAP_APPLICATION = json.loads(os.environ.get("VCAP_APPLICATION", "{}"))
 
+# -- Debug
+
+# Activates debugging
+DEBUG = is_truthy(os.environ.get("DEBUG", False))
+
 # -- Paths
 
 # Name of the project
@@ -173,17 +178,18 @@ FORM_RENDERER = "django.forms.renderers.TemplatesSetting"
 # -- Auth
 LOGIN_URL = reverse_lazy("login")
 
-AUTH_PASSWORD_VALIDATORS = [
-    {
-        'NAME': 'django.contrib.auth.password_validation.MinimumLengthValidator',
-        'OPTIONS': {
-            'min_length': 12,
-        }
-    },
-    {
-        'NAME': 'django.contrib.auth.password_validation.CommonPasswordValidator',
-    },
-]
+if DEBUG is False:
+    AUTH_PASSWORD_VALIDATORS = [
+        {
+            "NAME": "django.contrib.auth.password_validation.MinimumLengthValidator",
+            "OPTIONS": {
+                "min_length": 12,
+            },
+        },
+        {
+            "NAME": "django.contrib.auth.password_validation.CommonPasswordValidator",
+        },
+    ]
 
 if SSO_ENABLED:
     LOGIN_URL = reverse_lazy("authbroker_client:login")
@@ -238,11 +244,6 @@ ROOT_URLCONF = f"urls"
 
 # URL path where static files are served
 STATIC_URL = "/assets/"
-
-# -- Debug
-
-# Activates debugging
-DEBUG = is_truthy(os.environ.get("DEBUG", False))
 
 # -- Database
 

--- a/settings/common.py
+++ b/settings/common.py
@@ -172,6 +172,19 @@ FORM_RENDERER = "django.forms.renderers.TemplatesSetting"
 
 # -- Auth
 LOGIN_URL = reverse_lazy("login")
+
+AUTH_PASSWORD_VALIDATORS = [
+    {
+        'NAME': 'django.contrib.auth.password_validation.MinimumLengthValidator',
+        'OPTIONS': {
+            'min_length': 12,
+        }
+    },
+    {
+        'NAME': 'django.contrib.auth.password_validation.CommonPasswordValidator',
+    },
+]
+
 if SSO_ENABLED:
     LOGIN_URL = reverse_lazy("authbroker_client:login")
 


### PR DESCRIPTION
# TP2000-682


## Why
Thanks to a Security audit, it was Identified that when creating a username and password the old fashioned way without Staff SSO, the password manager would accept anything as a password. We don't use this functionality much, but it is in practice when staff SSO is not enabled in the project such as spinning up a local host. God knows how the auditors found that though. 

## What
This PR adds some simple settings to have a mandatory 12 character minimum for passwords, and checks the passwords against 20K odd similar passwords, under the recommendations of the pen test. 


## Checklist
- Requires migrations? - nah
- Requires dependency updates? - nope



