### PR TITLE
TP2000-757 Command to override broken check

### DIFF
--- a/checks/checks.py
+++ b/checks/checks.py
@@ -20,6 +20,10 @@ CheckResult = Tuple[bool, Optional[str]]
 
 
 Self = TypeVar("Self")
+INTERNAL_ERROR_MESSAGE = (
+    "An internal error occurred when processing checks, please notify the TAP "
+    "support team of this issue"
+)
 
 
 class Checker:
@@ -77,8 +81,7 @@ class Checker:
         except Exception as e:
             success, message = (
                 False,
-                f"An internal error occurred when processing checks, please notify a "
-                f"TAP developer of this issue : {str(e)}",
+                INTERNAL_ERROR_MESSAGE + " : " + str(e),
             )
         finally:
             return TrackedModelCheck.objects.create(

--- a/workbaskets/management/commands/override_check_successful.py
+++ b/workbaskets/management/commands/override_check_successful.py
@@ -54,7 +54,9 @@ class Command(WorkBasketCommandMixin, BaseCommand):
             )
             exit(1)
 
-        if not model_check.message.startswith("An internal error occurred"):
+        if not model_check.message or not model_check.message.startswith(
+            "An internal error occurred",
+        ):
             self.stdout.write(
                 self.style.ERROR(
                     f"Model check {model_check_id} appears to be a valid error. "

--- a/workbaskets/management/commands/override_check_successful.py
+++ b/workbaskets/management/commands/override_check_successful.py
@@ -1,0 +1,121 @@
+import logging
+from typing import Any
+from typing import Optional
+
+from django.core.exceptions import ObjectDoesNotExist
+from django.core.management import BaseCommand
+from django.core.management.base import CommandParser
+
+from checks.models import TrackedModelCheck
+from workbaskets.management.util import WorkBasketCommandMixin
+
+logger = logging.getLogger(__name__)
+
+
+class Command(WorkBasketCommandMixin, BaseCommand):
+    help = (
+        "Update the 'successful' attribute on a TrackedModelCheck instance "
+        "to True. As a precaution against inadvertently changing valid "
+        "failures, this command attempts to ensure a failed check was "
+        "not caused by a business rule failure. The command should still "
+        "be applied with caution."
+    )
+
+    def add_arguments(self, parser: CommandParser) -> None:
+        parser.add_argument("WORKBASKET_ID", type=int)
+        parser.add_argument("MODEL_CHECK_ID", type=int)
+
+    def handle(self, *args: Any, **options: Any) -> Optional[str]:
+        model_check = self.validate(
+            int(options["MODEL_CHECK_ID"]),
+            int(options["WORKBASKET_ID"]),
+        )
+        self.override_check_successful(model_check)
+
+    def validate(self, model_check_id, workbasket_id):
+        """Perform precautionary validation checks."""
+
+        try:
+            model_check = TrackedModelCheck.objects.get(pk=model_check_id)
+        except ObjectDoesNotExist:
+            self.stdout.write(
+                self.style.ERROR(
+                    f"Model check {model_check_id} not found. Exiting.",
+                ),
+            )
+            exit(1)
+
+        if model_check.successful:
+            self.stdout.write(
+                self.style.ERROR(
+                    f"Model check {model_check_id} successful={model_check.successful}. "
+                    f"Nothing to do. Exiting.",
+                ),
+            )
+            exit(1)
+
+        if not model_check.message.startswith("An internal error occurred"):
+            self.stdout.write(
+                self.style.ERROR(
+                    f"Model check {model_check_id} appears to be a valid error. "
+                    f"Exiting.",
+                ),
+            )
+            exit(1)
+
+        workbasket = self.get_workbasket_or_exit(workbasket_id)
+        if model_check.transaction_check.transaction.workbasket != workbasket:
+            self.stdout.write(
+                self.style.ERROR(
+                    f"Model check {model_check_id} is not associated with workbasket {workbasket_id}",
+                ),
+            )
+            exit(1)
+
+        return model_check
+
+    def override_check_successful(self, model_check):
+        """Override `model_check.successful` to True and, if no other
+        TrackedModelCheck instances on the parent TransactionCheck have a
+        `successful` attribute value of False, then also set
+        model_check.transaction_check.successful to True."""
+
+        tranx_check = model_check.transaction_check
+
+        self.stdout.write(f"Initial check values:")
+        self.output_check_summary(model_check, tranx_check)
+
+        model_check.successful = True
+        model_check.save()
+
+        bad_m_checks_on_t_check = TrackedModelCheck.objects.filter(
+            transaction_check=tranx_check,
+            successful=False,
+        )
+        if bad_m_checks_on_t_check:
+            self.stdout.write("Done:")
+            self.output_check_summary(model_check, tranx_check)
+            self.stdout.write(
+                f"{bad_m_checks_on_t_check.count()} unsuccessful model checks "
+                f"remaining on related transaction check, {tranx_check.pk}",
+            )
+            exit(0)
+
+        tranx_check.successful = True
+        tranx_check.save()
+
+        # Refresh for certainty.
+        model_check.refresh_from_db()
+        tranx_check.refresh_from_db()
+
+        self.stdout.write("Done:")
+        self.output_check_summary(model_check, tranx_check)
+
+    def output_check_summary(self, model_check, tranx_check, indent_count=4):
+        spaces = " " * indent_count
+        self.stdout.write(
+            f"{spaces}model_check({model_check.pk}).successful = {model_check.successful}",
+        )
+        self.stdout.write(
+            f"{spaces}model_check({model_check.pk}).tranx_check({tranx_check.pk}).successful = {tranx_check.successful}",
+        )

--- a/workbaskets/tests/test_commands.py
+++ b/workbaskets/tests/test_commands.py
@@ -1,0 +1,95 @@
+from io import StringIO
+
+import pytest
+from django.core.management import call_command
+
+from checks.checks import INTERNAL_ERROR_MESSAGE
+from checks.tests.factories import TrackedModelCheckFactory
+from common.tests.factories import WorkBasketFactory
+
+pytestmark = pytest.mark.django_db
+
+
+def test_override_check_success():
+    model_check = TrackedModelCheckFactory.create(
+        successful=False,
+        message=INTERNAL_ERROR_MESSAGE,
+    )
+    workbasket = model_check.transaction_check.transaction.workbasket
+
+    out = StringIO()
+    call_command(
+        "override_check",
+        f"{workbasket.pk}",
+        f"{model_check.pk}",
+        stdout=out,
+    )
+
+    assert "both set as successful" in out.getvalue()
+
+
+def test_override_check_workbasket_mismatch():
+    model_check = TrackedModelCheckFactory.create(
+        successful=False,
+        message=INTERNAL_ERROR_MESSAGE,
+    )
+    mismatching_workbasket = WorkBasketFactory.create()
+
+    out = StringIO()
+    with pytest.raises(SystemExit):
+        call_command(
+            "override_check",
+            f"{mismatching_workbasket.pk}",
+            f"{model_check.pk}",
+            stdout=out,
+        )
+
+    assert (
+        f"Model check {model_check.pk} is not associated with workbasket"
+        in out.getvalue()
+    )
+
+
+def test_override_check_invalid_error():
+    model_check = TrackedModelCheckFactory.create(
+        successful=False,
+    )
+    workbasket = model_check.transaction_check.transaction.workbasket
+
+    out = StringIO()
+    with pytest.raises(SystemExit):
+        call_command(
+            "override_check",
+            f"{workbasket.pk}",
+            f"{model_check.pk}",
+            stdout=out,
+        )
+
+    assert (
+        f"Model check {model_check.id} appears to be a valid error. " in out.getvalue()
+    )
+
+
+def test_override_check_tranx_check_not_completed():
+    model_check = TrackedModelCheckFactory.create(
+        successful=False,
+        message=INTERNAL_ERROR_MESSAGE,
+    )
+    tranx_check = model_check.transaction_check
+    tranx_check.completed = False
+    tranx_check.successful = None
+    tranx_check.save()
+    workbasket = tranx_check.transaction.workbasket
+
+    out = StringIO()
+    call_command(
+        "override_check",
+        f"{workbasket.pk}",
+        f"{model_check.pk}",
+        stdout=out,
+    )
+
+    assert (
+        f"Related transaction check, {tranx_check.pk}, has not completed "
+        in out.getvalue()
+    )


### PR DESCRIPTION
# TP2000-757 Command to override broken check
<!---
 * Include the JIRA ticket number, eg TP-123, to automatically link.
 * Use 50 characters maximum.
 * Do not end with a full-stop.
--->

## Why
<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Use as many lines as you like.
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions or deliberately ignored edge-cases.
--->
Very occassionally a measure fails its rule check (TrackedModelCheck) as a result of what appears to be an internal error - i.e. these aren’t business rule check errors. Until the root cause of these failures is found and fixed, they prevent their container workbaskets from being queued, sent to HMRC and published.

## What
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Explain like I'm 5.
 * Use pictures if you can.
--->
Interim data fixes have been applied several times via a Python shell on the Production service. To reduce the chance of mishap when repeating this, and to allow any engineer perform the fix, this PR introduces a new Django management command under the workbaskets application to perform the data fix:

`python manage.py override_check_successful <workbasket-id> <tracked-model-check-id>`

Including workbasket ID reduces the chance of an incorrect `TrackedModelCheck` ID being applied. The command additionally tests that the check instance is not a valid business rule failure by inspecting the check's message contents.

<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
--->
## Checklist
- Requires migrations? No
- Requires dependency updates? No

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
