### PR TITLE
TP2000-849  Add active state filter to quota search

### DIFF
--- a/quotas/filters.py
+++ b/quotas/filters.py
@@ -2,6 +2,7 @@ from django import forms
 from django.urls import reverse_lazy
 from django_filters import MultipleChoiceFilter
 
+from common.filters import ActiveStateMixin
 from common.filters import AutoCompleteFilter
 from common.filters import TamatoFilter
 from common.filters import TamatoFilterBackend
@@ -15,7 +16,7 @@ class OrderNumberFilterBackend(TamatoFilterBackend):
     search_fields = ("order_number",)  # XXX order is significant
 
 
-class QuotaFilter(TamatoFilter):
+class QuotaFilter(TamatoFilter, ActiveStateMixin):
     order_number = AutoCompleteFilter(
         label="Order number",
         field_name="order_number",

--- a/quotas/forms.py
+++ b/quotas/forms.py
@@ -21,6 +21,7 @@ class QuotaFilterForm(forms.Form):
             Field.text("origin", label_size=Size.SMALL),
             Field.radios("mechanism", legend_size=Size.SMALL),
             Field.radios("category", legend_size=Size.SMALL),
+            Field.radios("active_state", legend_size=Size.SMALL),
             Button("submit", "Search and Filter", css_class="govuk-!-margin-top-6"),
             HTML(
                 f'<a class="govuk-button govuk-button--secondary govuk-!-margin-top-6" href="{self.clear_url}"> Clear </a>',

--- a/quotas/tests/test_views.py
+++ b/quotas/tests/test_views.py
@@ -140,6 +140,37 @@ def test_quota_list_view(view, url_pattern, valid_user_client):
     assert_model_view_renders(view, url_pattern, valid_user_client)
 
 
+@pytest.mark.parametrize(
+    ("search_filter", "search_term"),
+    [
+        ("active_state", "active"),
+        ("active_state", "terminated"),
+    ],
+)
+def test_quota_list_view_active_state_filter(
+    valid_user_client,
+    date_ranges,
+    search_filter,
+    search_term,
+):
+    active_quota = factories.QuotaOrderNumberFactory.create(
+        valid_between=date_ranges.no_end,
+    )
+    inactive_quota = factories.QuotaOrderNumberFactory.create(
+        valid_between=date_ranges.earlier,
+    )
+
+    list_url = reverse("quota-ui-list")
+    url = f"{list_url}?{search_filter}={search_term}"
+
+    response = valid_user_client.get(url)
+    assert response.status_code == 200
+
+    soup = BeautifulSoup(str(response.content), "html.parser")
+    search_results = soup.select("tbody .govuk-table__row")
+    assert len(search_results) == 1
+
+
 def test_quota_ordernumber_api_list_view(valid_user_client, date_ranges):
     expected_results = [
         factories.QuotaOrderNumberFactory.create(

--- a/quotas/tests/test_views.py
+++ b/quotas/tests/test_views.py
@@ -141,10 +141,11 @@ def test_quota_list_view(view, url_pattern, valid_user_client):
 
 
 @pytest.mark.parametrize(
-    ("search_filter", "search_term"),
+    ("search_filter", "search_term", "valid"),
     [
-        ("active_state", "active"),
-        ("active_state", "terminated"),
+        ("active_state", "active", True),
+        ("active_state", "terminated", True),
+        ("active_state", "invalid", False),
     ],
 )
 def test_quota_list_view_active_state_filter(
@@ -152,6 +153,7 @@ def test_quota_list_view_active_state_filter(
     date_ranges,
     search_filter,
     search_term,
+    valid,
 ):
     active_quota = factories.QuotaOrderNumberFactory.create(
         valid_between=date_ranges.no_end,
@@ -168,7 +170,10 @@ def test_quota_list_view_active_state_filter(
 
     soup = BeautifulSoup(str(response.content), "html.parser")
     search_results = soup.select("tbody .govuk-table__row")
-    assert len(search_results) == 1
+    if valid:
+        assert len(search_results) == 1
+    else:
+        assert len(search_results) == 0
 
 
 def test_quota_ordernumber_api_list_view(valid_user_client, date_ranges):

--- a/quotas/tests/test_views.py
+++ b/quotas/tests/test_views.py
@@ -141,7 +141,7 @@ def test_quota_list_view(view, url_pattern, valid_user_client):
 
 
 @pytest.mark.parametrize(
-    ("search_filter", "search_term", "valid"),
+    ("search_filter", "checkbox", "valid"),
     [
         ("active_state", "active", True),
         ("active_state", "terminated", True),
@@ -152,7 +152,7 @@ def test_quota_list_view_active_state_filter(
     valid_user_client,
     date_ranges,
     search_filter,
-    search_term,
+    checkbox,
     valid,
 ):
     active_quota = factories.QuotaOrderNumberFactory.create(
@@ -163,7 +163,7 @@ def test_quota_list_view_active_state_filter(
     )
 
     list_url = reverse("quota-ui-list")
-    url = f"{list_url}?{search_filter}={search_term}"
+    url = f"{list_url}?{search_filter}={checkbox}"
 
     response = valid_user_client.get(url)
     assert response.status_code == 200


### PR DESCRIPTION
# TP2000-849  Add active state filter to quota search

## Why
The 'search and filter' form on the 'find and edit quotas' view is missing options to filter by "active" and "terminated" quotas.

## What
- Adds `ActiveStateMixin` to `QuotaFilter`
- Adds test

##
<img width="391" alt="Screenshot 2023-04-21 at 09 16 24" src="https://user-images.githubusercontent.com/118175145/233582334-b9011c35-f904-4633-9402-5f4509d8f913.png">

