### PR TITLE
TP2000-844  Add suffix and indent columns to find commodities view

### DIFF
--- a/commodities/jinja2/includes/commodities/list.jinja
+++ b/commodities/jinja2/includes/commodities/list.jinja
@@ -8,7 +8,7 @@
     {{ table_rows.append([
         {"html": commodity_link},
         {"text": commodity.suffix},
-        {"text": commodity.indents.all().last().indent},
+        {"text": commodity.indents.filter(validity_start__lte=today).last().indent},
         {"text": commodity.get_description().description},
     ]) or "" }}
 {% endfor %}

--- a/commodities/jinja2/includes/commodities/list.jinja
+++ b/commodities/jinja2/includes/commodities/list.jinja
@@ -7,12 +7,16 @@
     {%- endset %}
     {{ table_rows.append([
         {"html": commodity_link},
+        {"text": commodity.suffix},
+        {"text": commodity.indents.all().last().indent},
         {"text": commodity.get_description().description},
     ]) or "" }}
 {% endfor %}
 {{ govukTable({
     "head": [
         {"text": "Commodity code"},
+        {"text": "Suffix"},
+        {"text": "Indent"},
         {"text": "Commodity description"},
 
     ],

--- a/commodities/jinja2/includes/commodities/list.jinja
+++ b/commodities/jinja2/includes/commodities/list.jinja
@@ -8,7 +8,7 @@
     {{ table_rows.append([
         {"html": commodity_link},
         {"text": commodity.suffix},
-        {"text": commodity.indents.filter(validity_start__lte=today).last().indent},
+        {"text": commodity.get_indent_as_at(today).indent},
         {"text": commodity.get_description().description},
     ]) or "" }}
 {% endfor %}

--- a/commodities/jinja2/includes/commodities/tabs/core_data.jinja
+++ b/commodities/jinja2/includes/commodities/tabs/core_data.jinja
@@ -26,7 +26,7 @@
             },
             {
                 "key": {"text": "Indent number"},
-                "value": {"text": object.indents.all().last().indent},
+                "value": {"text": indent_number},
                 "actions": {"items": []}
             },
             {

--- a/commodities/models/orm.py
+++ b/commodities/models/orm.py
@@ -149,13 +149,13 @@ class GoodsNomenclature(TrackedModel, ValidityMixin, DescribedMixin):
 
         return indent_shift
 
-    def get_indent_as_at(self, date: date) -> GoodsNomenclatureIndent:
+    def get_indent_as_at(self, date: date) -> Optional[GoodsNomenclatureIndent]:
         """
         Returns the indent instance for the commodity as at the given date.
 
         The returned indent instance will be the most recent one whose
         `validity_start` date was the same as or before the given date. Returns
-        `None` if no indent instance was valid at the given date.
+        `None` if no indent instance was valid as at the given date.
         """
         indents = self.indents.filter(validity_start__lte=date)
         if not indents:

--- a/commodities/models/orm.py
+++ b/commodities/models/orm.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from datetime import date
 from typing import Optional
 from typing import Set
 
@@ -147,6 +148,19 @@ class GoodsNomenclature(TrackedModel, ValidityMixin, DescribedMixin):
             indent_shift += 1
 
         return indent_shift
+
+    def get_indent_as_at(self, date: date) -> GoodsNomenclatureIndent:
+        """
+        Returns the indent instance for the commodity as at the given date.
+
+        The returned indent instance will be the most recent one whose
+        `validity_start` date was the same as or before the given date. Returns
+        `None` if no indent instance was valid at the given date.
+        """
+        indents = self.indents.filter(validity_start__lte=date)
+        if not indents:
+            return None
+        return indents.last()
 
 
 class GoodsNomenclatureIndent(TrackedModel, ValidityStartMixin):

--- a/commodities/tests/test_views.py
+++ b/commodities/tests/test_views.py
@@ -92,9 +92,7 @@ def test_commodity_list_displays_commodity_suffix_indent_and_description(
     assert page.find("tbody").find("td", text=commodity1.suffix)
     assert page.find("tbody").find(
         "td",
-        text=commodity1.indents.filter(validity_start__lte=datetime.date.today())
-        .last()
-        .indent,
+        text=commodity1.get_indent_as_at(datetime.date.today()).indent,
     )
     assert page.find("tbody").find("td", text="A commodity code description")
 
@@ -103,9 +101,7 @@ def test_commodity_list_displays_commodity_suffix_indent_and_description(
     assert page.find("tbody").find("td", text=commodity2.suffix)
     assert page.find("tbody").find(
         "td",
-        text=commodity2.indents.filter(validity_start__lte=datetime.date.today())
-        .last()
-        .indent,
+        text=commodity2.get_indent_as_at(datetime.date.today()).indent,
     )
     assert page.find("tbody").find("td", text="A second commodity code description")
 

--- a/commodities/tests/test_views.py
+++ b/commodities/tests/test_views.py
@@ -68,9 +68,11 @@ def test_commodities_import_failure(file_name, error_msg, valid_user_client):
     assert error_msg in soup.select(".govuk-error-message")[0].text
 
 
-def test_commodity_list_displays_commodity_and_description(valid_user_client):
-    """Test that a list of commodity codes with links and their descriptions are
-    displayed on the list view template."""
+def test_commodity_list_displays_commodity_suffix_indent_and_description(
+    valid_user_client,
+):
+    """Test that a list of commodity codes with links and their suffixes,
+    indents and descriptions are displayed on the list view template."""
     commodity1 = GoodsNomenclatureDescriptionFactory.create(
         description="A commodity code description",
     ).described_goods_nomenclature
@@ -86,9 +88,14 @@ def test_commodity_list_displays_commodity_and_description(valid_user_client):
     )
     assert page.find("tbody").find("td", text=commodity1.item_id)
     assert page.find("tbody").find(href=f"/commodities/{commodity1.sid}/")
+    assert page.find("tbody").find("td", text=commodity1.suffix)
+    assert page.find("tbody").find("td", text=commodity1.indents.all().last().indent)
     assert page.find("tbody").find("td", text="A commodity code description")
+
     assert page.find("tbody").find("td", text=commodity2.item_id)
     assert page.find("tbody").find(href=f"/commodities/{commodity2.sid}/")
+    assert page.find("tbody").find("td", text=commodity2.suffix)
+    assert page.find("tbody").find("td", text=commodity2.indents.all().last().indent)
     assert page.find("tbody").find("td", text="A second commodity code description")
 
 

--- a/commodities/tests/test_views.py
+++ b/commodities/tests/test_views.py
@@ -1,3 +1,4 @@
+import datetime
 import json
 from os import path
 from unittest.mock import patch
@@ -89,13 +90,23 @@ def test_commodity_list_displays_commodity_suffix_indent_and_description(
     assert page.find("tbody").find("td", text=commodity1.item_id)
     assert page.find("tbody").find(href=f"/commodities/{commodity1.sid}/")
     assert page.find("tbody").find("td", text=commodity1.suffix)
-    assert page.find("tbody").find("td", text=commodity1.indents.all().last().indent)
+    assert page.find("tbody").find(
+        "td",
+        text=commodity1.indents.filter(validity_start__lte=datetime.date.today())
+        .last()
+        .indent,
+    )
     assert page.find("tbody").find("td", text="A commodity code description")
 
     assert page.find("tbody").find("td", text=commodity2.item_id)
     assert page.find("tbody").find(href=f"/commodities/{commodity2.sid}/")
     assert page.find("tbody").find("td", text=commodity2.suffix)
-    assert page.find("tbody").find("td", text=commodity2.indents.all().last().indent)
+    assert page.find("tbody").find(
+        "td",
+        text=commodity2.indents.filter(validity_start__lte=datetime.date.today())
+        .last()
+        .indent,
+    )
     assert page.find("tbody").find("td", text="A second commodity code description")
 
 

--- a/commodities/views.py
+++ b/commodities/views.py
@@ -90,9 +90,8 @@ class CommodityDetail(CommodityMixin, TrackedModelDetailView):
     def get_context_data(self, *args, **kwargs):
         context = super().get_context_data(*args, **kwargs)
 
-        context["indent_number"] = (
-            self.object.indents.filter(validity_start__lte=date.today()).last().indent
-        )
+        indent = self.object.get_indent_as_at(date.today())
+        context["indent_number"] = indent.indent if indent else "-"
 
         collection = get_chapter_collection(self.object)
         tx = WorkBasket.get_current_transaction(self.request)

--- a/commodities/views.py
+++ b/commodities/views.py
@@ -78,6 +78,11 @@ class CommodityList(CommodityMixin, WithPaginationListView):
     def get_queryset(self):
         return GoodsNomenclature.objects.current().order_by("item_id")
 
+    def get_context_data(self, *args, **kwargs):
+        context = super().get_context_data(*args, **kwargs)
+        context["today"] = date.today()
+        return context
+
 
 class CommodityDetail(CommodityMixin, TrackedModelDetailView):
     template_name = "commodities/detail.jinja"
@@ -85,10 +90,14 @@ class CommodityDetail(CommodityMixin, TrackedModelDetailView):
     def get_context_data(self, *args, **kwargs):
         context = super().get_context_data(*args, **kwargs)
 
+        context["indent_number"] = (
+            self.object.indents.filter(validity_start__lte=date.today()).last().indent
+        )
+
         collection = get_chapter_collection(self.object)
         tx = WorkBasket.get_current_transaction(self.request)
-        date = self.object.valid_between.upper
-        snapshot = collection.get_snapshot(tx, date)
+        snapshot_date = self.object.valid_between.upper
+        snapshot = collection.get_snapshot(tx, snapshot_date)
         commodity = snapshot.get_commodity(self.object, self.object.suffix)
         context["parent"] = snapshot.get_parent(commodity)
 


### PR DESCRIPTION
# TP2000-844  Add suffix and indent columns to find commodities view

## Why
Both suffix and indent data is missing from the find commodities view. Displaying this data would help users more easily find a relevant commodity code. 

## What
- Adds suffix and indent columns to find commodities view
- Update test

##
<img width="400" alt="Screenshot 2023-04-19 at 12 37 58" src="https://user-images.githubusercontent.com/118175145/233063622-98780baa-9bde-480e-85a3-2512f8a5dd3c.png">

