### PR TITLE
TP2000-814 Preserve footnote associations on measures edit

### DIFF
--- a/measures/tests/test_views.py
+++ b/measures/tests/test_views.py
@@ -1805,6 +1805,83 @@ def test_multiple_measure_edit_only_duties(
         assert measure.duty_sentence == duties
 
 
+def test_multiple_measure_edit_preserves_footnote_associations(
+    valid_user_client,
+    session_workbasket,
+):
+    """Tests that footnote associations are preserved in MeasureEditWizard."""
+
+    measure = factories.MeasureFactory.create()
+    footnote_association = factories.FootnoteAssociationMeasureFactory.create(
+        footnoted_measure=measure,
+    )
+    exp_footnote = measure.footnotes.first()
+
+    url = reverse("measure-ui-edit-multiple")
+    session = valid_user_client.session
+    session.update(
+        {
+            "workbasket": {
+                "id": session_workbasket.pk,
+                "status": session_workbasket.status,
+                "title": session_workbasket.title,
+            },
+            "MULTIPLE_MEASURE_SELECTIONS": {
+                measure.pk: 1,
+            },
+        },
+    )
+    session.save()
+
+    STEP_KEY = "measure_edit_wizard-current_step"
+
+    wizard_data = [
+        {
+            "data": {
+                STEP_KEY: START,
+                "start-fields_to_edit": [MeasureEditSteps.START_DATE],
+            },
+            "next_step": MeasureEditSteps.START_DATE,
+        },
+        {
+            "data": {
+                STEP_KEY: MeasureEditSteps.START_DATE,
+                "start_date-start_date_0": "01",
+                "start_date-start_date_1": "01",
+                "start_date-start_date_2": "2000",
+            },
+            "next_step": "complete",
+        },
+    ]
+    for step_data in wizard_data:
+        url = reverse(
+            "measure-ui-edit-multiple",
+            kwargs={"step": step_data["data"][STEP_KEY]},
+        )
+        response = valid_user_client.get(url)
+        assert response.status_code == 200
+
+        response = valid_user_client.post(url, step_data["data"])
+        assert response.status_code == 302
+
+        assert response.url == reverse(
+            "measure-ui-edit-multiple",
+            kwargs={"step": step_data["next_step"]},
+        )
+
+    workbasket_measures = Measure.objects.filter(
+        trackedmodel_ptr__transaction__workbasket_id=session_workbasket.id,
+    ).order_by("sid")
+
+    complete_response = valid_user_client.get(response.url)
+    # on success, the page redirects to the workbasket page
+    assert complete_response.status_code == 302
+    assert valid_user_client.session["MULTIPLE_MEASURE_SELECTIONS"] == {}
+    for measure in workbasket_measures:
+        assert measure.update_type == UpdateType.UPDATE
+        assert measure.footnotes.first() == exp_footnote
+
+
 def test_measure_list_redirects_to_search_with_no_params(valid_user_client):
     response = valid_user_client.get(reverse("measure-ui-list"))
     assert response.status_code == 302

--- a/measures/tests/test_views.py
+++ b/measures/tests/test_views.py
@@ -1815,8 +1815,8 @@ def test_multiple_measure_edit_preserves_footnote_associations(
     footnote_association = factories.FootnoteAssociationMeasureFactory.create(
         footnoted_measure=measure,
     )
-    exp_footnote_count = measure.footnotes.count()
-    exp_footnotes = measure.footnotes.all()
+    expected_footnote_count = measure.footnotes.count()
+    expected_footnotes = measure.footnotes.all()
 
     url = reverse("measure-ui-edit-multiple")
     session = valid_user_client.session
@@ -1880,9 +1880,9 @@ def test_multiple_measure_edit_preserves_footnote_associations(
     assert valid_user_client.session["MULTIPLE_MEASURE_SELECTIONS"] == {}
     for measure in workbasket_measures:
         assert measure.update_type == UpdateType.UPDATE
-        assert measure.footnotes.count() == exp_footnote_count
+        assert measure.footnotes.count() == expected_footnote_count
         for footnote in measure.footnotes.all():
-            assert footnote in exp_footnotes
+            assert footnote in expected_footnotes
 
 
 def test_measure_list_redirects_to_search_with_no_params(valid_user_client):

--- a/measures/tests/test_views.py
+++ b/measures/tests/test_views.py
@@ -1815,7 +1815,8 @@ def test_multiple_measure_edit_preserves_footnote_associations(
     footnote_association = factories.FootnoteAssociationMeasureFactory.create(
         footnoted_measure=measure,
     )
-    exp_footnote = measure.footnotes.first()
+    exp_footnote_count = measure.footnotes.count()
+    exp_footnotes = measure.footnotes.all()
 
     url = reverse("measure-ui-edit-multiple")
     session = valid_user_client.session
@@ -1870,7 +1871,7 @@ def test_multiple_measure_edit_preserves_footnote_associations(
         )
 
     workbasket_measures = Measure.objects.filter(
-        trackedmodel_ptr__transaction__workbasket_id=session_workbasket.id,
+        transaction__workbasket=session_workbasket,
     ).order_by("sid")
 
     complete_response = valid_user_client.get(response.url)
@@ -1879,7 +1880,9 @@ def test_multiple_measure_edit_preserves_footnote_associations(
     assert valid_user_client.session["MULTIPLE_MEASURE_SELECTIONS"] == {}
     for measure in workbasket_measures:
         assert measure.update_type == UpdateType.UPDATE
-        assert measure.footnotes.first() == exp_footnote
+        assert measure.footnotes.count() == exp_footnote_count
+        for footnote in measure.footnotes.all():
+            assert footnote in exp_footnotes
 
 
 def test_measure_list_redirects_to_search_with_no_params(valid_user_client):

--- a/measures/views.py
+++ b/measures/views.py
@@ -317,7 +317,7 @@ class MeasureEditWizard(
         new_generating_regulation = cleaned_data.get("generating_regulation", None)
         new_duties = cleaned_data.get("duties", None)
         for measure in selected_measures:
-            measure.new_version(
+            new_measure = measure.new_version(
                 workbasket=workbasket,
                 update_type=UpdateType.UPDATE,
                 valid_between=TaricDateRange(
@@ -335,11 +335,20 @@ class MeasureEditWizard(
             )
             if new_duties:
                 diff_components(
-                    instance=measure,
+                    instance=new_measure,
                     duty_sentence=new_duties,
-                    start_date=measure.valid_between.lower,
+                    start_date=new_measure.valid_between.lower,
                     workbasket=workbasket,
                     transaction=workbasket.current_transaction,
+                )
+            footnote_associations = FootnoteAssociationMeasure.objects.current().filter(
+                footnoted_measure=measure,
+            )
+            for fa in footnote_associations:
+                fa.new_version(
+                    workbasket=workbasket,
+                    update_type=UpdateType.UPDATE,
+                    footnoted_measure=new_measure,
                 )
             self.session_store.clear()
 


### PR DESCRIPTION
# TP2000-814 Preserve footnote associations on measures edit

## Why
When a measure is updated through the multiple measures edit journey, footnote associations present on the measure aren't being preserved on the new version of the measure because the association is based on the old measure's pk.

## What
- Updates existing footnote associations with the new version of the measure. 
- Adds unit test

## 

<img width="450" alt="Screenshot 2023-03-21 at 14 19 56" src="https://user-images.githubusercontent.com/118175145/226649551-1d312b89-209f-44f4-8aa4-56c3a0f59164.png">
