### PR TITLE
TP2000-793 fix slow approved_up_to_transaction() filtering

### DIFF
--- a/commodities/tests/test_commodity_tree_snapshot.py
+++ b/commodities/tests/test_commodity_tree_snapshot.py
@@ -89,6 +89,7 @@ def test_get_dependent_measures_ignores_archived_measures(
     assert Measure.objects.all().count() == 2
 
 
+@pytest.mark.skip("ARCHIVED still exists but should NEVER be used.")
 def test_get_dependent_measures_works_with_wonky_archived_measure(
     seed_database_with_indented_goods,
 ):

--- a/common/models/tracked_qs.py
+++ b/common/models/tracked_qs.py
@@ -22,7 +22,6 @@ from common.querysets import TransactionPartitionQuerySet
 from common.querysets import ValidityQuerySet
 from common.util import resolve_path
 from common.validators import UpdateType
-from workbaskets.validators import WorkflowStatus
 
 
 class TrackedModelQuerySet(
@@ -90,9 +89,6 @@ class TrackedModelQuerySet(
             .filter(latest=F("id"))
             .exclude(
                 update_type=UpdateType.DELETE,
-            )
-            .exclude(
-                transaction__workbasket__status=WorkflowStatus.ARCHIVED,
             )
         )
 

--- a/measures/tests/test_measure_snapshot.py
+++ b/measures/tests/test_measure_snapshot.py
@@ -60,13 +60,6 @@ def test_get_branch_measures(seed_database_with_indented_goods):
     old_regulation = factories.RegulationFactory.create(
         valid_between=TaricDateRange(date(1982, 1, 1), date(1982, 12, 31)),
     )
-    wonky_archived_measure = factories.MeasureFactory.create(
-        transaction=archived_transaction,
-        goods_nomenclature=goods,
-        generating_regulation=old_regulation,
-        terminating_regulation=old_regulation,
-        valid_between=TaricDateRange(date.today() + timedelta(days=-100)),
-    )
 
     draft_transaction = factories.TransactionFactory.create(draft=True)
     draft_measure = factories.MeasureFactory.create(


### PR DESCRIPTION
# TP2000-793 fix slow queryset filtering
<!---
 * Include the JIRA ticket number, eg TP-123, to automatically link.
 * Use 50 characters maximum.
 * Do not end with a full-stop.
--->

## Why
<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Use as many lines as you like.
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions or deliberately ignored edge-cases.
--->
`TrackedModelQuerySet.approved_up_to_transaction()` was updated to exclude ARCHIVED workbaskets from the queryset, which degraded response times.

## What
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Explain like I'm 5.
 * Use pictures if you can.
--->
All ARCHIVED workbaskets have been cleared and removed as part of [a separate task](https://uktrade.atlassian.net/browse/TOPS-1090). ARCHIVED workbaskets should never be used again now that the use case for their use has gone - single, system-wide workbaskets that needed to be swapped in and out of EDITING status. The problematic `exclude()` has therefore now been removed from `TrackedModelQuerySet.approved_up_to_transaction()`. Two tests that considered the use of ARCHIVED workbasket have also been amended.

<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
--->
## Checklist
- Requires migrations? No
- Requires dependency updates? No

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
