### PR TITLE
TP2000-749: Add quota step to multiple measures edit form

### DIFF
--- a/measures/conditions.py
+++ b/measures/conditions.py
@@ -14,7 +14,16 @@ def show_step_end_date(wizard):
         return MeasureEditSteps.END_DATE.value in cleaned_data.get("fields_to_edit")
 
 
+def show_step_quota_order_number(wizard):
+    cleaned_data = wizard.get_cleaned_data_for_step(START)
+    if cleaned_data:
+        return MeasureEditSteps.QUOTA_ORDER_NUMBER.value in cleaned_data.get(
+            "fields_to_edit",
+        )
+
+
 measure_edit_condition_dict = {
     MeasureEditSteps.START_DATE: show_step_start_date,
     MeasureEditSteps.END_DATE: show_step_end_date,
+    MeasureEditSteps.QUOTA_ORDER_NUMBER: show_step_quota_order_number,
 }

--- a/measures/constants.py
+++ b/measures/constants.py
@@ -6,3 +6,4 @@ START = "start"
 class MeasureEditSteps(models.TextChoices):
     START_DATE = ("start_date", "Start date")
     END_DATE = ("end_date", "End date")
+    QUOTA_ORDER_NUMBER = ("quota_order_number", "Quota order number")

--- a/measures/jinja2/measures/edit-multiple-start.jinja
+++ b/measures/jinja2/measures/edit-multiple-start.jinja
@@ -13,9 +13,9 @@
     <div class="govuk-grid-column-two-thirds govuk-!-padding-right-9">
       <span class="govuk-caption-l">{{ page_subtitle|default("") }}</span>
       <h1 class="govuk-heading-xl">{{ page_title }}</h1>
-            <p class="govuk-body"> You are about to edit the start and/or end dates of your selected measures.</p>
+            <p class="govuk-body"> You are about to edit one or more fields for your selected measures.</p>
       {{ govukWarningText({
-        "text": "You are currently only able to change the start and end dates of multiple measures.",
+        "text": "You are currently only able to change certain fields of multiple measures. These are listed below.",
         "iconFallbackText": "Warning"
       }) }}
     

--- a/measures/views.py
+++ b/measures/views.py
@@ -207,12 +207,11 @@ class MeasureEditWizard(
         (START, forms.MeasuresEditFieldsForm),
         (MeasureEditSteps.START_DATE, forms.MeasureStartDateForm),
         (MeasureEditSteps.END_DATE, forms.MeasureEndDateForm),
+        (MeasureEditSteps.QUOTA_ORDER_NUMBER, forms.MeasureQuotaOrderNumberForm),
     ]
 
     templates = {
         START: "measures/edit-multiple-start.jinja",
-        MeasureEditSteps.START_DATE: "measures/edit-wizard-step.jinja",
-        MeasureEditSteps.END_DATE: "measures/edit-wizard-step.jinja",
     }
 
     step_metadata = {
@@ -227,6 +226,10 @@ class MeasureEditWizard(
         MeasureEditSteps.END_DATE: {
             "title": "Edit the end date",
             "link_text": "End date",
+        },
+        MeasureEditSteps.QUOTA_ORDER_NUMBER: {
+            "title": "Edit the quota order number",
+            "link_text": "Quota order number",
         },
     }
 
@@ -248,7 +251,7 @@ class MeasureEditWizard(
 
     def get_form_kwargs(self, step):
         kwargs = {}
-        if step != START:
+        if step not in [START, MeasureEditSteps.QUOTA_ORDER_NUMBER]:
             kwargs["selected_measures"] = self.get_queryset()
         return kwargs
 
@@ -258,6 +261,7 @@ class MeasureEditWizard(
         workbasket = WorkBasket.current(self.request)
         new_start_date = None
         new_end_date = None
+        new_quota_order_number = None
         if cleaned_data.get("start_date"):
             new_start_date = datetime.date(
                 cleaned_data["start_date"].year,
@@ -270,6 +274,7 @@ class MeasureEditWizard(
                 cleaned_data["end_date"].month,
                 cleaned_data["end_date"].day,
             )
+        new_quota_order_number = cleaned_data.get("order_number", None)
         for measure in selected_measures:
             measure.new_version(
                 workbasket=workbasket,
@@ -280,6 +285,9 @@ class MeasureEditWizard(
                     else measure.valid_between.lower,
                     upper=new_end_date if new_end_date else measure.valid_between.upper,
                 ),
+                order_number=new_quota_order_number
+                if new_quota_order_number
+                else measure.order_number,
             )
             self.session_store.clear()
 

--- a/measures/views.py
+++ b/measures/views.py
@@ -261,7 +261,6 @@ class MeasureEditWizard(
         workbasket = WorkBasket.current(self.request)
         new_start_date = None
         new_end_date = None
-        new_quota_order_number = None
         if cleaned_data.get("start_date"):
             new_start_date = datetime.date(
                 cleaned_data["start_date"].year,


### PR DESCRIPTION
# TP2000-749: Add quota step to multiple measures edit form
<!---
 * Include the JIRA ticket number, eg TP-123, to automatically link.
 * Use 50 characters maximum.
 * Do not end with a full-stop.
--->

## Why
<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Use as many lines as you like.
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions or deliberately ignored edge-cases.
--->
* Users need to be able to edit the quota order number on multiple measures

## What
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Explain like I'm 5.
 * Use pictures if you can.
--->
* Adds an extra step to the multiple measures edit wizard to allow editing of quota order number

<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
## Checklist
- Requires migrations?
- Requires dependency updates?
--->

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
<img width="751" alt="Screenshot 2023-02-27 at 14 32 34" src="https://user-images.githubusercontent.com/25905279/221591419-a73c21ab-13ef-4a5b-b6ea-20fead6b56f8.png">
<img width="766" alt="Screenshot 2023-02-27 at 14 32 56" src="https://user-images.githubusercontent.com/25905279/221591494-4ce82853-1457-40bd-9b52-097222b496f2.png">
