### PR TITLE
TP2000-792 Queue multi-page display quirks

### DIFF
--- a/publishing/jinja2/includes/envelope-queue.jinja
+++ b/publishing/jinja2/includes/envelope-queue.jinja
@@ -88,7 +88,7 @@
 
 
   {%- set process_envelope_cell_content %}
-    {% if loop.index == 1 %}
+    {% if loop.index == 1 and page_obj.number == 1 %}
       {# First row. #}
       {{ process_envelope_content(obj) }}
     {% endif %}
@@ -96,7 +96,7 @@
 
 
   {%- set accept_envelope_cell_content %}
-    {% if loop.index == 1 %}
+    {% if loop.index == 1 and page_obj.number == 1 %}
       {# First row. #}
       {{ accept_envelope_link(obj) }}
     {% endif %}
@@ -104,7 +104,7 @@
 
 
   {%- set reject_cell_content %}
-    {% if loop.index == 1 %}
+    {% if loop.index == 1 and page_obj.number == 1 %}
       {# First row. #}
       {{ reject_envelope_link(obj) }}
     {% endif %}

--- a/publishing/jinja2/includes/packaged-workbasket-queue.jinja
+++ b/publishing/jinja2/includes/packaged-workbasket-queue.jinja
@@ -89,7 +89,7 @@
 
 
   {%- set order_cell_content %}
-    {% if loop.index == 1 %}
+    {% if loop.index == 1 and page_obj.number == 1 %}
       {# First row. #}
       {% if obj == currently_processing %}
         <span class="processing-state tamato-badge-light-green">CDS DOWNLOADED</span>
@@ -98,7 +98,7 @@
       {% else %}
         <span class="processing-state tamato-badge-light-purple">CDS NOTIFIED</span>
       {% endif %}
-    {% elif loop.index == 2 and currently_processing %}
+    {% elif loop.index == 2 and currently_processing and page_obj.number == 1 %}
       {# Second row. #}
       <button
         class="govuk-link fake-link"

--- a/publishing/jinja2/publishing/envelope_queue.jinja
+++ b/publishing/jinja2/publishing/envelope_queue.jinja
@@ -66,6 +66,4 @@
       {% include "includes/common/pagination.jinja" %}
     </div>
   </div>
-
-  {% include "includes/common/pagination.jinja" %}
 {% endblock %}

--- a/publishing/views.py
+++ b/publishing/views.py
@@ -151,6 +151,7 @@ class EnvelopeQueueView(
 ):
     """UI view used to download and manage envelope processing."""
 
+    paginate_by = 2
     model = PackagedWorkBasket
     permission_required = "publishing.consume_from_packaging_queue"
 


### PR DESCRIPTION
# TP2000-792 Queue multi-page display quirks
<!---
 * Include the JIRA ticket number, eg TP-123, to automatically link.
 * Use 50 characters maximum.
 * Do not end with a full-stop.
--->

## Why
<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Use as many lines as you like.
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions or deliberately ignored edge-cases.
--->
When multiple pages are necessary to display all queued items on the packaging and envelope queue views, the following issues appear:

- Two rows of page navigation are shown on the envelope queue page.
- On pages beyond the first page, the top-most row of the packaging queue page displays the “GENERATING ENVELOPE” notice.
- On pages beyond the first page, the top-most row of the envelope queue page displays the “GENERATING ENVELOPE” notice and the “Accept” and “Reject” placeholders.

## What
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Explain like I'm 5.
 * Use pictures if you can.
--->
Remove the extra page navigation from the envelope queue page.
Display correct information on the top-most queued item row for pages > 1.

<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
--->
## Checklist
- Requires migrations? No
- Requires dependency updates? No

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
