### PR TITLE
TP2000-526 Remove measures limit in workbasket review view

### DIFF
--- a/workbaskets/views/ui.py
+++ b/workbaskets/views/ui.py
@@ -34,7 +34,6 @@ from common.views import WithPaginationListView
 from exporter.models import Upload
 from measures.filters import MeasureFilter
 from measures.models import Measure
-from measures.pagination import MeasurePaginator
 from workbaskets import forms
 from workbaskets.models import WorkBasket
 from workbaskets.session_store import SessionStore
@@ -243,7 +242,6 @@ class ReviewMeasuresWorkbasketView(PermissionRequiredMixin, TamatoListView):
 
     template_name = "workbaskets/review-workbasket.jinja"
     permission_required = "workbaskets.change_workbasket"
-    paginator_class = MeasurePaginator
     filterset_class = MeasureFilter
 
 


### PR DESCRIPTION
# TP2000-526 Remove measures limit in workbasket review view

## Why

The 'Review measures' view on the workbasket page is limited to 1000 measures. It has been proposed that this limit can now be removed.

## What
- Removes paginator class that set the limit from ReviewMeasuresWorkbasketView
