### PR TITLE
TP2000-763 Add error message to commodity and duties form

### DIFF
--- a/measures/forms.py
+++ b/measures/forms.py
@@ -1019,7 +1019,7 @@ class MeasureCommodityAndDutiesForm(forms.Form):
         help_text=(
             "Search for a commodity code by typing in the code's number or a keyword. "
             "After you've typed at least 3 numbers, a dropdown list will appear. "
-            "You can then select the correct quota from the dropdown list."
+            "You can then select the correct commodity from the dropdown list."
         ),
         queryset=GoodsNomenclature.objects.all(),
         attrs={"min_length": 3},

--- a/measures/forms.py
+++ b/measures/forms.py
@@ -1023,6 +1023,7 @@ class MeasureCommodityAndDutiesForm(forms.Form):
         ),
         queryset=GoodsNomenclature.objects.all(),
         attrs={"min_length": 3},
+        error_messages={"required": "Select a commodity code"},
     )
 
     duties = forms.CharField(
@@ -1062,7 +1063,7 @@ class MeasureCommodityAndDutiesForm(forms.Form):
         return cleaned_data
 
 
-MeasureCommodityAndDutiesFormSet = formset_factory(
+MeasureCommodityAndDutiesFormSetBase = formset_factory(
     MeasureCommodityAndDutiesForm,
     prefix="measure_commodities_duties_formset",
     formset=FormSet,
@@ -1072,6 +1073,15 @@ MeasureCommodityAndDutiesFormSet = formset_factory(
     validate_min=True,
     validate_max=True,
 )
+
+
+class MeasureCommodityAndDutiesFormSet(MeasureCommodityAndDutiesFormSetBase):
+    def full_clean(self):
+        super().full_clean()
+        if self._non_form_errors:
+            for e in self._non_form_errors.as_data():
+                if e.code == "too_few_forms":
+                    e.message = "Select one or more commodity codes"
 
 
 class MeasureFootnotesForm(forms.Form):

--- a/measures/forms.py
+++ b/measures/forms.py
@@ -1063,7 +1063,7 @@ class MeasureCommodityAndDutiesForm(forms.Form):
         return cleaned_data
 
 
-MeasureCommodityAndDutiesFormSetBase = formset_factory(
+MeasureCommodityAndDutiesBaseFormSet = formset_factory(
     MeasureCommodityAndDutiesForm,
     prefix="measure_commodities_duties_formset",
     formset=FormSet,
@@ -1075,13 +1075,14 @@ MeasureCommodityAndDutiesFormSetBase = formset_factory(
 )
 
 
-class MeasureCommodityAndDutiesFormSet(MeasureCommodityAndDutiesFormSetBase):
-    def full_clean(self):
-        super().full_clean()
-        if self._non_form_errors:
-            for e in self._non_form_errors.as_data():
-                if e.code == "too_few_forms":
-                    e.message = "Select one or more commodity codes"
+class MeasureCommodityAndDutiesFormSet(MeasureCommodityAndDutiesBaseFormSet):
+    def non_form_errors(self):
+        self._non_form_errors = super().non_form_errors()
+        for e in self._non_form_errors.as_data():
+            if e.code == "too_few_forms":
+                e.message = "Select one or more commodity codes"
+
+        return self._non_form_errors
 
 
 class MeasureFootnotesForm(forms.Form):

--- a/measures/jinja2/measures/create-formset.jinja
+++ b/measures/jinja2/measures/create-formset.jinja
@@ -1,12 +1,27 @@
 {% extends "measures/create-wizard-step.jinja" %}
 
 {% from "components/fieldset/macro.njk" import govukFieldset %}
+{% from "components/error-summary/macro.njk" import govukErrorSummary %}
 
 {% set page_title = step_metadata[wizard.steps.current].title %}
 
 {% block form %}
   {% set formset = form %}
   {{ crispy(formset.management_form, no_form_tags) }}
+
+  {% if formset.non_form_errors() %}
+    {% set error_list = [] %}
+    {% for error in formset.non_form_errors() %}
+      {{ error_list.append({
+        "html": '<p class="govuk-error-message">' ~ error ~ '</p>',
+      }) or "" }}
+    {% endfor %}
+
+    {{ govukErrorSummary({
+      "titleText": "There is a problem",
+      "errorList": error_list
+    }) }}
+  {% endif %}
 
   {% for form in formset %}
     {{ crispy(form) }}

--- a/measures/tests/test_forms.py
+++ b/measures/tests/test_forms.py
@@ -464,7 +464,7 @@ def test_measure_forms_duties_form(duties, is_valid, duty_sentence_parser, date_
             "test",
             "Select a valid choice. That choice is not one of the available choices.",
         ),
-        ("", "This field is required."),
+        ("", "Select a commodity code"),
     ],
 )
 def test_measure_forms_commodity_and_duties_form_invalid(

--- a/measures/tests/test_forms.py
+++ b/measures/tests/test_forms.py
@@ -484,6 +484,10 @@ def test_measure_forms_commodity_and_duties_form_invalid(
     assert not form.is_valid()
     assert error_message in form.errors["commodity"]
 
+    formset = forms.MeasureCommodityAndDutiesFormSet({})
+    assert not formset.is_valid()
+    assert "Select one or more commodity codes" in formset.non_form_errors()
+
 
 def test_measure_forms_conditions_form_valid_data():
     """Tests that MeasureConditionsForm is valid when initialised with minimal

--- a/measures/tests/test_forms.py
+++ b/measures/tests/test_forms.py
@@ -467,7 +467,7 @@ def test_measure_forms_duties_form(duties, is_valid, duty_sentence_parser, date_
         ("", "This field is required."),
     ],
 )
-def test_measure_forms_comm_and_duties_form_invalid(
+def test_measure_forms_commodity_and_duties_form_invalid(
     commodity,
     error_message,
     duty_sentence_parser,
@@ -483,15 +483,6 @@ def test_measure_forms_comm_and_duties_form_invalid(
     )
     assert not form.is_valid()
     assert error_message in form.errors["commodity"]
-
-    empty = {}
-    form = forms.MeasureCommodityAndDutiesForm(
-        empty,
-        prefix="",
-        measure_start_date=date_ranges.normal,
-    )
-    assert not form.is_valid()
-    assert "This field is required." in form.errors["commodity"]
 
 
 def test_measure_forms_conditions_form_valid_data():

--- a/measures/tests/test_forms.py
+++ b/measures/tests/test_forms.py
@@ -457,6 +457,43 @@ def test_measure_forms_duties_form(duties, is_valid, duty_sentence_parser, date_
         assert "Enter a valid duty sentence." in form.errors["__all__"]
 
 
+@pytest.mark.parametrize(
+    "commodity, error_message",
+    [
+        (
+            "test",
+            "Select a valid choice. That choice is not one of the available choices.",
+        ),
+        ("", "This field is required."),
+    ],
+)
+def test_measure_forms_comm_and_duties_form_invalid(
+    commodity,
+    error_message,
+    duty_sentence_parser,
+    date_ranges,
+):
+    data = {
+        "commodity": commodity,
+    }
+    form = forms.MeasureCommodityAndDutiesForm(
+        data,
+        prefix="",
+        measure_start_date=date_ranges.normal,
+    )
+    assert not form.is_valid()
+    assert error_message in form.errors["commodity"]
+
+    empty = {}
+    form = forms.MeasureCommodityAndDutiesForm(
+        empty,
+        prefix="",
+        measure_start_date=date_ranges.normal,
+    )
+    assert not form.is_valid()
+    assert "This field is required." in form.errors["commodity"]
+
+
 def test_measure_forms_conditions_form_valid_data():
     """Tests that MeasureConditionsForm is valid when initialised with minimal
     required fields."""


### PR DESCRIPTION
# TP2000-763 Add error message to commodity and duties form

## Why
The commodity and duties form in the create measure journey is lacking an error message to say that a selection is required if a user tries to continue without selecting a commodity.

## What
- Overrides `non_form_errors()` to provide a more meaningful error message
- Adds unit test

<img width="450" alt="Screenshot 2023-02-24 at 15 52 39" src="https://user-images.githubusercontent.com/118175145/221520739-69998c6a-7912-41fb-a17c-ca7a7430c5fa.png">

