### PR TITLE
TP2000-488  Include accessibility statement

### DIFF
--- a/common/jinja2/common/accessibility.jinja
+++ b/common/jinja2/common/accessibility.jinja
@@ -27,7 +27,7 @@
       <li>Tariff application platform</li>
     </ul>
     <p class="govuk-body">
-      We anticipate the outcome of all tests to be complete by <b>30th June 2023</b>.
+      We anticipate the outcome of all tests to be complete by <b>12th December 2023</b>.
     </p>
 
     <h2 class="govuk-heading-m" id="what-to-do-if-you-cannot-access-parts-of-this-website">

--- a/common/jinja2/common/accessibility.jinja
+++ b/common/jinja2/common/accessibility.jinja
@@ -5,53 +5,52 @@
 {% block breadcrumb %}{% endblock %}
 
 {% block content %}
-<div class="govuk-width-container">
-  <main class="govuk-main-wrapper govuk-main-wrapper--l" id="main-content" role="main">
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-two-thirds">
-        <h1 class="govuk-heading-l">Accessibility statement for the Tariff application platform</h1>
-        <p class="govuk-body" id="about-the-accessibility-of-this-service">
-          The Department for Business and Trade digital team is committed to making sure our online services are accessible
-          to all users and comply with level AA of the Web Content Accessibility Guidelines – WCAG 2.1,
-          in line with The Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018.
-        </p>
-        <p class="govuk-body">
-          In order to help us achieve and maintain our objective, we have commissioned 
-          <a href="https://digitalaccessibilitycentre.org/">
-            The Digital Accessibility Centre (DAC)
-          </a>
-          to carry out WCAG 2.1 AA level technical compliance audits that also include extensive manual testing.
-        </p>
-        <p class="govuk-body">
-          The services/websites currently booked in for testing are:
-        </p>
-        <ul class="govuk-list govuk-list--bullet">
-          <li>Tariff application platform</li>
-        </ul>
-        <p class="govuk-body">
-          We anticipate the outcome of all tests to be complete by <b>30th June 2023</b>.
-        </p>
-        <h2 class="govuk-heading-m" id="what-to-do-if-you-cannot-access-parts-of-this-website">
-          What to do if you cannot access parts of this website
-        </h2>
-        <p class="govuk-body">
-          If you need information on this website in a different format, email <a class="govuk-link" href="mailto:stephen.corder@trade.gov.uk">stephen.corder@trade.gov.uk</a>.
-        </p>
-        <p class="govuk-body">
-          If you have a problem with accessing any of the pages on this site you can contact us at 
-          <a class="govuk-link" href="mailto:9cf0f83c.trade.gov.uk@uk.teams.ms">9cf0f83c.trade.gov.uk@uk.teams.ms</a>.
-          We’ll get back to you within 5 working days.
-        </p>
-        <h2 class="govuk-heading-m" id="reporting-accessibility-problems">
-          Reporting accessibility problems with this website
-        </h2>
-        <p class="govuk-body">
-          We’re always looking to improve the accessibility of this website.
-          If you find any problems or think we’re not meeting the requirements of the accessibility regulations,
-          please tell us by contacting <a class="govuk-link" href="mailto:stephen.corder@trade.gov.uk">stephen.corder@trade.gov.uk</a>.
-        </p>
-      </div>
-    </div>
-  </main>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">Accessibility statement for the Tariff application platform</h1>
+    <p class="govuk-body" id="about-the-accessibility-of-this-service">
+      The Department for Business and Trade digital team is committed to making sure our online services are accessible
+      to all users and comply with level AA of the Web Content Accessibility Guidelines – WCAG 2.1,
+      in line with The Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018.
+    </p>
+    <p class="govuk-body">
+      In order to help us achieve and maintain our objective, we have commissioned
+      <a href="https://digitalaccessibilitycentre.org/">
+        The Digital Accessibility Centre (DAC)
+      </a>
+      to carry out WCAG 2.1 AA level technical compliance audits that also include extensive manual testing.
+    </p>
+    <p class="govuk-body">
+      The services/websites currently booked in for testing are:
+    </p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>Tariff application platform</li>
+    </ul>
+    <p class="govuk-body">
+      We anticipate the outcome of all tests to be complete by <b>30th June 2023</b>.
+    </p>
+
+    <h2 class="govuk-heading-m" id="what-to-do-if-you-cannot-access-parts-of-this-website">
+      What to do if you cannot access parts of this website
+    </h2>
+    <p class="govuk-body">
+      If you need information on this website in a different format, email
+      <a class="govuk-link" href="mailto:stephen.corder@trade.gov.uk">stephen.corder@trade.gov.uk</a>.
+    </p>
+    <p class="govuk-body">
+      If you have a problem with accessing any of the pages on this site you can contact us at
+      <a class="govuk-link" href="mailto:9cf0f83c.trade.gov.uk@uk.teams.ms">9cf0f83c.trade.gov.uk@uk.teams.ms</a>.
+      We’ll get back to you within 5 working days.
+    </p>
+
+    <h2 class="govuk-heading-m" id="reporting-accessibility-problems">
+      Reporting accessibility problems with this website
+    </h2>
+    <p class="govuk-body">
+      We’re always looking to improve the accessibility of this website.
+      If you find any problems or think we’re not meeting the requirements of the accessibility regulations,
+      please tell us by contacting <a class="govuk-link" href="mailto:stephen.corder@trade.gov.uk">stephen.corder@trade.gov.uk</a>.
+    </p>
+  </div>
 </div>
 {% endblock %}

--- a/common/jinja2/common/accessibility.jinja
+++ b/common/jinja2/common/accessibility.jinja
@@ -1,0 +1,57 @@
+{% extends "layouts/layout.jinja" %}
+
+{% set page_title = "Accessibility statement" %}
+
+{% block breadcrumb %}{% endblock %}
+
+{% block content %}
+<div class="govuk-width-container">
+  <main class="govuk-main-wrapper govuk-main-wrapper--l" id="main-content" role="main">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <h1 class="govuk-heading-l">Accessibility statement for the Tariff application platform</h1>
+        <p class="govuk-body" id="about-the-accessibility-of-this-service">
+          The Department for Business and Trade digital team is committed to making sure our online services are accessible
+          to all users and comply with level AA of the Web Content Accessibility Guidelines – WCAG 2.1,
+          in line with The Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018.
+        </p>
+        <p class="govuk-body">
+          In order to help us achieve and maintain our objective, we have commissioned 
+          <a href="https://digitalaccessibilitycentre.org/">
+            The Digital Accessibility Centre (DAC)
+          </a>
+          to carry out WCAG 2.1 AA level technical compliance audits that also include extensive manual testing.
+        </p>
+        <p class="govuk-body">
+          The services/websites currently booked in for testing are:
+        </p>
+        <ul class="govuk-list govuk-list--bullet">
+          <li>Tariff application platform</li>
+        </ul>
+        <p class="govuk-body">
+          We anticipate the outcome of all tests to be complete by <b>30th June 2023</b>.
+        </p>
+        <h1 class="govuk-heading-m" id="what-to-do-if-you-cannot-access-parts-of-this-website">
+          What to do if you cannot access parts of this website
+        </h1>
+        <p class="govuk-body">
+          If you need information on this website in a different format, email <a class="govuk-link" href="mailto:stephen.corder@trade.gov.uk">stephen.corder@trade.gov.uk</a>.
+        </p>
+        <p class="govuk-body">
+          If you have a problem with accessing any of the pages on this site you can contact us at 
+          <a class="govuk-link" href="mailto:9cf0f83c.trade.gov.uk@uk.teams.ms">9cf0f83c.trade.gov.uk@uk.teams.ms</a>.
+          We’ll get back to you within 5 working days.
+        </p>
+        <h1 class="govuk-heading-m" id="reporting-accessibility-problems">
+          Reporting accessibility problems with this website
+        </h1>
+        <p class="govuk-body">
+          We’re always looking to improve the accessibility of this website.
+          If you find any problems or think we’re not meeting the requirements of the accessibility regulations,
+          please tell us by contacting <a class="govuk-link" href="mailto:stephen.corder@trade.gov.uk">stephen.corder@trade.gov.uk</a>.
+        </p>
+      </div>
+    </div>
+  </main>
+</div>
+{% endblock %}

--- a/common/jinja2/common/accessibility.jinja
+++ b/common/jinja2/common/accessibility.jinja
@@ -31,9 +31,9 @@
         <p class="govuk-body">
           We anticipate the outcome of all tests to be complete by <b>30th June 2023</b>.
         </p>
-        <h1 class="govuk-heading-m" id="what-to-do-if-you-cannot-access-parts-of-this-website">
+        <h2 class="govuk-heading-m" id="what-to-do-if-you-cannot-access-parts-of-this-website">
           What to do if you cannot access parts of this website
-        </h1>
+        </h2>
         <p class="govuk-body">
           If you need information on this website in a different format, email <a class="govuk-link" href="mailto:stephen.corder@trade.gov.uk">stephen.corder@trade.gov.uk</a>.
         </p>
@@ -42,9 +42,9 @@
           <a class="govuk-link" href="mailto:9cf0f83c.trade.gov.uk@uk.teams.ms">9cf0f83c.trade.gov.uk@uk.teams.ms</a>.
           We’ll get back to you within 5 working days.
         </p>
-        <h1 class="govuk-heading-m" id="reporting-accessibility-problems">
+        <h2 class="govuk-heading-m" id="reporting-accessibility-problems">
           Reporting accessibility problems with this website
-        </h1>
+        </h2>
         <p class="govuk-body">
           We’re always looking to improve the accessibility of this website.
           If you find any problems or think we’re not meeting the requirements of the accessibility regulations,

--- a/common/jinja2/layouts/layout.jinja
+++ b/common/jinja2/layouts/layout.jinja
@@ -61,6 +61,10 @@
           "text": "Privacy policy"
         },
         {
+          "href": url("accessibility-statement"),
+          "text": "Accessibility statement"
+        },
+        {
           "href": "https://uktrade.github.io/tariff-data-manual/#home",
           "text": "Tariff data manual"
         },

--- a/common/tests/test_views.py
+++ b/common/tests/test_views.py
@@ -134,7 +134,7 @@ def test_index_displays_footer_links(valid_user_client):
     page = BeautifulSoup(str(response.content), "html.parser")
     a_tags = page.select("footer a")
 
-    assert len(a_tags) == 6
+    assert len(a_tags) == 7
     assert "Privacy policy" in a_tags[0].text
     assert (
         a_tags[0].attrs["href"]
@@ -173,3 +173,16 @@ def test_handler500(client):
 
     assert response.status_code == 500
     assert response.template_name == "common/500.jinja"
+
+
+def test_accessibility_statement_view_returns_200(valid_user_client):
+    url = reverse("accessibility-statement")
+    response = valid_user_client.get(url)
+
+    assert response.status_code == 200
+
+    page = BeautifulSoup(str(response.content), "html.parser")
+    assert (
+        "Accessibility statement for the Tariff application platform"
+        in page.select("h1")[0].text
+    )

--- a/common/urls.py
+++ b/common/urls.py
@@ -18,6 +18,11 @@ urlpatterns = [
     path("search/", views.SearchPageView.as_view(), name="search-page"),
     path("healthcheck", views.healthcheck, name="healthcheck"),
     path("app-info", views.AppInfoView.as_view(), name="app-info"),
+    path(
+        "accessibility-statement",
+        views.AccessibilityStatementView.as_view(),
+        name="accessibility-statement",
+    ),
     path("login", views.LoginView.as_view(), name="login"),
     path("logout", views.LogoutView.as_view(), name="logout"),
     path("api-auth/", include("rest_framework.urls")),

--- a/common/views.py
+++ b/common/views.py
@@ -383,3 +383,7 @@ def handler403(request, *args, **kwargs):
 
 def handler500(request, *args, **kwargs):
     return TemplateResponse(request=request, template="common/500.jinja", status=500)
+
+
+class AccessibilityStatementView(TemplateView):
+    template_name = "common/accessibility.jinja"

--- a/pii-secret-exclude.txt
+++ b/pii-secret-exclude.txt
@@ -23,3 +23,4 @@ common/jinja2/common/403.jinja
 common/jinja2/common/500.jinja
 settings/envs/docker.env 
 Dockerfile
+common/jinja2/common/accessibility.jinja


### PR DESCRIPTION
# TP2000-488  Include accessibility statement


## Why
TAP must include a link to its accessibility statement.

## What
- Creates new page to host accessibility statement (viewable at /accessibility-statement)
- Adds accessibility statement link to footer
- Adds test

#
<img width="450" alt="Screenshot 2023-04-03 at 12 05 10" src="https://user-images.githubusercontent.com/118175145/229491962-4f10a7a5-545a-40c5-9936-0d987b696820.png">

<img width="450" alt="Screenshot 2023-04-03 at 12 05 36" src="https://user-images.githubusercontent.com/118175145/229492049-69cc46ed-9561-4dd7-8d35-3cc5aa7f49c1.png">


