### PR TITLE
TP2000-820 Decouple envelope name from S3 object key

### DIFF
--- a/publishing/storages.py
+++ b/publishing/storages.py
@@ -22,11 +22,14 @@ class EnvelopeStorage(S3Boto3Storage):
     def generate_filename(self, filename: str) -> str:
         from django.conf import settings
 
-        filename = path.join(
-            settings.HMRC_ENVELOPE_STORAGE_DIRECTORY,
-            filename,
-        )
-        return super().generate_filename(filename)
+        # Suffix the filename with a time stamp so that envelopes are not
+        # overwritten on S3 instances with versioning disabled.
+        name, extension = path.splitext(filename)
+        date_time = timezone.now().isoformat()
+        filename = f"{name}__{date_time}{extension}"
+        filepath = path.join(settings.HMRC_ENVELOPE_STORAGE_DIRECTORY, filename)
+
+        return super().generate_filename(filepath)
 
     def get_object_parameters(self, name):
         self.object_parameters.update(


### PR DESCRIPTION
# TP2000-820 Decouple envelope name from S3 object key
<!---
 * Include the JIRA ticket number, eg TP-123, to automatically link.
 * Use 50 characters maximum.
 * Do not end with a full-stop.
--->

## Why
<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Use as many lines as you like.
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions or deliberately ignored edge-cases.
--->
When an envelope is rejected during packaging process, its ID is recycled for use by the next envelope. Currently, the S3 object name of an envelope is the same its external envelope file name (i.e. the name seen when downloading an envelope through the TAP UI). If S3 versioning is not enabled, then this S3 object naming policy results in rejected envelopes being overwritten and lost within S3.

## What
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Explain like I'm 5.
 * Use pictures if you can.
--->
This PR decouples the S3 object name from the external envelope file name by introducing a time stamp as part of the S3 object name. An envelope's file name remains unchanged when downloading via the TAP UI.

<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
--->
## Checklist
- Requires migrations? No
- Requires dependency updates? No

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
