### PR TITLE
TP2000-800  Implement geo area end-date editing

### DIFF
--- a/geo_areas/forms.py
+++ b/geo_areas/forms.py
@@ -39,7 +39,6 @@ class GeographicalAreaEndDateForm(ValidityPeriodForm):
         super().__init__(*args, **kwargs)
 
         self.fields["start_date"].required = False
-        self.fields["end_date"].required = False
 
         self.helper = FormHelper(self)
         self.helper.label_size = Size.SMALL

--- a/geo_areas/forms.py
+++ b/geo_areas/forms.py
@@ -39,10 +39,20 @@ class GeographicalAreaEndDateForm(ValidityPeriodForm):
         super().__init__(*args, **kwargs)
 
         self.fields["start_date"].required = False
-        self.fields[
-            "end_date"
-        ].help_text = (
-            "Leave empty if a geographical area is needed for an unlimited time"
+        self.fields["end_date"].required = False
+
+        self.helper = FormHelper(self)
+        self.helper.label_size = Size.SMALL
+        self.helper.legend_size = Size.SMALL
+
+        self.helper.layout = Layout(
+            "end_date",
+            Submit(
+                "submit",
+                "Save",
+                data_module="govuk-button",
+                data_prevent_double_click="true",
+            ),
         )
 
     def clean(self):

--- a/geo_areas/forms.py
+++ b/geo_areas/forms.py
@@ -1,6 +1,11 @@
+from crispy_forms_gds.helper import FormHelper
 from crispy_forms_gds.layout import Field
+from crispy_forms_gds.layout import Layout
+from crispy_forms_gds.layout import Size
+from crispy_forms_gds.layout import Submit
 
 from common.forms import CreateDescriptionForm
+from common.forms import ValidityPeriodForm
 from common.forms import delete_form_for
 from geo_areas.models import GeographicalArea
 from geo_areas.models import GeographicalAreaDescription
@@ -27,3 +32,42 @@ GeographicalAreaDeleteForm = delete_form_for(GeographicalArea)
 
 
 GeographicalAreaDescriptionDeleteForm = delete_form_for(GeographicalAreaDescription)
+
+
+class GeographicalAreaEndDateForm(ValidityPeriodForm):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self.fields["start_date"].required = False
+        self.fields[
+            "end_date"
+        ].help_text = (
+            "Leave empty if a geographical area is needed for an unlimited time"
+        )
+
+    def clean(self):
+        self.cleaned_data["start_date"] = self.instance.valid_between.lower
+        return super().clean()
+
+    class Meta:
+        model = GeographicalArea
+        fields = ("valid_between",)
+
+
+class GeographicalAreaEditForm(GeographicalAreaEndDateForm):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self.helper = FormHelper(self)
+        self.helper.label_size = Size.SMALL
+        self.helper.legend_size = Size.SMALL
+
+        self.helper.layout = Layout(
+            "end_date",
+            Submit(
+                "submit",
+                "Save",
+                data_module="govuk-button",
+                data_prevent_double_click="true",
+            ),
+        )

--- a/geo_areas/tests/test_forms.py
+++ b/geo_areas/tests/test_forms.py
@@ -1,9 +1,6 @@
-import datetime
-
 import pytest
 
 from common.tests import factories
-from common.util import TaricDateRange
 from geo_areas import forms
 
 pytestmark = pytest.mark.django_db
@@ -36,29 +33,25 @@ def test_geographical_area_create_description_form_invalid_data():
     assert "Enter the day, month and year" in form.errors["validity_start"]
 
 
-def test_geographical_area_end_date_form_valid():
-    valid_between = TaricDateRange(
-        datetime.date(1999, 1, 1),
-        datetime.date(1999, 9, 9),
+def test_geographical_area_end_date_form_valid(date_ranges):
+    geo_area = factories.GeographicalAreaFactory.create(
+        valid_between=date_ranges.normal,
     )
-    geo_area = factories.GeographicalAreaFactory.create(valid_between=valid_between)
 
     form_data = {
-        "end_date_0": "2",
-        "end_date_1": "2",
-        "end_date_2": "2000",
+        "end_date_0": date_ranges.later.upper.day,
+        "end_date_1": date_ranges.later.upper.month,
+        "end_date_2": date_ranges.later.upper.year,
     }
     form = forms.GeographicalAreaEndDateForm(data=form_data, instance=geo_area)
 
     assert form.is_valid()
 
 
-def test_geographical_area_end_date_form_invalid():
-    valid_between = TaricDateRange(
-        datetime.date(1999, 1, 1),
-        datetime.date(1999, 9, 9),
+def test_geographical_area_end_date_form_invalid(date_ranges):
+    geo_area = factories.GeographicalAreaFactory.create(
+        valid_between=date_ranges.normal,
     )
-    geo_area = factories.GeographicalAreaFactory.create(valid_between=valid_between)
 
     form_data = {
         "end_date_0": "z",

--- a/geo_areas/tests/test_forms.py
+++ b/geo_areas/tests/test_forms.py
@@ -1,6 +1,9 @@
+import datetime
+
 import pytest
 
 from common.tests import factories
+from common.util import TaricDateRange
 from geo_areas import forms
 
 pytestmark = pytest.mark.django_db
@@ -31,3 +34,37 @@ def test_geographical_area_create_description_form_invalid_data():
     assert "This field is required." in form.errors["described_geographicalarea"]
     assert "This field is required." in form.errors["description"]
     assert "Enter the day, month and year" in form.errors["validity_start"]
+
+
+def test_geographical_area_end_date_form_valid():
+    valid_between = TaricDateRange(
+        datetime.date(1999, 1, 1),
+        datetime.date(1999, 9, 9),
+    )
+    geo_area = factories.GeographicalAreaFactory.create(valid_between=valid_between)
+
+    form_data = {
+        "end_date_0": "2",
+        "end_date_1": "2",
+        "end_date_2": "2000",
+    }
+    form = forms.GeographicalAreaEndDateForm(data=form_data, instance=geo_area)
+
+    assert form.is_valid()
+
+
+def test_geographical_area_end_date_form_invalid():
+    valid_between = TaricDateRange(
+        datetime.date(1999, 1, 1),
+        datetime.date(1999, 9, 9),
+    )
+    geo_area = factories.GeographicalAreaFactory.create(valid_between=valid_between)
+
+    form_data = {
+        "end_date_0": "z",
+        "end_date_1": "z",
+        "end_date_2": "zzzz",
+    }
+    form = forms.GeographicalAreaEndDateForm(data=form_data, instance=geo_area)
+
+    assert not form.is_valid()

--- a/geo_areas/tests/test_views.py
+++ b/geo_areas/tests/test_views.py
@@ -1,3 +1,5 @@
+import datetime
+
 import pytest
 from bs4 import BeautifulSoup
 from rest_framework.reverse import reverse
@@ -9,6 +11,8 @@ from common.tests.util import assert_read_only_model_view_returns_list
 from common.tests.util import get_class_based_view_urls_matching_url
 from common.tests.util import view_is_subclass
 from common.tests.util import view_urlpattern_ids
+from common.util import TaricDateRange
+from common.validators import UpdateType
 from common.views import TamatoListView
 from common.views import TrackedModelDetailMixin
 from geo_areas.models import GeographicalArea
@@ -115,3 +119,58 @@ def test_geo_area_api_list_view(valid_user_client):
         expected_results,
         valid_user_client,
     )
+
+
+def test_geo_area_update_view_200(valid_user_client):
+    geo_area = factories.GeographicalAreaFactory.create()
+    url = reverse(
+        "geo_area-ui-edit",
+        kwargs={"sid": geo_area.sid},
+    )
+    response = valid_user_client.get(url)
+    assert response.status_code == 200
+
+
+def test_geo_area_edit_update_view_200(valid_user_client):
+    geo_area = factories.GeographicalAreaFactory.create()
+    url = reverse(
+        "geo_area-ui-edit-update",
+        kwargs={"sid": geo_area.sid},
+    )
+    response = valid_user_client.get(url)
+    assert response.status_code == 200
+
+
+def test_geo_area_update_view_edit_end_date(valid_user_client, session_workbasket):
+    valid_between = TaricDateRange(
+        datetime.date(1999, 1, 1),
+        datetime.date(1999, 9, 9),
+    )
+    geo_area = factories.GeographicalAreaFactory.create(valid_between=valid_between)
+
+    form_data = {
+        "end_date_0": "2",
+        "end_date_1": "2",
+        "end_date_2": "2000",
+    }
+    new_end_date = datetime.date(2000, 2, 2)
+
+    url = reverse(
+        "geo_area-ui-edit",
+        kwargs={"sid": geo_area.sid},
+    )
+    response = valid_user_client.post(url, form_data)
+    assert response.status_code == 302
+
+    redirect_url = reverse(
+        "geo_area-ui-confirm-update",
+        kwargs={"sid": geo_area.sid},
+    )
+    assert response.url == redirect_url
+
+    geo_areas = GeographicalArea.objects.filter(
+        transaction__workbasket=session_workbasket,
+    )
+    for geo_area in geo_areas:
+        assert geo_area.valid_between.upper == new_end_date
+        assert geo_area.update_type == UpdateType.UPDATE

--- a/geo_areas/tests/test_views.py
+++ b/geo_areas/tests/test_views.py
@@ -1,5 +1,3 @@
-import datetime
-
 import pytest
 from bs4 import BeautifulSoup
 from rest_framework.reverse import reverse
@@ -11,7 +9,6 @@ from common.tests.util import assert_read_only_model_view_returns_list
 from common.tests.util import get_class_based_view_urls_matching_url
 from common.tests.util import view_is_subclass
 from common.tests.util import view_urlpattern_ids
-from common.util import TaricDateRange
 from common.validators import UpdateType
 from common.views import TamatoListView
 from common.views import TrackedModelDetailMixin
@@ -141,19 +138,21 @@ def test_geo_area_edit_update_view_200(valid_user_client):
     assert response.status_code == 200
 
 
-def test_geo_area_update_view_edit_end_date(valid_user_client, session_workbasket):
-    valid_between = TaricDateRange(
-        datetime.date(1999, 1, 1),
-        datetime.date(1999, 9, 9),
+def test_geo_area_update_view_edit_end_date(
+    valid_user_client,
+    session_workbasket,
+    date_ranges,
+):
+    geo_area = factories.GeographicalAreaFactory.create(
+        valid_between=date_ranges.normal,
     )
-    geo_area = factories.GeographicalAreaFactory.create(valid_between=valid_between)
 
     form_data = {
-        "end_date_0": "2",
-        "end_date_1": "2",
-        "end_date_2": "2000",
+        "end_date_0": date_ranges.later.upper.day,
+        "end_date_1": date_ranges.later.upper.month,
+        "end_date_2": date_ranges.later.upper.year,
     }
-    new_end_date = datetime.date(2000, 2, 2)
+    new_end_date = date_ranges.later.upper
 
     url = reverse(
         "geo_area-ui-edit",

--- a/geo_areas/views.py
+++ b/geo_areas/views.py
@@ -12,11 +12,14 @@ from geo_areas import business_rules
 from geo_areas import forms
 from geo_areas.filters import GeographicalAreaFilter
 from geo_areas.forms import GeographicalAreaCreateDescriptionForm
+from geo_areas.forms import GeographicalAreaEditForm
 from geo_areas.models import GeographicalArea
 from geo_areas.models import GeographicalAreaDescription
 from workbaskets.models import WorkBasket
 from workbaskets.views.generic import CreateTaricCreateView
 from workbaskets.views.generic import CreateTaricDeleteView
+from workbaskets.views.generic import CreateTaricUpdateView
+from workbaskets.views.generic import EditTaricView
 
 
 class GeoAreaViewSet(viewsets.ReadOnlyModelViewSet):
@@ -126,3 +129,35 @@ class GeoAreaDescriptionDelete(
 ):
     form_class = forms.GeographicalAreaDescriptionDeleteForm
     success_path = "detail"
+
+
+class GeoAreaUpdateMixin(GeoAreaMixin, TrackedModelDetailMixin):
+    form_class = GeographicalAreaEditForm
+
+    validate_business_rules = (
+        business_rules.GA1,
+        business_rules.GA3,
+        business_rules.GA4,
+        business_rules.GA5,
+        business_rules.GA6,
+        business_rules.GA7,
+        business_rules.GA10,
+        business_rules.GA11,
+        business_rules.GA21,
+        business_rules.GA22,
+    )
+
+
+class GeoAreaUpdate(GeoAreaUpdateMixin, CreateTaricUpdateView):
+    """UI endpoint to create geo area UPDATE instances."""
+
+
+class GeoAreaConfirmUpdate(GeoAreaMixin, TrackedModelDetailView):
+    template_name = "common/confirm_update.jinja"
+
+
+class GeoAreaEditUpdate(
+    GeoAreaUpdateMixin,
+    EditTaricView,
+):
+    """UI endpoint to edit geo area UPDATE instances."""

--- a/geo_areas/views.py
+++ b/geo_areas/views.py
@@ -133,6 +133,7 @@ class GeoAreaDescriptionDelete(
 
 class GeoAreaUpdateMixin(GeoAreaMixin, TrackedModelDetailMixin):
     form_class = GeographicalAreaEditForm
+    permission_required = "common.change_trackedmodel"
 
     validate_business_rules = (
         business_rules.GA1,

--- a/geo_areas/views.py
+++ b/geo_areas/views.py
@@ -133,7 +133,6 @@ class GeoAreaDescriptionDelete(
 
 class GeoAreaUpdateMixin(GeoAreaMixin, TrackedModelDetailMixin):
     form_class = GeographicalAreaEditForm
-    permission_required = "common.change_trackedmodel"
 
     validate_business_rules = (
         business_rules.GA1,


### PR DESCRIPTION
# TP2000-800  Implement geo area end-date editing

## Why
Users are unable to edit an end date for a geographical area.

## What
- Adds form to allow editing an end date for a geo area (accessible via 'Edit this geographical area' link on geo area view or /geographical-areas/SID/edit)
- Adds unit tests

##
<img width="500" alt="Screenshot 2023-03-24 at 12 12 18" src="https://user-images.githubusercontent.com/118175145/227520653-657d2447-53f2-4f79-bc15-e17317410fc1.png">

