### PR TITLE
TP2000-768 Show proper description and url for geo area memberships in workbasket

### DIFF
--- a/common/tests/test_models.py
+++ b/common/tests/test_models.py
@@ -449,10 +449,12 @@ def test_trackedmodel_str(trackedmodel_factory):
     """Verify no __str__ methods of TrackedModel classes crash or return non-
     strings."""
     instance = trackedmodel_factory.create()
-    result = instance.__str__()
 
-    assert isinstance(result, str)
-    assert len(result.strip())
+    with override_current_transaction(instance.transaction):
+        result = instance.__str__()
+
+        assert isinstance(result, str)
+        assert len(result.strip())
 
 
 @pytest.mark.django_db(transaction=True, reset_sequences=True)

--- a/common/tests/test_models.py
+++ b/common/tests/test_models.py
@@ -451,7 +451,7 @@ def test_trackedmodel_str(trackedmodel_factory):
     instance = trackedmodel_factory.create()
 
     with override_current_transaction(instance.transaction):
-        result = instance.__str__()
+        result = str(instance)
 
         assert isinstance(result, str)
         assert len(result.strip())

--- a/geo_areas/models.py
+++ b/geo_areas/models.py
@@ -16,6 +16,7 @@ from common.models.mixins.description import DescriptionMixin
 from common.models.mixins.validity import ValidityMixin
 from common.models.tracked_qs import TrackedModelQuerySet
 from common.models.trackedmodel import TrackedModel
+from common.models.utils import GetTabURLMixin
 from geo_areas import business_rules
 from geo_areas.validators import AreaCode
 from geo_areas.validators import area_id_validator
@@ -157,7 +158,7 @@ class GeographicalArea(TrackedModel, ValidityMixin, DescribedMixin):
         )
 
 
-class GeographicalMembership(TrackedModel, ValidityMixin):
+class GeographicalMembership(GetTabURLMixin, TrackedModel, ValidityMixin):
     """
     A Geographical Membership describes the membership of a region or country to
     a group.
@@ -167,6 +168,10 @@ class GeographicalMembership(TrackedModel, ValidityMixin):
     The validity ranges of all memberships must also fit completely within the validity
     ranges of the groups.
     """
+
+    url_pattern_name_prefix = "geo_area"
+    url_suffix = "#memberships"
+    url_relation_field = "geo_group"
 
     record_code = "250"
     subrecord_code = "15"

--- a/geo_areas/models.py
+++ b/geo_areas/models.py
@@ -201,7 +201,12 @@ class GeographicalMembership(GetTabURLMixin, TrackedModel, ValidityMixin):
     )
 
     def __str__(self):
-        return f"{self.geo_group.get_area_code_display()} {self.geo_group.structure_description} member {self.member.get_area_code_display()} {self.member.structure_description}"
+        return (
+            f"{self.geo_group.get_area_code_display()} "
+            f"{self.geo_group.structure_description} member "
+            f"{self.member.get_area_code_display()} "
+            f"{self.member.structure_description}"
+        )
 
     def other(self, area: GeographicalArea) -> GeographicalArea:
         """

--- a/geo_areas/models.py
+++ b/geo_areas/models.py
@@ -195,6 +195,9 @@ class GeographicalMembership(TrackedModel, ValidityMixin):
         UpdateValidity,
     )
 
+    def __str__(self):
+        return f"{self.geo_group.get_area_code_display()} {self.geo_group.structure_description} member {self.member.get_area_code_display()} {self.member.structure_description}"
+
     def other(self, area: GeographicalArea) -> GeographicalArea:
         """
         When passed an area that is part of this membership, returns the other

--- a/geo_areas/tests/test_models.py
+++ b/geo_areas/tests/test_models.py
@@ -196,7 +196,7 @@ def test_geo_membership_str():
     instance = factories.GeographicalMembershipFactory.create()
 
     with override_current_transaction(instance.transaction):
-        result = instance.__str__()
+        result = str(instance)
         assert isinstance(result, str)
         assert len(result.strip())
 

--- a/geo_areas/tests/test_models.py
+++ b/geo_areas/tests/test_models.py
@@ -189,3 +189,17 @@ def test_with_current_descriptions(queued_workbasket):
     assert (
         area.description == f"{description_1.description} {description_2.description}"
     )
+
+
+def test_geo_membership_str():
+    instance = factories.GeographicalMembershipFactory.create()
+
+    with override_current_transaction(instance.transaction):
+        result = instance.__str__()
+        assert isinstance(result, str)
+        assert len(result.strip())
+
+        assert str(instance.geo_group.get_area_code_display()) in result
+        assert str(instance.geo_group.structure_description) in result
+        assert str(instance.member.get_area_code_display()) in result
+        assert str(instance.member.structure_description) in result

--- a/geo_areas/tests/test_models.py
+++ b/geo_areas/tests/test_models.py
@@ -75,12 +75,13 @@ def test_get_current_memberships_when_region_and_country_share_sid():
 
 def test_other_on_membership():
     membership = factories.GeographicalMembershipFactory()
-    assert membership.other(membership.member) == membership.geo_group
-    assert membership.other(membership.geo_group) == membership.member
-    with pytest.raises(ValueError):
-        membership.other(factories.GeoGroupFactory())
-    with pytest.raises(ValueError):
-        membership.other(factories.CountryFactory())
+    with override_current_transaction(membership.transaction):
+        assert membership.other(membership.member) == membership.geo_group
+        assert membership.other(membership.geo_group) == membership.member
+        with pytest.raises(ValueError):
+            membership.other(factories.GeoGroupFactory())
+        with pytest.raises(ValueError):
+            membership.other(factories.CountryFactory())
 
 
 def test_other_on_later_version():

--- a/measures/tests/test_views.py
+++ b/measures/tests/test_views.py
@@ -1647,11 +1647,11 @@ def test_measure_list_selected_measures_list(valid_user_client):
     assert response.status_code == 200
 
     soup = BeautifulSoup(str(response.content), "html.parser")
-    measure_ids_in_table = [a.text for a in soup.select("details table tr td a")]
+    measure_ids_in_table = {a.text for a in soup.select("details table tr td a")}
 
-    selected_measures_ids = [str(measure.sid) for measure in measures]
+    selected_measures_ids = {str(measure.sid) for measure in measures}
 
-    assert measure_ids_in_table == selected_measures_ids
+    assert not measure_ids_in_table.difference(selected_measures_ids)
 
 
 def test_multiple_measure_edit_only_quota_order_number(


### PR DESCRIPTION
# TP2000-768 Show proper description and url for geo area memberships in workbasket
<!---
 * Include the JIRA ticket number, eg TP-123, to automatically link.
 * Use 50 characters maximum.
 * Do not end with a full-stop.
--->

## Why
<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Use as many lines as you like.
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions or deliberately ignored edge-cases.
--->
* URL did not work
* Content was not very helpful/descriptive

## What
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Explain like I'm 5.
 * Use pictures if you can.
--->
* Updates the `__str__ `method to get the proper description for geo area memberships
* Adds GetTabURLMixin to get the proper URL for geo area memberships

<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
## Checklist
- Requires migrations?
- Requires dependency updates?
--->

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
<img width="1209" alt="Screenshot 2023-03-30 at 17 24 46" src="https://user-images.githubusercontent.com/25905279/228902567-ff0281f6-9a16-4d2b-8621-91f91ac37c48.png">
