### PR TITLE
TP2000-767  Prevent duplicate footnote selection

### DIFF
--- a/measures/forms.py
+++ b/measures/forms.py
@@ -1147,7 +1147,7 @@ class MeasureFootnotesFormSet(FormSet):
         footnotes = [d["footnote"] for d in cleaned_data if "footnote" in d]
         num_unique = len(set(footnotes))
         if len(footnotes) != num_unique:
-            raise ValidationError("The same footnote cannot be selected more than once")
+            raise ValidationError("The same footnote cannot be added more than once")
         return cleaned_data
 
 

--- a/measures/forms.py
+++ b/measures/forms.py
@@ -1143,6 +1143,13 @@ class MeasureFootnotesFormSet(FormSet):
     form = MeasureFootnotesForm
 
     def clean(self):
+        """
+        Hook for formset-wide cleaning to check if the same footnote has been
+        added more than once.
+
+        If so, raises a ValidationError that will be accessibile via
+        formset.non_form_errors()
+        """
         cleaned_data = super().cleaned_data
         footnotes = [d["footnote"] for d in cleaned_data if "footnote" in d]
         num_unique = len(set(footnotes))

--- a/measures/forms.py
+++ b/measures/forms.py
@@ -1142,6 +1142,14 @@ class MeasureFootnotesForm(forms.Form):
 class MeasureFootnotesFormSet(FormSet):
     form = MeasureFootnotesForm
 
+    def clean(self):
+        cleaned_data = super().cleaned_data
+        footnotes = [d["footnote"] for d in cleaned_data if "footnote" in d]
+        num_unique = len(set(footnotes))
+        if len(footnotes) != num_unique:
+            raise ValidationError("The same footnote cannot be selected more than once")
+        return cleaned_data
+
 
 class MeasureUpdateFootnotesForm(MeasureFootnotesForm):
     """

--- a/measures/tests/test_forms.py
+++ b/measures/tests/test_forms.py
@@ -1034,6 +1034,5 @@ def test_measure_forms_footnotes_invalid():
     formset = forms.MeasureFootnotesFormSet(data)
     assert not formset.is_valid()
     assert (
-        "The same footnote cannot be selected more than once"
-        in formset.non_form_errors()
+        "The same footnote cannot be added more than once" in formset.non_form_errors()
     )

--- a/measures/tests/test_forms.py
+++ b/measures/tests/test_forms.py
@@ -1004,3 +1004,36 @@ def test_measure_end_date_validation_fail():
         "The end date cannot be before the start date: Start date 01/01/2000 does not start before 01/01/1999"
         in form.errors["__all__"]
     )
+
+
+def test_measure_forms_footnotes_valid():
+    footnote = factories.FootnoteFactory.create()
+    data = {
+        "footnote": footnote.pk,
+    }
+    form = forms.MeasureFootnotesForm(data, prefix="")
+    assert form.is_valid()
+    assert form.cleaned_data["footnote"] == footnote
+
+
+def test_measure_forms_footnotes_invalid():
+    data = {
+        "footnote": "foo",
+    }
+    form = forms.MeasureFootnotesForm(data, prefix="")
+    assert form.errors["footnote"] == [
+        "Select a valid choice. That choice is not one of the available choices.",
+    ]
+    assert not form.is_valid()
+
+    footnote = factories.FootnoteFactory.create()
+    data = {
+        "form-0-footnote": footnote.pk,
+        "form-1-footnote": footnote.pk,
+    }
+    formset = forms.MeasureFootnotesFormSet(data)
+    assert not formset.is_valid()
+    assert (
+        "The same footnote cannot be selected more than once"
+        in formset.non_form_errors()
+    )


### PR DESCRIPTION
# TP2000-767  Prevent duplicate footnote selection

## Why
Users should not be able to add the same footnote more than once in the footnotes form step of the create measure journey.

## What
- Displays an error if the same footnote is added multiple times
- Adds missing unit tests for the form

<img width="450" alt="Screenshot 2023-03-13 at 15 45 50" src="https://user-images.githubusercontent.com/118175145/224753757-a91cdf19-d986-47a3-8072-9a218adfa7b3.png">

