### PR TITLE
TP2000-802  Add memberships to geo area editing

### DIFF
--- a/geo_areas/forms.py
+++ b/geo_areas/forms.py
@@ -152,7 +152,7 @@ class GeographicalMembershipValidityPeriodForm(forms.ModelForm):
         fields = ["valid_between"]
 
 
-class GeographicalMembershipEditForm(
+class GeographicalMembershipAddForm(
     BindNestedFormMixin,
     GeographicalMembershipValidityPeriodForm,
 ):
@@ -278,7 +278,7 @@ class GeographicalAreaEndDateForm(ValidityPeriodForm):
 
 class GeographicalAreaEditForm(
     GeographicalAreaEndDateForm,
-    GeographicalMembershipEditForm,
+    GeographicalMembershipAddForm,
 ):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/geo_areas/forms.py
+++ b/geo_areas/forms.py
@@ -206,24 +206,26 @@ class GeographicalMembershipAddForm(
 
         if area_group and member:
             # Check if membership already exists
-            if GeographicalMembership.objects.filter(
+            is_member = GeographicalMembership.objects.filter(
                 geo_group=self.instance,
                 member=member,
-            ):
+            )
+            has_member = GeographicalMembership.objects.filter(
+                geo_group=area_group,
+                member=self.instance,
+            )
+            if is_member:
                 self.add_error(
                     "member",
                     "The selected country or region is already a member of this area group.",
                 )
-            if GeographicalMembership.objects.filter(
-                geo_group=area_group,
-                member=self.instance,
-            ):
+            if has_member:
                 self.add_error(
                     "geo_group",
                     "The selected area group already has this country or region as a member.",
                 )
 
-            # A membership start date is required
+            # Check if membership start and end date is valid
             rule_message = "must be within the validity period of the area group."
             if not start_date:
                 self.add_error(
@@ -236,18 +238,16 @@ class GeographicalMembershipAddForm(
                         "membership_start_date",
                         "The start date " + rule_message,
                     )
-                if area_group.valid_between.upper:
-                    if end_date:
-                        if end_date > area_group.valid_between.upper:
-                            self.add_error(
-                                "membership_end_date",
-                                "The end date " + rule_message,
-                            )
-                    else:
-                        self.add_error(
-                            "membership_end_date",
-                            "The end date " + rule_message,
-                        )
+            if area_group.valid_between.upper:
+                if (
+                    end_date
+                    and end_date > area_group.valid_between.upper
+                    or not end_date
+                ):
+                    self.add_error(
+                        "membership_end_date",
+                        "The end date " + rule_message,
+                    )
 
         return cleaned_data
 

--- a/geo_areas/forms.py
+++ b/geo_areas/forms.py
@@ -147,10 +147,6 @@ class GeographicalMembershipValidityPeriodForm(forms.ModelForm):
 
         return cleaned_data
 
-    class Meta:
-        model = GeographicalMembership
-        fields = ["valid_between"]
-
 
 class GeographicalMembershipAddForm(
     BindNestedFormMixin,

--- a/geo_areas/forms.py
+++ b/geo_areas/forms.py
@@ -1,14 +1,27 @@
+from datetime import date
+
 from crispy_forms_gds.helper import FormHelper
+from crispy_forms_gds.layout import Accordion
+from crispy_forms_gds.layout import AccordionSection
 from crispy_forms_gds.layout import Field
 from crispy_forms_gds.layout import Layout
 from crispy_forms_gds.layout import Size
 from crispy_forms_gds.layout import Submit
+from django import forms
+from django.db.models import TextChoices
 
+from common.forms import BindNestedFormMixin
 from common.forms import CreateDescriptionForm
+from common.forms import DateInputFieldFixed
+from common.forms import GovukDateRangeField
+from common.forms import RadioNested
 from common.forms import ValidityPeriodForm
 from common.forms import delete_form_for
+from common.util import TaricDateRange
 from geo_areas.models import GeographicalArea
 from geo_areas.models import GeographicalAreaDescription
+from geo_areas.models import GeographicalMembership
+from geo_areas.validators import AreaCode
 
 
 class GeographicalAreaCreateDescriptionForm(CreateDescriptionForm):
@@ -34,25 +47,225 @@ GeographicalAreaDeleteForm = delete_form_for(GeographicalArea)
 GeographicalAreaDescriptionDeleteForm = delete_form_for(GeographicalAreaDescription)
 
 
+class GeoAreaType(TextChoices):
+    COUNTRY = "COUNTRY", "Add a country"
+    REGION = "REGION", "Add a region"
+
+
+class GeoAreaCountryForm(forms.Form):
+    country = forms.ModelChoiceField(
+        label="Country",
+        queryset=GeographicalArea.objects.filter(area_code=AreaCode.COUNTRY),
+        required=False,
+    )
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self.fields["country"].queryset = (
+            GeographicalArea.objects.filter(area_code=AreaCode.COUNTRY)
+            .current()
+            .with_latest_description()
+            .as_at_today()
+            .order_by("description")
+        )
+        self.fields[
+            "country"
+        ].label_from_instance = lambda obj: f"{obj.area_id} - {obj.description}"
+
+
+class GeoAreaRegionForm(forms.Form):
+    region = forms.ModelChoiceField(
+        label="Region",
+        queryset=GeographicalArea.objects.filter(area_code=AreaCode.REGION),
+        required=False,
+    )
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self.fields["region"].queryset = (
+            GeographicalArea.objects.filter(area_code=AreaCode.REGION)
+            .current()
+            .with_latest_description()
+            .as_at_today()
+            .order_by("description")
+        )
+        self.fields[
+            "region"
+        ].label_from_instance = lambda obj: f"{obj.area_id} - {obj.description}"
+
+
+class GeographicalMembershipValidityPeriodForm(forms.ModelForm):
+    membership_start_date = DateInputFieldFixed(
+        label="Start date",
+        required=False,
+    )
+    membership_end_date = DateInputFieldFixed(
+        label="End date",
+        help_text="Leave empty if a membership is needed for an unlimited time.",
+        required=False,
+    )
+    membership_valid_between = GovukDateRangeField(required=False)
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def clean(self):
+        cleaned_data = super().clean()
+
+        start_date = cleaned_data.pop("membership_start_date", None)
+        end_date = cleaned_data.pop("membership_end_date", None)
+
+        if end_date and start_date and end_date < start_date:
+            self.add_error(
+                "membership_start_date",
+                "The start date must be the same as or before the end date.",
+            )
+            self.add_error(
+                "membership_end_date",
+                "The end date must be the same as or after the start date.",
+            )
+
+        cleaned_data["membership_valid_between"] = TaricDateRange(start_date, end_date)
+
+        if start_date:
+            day, month, year = (start_date.day, start_date.month, start_date.year)
+            self.fields["membership_start_date"].initial = date(
+                day=int(day),
+                month=int(month),
+                year=int(year),
+            )
+
+        if end_date:
+            day, month, year = (end_date.day, end_date.month, end_date.year)
+            self.fields["membership_end_date"].initial = date(
+                day=int(day),
+                month=int(month),
+                year=int(year),
+            )
+
+        return cleaned_data
+
+    class Meta:
+        model = GeographicalMembership
+        fields = ["valid_between"]
+
+
+class GeographicalMembershipEditForm(
+    BindNestedFormMixin,
+    GeographicalMembershipValidityPeriodForm,
+):
+    geo_group = forms.ModelChoiceField(
+        help_text="Select the area group to add this country or region to from the dropdown.",
+        queryset=GeographicalArea.objects.filter(area_code=AreaCode.GROUP),
+        required=False,
+    )
+
+    member = RadioNested(
+        help_text="Select a country or region to add to this area group.",
+        choices=GeoAreaType.choices,
+        nested_forms={
+            GeoAreaType.COUNTRY.value: [GeoAreaCountryForm],
+            GeoAreaType.REGION.value: [GeoAreaRegionForm],
+        },
+        required=False,
+    )
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self.fields["geo_group"].queryset = (
+            GeographicalArea.objects.filter(area_code=AreaCode.GROUP)
+            .current()
+            .with_latest_description()
+            .as_at_today()
+            .order_by("description")
+        )
+        self.fields[
+            "geo_group"
+        ].label_from_instance = lambda obj: f"{obj.area_id} - {obj.description}"
+
+        self.fields["geo_group"].label = ""
+        self.fields["member"].label = ""
+
+    def clean(self):
+        cleaned_data = super().clean()
+
+        # Get the selected country or region from nested forms
+        geo_area_choice = cleaned_data.get("member", "")
+        if geo_area_choice == GeoAreaType.COUNTRY:
+            cleaned_data["member"] = cleaned_data.get("country")
+        else:
+            cleaned_data["member"] = cleaned_data.get("region")
+
+        area_group = (
+            self.instance if self.instance.is_group() else cleaned_data["geo_group"]
+        )
+        member = (
+            self.instance if not self.instance.is_group() else cleaned_data["member"]
+        )
+        start_date = cleaned_data["membership_valid_between"].lower
+        end_date = cleaned_data["membership_valid_between"].upper
+
+        if area_group and member:
+            # Check if membership already exists
+            if GeographicalMembership.objects.filter(
+                geo_group=self.instance,
+                member=member,
+            ):
+                self.add_error(
+                    "member",
+                    "The selected country or region is already a member of this area group.",
+                )
+            if GeographicalMembership.objects.filter(
+                geo_group=area_group,
+                member=self.instance,
+            ):
+                self.add_error(
+                    "geo_group",
+                    "The selected area group already has this country or region as a member.",
+                )
+
+            # A membership start date is required
+            rule_message = "must be within the validity period of the area group."
+            if not start_date:
+                self.add_error(
+                    "membership_start_date",
+                    "A start date is required.",
+                )
+            else:
+                if start_date < area_group.valid_between.lower:
+                    self.add_error(
+                        "membership_start_date",
+                        "The start date " + rule_message,
+                    )
+                if area_group.valid_between.upper:
+                    if end_date:
+                        if end_date > area_group.valid_between.upper:
+                            self.add_error(
+                                "membership_end_date",
+                                "The end date " + rule_message,
+                            )
+                    else:
+                        self.add_error(
+                            "membership_end_date",
+                            "The end date " + rule_message,
+                        )
+
+        return cleaned_data
+
+    class Meta:
+        model = GeographicalMembership
+        fields = ["geo_group", "member"]
+
+
 class GeographicalAreaEndDateForm(ValidityPeriodForm):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
         self.fields["start_date"].required = False
-
-        self.helper = FormHelper(self)
-        self.helper.label_size = Size.SMALL
-        self.helper.legend_size = Size.SMALL
-
-        self.helper.layout = Layout(
-            "end_date",
-            Submit(
-                "submit",
-                "Save",
-                data_module="govuk-button",
-                data_prevent_double_click="true",
-            ),
-        )
+        self.fields["end_date"].label = ""
 
     def clean(self):
         self.cleaned_data["start_date"] = self.instance.valid_between.lower
@@ -63,16 +276,36 @@ class GeographicalAreaEndDateForm(ValidityPeriodForm):
         fields = ("valid_between",)
 
 
-class GeographicalAreaEditForm(GeographicalAreaEndDateForm):
+class GeographicalAreaEditForm(
+    GeographicalAreaEndDateForm,
+    GeographicalMembershipEditForm,
+):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+
+        # Which geographical membership form field is shown depends
+        # on the type of geographical area being edited
+        if self.instance.is_group():
+            form_field = "member"
+        else:
+            form_field = "geo_group"
+
+        self.bind_nested_forms(*args, **kwargs)
 
         self.helper = FormHelper(self)
         self.helper.label_size = Size.SMALL
         self.helper.legend_size = Size.SMALL
 
         self.helper.layout = Layout(
-            "end_date",
+            Accordion(
+                AccordionSection(
+                    "Memberships",
+                    form_field,
+                    "membership_start_date",
+                    "membership_end_date",
+                ),
+                AccordionSection("End date", "end_date"),
+            ),
             Submit(
                 "submit",
                 "Save",

--- a/geo_areas/forms.py
+++ b/geo_areas/forms.py
@@ -55,7 +55,7 @@ class GeoAreaType(TextChoices):
 class GeoAreaCountryForm(forms.Form):
     country = forms.ModelChoiceField(
         label="Country",
-        queryset=GeographicalArea.objects.filter(area_code=AreaCode.COUNTRY),
+        queryset=None,  # populated in __init__
         required=False,
     )
 
@@ -77,7 +77,7 @@ class GeoAreaCountryForm(forms.Form):
 class GeoAreaRegionForm(forms.Form):
     region = forms.ModelChoiceField(
         label="Region",
-        queryset=GeographicalArea.objects.filter(area_code=AreaCode.REGION),
+        queryset=None,  # populated in __init__
         required=False,
     )
 

--- a/geo_areas/tests/test_views.py
+++ b/geo_areas/tests/test_views.py
@@ -181,8 +181,8 @@ def test_geo_area_update_view_membership_add_country_or_region(
     valid_user_client,
     session_workbasket,
 ):
-    """Tests that a country or region can be added to the membership of the area
-    group being edited."""
+    """Tests that a country or region can be added as a member of the area group
+    being edited."""
     area_group = factories.GeographicalAreaFactory.create(area_code=AreaCode.GROUP)
     country = factories.GeographicalAreaFactory.create(area_code=AreaCode.COUNTRY)
 
@@ -191,7 +191,6 @@ def test_geo_area_update_view_membership_add_country_or_region(
         member__sid=country.sid,
     )
     assert not membership
-    expected_valid_between = area_group.valid_between
 
     form_data = {
         "member": "COUNTRY",
@@ -200,6 +199,8 @@ def test_geo_area_update_view_membership_add_country_or_region(
         "membership_start_date_1": area_group.valid_between.lower.month,
         "membership_start_date_2": area_group.valid_between.lower.year,
     }
+    expected_valid_between = area_group.valid_between
+
     url = reverse(
         "geo_area-ui-edit",
         kwargs={"sid": area_group.sid},
@@ -223,6 +224,7 @@ def test_geo_area_update_view_membership_add_country_or_region(
         )
         assert membership
         assert membership.valid_between == expected_valid_between
+        assert membership.update_type == UpdateType.CREATE
         assert geo_area.update_type == UpdateType.UPDATE
 
 
@@ -230,8 +232,8 @@ def test_geo_area_update_view_membership_add_to_group(
     valid_user_client,
     session_workbasket,
 ):
-    """Tests that the country or region being edited can be added to the
-    membership of an area group."""
+    """Tests that the country or region being edited can be added as a member of
+    an area group."""
     region = factories.GeographicalAreaFactory.create(area_code=AreaCode.REGION)
     area_group = factories.GeographicalAreaFactory.create(area_code=AreaCode.GROUP)
 
@@ -241,14 +243,13 @@ def test_geo_area_update_view_membership_add_to_group(
     )
     assert not membership
 
-    expected_valid_between = area_group.valid_between
-
     form_data = {
         "geo_group": area_group.pk,
         "membership_start_date_0": area_group.valid_between.lower.day,
         "membership_start_date_1": area_group.valid_between.lower.month,
         "membership_start_date_2": area_group.valid_between.lower.year,
     }
+    expected_valid_between = area_group.valid_between
 
     url = reverse(
         "geo_area-ui-edit",
@@ -273,4 +274,5 @@ def test_geo_area_update_view_membership_add_to_group(
         )
         assert membership
         assert membership.valid_between == expected_valid_between
+        assert membership.update_type == UpdateType.CREATE
         assert geo_area.update_type == UpdateType.UPDATE


### PR DESCRIPTION
# TP2000-802  Add membership creation to geo area editing

## Why
Users are unable to add countries or regions to geographical area groups to create new geographical memberships.

## What
- Extends `GeographicalAreaEditForm` to allow adding a single country or region as a member of a single area group
- Adds tests

##
When editing an area group:
<img width="450" alt="Screenshot 2023-03-31 at 13 35 35" src="https://user-images.githubusercontent.com/118175145/229122400-794ddebb-db07-415a-a511-882435960f7e.png">

When editing a country or region:
<img width="450" alt="Screenshot 2023-03-31 at 13 42 25" src="https://user-images.githubusercontent.com/118175145/229122979-b9602e6d-de76-498b-a6bd-45cd026b02a6.png">


