### PR TITLE
TP2000-759 Fix werkzeug dependabot alerts

### DIFF
--- a/common/jinja2.py
+++ b/common/jinja2.py
@@ -12,7 +12,7 @@ from django.utils.safestring import mark_safe
 from django.utils.timezone import template_localtime
 from govuk_frontend_jinja.templates import Environment
 from govuk_frontend_jinja.templates import NunjucksExtension
-from jinja2 import Markup
+from jinja2.utils import markupsafe
 from webpack_loader.templatetags.webpack_loader import render_bundle
 from webpack_loader.templatetags.webpack_loader import webpack_static
 
@@ -87,7 +87,7 @@ def break_words(word):
     >>> break_words("hello/goodbye")
     "hello&8203;/&8203;goodbye"
     """
-    return Markup(re.sub(r"([^\w]+)", r"&#8203;\1&#8203;", word))
+    return markupsafe.Markup(re.sub(r"([^\w]+)", r"&#8203;\1&#8203;", word))
 
 
 def query_transform(request, **kwargs):

--- a/pii-secret-exclude.txt
+++ b/pii-secret-exclude.txt
@@ -16,7 +16,6 @@ common/jinja2/components/sort_icon.jinja
 reports/tests/test_report_models.py
 workbaskets/tests/test_admin.py
 common/tests/test_migrations.py
-Order
 common/static/common/js/chart.js
 reports/jinja2/reports/report_chart.jinja
 reports/jinja2/reports/report_chart_timescale.jinja

--- a/pii-secret-exclude.txt
+++ b/pii-secret-exclude.txt
@@ -9,6 +9,7 @@ pyproject.toml
 README.rst
 requirements.txt
 requirements-dev.txt
+requirements-dev-jupyter.txt
 runtime.txt
 sample.env
 common/jinja2/components/sort_icon.jinja

--- a/requirements-dev-jupyter.txt
+++ b/requirements-dev-jupyter.txt
@@ -1,0 +1,4 @@
+-r requirements-dev.txt
+
+ipython
+jupyter

--- a/requirements.txt
+++ b/requirements.txt
@@ -40,9 +40,9 @@ gevent==21.12.0
 govuk-frontend-jinja @ git+https://github.com/alphagov/govuk-frontend-jinja.git@15845e4cca3a05df72c6e13ec6a7e35acc682f52
 govuk-tech-docs-sphinx-theme==1.0.0
 gunicorn==20.0.4
-Jinja2==2.11.3
+Jinja2==3.1.2
 lxml==4.9.1
-markupsafe==2.0.1
+markupsafe==2.1.2
 moto==2.1.0
 notifications-python-client==6.4.1
 openpyxl==3.0.7
@@ -68,6 +68,6 @@ sphinx-gherkindoc==3.6.2
 sqlite-s3vfs==0.0.26
 urllib3==1.26.5
 wrapt==1.12.1
-Werkzeug==1.0.1
+Werkzeug==2.2.3
 whitenoise==5.2.0
 xmldiff==2.4


### PR DESCRIPTION
# TP2000-759 Fix werkzeug dependabot alerts
<!---
 * Include the JIRA ticket number, eg TP-123, to automatically link.
 * Use 50 characters maximum.
 * Do not end with a full-stop.
--->

## Why
<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Use as many lines as you like.
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions or deliberately ignored edge-cases.
--->
Dependabot has raised two alerts for the WerkZeug package used by Tamato. The auto-generated PR breaks Tamato's CI checks so it's necessary to make additional manual changes. 

## What
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Explain like I'm 5.
 * Use pictures if you can.
--->
This PR:
Updates the WerkZeug package to a version that resolves the Dependabot alerts.
Resolves clashing requirements dependencies.
Manual testing in a staging environment (Training) didn't uncover any breaking changes to the Tamato.

<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
--->
## Checklist
- Requires migrations? No
- Requires dependency updates? Yes

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
