### PR TITLE
TP2000 775 automation copy changes

### DIFF
--- a/common/forms.py
+++ b/common/forms.py
@@ -161,7 +161,7 @@ class WorkbasketActions(TextChoices):
 
 
 class DITTariffManagerActions(TextChoices):
-    PACKAGE_WORKBASKETS = "PACKAGE_WORKBASKETS", "Order and package workbaskets"
+    PACKAGE_WORKBASKETS = "PACKAGE_WORKBASKETS", "Package Workbaskets"
 
 
 class HMRCCDSManagerActions(TextChoices):

--- a/common/tests/test_views.py
+++ b/common/tests/test_views.py
@@ -20,7 +20,7 @@ def test_index_displays_workbasket_action_form(valid_user_client):
     page = BeautifulSoup(str(response.content), "html.parser")
     assert "Create new workbasket" in page.select("label")[0].text
     assert "Select an existing workbasket" in page.select("label")[1].text
-    assert "Order and package workbaskets" in page.select("label")[2].text
+    assert "Package Workbaskets" in page.select("label")[2].text
     assert "Process envelopes" in page.select("label")[3].text
     assert "Search the tariff" in page.select("label")[4].text
 

--- a/publishing/forms.py
+++ b/publishing/forms.py
@@ -31,7 +31,7 @@ class LoadingReportForm(ModelForm):
         self.helper.layout = Layout(
             Field("file"),
             Field.textarea("comments", rows=5),
-            HTML.warning("Upon submission, DIT and HMRC will be notified."),
+            HTML.warning("Upon submission, DBT and HMRC will be notified."),
             Submit(
                 "submit",
                 "Submit",

--- a/publishing/jinja2/includes/queue-paused.jinja
+++ b/publishing/jinja2/includes/queue-paused.jinja
@@ -7,7 +7,7 @@
 
 <div class="govuk-grid-column-three-quarters">
   {{ govukWarningText({
-    "text": "Queue paused. Click the 'Unpause CDS queue' button to resume ordering.",
+    "text": "Queue stopped. Click the 'Start CDS queue' button to resume ordering.",
     "iconFallbackText": "Warning",
     "classes": "govuk-!-margin-bottom-0",
   }) }}
@@ -23,7 +23,7 @@
       name="unpause_queue"
       value="unpause_queue"
     >
-      Unpause CDS queue
+      Start CDS queue
       <img
         class="icon icon-unpause-cds-queue"
         src="{{ static('/common/images/play-arrow-rounded.svg') }}"

--- a/publishing/jinja2/includes/queue-unpaused.jinja
+++ b/publishing/jinja2/includes/queue-unpaused.jinja
@@ -32,7 +32,7 @@
       name="pause_queue"
       value="pause_queue"
     >
-      Pause CDS queue
+      Stop CDS queue
       <img
         class="icon icon-pause-cds-queue"
         src="{{ static('/common/images/pause-outline.svg') }}"

--- a/publishing/jinja2/includes/queue-unpaused.jinja
+++ b/publishing/jinja2/includes/queue-unpaused.jinja
@@ -3,7 +3,7 @@
 
 
 <div class="govuk-grid-column-full">
-  <h2 class="govuk-heading-m">Workbaskets - Ready to order</h2>
+  <h2 class="govuk-heading-m">Workbaskets Queue</h2>
 </div>
 
 <div class="govuk-grid-column-three-quarters">

--- a/publishing/jinja2/publishing/complete-envelope-processing-confirm.jinja
+++ b/publishing/jinja2/publishing/complete-envelope-processing-confirm.jinja
@@ -21,9 +21,9 @@
 
 {% set notified_message %}
   {% if page_title == "Accept envelope confirmation" %}
-    Email was sent to inform DIT.
+    Email was sent to inform DBT.
   {% else %}
-    The DIT team has been notified of the rejection. Once the envelope has been corrected, new envelopes will be available for download.
+    The DBT team has been notified of the rejection. Once the envelope has been corrected, new envelopes will be available for download.
   {% endif %}
 {% endset %}
 

--- a/publishing/jinja2/publishing/envelope_queue.jinja
+++ b/publishing/jinja2/publishing/envelope_queue.jinja
@@ -33,8 +33,9 @@
         {{ govukDetails({
           "summaryText": "How to process an envelope",
           "html": (
-            "<p>To begin, simply click on the \"Process envelope\" link "
-            "to alert DIT that you are currently processing this file. "
+
+            "<p>To begin, simply click on the \"Process envelope\" link"
+            "to alert DBT that you are currently processing this file. "
             "Click the \"Download envelope\" link to download the envelope "
             "in XML format. Once you ingest the envelope into CDS, you can "
             "use the options on the interface to accept or reject it. "

--- a/publishing/jinja2/publishing/envelope_queue.jinja
+++ b/publishing/jinja2/publishing/envelope_queue.jinja
@@ -25,7 +25,7 @@
     <div class="govuk-grid-column-full">
       {% if queue_paused %}
         {{ govukWarningText({
-          "text": "Queue paused. Awaiting DIT staff to restart the queue.",
+          "text": "Queue stopped. Awaiting DBT staff to restart the queue.",
           "iconFallbackText": "Warning",
           "classes": "govuk-!-margin-bottom-0",
         }) }}

--- a/publishing/jinja2/publishing/packaged_workbasket_queue.jinja
+++ b/publishing/jinja2/publishing/packaged_workbasket_queue.jinja
@@ -2,7 +2,7 @@
 
 {% from "components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
 
-{% set page_title = "Order and package workbaskets" %}
+{% set page_title = "Package Workbaskets" %}
 {% set list_include = "includes/packaged-workbasket-queue.jinja" %}
 
 {% block breadcrumb %}


### PR DESCRIPTION
# TP2000-775-automation-copy-changes


## Why
This PR holds a couple of content changes around the automation process. This includes things such as: 
- changing DIT to DBT
- changing pause and unpause to stop and start on the queue buttons
- renaming a couple of H1s an H2s from Order and Package workbaskets to Package Workbaskets



## Checklist
- Requires migrations? - no
- Requires dependency updates? - no


<!---
Links to relevant material
See: [ticket with all the changes in ](https://uktrade.atlassian.net/browse/TP2000-775)
--->
