### PR TITLE
TP2000-758 Update quota order number page in create measure journey

### DIFF
--- a/measures/forms.py
+++ b/measures/forms.py
@@ -857,7 +857,6 @@ class MeasureQuotaOrderNumberForm(forms.Form):
         help_text=(
             "Search for a quota using its order number. "
             "You can then select the correct quota from the dropdown list. "
-            "Leave this field blank if the measure is not a quota."
         ),
         queryset=QuotaOrderNumber.objects.all(),
         required=False,
@@ -954,7 +953,6 @@ class MeasureGeographicalAreaForm(BindNestedFormMixin, forms.Form):
 
         if geo_area_choice:
             if not self.formset_submit():
-
                 if geo_area_choice == GeoAreaType.ERGA_OMNES:
                     cleaned_data["geo_area_list"] = [self.erga_omnes_instance]
 

--- a/measures/tests/test_forms.py
+++ b/measures/tests/test_forms.py
@@ -99,6 +99,14 @@ def test_measure_forms_quota_order_number_valid_data(quota_order_number):
     }
     form = forms.MeasureQuotaOrderNumberForm(data, prefix="")
     assert form.is_valid()
+    assert form.cleaned_data["order_number"] == quota_order_number
+
+    empty = {
+        "order_number": "",
+    }
+    form = forms.MeasureQuotaOrderNumberForm(empty, prefix="")
+    assert form.is_valid()
+    assert form.cleaned_data["order_number"] == None
 
 
 def test_measure_forms_geo_area_valid_data_erga_omnes(erga_omnes):

--- a/measures/views.py
+++ b/measures/views.py
@@ -218,11 +218,11 @@ class MeasureCreateWizard(
             "link_text": "Measure details",
         },
         REGULATION_ID: {
-            "title": "Enter the Regulation ID",
+            "title": "Enter the regulation ID",
             "link_text": "Regulation ID",
         },
         QUOTA_ORDER_NUMBER: {
-            "title": "Enter the Quota Order Number",
+            "title": "Enter a quota order number (optional)",
             "link_text": "Quota Order Number",
         },
         GEOGRAPHICAL_AREA: {

--- a/measures/views.py
+++ b/measures/views.py
@@ -223,7 +223,7 @@ class MeasureCreateWizard(
         },
         QUOTA_ORDER_NUMBER: {
             "title": "Enter a quota order number (optional)",
-            "link_text": "Quota Order Number",
+            "link_text": "Quota order number",
         },
         GEOGRAPHICAL_AREA: {
             "title": "Select the geographical area",


### PR DESCRIPTION
# TP2000-758 Update quota order number page in create measure journey

## Why
The quota order number page in the create measure journey requires small content amendment to make it consistent with the other pages. 

## What
- Amends title (adds optional to title, uses lowercase)
- Removes now redundant sentence in help text
- Extends unit test coverage

Before:
<img width="450" alt="Screenshot 2023-02-20 at 10 35 35" src="https://user-images.githubusercontent.com/118175145/220081754-eb7f5920-b1ee-45e0-8dcb-01eba7ddce5d.png">

After:
<img width="450" alt="after-quota-order-number" src="https://user-images.githubusercontent.com/118175145/220081809-e0769cb0-b990-4406-97cd-2e6fdbc8fa6e.png">

