### PR TITLE
TP2000-826  Prevent only description deletion

### DIFF
--- a/additional_codes/tests/test_views.py
+++ b/additional_codes/tests/test_views.py
@@ -93,12 +93,27 @@ def test_additional_code_edit_views(
         use_edit_view(additional_code, data_changes)
 
 
-@pytest.mark.parametrize(
-    "factory",
-    (factories.AdditionalCodeFactory, factories.AdditionalCodeDescriptionFactory),
-)
-def test_additional_code_delete_form(factory, use_delete_form):
-    use_delete_form(factory())
+def test_additional_code_delete_form(use_delete_form):
+    use_delete_form(factories.AdditionalCodeFactory())
+
+
+def test_additional_code_description_delete_form(use_delete_form):
+    additional_code = factories.AdditionalCodeFactory()
+    (
+        description1,
+        description2,
+    ) = factories.AdditionalCodeDescriptionFactory.create_batch(
+        2,
+        described_additionalcode=additional_code,
+    )
+    use_delete_form(description1)
+    try:
+        use_delete_form(description2)
+    except ValidationError as e:
+        assert (
+            "This description cannot be deleted because at least one description record is mandatory."
+            in e.message
+        )
 
 
 @pytest.mark.parametrize(

--- a/additional_codes/views.py
+++ b/additional_codes/views.py
@@ -22,6 +22,7 @@ from additional_codes.serializers import AdditionalCodeTypeSerializer
 from common.models import TrackedModel
 from common.serializers import AutoCompleteSerializer
 from common.validators import UpdateType
+from common.views import DescriptionDeleteMixin
 from common.views import TamatoListView
 from common.views import TrackedModelDetailMixin
 from common.views import TrackedModelDetailView
@@ -259,6 +260,7 @@ class AdditionalCodeDelete(
 
 class AdditionalCodeDescriptionDelete(
     AdditionalCodeDescriptionMixin,
+    DescriptionDeleteMixin,
     TrackedModelDetailMixin,
     CreateTaricDeleteView,
 ):

--- a/certificates/tests/test_views.py
+++ b/certificates/tests/test_views.py
@@ -23,12 +23,24 @@ from common.views import TrackedModelDetailMixin
 pytestmark = pytest.mark.django_db
 
 
-@pytest.mark.parametrize(
-    "factory",
-    (factories.CertificateFactory, factories.CertificateDescriptionFactory),
-)
-def test_certificate_delete(factory, use_delete_form):
-    use_delete_form(factory())
+def test_certificate_delete(use_delete_form):
+    use_delete_form(factories.CertificateFactory())
+
+
+def test_certificate_description_delete_form(use_delete_form):
+    certificate = factories.CertificateFactory()
+    description1, description2 = factories.CertificateDescriptionFactory.create_batch(
+        2,
+        described_certificate=certificate,
+    )
+    use_delete_form(description1)
+    try:
+        use_delete_form(description2)
+    except ValidationError as e:
+        assert (
+            "This description cannot be deleted because at least one description record is mandatory."
+            in e.message
+        )
 
 
 def test_certificate_create_form_creates_certificate_description_object(

--- a/certificates/views.py
+++ b/certificates/views.py
@@ -14,6 +14,7 @@ from certificates.serializers import CertificateTypeSerializer
 from common.models import TrackedModel
 from common.serializers import AutoCompleteSerializer
 from common.validators import UpdateType
+from common.views import DescriptionDeleteMixin
 from common.views import TamatoListView
 from common.views import TrackedModelDetailMixin
 from common.views import TrackedModelDetailView
@@ -259,6 +260,7 @@ class CertificateDelete(
 
 class CertificateDescriptionDelete(
     CertificateDescriptionMixin,
+    DescriptionDeleteMixin,
     TrackedModelDetailMixin,
     CreateTaricDeleteView,
 ):

--- a/common/jinja2/common/delete.jinja
+++ b/common/jinja2/common/delete.jinja
@@ -1,7 +1,8 @@
 {% extends "layouts/form.jinja" %}
-{% from "components/breadcrumbs.jinja" import breadcrumbs %}
 
+{% from "components/breadcrumbs.jinja" import breadcrumbs %}
 {% from "components/warning-text/macro.njk" import govukWarningText %}
+{% from "components/button/macro.njk" import govukButton %}
 
 {% set page_title = "Delete " ~ object._meta.verbose_name ~ " " ~ object|string %}
 
@@ -21,5 +22,10 @@
   {% call django_form(action=object.get_url("delete")) %}
     {{ crispy(form) }}
   {% endcall %}
-  <a href="{{ object.get_url() }}" class="govuk-link">Cancel</a>
+
+  {{ govukButton({
+    "html": "Cancel",
+    "href": object.get_url(),
+    "classes": "govuk-button--secondary"
+  }) }}
 {% endblock %}

--- a/common/jinja2/common/delete.jinja
+++ b/common/jinja2/common/delete.jinja
@@ -24,7 +24,7 @@
   {% endcall %}
 
   {{ govukButton({
-    "html": "Cancel",
+    "text": "Cancel",
     "href": object.get_url(),
     "classes": "govuk-button--secondary"
   }) }}

--- a/common/jinja2/includes/common/tabs/descriptions.jinja
+++ b/common/jinja2/includes/common/tabs/descriptions.jinja
@@ -5,10 +5,10 @@
   <div class="govuk-grid-column-three-quarters">
     {% set description_rows = [] %}
     {% set descriptions = object.get_descriptions() %}
-    {% set is_last = descriptions|length == 1 %}
+    {% set is_only_description = descriptions|length == 1 %}
     {% for description in descriptions %}
       {% set edit_url = description.get_url("edit") %}
-      {% set delete_url = "" if is_last else description.get_url("delete") %}
+      {% set delete_url = "" if is_only_description else description.get_url("delete") %}
       {% set description_row = [
         {"text": "{:%d %b %Y}".format(description.validity_start)},
         {"text": description.description},

--- a/common/jinja2/includes/common/tabs/descriptions.jinja
+++ b/common/jinja2/includes/common/tabs/descriptions.jinja
@@ -4,9 +4,11 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-three-quarters">
     {% set description_rows = [] %}
-    {% for description in object.get_descriptions() %}
+    {% set descriptions = object.get_descriptions() %}
+    {% set is_last = descriptions|length == 1 %}
+    {% for description in descriptions %}
       {% set edit_url = description.get_url("edit") %}
-      {% set delete_url = description.get_url("delete") %}
+      {% set delete_url = "" if is_last else description.get_url("delete") %}
       {% set description_row = [
         {"text": "{:%d %b %Y}".format(description.validity_start)},
         {"text": description.description},

--- a/common/views.py
+++ b/common/views.py
@@ -336,7 +336,7 @@ class TrackedModelChangeView(
 
 
 class DescriptionDeleteMixin:
-    """Prevents the last description of the described object from being
+    """Prevents the only description of the described object from being
     deleted."""
 
     def form_valid(self, form):

--- a/common/views.py
+++ b/common/views.py
@@ -335,6 +335,21 @@ class TrackedModelChangeView(
         return FormMixin.form_valid(self, form)
 
 
+class DescriptionDeleteMixin:
+    """Prevents the last description of the described object from being
+    deleted."""
+
+    def form_valid(self, form):
+        described_object = self.object.get_described_object()
+        if described_object.get_descriptions().count() == 1:
+            form.add_error(
+                None,
+                "This description cannot be deleted because at least one description record is mandatory.",
+            )
+            return self.form_invalid(form)
+        return super().form_valid(form)
+
+
 class SortingMixin:
     """
     Can be used to sort a queryset in a view using GET params. Checks the GET

--- a/footnotes/tests/test_views.py
+++ b/footnotes/tests/test_views.py
@@ -91,7 +91,7 @@ def test_footnote_business_rule_application(
     )
 
 
-def test_delete_form(use_delete_form):
+def test_footnote_delete_form(use_delete_form):
     use_delete_form(factories.FootnoteFactory())
 
 

--- a/footnotes/tests/test_views.py
+++ b/footnotes/tests/test_views.py
@@ -91,12 +91,24 @@ def test_footnote_business_rule_application(
     )
 
 
-@pytest.mark.parametrize(
-    "factory",
-    (factories.FootnoteFactory, factories.FootnoteDescriptionFactory),
-)
-def test_delete_form(factory, use_delete_form):
-    use_delete_form(factory())
+def test_delete_form(use_delete_form):
+    use_delete_form(factories.FootnoteFactory())
+
+
+def test_footnote_description_delete_form(use_delete_form):
+    footnote = factories.FootnoteFactory()
+    description1, description2 = factories.FootnoteDescriptionFactory.create_batch(
+        2,
+        described_footnote=footnote,
+    )
+    use_delete_form(description1)
+    try:
+        use_delete_form(description2)
+    except ValidationError as e:
+        assert (
+            "This description cannot be deleted because at least one description record is mandatory."
+            in e.message
+        )
 
 
 @pytest.mark.parametrize(

--- a/footnotes/views.py
+++ b/footnotes/views.py
@@ -8,6 +8,7 @@ from rest_framework import viewsets
 from common.models import TrackedModel
 from common.serializers import AutoCompleteSerializer
 from common.validators import UpdateType
+from common.views import DescriptionDeleteMixin
 from common.views import TamatoListView
 from common.views import TrackedModelDetailMixin
 from common.views import TrackedModelDetailView
@@ -272,6 +273,7 @@ class FootnoteDescriptionConfirmUpdate(
 
 class FootnoteDescriptionDelete(
     FootnoteDescriptionMixin,
+    DescriptionDeleteMixin,
     TrackedModelDetailMixin,
     CreateTaricDeleteView,
 ):

--- a/geo_areas/tests/test_views.py
+++ b/geo_areas/tests/test_views.py
@@ -1,5 +1,6 @@
 import pytest
 from bs4 import BeautifulSoup
+from django.core.exceptions import ValidationError
 from rest_framework.reverse import reverse
 
 from common.models.utils import override_current_transaction
@@ -21,12 +22,27 @@ from geo_areas.views import GeoAreaList
 pytestmark = pytest.mark.django_db
 
 
-@pytest.mark.parametrize(
-    "factory",
-    (factories.GeographicalAreaFactory, factories.GeographicalAreaDescriptionFactory),
-)
-def test_geo_area_delete(factory, use_delete_form):
-    use_delete_form(factory())
+def test_geo_area_delete(use_delete_form):
+    use_delete_form(factories.GeographicalAreaFactory())
+
+
+def test_geo_area_description_delete_form(use_delete_form):
+    geo_area = factories.GeographicalAreaFactory()
+    (
+        description1,
+        description2,
+    ) = factories.GeographicalAreaDescriptionFactory.create_batch(
+        2,
+        described_geographicalarea=geo_area,
+    )
+    use_delete_form(description1)
+    try:
+        use_delete_form(description2)
+    except ValidationError as e:
+        assert (
+            "This description cannot be deleted because at least one description record is mandatory."
+            in e.message
+        )
 
 
 @pytest.mark.parametrize(

--- a/geo_areas/views.py
+++ b/geo_areas/views.py
@@ -7,6 +7,7 @@ from common.models.trackedmodel import TrackedModel
 from common.serializers import AutoCompleteSerializer
 from common.util import TaricDateRange
 from common.validators import UpdateType
+from common.views import DescriptionDeleteMixin
 from common.views import TamatoListView
 from common.views import TrackedModelDetailMixin
 from common.views import TrackedModelDetailView
@@ -128,6 +129,7 @@ class GeoAreaDescriptionConfirmCreate(
 
 class GeoAreaDescriptionDelete(
     GeoAreaDescriptionMixin,
+    DescriptionDeleteMixin,
     TrackedModelDetailMixin,
     CreateTaricDeleteView,
 ):


### PR DESCRIPTION
# TP2000-826  Prevent only description deletion

## Why
When additional codes, certificates, footnotes and geo areas have only one description, TAP allows users to delete it, which results in a business rule violation. 

## What
- Hides delete link from description tab if only one description is available
- Adds `DescriptionDeleteMixin`, used by delete forms to prevent the only description from being deleted
- Styles the cancel link as a button
- Adds tests

## 
<img width="500" alt="Screenshot 2023-04-14 at 09 58 47" src="https://user-images.githubusercontent.com/118175145/232000008-0eb1bb44-16d8-4b6e-a5b8-4f4b79f387ce.png">


