### PR TITLE
TP2000-791 Enable filtering by commodity code chapter

### DIFF
--- a/measures/filters.py
+++ b/measures/filters.py
@@ -75,6 +75,16 @@ class MeasureFilter(TamatoFilter):
         },
     )
 
+    goods_nomenclature__item_id = CharFilter(
+        label="Commodity code starts with:",
+        widget=forms.TextInput(
+            attrs={
+                "class": GOV_UK_TWO_THIRDS,
+            },
+        ),
+        lookup_expr="startswith",
+    )
+
     additional_code = AutoCompleteFilter(
         label="Additional code",
         field_name="additional_code",

--- a/measures/filters.py
+++ b/measures/filters.py
@@ -66,7 +66,7 @@ class MeasureFilter(TamatoFilter):
     )
 
     goods_nomenclature = AutoCompleteFilter(
-        label="Commodity code",
+        label="Specific commodity code",
         field_name="goods_nomenclature__item_id",
         queryset=GoodsNomenclature.objects.all(),
         attrs={
@@ -76,7 +76,7 @@ class MeasureFilter(TamatoFilter):
     )
 
     goods_nomenclature__item_id = CharFilter(
-        label="Commodity code starts with:",
+        label="Commodity code starts with",
         widget=forms.TextInput(
             attrs={
                 "class": GOV_UK_TWO_THIRDS,

--- a/measures/forms.py
+++ b/measures/forms.py
@@ -712,6 +712,7 @@ class MeasureFilterForm(forms.Form):
             Div(
                 Field.text("sid", field_width=Fluid.TWO_THIRDS),
                 "goods_nomenclature",
+                "goods_nomenclature__item_id",
                 "additional_code",
                 "order_number",
                 "measure_type",


### PR DESCRIPTION
# TP2000-791 Enable filtering by commodity code chapter
<!---
 * Include the JIRA ticket number, eg TP-123, to automatically link.
 * Use 50 characters maximum.
 * Do not end with a full-stop.
--->

## Why
<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Use as many lines as you like.
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions or deliberately ignored edge-cases.
--->
* Users need to quickly return all the measures for commodity codes under a certain chapter in the search page for multiple editing

## What
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Explain like I'm 5.
 * Use pictures if you can.
--->
* Adds an extra filter field for commodity codes starting with given digits
* Renames the existing commodity code filter field to 'Specific commodity code' for clarity

<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
## Checklist
- Requires migrations?
- Requires dependency updates?
--->

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->

![FireShot Capture 052 - Find and edit measures - Manage Trade Tariffs - localhost copy](https://user-images.githubusercontent.com/25905279/223405712-416f05ef-39a3-4074-aa3d-b48f1475e68a.png)

