### PR TITLE
TP2000-829 Add DJANGO_AUTO_FIELD spec to settings

### DIFF
--- a/settings/common.py
+++ b/settings/common.py
@@ -58,6 +58,11 @@ STATICFILES_FINDERS = [
 
 STATICFILES_STORAGE = "whitenoise.storage.CompressedStaticFilesStorage"
 
+
+# Auto field type specification required since Django 3.2.
+DEFAULT_AUTO_FIELD = "django.db.models.AutoField"
+
+
 # -- Application
 
 DJANGO_CORE_APPS = [


### PR DESCRIPTION
# TP2000-829 Add DJANGO_AUTO_FIELD spec to settings
<!---
 * Include the JIRA ticket number, eg TP-123, to automatically link.
 * Use 50 characters maximum.
 * Do not end with a full-stop.
--->

## Why
<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Use as many lines as you like.
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions or deliberately ignored edge-cases.
--->
[Since Django 3.2](https://docs.djangoproject.com/en/3.2/ref/settings/#std-setting-DEFAULT_AUTO_FIELD), if a primary key is not explicity specified on a model and no value is given for `DJANGO_AUTO_FIELD` in `settings.py`, then the following type of error is output by Django when its checks are executed:

```
importer.ImportBatch: (models.W042) Auto-created primary key used when not defining a primary key type, by default 'django.db.models.AutoField'.
	HINT: Configure the DEFAULT_AUTO_FIELD setting or the AppConfig.default_auto_field attribute to point to a subclass of AutoField, e.g. 'django.db.models.BigAutoField'.
```


## What
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Explain like I'm 5.
 * Use pictures if you can.
--->
This PR adds the `DEFAULT_AUTO_FIELD` setting to TAP's settings file, assigning it the default value, `"django.db.models.AutoField"`, that would have been created if Django had generated the project.

<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
--->
## Checklist
- Requires migrations? No
- Requires dependency updates? No

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
