### PR TITLE
TP2000-799 Amend "create a new measure" link on Find and Edit measures page

### DIFF
--- a/measures/jinja2/measures/search.jinja
+++ b/measures/jinja2/measures/search.jinja
@@ -6,7 +6,6 @@
 
 {% set form_url = "measure-ui-list" %}
 {% set list_include = "includes/measures/list.jinja" %}
-{% set create_url = create_url or "create" %}
 
 {% set page_title = "Find and edit " ~ object_list.model._meta.verbose_name_plural %}
 
@@ -14,7 +13,7 @@
   <h1 class="govuk-heading-xl">{{ page_title }}</h1>
   <p class="govuk-body">
     Search for {{object_list.model._meta.verbose_name_plural}}.
-    Alternatively, <a class="govuk-link" href="{{ create_url }}">create a new {{ object_list.model._meta.verbose_name }}</a>.
+    Alternatively, <a class="govuk-link" href="{{ url("measure-ui-create") }}">create a new {{ object_list.model._meta.verbose_name }}</a>.
   </p>
 
   <div class="filter-layout full-width-search">


### PR DESCRIPTION
# TP2000-799 Amend "create a new measure" link on Find and edit measures page

## Why
The “create a new measure” link on the Find and edit measures page (measures/search) resolves to an incorrect url (measures/search/create), resulting in a page not found 404 error.

## What
- Corrects the url that 'create a new measure' link uses
