### PR TITLE
TP2000-798  Update geo areas view

### DIFF
--- a/common/jinja2/includes/common/actions.jinja
+++ b/common/jinja2/includes/common/actions.jinja
@@ -1,0 +1,15 @@
+<div class="govuk-grid-column-one-quarter">
+    <div class="app-related-items" role="complementary">
+        <h2 class="govuk-heading-s" id="subsection-title">Actions</h2>
+        <ul class="govuk-list govuk-!-font-size-16">
+        {% set edit_url = object.get_url('edit') %}
+        {% if edit_url %}
+            <li><a class="govuk-link" href="{{ edit_url }}">Edit this {{object._meta.verbose_name}}</a></li>
+        {% endif %}
+        {% set delete_url = object.get_url('delete') %}
+        {% if delete_url %}
+            <li><a class="govuk-link" href="{{ delete_url }}">Delete this {{object._meta.verbose_name}}</a></li>
+        {% endif %}
+        </ul>
+    </div>
+</div>

--- a/common/jinja2/includes/common/tabs/core_data.jinja
+++ b/common/jinja2/includes/common/tabs/core_data.jinja
@@ -7,20 +7,6 @@
         {% endblock %}
     </div>
     {% if not omit_actions and object.get_url('edit') %}
-        <div class="govuk-grid-column-one-quarter">
-            <div class="app-related-items" role="complementary">
-                <h2 class="govuk-heading-s" id="subsection-title">Actions</h2>
-                <ul class="govuk-list govuk-!-font-size-16">
-                    {% set edit_url = object.get_url('edit') %}
-                    {% if edit_url %}
-                        <li><a class="govuk-link" href="{{ edit_url }}">Edit this {{object._meta.verbose_name}}</a></li>
-                    {% endif %}
-                    {% set delete_url = object.get_url('delete') %}
-                    {% if delete_url %}
-                        <li><a class="govuk-link" href="{{ delete_url }}">Delete this {{object._meta.verbose_name}}</a></li>
-                    {% endif %}
-                </ul>
-            </div>
-        </div>
+        {% include "includes/common/actions.jinja"%}
     {% endif %}
 </div>

--- a/common/jinja2/includes/common/tabs/descriptions.jinja
+++ b/common/jinja2/includes/common/tabs/descriptions.jinja
@@ -18,7 +18,7 @@
         {{ description_row.append({"html": create_link(delete_url, "Delete") }) or "" }}
       {% endif %}
         {{ description_rows.append(description_row) or "" }}
-      {% endfor %}
+    {% endfor %}
 
     <h2 class="govuk-heading-l">Descriptions</h2>
     <p><a class="govuk-link" href={{object.get_url("description-create")}}>Create a new description</a></p>

--- a/common/jinja2/includes/common/tabs/descriptions.jinja
+++ b/common/jinja2/includes/common/tabs/descriptions.jinja
@@ -1,33 +1,38 @@
 {% from "components/table/macro.njk" import govukTable %}
 {% from 'macros/create_link.jinja' import create_link %}
 
-{% set description_rows = [] %}
-{% for description in object.get_descriptions() %}
-	{% set edit_url = description.get_url("edit") %}
-	{% set delete_url = description.get_url("delete") %}
-	{% set description_row = [
-		{"text": "{:%d %b %Y}".format(description.validity_start)},
-		{"text": description.description},
-	]%}
-	{% if not omit_actions and edit_url %}
-		{{ description_row.append({"html": create_link(edit_url, "Edit") }) or "" }}
-	{% endif %}
-	{% if not omit_actions and delete_url %}
-		{{ description_row.append({"html": create_link(delete_url, "Delete") }) or "" }}
-	{% endif %}
-	{{ description_rows.append(description_row) or "" }}
-{% endfor %}
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-three-quarters">
+	{% set description_rows = [] %}
+	{% for description in object.get_descriptions() %}
+		{% set edit_url = description.get_url("edit") %}
+		{% set delete_url = description.get_url("delete") %}
+		{% set description_row = [
+			{"text": "{:%d %b %Y}".format(description.validity_start)},
+			{"text": description.description},
+		]%}
+		{% if not omit_actions and edit_url %}
+			{{ description_row.append({"html": create_link(edit_url, "Edit") }) or "" }}
+		{% endif %}
+		{% if not omit_actions and delete_url %}
+			{{ description_row.append({"html": create_link(delete_url, "Delete") }) or "" }}
+		{% endif %}
+			{{ description_rows.append(description_row) or "" }}
+		{% endfor %}
 
-<h2 class="govuk-heading-l">Descriptions</h2>
-<p><a class="govuk-link" href={{object.get_url("description-create")}}>Create a new description</a></p>
-{% set head = [
-	{"text": "Start date", "classes":  "govuk-!-width-one-eighth"},
-	{"text": "Description"},
-]%}
-{% if not omit_actions and description_rows.0|length >= 3 %}
-	{{ head.append({"text": "Actions"}) or "" }}
-{% endif %}
-{{ govukTable({
-	"head": head,
-	"rows": description_rows
-}) }}
+		<h2 class="govuk-heading-l">Descriptions</h2>
+		<p><a class="govuk-link" href={{object.get_url("description-create")}}>Create a new description</a></p>
+		{% set head = [
+			{"text": "Start date", "classes":  "govuk-!-width-one-eighth"},
+			{"text": "Description"},
+		]%}
+		{% if not omit_actions and description_rows.0|length >= 3 %}
+			{{ head.append({"text": "Actions"}) or "" }}
+		{% endif %}
+		{{ govukTable({
+			"head": head,
+			"rows": description_rows
+		}) }}
+	</div>
+	{% include "includes/common/actions.jinja"%}
+</div>

--- a/common/jinja2/includes/common/tabs/descriptions.jinja
+++ b/common/jinja2/includes/common/tabs/descriptions.jinja
@@ -2,22 +2,22 @@
 {% from 'macros/create_link.jinja' import create_link %}
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-three-quarters">
-	{% set description_rows = [] %}
-	{% for description in object.get_descriptions() %}
-		{% set edit_url = description.get_url("edit") %}
-		{% set delete_url = description.get_url("delete") %}
-		{% set description_row = [
-			{"text": "{:%d %b %Y}".format(description.validity_start)},
-			{"text": description.description},
-		]%}
-		{% if not omit_actions and edit_url %}
-			{{ description_row.append({"html": create_link(edit_url, "Edit") }) or "" }}
-		{% endif %}
-		{% if not omit_actions and delete_url %}
-			{{ description_row.append({"html": create_link(delete_url, "Delete") }) or "" }}
-		{% endif %}
-			{{ description_rows.append(description_row) or "" }}
+	<div class="govuk-grid-column-three-quarters">
+		{% set description_rows = [] %}
+		{% for description in object.get_descriptions() %}
+			{% set edit_url = description.get_url("edit") %}
+			{% set delete_url = description.get_url("delete") %}
+			{% set description_row = [
+				{"text": "{:%d %b %Y}".format(description.validity_start)},
+				{"text": description.description},
+			]%}
+			{% if not omit_actions and edit_url %}
+				{{ description_row.append({"html": create_link(edit_url, "Edit") }) or "" }}
+			{% endif %}
+			{% if not omit_actions and delete_url %}
+				{{ description_row.append({"html": create_link(delete_url, "Delete") }) or "" }}
+			{% endif %}
+				{{ description_rows.append(description_row) or "" }}
 		{% endfor %}
 
 		<h2 class="govuk-heading-l">Descriptions</h2>

--- a/common/jinja2/includes/common/tabs/descriptions.jinja
+++ b/common/jinja2/includes/common/tabs/descriptions.jinja
@@ -2,37 +2,37 @@
 {% from 'macros/create_link.jinja' import create_link %}
 
 <div class="govuk-grid-row">
-	<div class="govuk-grid-column-three-quarters">
-		{% set description_rows = [] %}
-		{% for description in object.get_descriptions() %}
-			{% set edit_url = description.get_url("edit") %}
-			{% set delete_url = description.get_url("delete") %}
-			{% set description_row = [
-				{"text": "{:%d %b %Y}".format(description.validity_start)},
-				{"text": description.description},
-			]%}
-			{% if not omit_actions and edit_url %}
-				{{ description_row.append({"html": create_link(edit_url, "Edit") }) or "" }}
-			{% endif %}
-			{% if not omit_actions and delete_url %}
-				{{ description_row.append({"html": create_link(delete_url, "Delete") }) or "" }}
-			{% endif %}
-				{{ description_rows.append(description_row) or "" }}
-		{% endfor %}
+  <div class="govuk-grid-column-three-quarters">
+    {% set description_rows = [] %}
+    {% for description in object.get_descriptions() %}
+      {% set edit_url = description.get_url("edit") %}
+      {% set delete_url = description.get_url("delete") %}
+      {% set description_row = [
+        {"text": "{:%d %b %Y}".format(description.validity_start)},
+        {"text": description.description},
+      ]%}
+      {% if not omit_actions and edit_url %}
+        {{ description_row.append({"html": create_link(edit_url, "Edit") }) or "" }}
+      {% endif %}
+      {% if not omit_actions and delete_url %}
+        {{ description_row.append({"html": create_link(delete_url, "Delete") }) or "" }}
+      {% endif %}
+        {{ description_rows.append(description_row) or "" }}
+      {% endfor %}
 
-		<h2 class="govuk-heading-l">Descriptions</h2>
-		<p><a class="govuk-link" href={{object.get_url("description-create")}}>Create a new description</a></p>
-		{% set head = [
-			{"text": "Start date", "classes":  "govuk-!-width-one-eighth"},
-			{"text": "Description"},
-		]%}
-		{% if not omit_actions and description_rows.0|length >= 3 %}
-			{{ head.append({"text": "Actions"}) or "" }}
-		{% endif %}
-		{{ govukTable({
-			"head": head,
-			"rows": description_rows
-		}) }}
-	</div>
-	{% include "includes/common/actions.jinja"%}
+    <h2 class="govuk-heading-l">Descriptions</h2>
+    <p><a class="govuk-link" href={{object.get_url("description-create")}}>Create a new description</a></p>
+    {% set head = [
+      {"text": "Start date", "classes":  "govuk-!-width-one-eighth"},
+      {"text": "Description"},
+    ]%}
+    {% if not omit_actions and description_rows.0|length >= 3 %}
+      {{ head.append({"text": "Actions"}) or "" }}
+    {% endif %}
+    {{ govukTable({
+      "head": head,
+      "rows": description_rows
+    }) }}
+  </div>
+  {% include "includes/common/actions.jinja"%}
 </div>

--- a/geo_areas/jinja2/geo_areas/detail.jinja
+++ b/geo_areas/jinja2/geo_areas/detail.jinja
@@ -5,7 +5,8 @@
 {% from "components/table/macro.njk" import govukTable %}
 {% from "components/summary-list/macro.njk" import govukSummaryList %}
 
-{% set page_title = "Geographical area: " ~  object.area_id  %}
+{% set area_code = " (" ~ object.get_area_code_display() ~ ")" %}
+{% set page_title = "Geographical area: " ~  object.area_id ~ area_code %}
 
 {% set core_data_tab_html %}{% include "includes/geo_areas/tabs/core_data.jinja" %}{% endset %}
 {% set description_tab_html %}{% include "includes/common/tabs/descriptions.jinja" %}{% endset %}

--- a/geo_areas/jinja2/includes/geo_areas/tabs/core_data.jinja
+++ b/geo_areas/jinja2/includes/geo_areas/tabs/core_data.jinja
@@ -13,7 +13,7 @@
 				"value": {"text": object.get_description().description},
 				"actions": {"items": []}
 			},
-            {
+			{
 				"key": {"text": "Area code"},
 				"value": {"text": object.get_area_code_display()},
 				"actions": {"items": []}

--- a/geo_areas/jinja2/includes/geo_areas/tabs/core_data.jinja
+++ b/geo_areas/jinja2/includes/geo_areas/tabs/core_data.jinja
@@ -1,40 +1,40 @@
 <div class="geo_areas__core-data govuk-grid-row">
-	<div class="geo_areas__core-data__content govuk-grid-column-three-quarters">
-		<h2 class="govuk-heading-l">Details</h2>
-		{{ govukSummaryList({
-			"rows": [
-			{
-				"key": {"text": "Geographical area ID"},
-				"value": {"text": object.area_id},
-				"actions": {"items": []}
-			},
-			{
-				"key": {"text": "Description"},
-				"value": {"text": object.get_description().description},
-				"actions": {"items": []}
-			},
-			{
-				"key": {"text": "Area code"},
-				"value": {"text": object.get_area_code_display()},
-				"actions": {"items": []}
-			},
-			{
-				"key": {"text": "Start date"},
-				"value": {"text": "{:%d %b %Y}".format(object.valid_between.lower)},
-				"actions": {"items": []}
-			},
-			{
-				"key": {"text": "End date"},
-				"value": {"text": "{:%d %b %Y}".format(object.valid_between.upper) if object.valid_between.upper else "-"},
-				"actions": {"items": []}
-			},
-			{
-				"key": {"text": "Status"},
-				"value": {"text": object.transaction.workbasket.get_status_display()},
-				"actions": {"items": []}
-			},
-			]
-		})}}
-	</div>
-	{% include "includes/common/actions.jinja"%}
+  <div class="geo_areas__core-data__content govuk-grid-column-three-quarters">
+    <h2 class="govuk-heading-l">Details</h2>
+    {{ govukSummaryList({
+      "rows": [
+        {
+          "key": {"text": "Geographical area ID"},
+          "value": {"text": object.area_id},
+          "actions": {"items": []}
+        },
+        {
+          "key": {"text": "Description"},
+          "value": {"text": object.get_description().description},
+          "actions": {"items": []}
+        },
+        {
+          "key": {"text": "Area code"},
+          "value": {"text": object.get_area_code_display()},
+          "actions": {"items": []}
+        },
+        {
+          "key": {"text": "Start date"},
+          "value": {"text": "{:%d %b %Y}".format(object.valid_between.lower)},
+          "actions": {"items": []}
+        },
+        {
+          "key": {"text": "End date"},
+          "value": {"text": "{:%d %b %Y}".format(object.valid_between.upper) if object.valid_between.upper else "-"},
+          "actions": {"items": []}
+        },
+        {
+          "key": {"text": "Status"},
+          "value": {"text": object.transaction.workbasket.get_status_display()},
+          "actions": {"items": []}
+        },
+      ]
+    })}}
+  </div>
+  {% include "includes/common/actions.jinja"%}
 </div>

--- a/geo_areas/jinja2/includes/geo_areas/tabs/core_data.jinja
+++ b/geo_areas/jinja2/includes/geo_areas/tabs/core_data.jinja
@@ -1,5 +1,5 @@
-<div class="additional_code__core-data">
-	<div class="additional_code__core-data__content">
+<div class="geo_areas__core-data govuk-grid-row">
+	<div class="geo_areas__core-data__content govuk-grid-column-three-quarters">
 		<h2 class="govuk-heading-l">Details</h2>
 		{{ govukSummaryList({
 			"rows": [
@@ -36,4 +36,5 @@
 			]
 		})}}
 	</div>
+	{% include "includes/common/actions.jinja"%}
 </div>

--- a/geo_areas/jinja2/includes/geo_areas/tabs/memberships.jinja
+++ b/geo_areas/jinja2/includes/geo_areas/tabs/memberships.jinja
@@ -1,30 +1,35 @@
-<h2 class="govuk-heading-l">Memberships</h2>
-{% if object.get_area_code_display() in ["Country", "Region"] %}
-  <p class="govuk-body">This {{ object.get_area_code_display().lower() }} is a member of:</p>
-{% else %}
-  <p class="govuk-body">This {{ object.get_area_code_display().lower() }} has the following members:</p>
-{% endif %}
-{% set table_rows = [] %}
-{% for membership in object.get_current_memberships() %}
-  {{ table_rows.append([
-    {"text": "{:%d %b %Y}".format(membership.valid_between.lower)},
-    {"text": "{:%d %b %Y}".format(membership.valid_between.upper) if membership.valid_between.upper else "-"},
-    {"text": membership.other(object).area_id},
-    {"text": membership.other(object).get_description().description},
-    {"text": membership.other(object).get_area_code_display()},
-  ]) or "" }}
-{% endfor %}
-{% if table_rows == [] %}
-  <p class="govuk-body">There are no memberships for this geographical area.</p>
-{% else %}
-  {{ govukTable({
-    "head": [
-      {"text": "Start date"},
-      {"text": "End date"},
-      {"text": "ID"},
-      {"text": "Description", "classes": "govuk-!-width-one-half"},
-      {"text": "Area code"},
-    ],
-    "rows": table_rows
-  }) }}
-{% endif %}
+<div class="geo_areas__core-data govuk-grid-row">
+	<div class="geo_areas__core-data__content govuk-grid-column-three-quarters">
+    <h2 class="govuk-heading-l">Memberships</h2>
+    {% if object.get_area_code_display() in ["Country", "Region"] %}
+      <p class="govuk-body">This {{ object.get_area_code_display().lower() }} is a member of:</p>
+    {% else %}
+      <p class="govuk-body">This {{ object.get_area_code_display().lower() }} has the following members:</p>
+    {% endif %}
+    {% set table_rows = [] %}
+    {% for membership in object.get_current_memberships() %}
+      {{ table_rows.append([
+        {"text": "{:%d %b %Y}".format(membership.valid_between.lower)},
+        {"text": "{:%d %b %Y}".format(membership.valid_between.upper) if membership.valid_between.upper else "-"},
+        {"text": membership.other(object).area_id},
+        {"text": membership.other(object).get_description().description},
+        {"text": membership.other(object).get_area_code_display()},
+      ]) or "" }}
+    {% endfor %}
+    {% if table_rows == [] %}
+      <p class="govuk-body">There are no memberships for this geographical area.</p>
+    {% else %}
+      {{ govukTable({
+        "head": [
+          {"text": "Start date"},
+          {"text": "End date"},
+          {"text": "ID"},
+          {"text": "Description", "classes": "govuk-!-width-one-half"},
+          {"text": "Area code"},
+        ],
+        "rows": table_rows
+        }) }}
+      {% endif %}
+  </div>
+	{% include "includes/common/actions.jinja"%}
+</div>

--- a/geo_areas/jinja2/includes/geo_areas/tabs/memberships.jinja
+++ b/geo_areas/jinja2/includes/geo_areas/tabs/memberships.jinja
@@ -1,5 +1,5 @@
-<div class="geo_areas__core-data govuk-grid-row">
-  <div class="geo_areas__core-data__content govuk-grid-column-three-quarters">
+<div class="geo_areas__memberships govuk-grid-row">
+  <div class="geo_areas__memberships__content govuk-grid-column-three-quarters">
     <h2 class="govuk-heading-l">Memberships</h2>
     {% if object.get_area_code_display() in ["Country", "Region"] %}
       <p class="govuk-body">This {{ object.get_area_code_display().lower() }} is a member of:</p>

--- a/geo_areas/jinja2/includes/geo_areas/tabs/memberships.jinja
+++ b/geo_areas/jinja2/includes/geo_areas/tabs/memberships.jinja
@@ -1,4 +1,9 @@
 <h2 class="govuk-heading-l">Memberships</h2>
+{% if object.get_area_code_display() in ["Country", "Region"] %}
+  <p class="govuk-body">This {{ object.get_area_code_display().lower() }} is a member of:</p>
+{% else %}
+  <p class="govuk-body">This {{ object.get_area_code_display().lower() }} has the following members:</p>
+{% endif %}
 {% set table_rows = [] %}
 {% for membership in object.get_current_memberships() %}
   {{ table_rows.append([

--- a/geo_areas/jinja2/includes/geo_areas/tabs/memberships.jinja
+++ b/geo_areas/jinja2/includes/geo_areas/tabs/memberships.jinja
@@ -4,7 +4,7 @@
     {% if object.get_area_code_display() in ["Country", "Region"] %}
       <p class="govuk-body">This {{ object.get_area_code_display().lower() }} is a member of:</p>
     {% else %}
-      <p class="govuk-body">This {{ object.get_area_code_display().lower() }} has the following members:</p>
+      <p class="govuk-body">This geographical area group has the following members:</p>
     {% endif %}
     {% set table_rows = [] %}
     {% for membership in object.get_current_memberships() %}

--- a/geo_areas/jinja2/includes/geo_areas/tabs/memberships.jinja
+++ b/geo_areas/jinja2/includes/geo_areas/tabs/memberships.jinja
@@ -6,6 +6,7 @@
     {"text": "{:%d %b %Y}".format(membership.valid_between.upper) if membership.valid_between.upper else "-"},
     {"text": membership.other(object).area_id},
     {"text": membership.other(object).get_description().description},
+    {"text": membership.other(object).get_area_code_display()},
   ]) or "" }}
 {% endfor %}
 {% if table_rows == [] %}
@@ -16,7 +17,8 @@
       {"text": "Start date"},
       {"text": "End date"},
       {"text": "ID"},
-      {"text": "Description", "classes": "govuk-!-width-one-half"}
+      {"text": "Description", "classes": "govuk-!-width-one-half"},
+      {"text": "Area code"},
     ],
     "rows": table_rows
   }) }}

--- a/geo_areas/jinja2/includes/geo_areas/tabs/memberships.jinja
+++ b/geo_areas/jinja2/includes/geo_areas/tabs/memberships.jinja
@@ -1,5 +1,5 @@
 <div class="geo_areas__core-data govuk-grid-row">
-	<div class="geo_areas__core-data__content govuk-grid-column-three-quarters">
+  <div class="geo_areas__core-data__content govuk-grid-column-three-quarters">
     <h2 class="govuk-heading-l">Memberships</h2>
     {% if object.get_area_code_display() in ["Country", "Region"] %}
       <p class="govuk-body">This {{ object.get_area_code_display().lower() }} is a member of:</p>
@@ -29,7 +29,7 @@
         ],
         "rows": table_rows
         }) }}
-      {% endif %}
+    {% endif %}
   </div>
-	{% include "includes/common/actions.jinja"%}
+  {% include "includes/common/actions.jinja"%}
 </div>


### PR DESCRIPTION
# TP2000-798  Update geo areas view

## Why
Content on geo areas view could be improved to contextualise the data presented to users.

## What
- Adds area code to page title of a geo area
- Adds area code column to memberships tab
- Adds memberships table description
- Adds action pane to tabs

<img width="450" alt="Screenshot 2023-03-22 at 15 43 03" src="https://user-images.githubusercontent.com/118175145/226962617-68e7ea5c-04ab-4330-afd0-f2244afc7e79.png">

