### PR TITLE
TP2000-830  Expand validation for editing geo areas

### DIFF
--- a/common/views.py
+++ b/common/views.py
@@ -262,7 +262,6 @@ class BusinessRulesMixin:
     """Check business rules on form_submission."""
 
     validate_business_rules: Tuple[Type[BusinessRule], ...] = tuple()
-    validate_indirect_business_rules: Tuple[Type[BusinessRule], ...] = tuple()
 
     def form_violates(self, form) -> bool:
         """

--- a/common/views.py
+++ b/common/views.py
@@ -33,7 +33,6 @@ from django.views.generic.edit import FormMixin
 from django_filters.views import FilterView
 from redis.exceptions import TimeoutError as RedisTimeoutError
 
-from checks.checks import IndirectBusinessRuleChecker
 from common import forms
 from common.business_rules import BusinessRule
 from common.business_rules import BusinessRuleViolation
@@ -281,14 +280,6 @@ class BusinessRulesMixin:
             except BusinessRuleViolation as v:
                 form.add_error(None, v.args[0])
                 violations = True
-
-        for rule in self.validate_indirect_business_rules:
-            checkers = IndirectBusinessRuleChecker.of(rule).checkers_for(self.object)
-            for checker in checkers:
-                (rule_passed, message) = checker.run(self.object)
-                if not rule_passed:
-                    form.add_error(None, message.partition(": ")[-1])
-                    violations = True
 
         return violations
 

--- a/geo_areas/tests/test_forms.py
+++ b/geo_areas/tests/test_forms.py
@@ -63,9 +63,9 @@ def test_geographical_area_end_date_form_valid_date(date_ranges):
         "end_date_1": date_ranges.later.upper.month,
         "end_date_2": date_ranges.later.upper.year,
     }
-    form = forms.GeographicalAreaEndDateForm(data=form_data, instance=geo_area)
-
-    assert form.is_valid()
+    with override_current_transaction(Transaction.objects.last()):
+        form = forms.GeographicalAreaEndDateForm(data=form_data, instance=geo_area)
+        assert form.is_valid()
 
 
 def test_geographical_area_end_date_form_invalid_date(date_ranges):

--- a/geo_areas/tests/test_forms.py
+++ b/geo_areas/tests/test_forms.py
@@ -70,17 +70,33 @@ def test_geographical_area_end_date_form_valid_date(date_ranges):
 
 def test_geographical_area_end_date_form_invalid_date(date_ranges):
     geo_area = factories.GeographicalAreaFactory.create(
-        valid_between=date_ranges.normal,
+        valid_between=date_ranges.no_end,
+    )
+    order_origin_number = factories.QuotaOrderNumberOriginFactory.create(
+        geographical_area=geo_area,
+        valid_between=date_ranges.no_end,
     )
 
-    form_data = {
+    invalid_date_1 = {
         "end_date_0": "z",
         "end_date_1": "z",
         "end_date_2": "zzzz",
     }
-    form = forms.GeographicalAreaEndDateForm(data=form_data, instance=geo_area)
-
+    form = forms.GeographicalAreaEndDateForm(data=invalid_date_1, instance=geo_area)
     assert not form.is_valid()
+
+    invalid_date_2 = {
+        "end_date_0": date_ranges.later.upper.day,
+        "end_date_1": date_ranges.later.upper.month,
+        "end_date_2": date_ranges.later.upper.year,
+    }
+    with override_current_transaction(Transaction.objects.last()):
+        form = forms.GeographicalAreaEndDateForm(data=invalid_date_2, instance=geo_area)
+        assert not form.is_valid()
+        assert (
+            "The end date must span the validity period of the quota order number origin that specifies this geographical area."
+            in form.errors["end_date"]
+        )
 
 
 def test_geographical_membership_add_form_valid_data(date_ranges):

--- a/geo_areas/tests/test_views.py
+++ b/geo_areas/tests/test_views.py
@@ -146,6 +146,7 @@ def test_geo_area_update_view_edit_end_date(
     session_workbasket,
     date_ranges,
 ):
+    """Tests that a geographical area's end date can be edited."""
     geo_area = factories.GeographicalAreaFactory.create(
         valid_between=date_ranges.normal,
     )
@@ -176,6 +177,44 @@ def test_geo_area_update_view_edit_end_date(
     for geo_area in geo_areas:
         assert geo_area.valid_between.upper == new_end_date
         assert geo_area.update_type == UpdateType.UPDATE
+
+
+def test_geo_area_update_view_edit_end_date_invalid_date(
+    valid_user_client,
+    session_workbasket,
+    date_ranges,
+):
+    """Tests that HTML contains a form validation error after posting to geo
+    area update endpoint with an invalid end date as checked against indirect
+    business rule ON6."""
+
+    geo_area = factories.GeographicalAreaFactory.create(
+        valid_between=date_ranges.normal,
+    )
+    order_origin_number = factories.QuotaOrderNumberOriginFactory.create(
+        geographical_area=geo_area,
+        valid_between=date_ranges.no_end,
+    )
+
+    form_data = {
+        "end_date_0": date_ranges.later.upper.day,
+        "end_date_1": date_ranges.later.upper.month,
+        "end_date_2": date_ranges.later.upper.year,
+    }
+
+    url = reverse(
+        "geo_area-ui-edit",
+        kwargs={"sid": geo_area.sid},
+    )
+    response = valid_user_client.post(url, form_data)
+    assert response.status_code == 200
+
+    page = BeautifulSoup(str(response.content), "html.parser")
+    a_tags = page.select("ul.govuk-list.govuk-error-summary__list a")
+    assert (
+        a_tags[0].text
+        == "The validity period of the geographical area must span the validity period of the quota order number origin."
+    )
 
 
 def test_geo_area_update_view_membership_add_country_or_region(

--- a/geo_areas/tests/test_views.py
+++ b/geo_areas/tests/test_views.py
@@ -195,44 +195,6 @@ def test_geo_area_update_view_edit_end_date(
         assert geo_area.update_type == UpdateType.UPDATE
 
 
-def test_geo_area_update_view_edit_end_date_invalid_date(
-    valid_user_client,
-    session_workbasket,
-    date_ranges,
-):
-    """Tests that HTML contains a form validation error after posting to geo
-    area update endpoint with an invalid end date as checked against indirect
-    business rule ON6."""
-
-    geo_area = factories.GeographicalAreaFactory.create(
-        valid_between=date_ranges.normal,
-    )
-    order_origin_number = factories.QuotaOrderNumberOriginFactory.create(
-        geographical_area=geo_area,
-        valid_between=date_ranges.no_end,
-    )
-
-    form_data = {
-        "end_date_0": date_ranges.later.upper.day,
-        "end_date_1": date_ranges.later.upper.month,
-        "end_date_2": date_ranges.later.upper.year,
-    }
-
-    url = reverse(
-        "geo_area-ui-edit",
-        kwargs={"sid": geo_area.sid},
-    )
-    response = valid_user_client.post(url, form_data)
-    assert response.status_code == 200
-
-    page = BeautifulSoup(str(response.content), "html.parser")
-    a_tags = page.select("ul.govuk-list.govuk-error-summary__list a")
-    assert (
-        a_tags[0].text
-        == "The validity period of the geographical area must span the validity period of the quota order number origin."
-    )
-
-
 def test_geo_area_update_view_membership_add_country_or_region(
     valid_user_client,
     session_workbasket,

--- a/geo_areas/views.py
+++ b/geo_areas/views.py
@@ -20,7 +20,6 @@ from geo_areas.forms import GeoMembershipAction
 from geo_areas.models import GeographicalArea
 from geo_areas.models import GeographicalAreaDescription
 from geo_areas.models import GeographicalMembership
-from quotas import business_rules as quotas_business_rules
 from workbaskets.models import WorkBasket
 from workbaskets.views.generic import CreateTaricCreateView
 from workbaskets.views.generic import CreateTaricDeleteView
@@ -142,19 +141,12 @@ class GeoAreaUpdateMixin(GeoAreaMixin, TrackedModelDetailMixin):
     form_class = GeographicalAreaEditForm
 
     validate_business_rules = (
-        business_rules.GA1,
-        business_rules.GA3,
-        business_rules.GA4,
         business_rules.GA5,
         business_rules.GA6,
         business_rules.GA7,
         business_rules.GA10,
         business_rules.GA11,
-        business_rules.GA21,
-        business_rules.GA22,
     )
-
-    validate_indirect_business_rules = (quotas_business_rules.ON6,)
 
     def get_form_kwargs(self):
         kwargs = super().get_form_kwargs()

--- a/geo_areas/views.py
+++ b/geo_areas/views.py
@@ -19,6 +19,7 @@ from geo_areas.forms import GeoMembershipAction
 from geo_areas.models import GeographicalArea
 from geo_areas.models import GeographicalAreaDescription
 from geo_areas.models import GeographicalMembership
+from quotas import business_rules as quotas_business_rules
 from workbaskets.models import WorkBasket
 from workbaskets.views.generic import CreateTaricCreateView
 from workbaskets.views.generic import CreateTaricDeleteView
@@ -150,6 +151,8 @@ class GeoAreaUpdateMixin(GeoAreaMixin, TrackedModelDetailMixin):
         business_rules.GA21,
         business_rules.GA22,
     )
+
+    validate_indirect_business_rules = (quotas_business_rules.ON6,)
 
     def get_form_kwargs(self):
         kwargs = super().get_form_kwargs()


### PR DESCRIPTION
# TP2000-830  Expand validation for editing geo areas

## Why
Form validation for editing the end date of a geographical area needs to cover where the validity period of the geographical area would no longer span the validity period of a linked quota order number origin.

## What
- Adds validation to `GeographicalAreaEndDateForm`
- Adds test

~~Adds the ability to `BusinessRulesMixin` to run indirect business rules for `TrackedModelChangeViews`~~
~~Adds indirect business rule ON6 to geo area update view~~


##
<img width="450" alt="Screenshot 2023-04-17 at 12 45 38" src="https://user-images.githubusercontent.com/118175145/232513509-826431ba-45f3-45e5-b346-27232eeea29d.png">



