### PR TITLE
TP2000-772  Add duties to multiple measures edit journey

### DIFF
--- a/measures/conditions.py
+++ b/measures/conditions.py
@@ -28,9 +28,16 @@ def show_step_regulation(wizard):
         return MeasureEditSteps.REGULATION.value in cleaned_data.get("fields_to_edit")
 
 
+def show_step_duties(wizard):
+    cleaned_data = wizard.get_cleaned_data_for_step(START)
+    if cleaned_data:
+        return MeasureEditSteps.DUTIES.value in cleaned_data.get("fields_to_edit")
+
+
 measure_edit_condition_dict = {
     MeasureEditSteps.START_DATE: show_step_start_date,
     MeasureEditSteps.END_DATE: show_step_end_date,
     MeasureEditSteps.QUOTA_ORDER_NUMBER: show_step_quota_order_number,
     MeasureEditSteps.REGULATION: show_step_regulation,
+    MeasureEditSteps.DUTIES: show_step_duties,
 }

--- a/measures/constants.py
+++ b/measures/constants.py
@@ -8,3 +8,4 @@ class MeasureEditSteps(models.TextChoices):
     END_DATE = ("end_date", "End date")
     QUOTA_ORDER_NUMBER = ("quota_order_number", "Quota order number")
     REGULATION = ("regulation", "Regulation")
+    DUTIES = ("duties", "Duties")

--- a/measures/forms.py
+++ b/measures/forms.py
@@ -1335,3 +1335,47 @@ class MeasureRegulationForm(forms.Form):
                 data_prevent_double_click="true",
             ),
         )
+
+
+class MeasureDutiesForm(forms.Form):
+    duties = forms.CharField(
+        label="Duties",
+        help_text="Enter the duty that applies to the measures.",
+    )
+
+    def __init__(self, *args, **kwargs):
+        self.selected_measures = kwargs.pop("selected_measures", None)
+        self.measures_start_date = kwargs.pop("measures_start_date", None)
+        super().__init__(*args, **kwargs)
+
+        self.helper = FormHelper(self)
+        self.helper.form_tag = False
+        self.helper.legend_size = Size.SMALL
+        self.helper.layout = Layout(
+            Fieldset(
+                "duties",
+                HTML.details(
+                    "Help with duties",
+                    "This is expressed as a percentage (for example, 4%), "
+                    "a specific duty (for example, 33 GBP/100kg) "
+                    "or a compound duty (for example, 3.5% + 11 GBP / 100 kg).",
+                ),
+            ),
+            Submit(
+                "submit",
+                "Save measure duties",
+                data_module="govuk-button",
+                data_prevent_double_click="true",
+            ),
+        )
+
+    def clean(self):
+        cleaned_data = super().clean()
+        duties = cleaned_data.get("duties", "")
+        if self.measures_start_date:
+            validate_duties(duties, self.measures_start_date)
+        else:
+            for measure in self.selected_measures:
+                validate_duties(duties, measure.valid_between.lower)
+
+        return cleaned_data

--- a/measures/tests/test_views.py
+++ b/measures/tests/test_views.py
@@ -1781,11 +1781,9 @@ def test_multiple_measure_edit_only_duties(
             "measure-ui-edit-multiple",
             kwargs={"step": step_data["data"][STEP_KEY]},
         )
-        print(url)
         response = valid_user_client.get(url)
         assert response.status_code == 200
 
-        print(step_data["data"])
         response = valid_user_client.post(url, step_data["data"])
         assert response.status_code == 302
 


### PR DESCRIPTION
# TP2000-772  Add duties to multiple measures edit journey

## Why
Users need to be able to edit duties for multiple measures.

## What
- Adds duties step to multiple measures edit wizard to allow editing duties

<img width="250" alt="Screenshot 2023-03-17 at 10 36 16" src="https://user-images.githubusercontent.com/118175145/225883304-05d11ca2-fc61-4761-a3d0-74ad874dfb80.png">
<img width="500" alt="Screenshot 2023-03-17 at 10 36 50" src="https://user-images.githubusercontent.com/118175145/225883314-0b67280d-4513-4d17-a51d-f5b1c8d6b979.png">
