### PR TITLE
TP2000-738 Display rule check progress

### DIFF
--- a/common/jinja2/common/app_info.jinja
+++ b/common/jinja2/common/app_info.jinja
@@ -36,6 +36,7 @@
       {% set table_head = [
           {"text": "Workbasket ID"},
           {"text": "Time started"},
+          {"text": "Checks completed"},
           {"text": "Celery task ID"},
       ] %}
       {% set table_rows = [] %}
@@ -46,6 +47,7 @@
             {{ table_rows.append([
                 {"text": check.workbasket_id},
                 {"text": check.date_time_start},
+                {"text": check.checks_completed},
                 {"text": check.task_id},
             ]) or "" }}
           {% endfor %}

--- a/common/views.py
+++ b/common/views.py
@@ -40,6 +40,7 @@ from common.celery import app
 from common.models import TrackedModel
 from common.pagination import build_pagination_list
 from common.validators import UpdateType
+from workbaskets.models import WorkBasket
 from workbaskets.views.mixins import WithCurrentWorkBasket
 
 
@@ -147,11 +148,17 @@ class AppInfoView(
                             task_info.get("time_start"),
                         ),
                     ).strftime("%Y-%m-%d, %H:%M:%S")
+
+                    workbasket_id = task_info.get("args", [""])[0]
+                    workbasket = WorkBasket.objects.get(id=workbasket_id)
+                    num_completed, total = workbasket.rule_check_progress()
+
                     results.append(
                         {
                             "task_id": task_info.get("id"),
-                            "workbasket_id": task_info.get("args", [""])[0],
+                            "workbasket_id": workbasket_id,
                             "date_time_start": date_time_start,
+                            "checks_completed": f"{num_completed} out of {total}",
                         },
                     )
 

--- a/workbaskets/jinja2/workbaskets/summary-workbasket.jinja
+++ b/workbaskets/jinja2/workbaskets/summary-workbasket.jinja
@@ -64,7 +64,7 @@
   <h2 class="govuk-heading-s">
     Live status : 
     {% if context == 'in-progress' %}
-      rule check in progress. Checking {{ workbasket.tracked_models.count() }} objects in basket. Come back later or refresh to see results.
+      rule check in progress.
       {{ terminate_rule_check_form }}
     {% elif context == 'no-checks'%}
       no rule check performed yet.
@@ -95,7 +95,12 @@
 
 {% set rule_check_block %}
   {% if rule_check_in_progress %}
-    {{ live_rule_check('in-progress') }}    
+    {{ live_rule_check('in-progress') }}
+    <p class="govuk-body govuk-!-font-weight-bold">
+      Checking {{ workbasket.tracked_models.count() }} objects in basket.
+      {{rule_check_progress}}.
+      Come back later or refresh to see results.
+    </p>
   {% elif workbasket.tracked_model_check_errors.exists() %}
     <div class="govuk-error-summary" aria-labelledby="summary-title" role="alert" data-module="govuk-error-summary">
       {{ rule_check_result_content() }} 

--- a/workbaskets/models.py
+++ b/workbaskets/models.py
@@ -4,6 +4,7 @@ import logging
 from abc import ABCMeta
 from abc import abstractmethod
 from typing import Optional
+from typing import Tuple
 
 from celery.result import AsyncResult
 from django.conf import settings
@@ -345,6 +346,27 @@ class WorkBasket(TimestampedMixin):
         if not task_result:
             return None
         return task_result.status
+
+    def rule_check_progress(self) -> Tuple[int, int]:
+        """
+        Provides progress of a rule check for the WorkBasket.
+
+        Returns:
+            num_completed: the number of transaction checks already completed
+            total: the total number of transactions to be checked
+        """
+        transaction_checks = TransactionCheck.objects.filter(
+            transaction__workbasket=self,
+            completed=True,
+        )
+        num_completed = transaction_checks.count()
+
+        transactions = Transaction.objects.filter(
+            workbasket=self,
+        )
+        total = transactions.count()
+
+        return num_completed, total
 
     @property
     def approved(self):

--- a/workbaskets/tests/test_models.py
+++ b/workbaskets/tests/test_models.py
@@ -5,6 +5,7 @@ import pytest
 from django.conf import settings
 from django_fsm import TransitionNotAllowed
 
+from checks.tests.factories import TransactionCheckFactory
 from common.models import TrackedModel
 from common.models.transactions import Transaction
 from common.models.transactions import TransactionPartition
@@ -369,3 +370,12 @@ def test_queue(valid_user, unapproved_checked_transaction):
 
     for transaction in wb.transactions.all():
         assert transaction.partition == TransactionPartition.REVISION
+
+
+def test_workbasket_rule_check_progress():
+    workbasket = factories.WorkBasketFactory.create()
+    transactions = TransactionFactory.create_batch(5, workbasket=workbasket)
+    check = TransactionCheckFactory.create(transaction=transactions[0], completed=True)
+    num_completed, total = workbasket.rule_check_progress()
+    assert num_completed == 1
+    assert total == len(transactions)

--- a/workbaskets/tests/test_models.py
+++ b/workbaskets/tests/test_models.py
@@ -373,8 +373,11 @@ def test_queue(valid_user, unapproved_checked_transaction):
 
 
 def test_workbasket_rule_check_progress():
+    """Tests that `rule_check_progress()` returns the number of completed
+    transaction checks and total number of transactions to be checked for the
+    workbasket."""
     workbasket = factories.WorkBasketFactory.create()
-    transactions = TransactionFactory.create_batch(5, workbasket=workbasket)
+    transactions = TransactionFactory.create_batch(3, workbasket=workbasket)
     check = TransactionCheckFactory.create(transaction=transactions[0], completed=True)
     num_completed, total = workbasket.rule_check_progress()
     assert num_completed == 1

--- a/workbaskets/views/ui.py
+++ b/workbaskets/views/ui.py
@@ -398,6 +398,13 @@ class CurrentWorkBasket(TemplateResponseMixin, FormMixin, View):
             else:
                 self.workbasket.save_to_session(self.request.session)
 
+            num_completed, total = self.workbasket.rule_check_progress()
+            context.update(
+                {
+                    "rule_check_progress": f"Completed {num_completed} out of {total} checks",
+                },
+            )
+
         return context
 
     def form_valid(self, form):


### PR DESCRIPTION
# TP2000-738 Display rule check progress

## Why
Users are not able to see the progress of a rule check.

## What
- Adds `rule_check_progress` function to `WorkBasket` model to provide progress of a rule check for the workbasket
- Displays rule check progress on workbasket summary and application information pages.

##
Workbasket summary:
<img width="450" alt="workbasket-summary" src="https://user-images.githubusercontent.com/118175145/233590349-44e1d003-f928-4632-a46e-f1d91ef6eeba.png">

Application information:
<img width="450" alt="app-info" src="https://user-images.githubusercontent.com/118175145/233590363-abd124e3-61ef-441e-891b-60798e32367c.png">

