### PR TITLE
TP2000-477 Prepopulate geo exclusions

### DIFF
--- a/common/forms.py
+++ b/common/forms.py
@@ -718,7 +718,7 @@ def formset_add_or_delete(prefixes, data):
     formset_data = {}
     for k, v in data.items():
         for prefix in prefixes:
-            if k in [f"{prefix}-ADD", f"{prefix}-DELETE"]:
+            if k.endswith("-ADD") or k.endswith("-DELETE"):
                 formset_data[k] = v
     if len(formset_data) > 0:
         return True

--- a/common/forms.py
+++ b/common/forms.py
@@ -581,7 +581,7 @@ class FormSet(forms.BaseFormSet):
         if initial:
             num_initial = len(initial)
         else:
-            num_initial = 0
+            num_initial = len(formset_initial.values())
 
         if num_initial < 1:
             data[f"{self.prefix}-ADD"] = "1"

--- a/common/forms.py
+++ b/common/forms.py
@@ -1,3 +1,4 @@
+import re
 from collections import defaultdict
 from datetime import date
 from typing import Type
@@ -669,19 +670,16 @@ def unprefix_formset_data(prefix, data):
     output = []
     formset_data = {}
 
-    # management form data is not needed
-    management_form_fields = [
-        "INITIAL_FORMS",
-        "MAX_NUM_FORMS",
-        "MIN_NUM_FORMS",
-        "TOTAL_FORMS",
-        "ADD",
-        "DELETE",
-    ]
+    pattern = f"({prefix}-([0-9]-)?DELETE|ADD|INITIAL_FORMS|MAX_NUM_FORMS|MIN_NUM_FORMS|TOTAL_FORMS)+"
+    keys_to_delete = []
 
-    for field in management_form_fields:
-        if f"{prefix}-{field}" in data.keys():
-            del data[f"{prefix}-{field}"]
+    for key in data.keys():
+        found = re.search(pattern, key)
+        if found:
+            keys_to_delete.append(key)
+
+    for key in keys_to_delete:
+        del data[key]
 
     for k, v in data.items():
         if prefix in k:

--- a/common/templates/common/widgets/nested_radio.html
+++ b/common/templates/common/widgets/nested_radio.html
@@ -36,10 +36,8 @@
 
 			{% for form in nested_form %}
 				{% for field in form %}
-					{% if field.data %}
-						{% include "gds/field.html" %}
-						{% include "common/widgets/formset_delete_button.html" with prefix=form.prefix %}
-					{% endif %}
+					{% include "gds/field.html" %}
+					{% include "common/widgets/formset_delete_button.html" with prefix=form.prefix %}
 				{% endfor %}
 			{% endfor %}
 

--- a/common/tests/test_forms.py
+++ b/common/tests/test_forms.py
@@ -4,6 +4,7 @@ from django import forms
 from common.forms import BindNestedFormMixin
 from common.forms import FormSet
 from common.forms import RadioNested
+from common.forms import formset_add_or_delete
 from common.forms import formset_factory
 from common.forms import unprefix_formset_data
 
@@ -258,3 +259,43 @@ def test_unprefix_formset_data(data, exp):
         unprefix_formset_data("measure-conditions-formset", {**base_data, **data})
         == exp
     )
+
+
+@pytest.mark.parametrize(
+    "data,exp",
+    [
+        (
+            {
+                "measure-conditions-formset-0-applicable_duty": "test1",
+                "measure-conditions-formset-1-applicable_duty": "test2",
+                "measure-conditions-formset-2-applicable_duty": "test3",
+                "measure-conditions-formset-3-applicable_duty": "test4",
+            },
+            False,
+        ),
+        (
+            {
+                "measure-conditions-formset-0-applicable_duty": "test1",
+            },
+            False,
+        ),
+        (
+            {
+                "measure-conditions-formset-0-applicable_duty": "test1",
+                "measure-conditions-formset-__prefix__-applicable_duty": "test2",
+                "measure-conditions-formset-ADD": "1",
+            },
+            True,
+        ),
+        (
+            {
+                "measure-conditions-formset-0-applicable_duty": "test1",
+                "measure-conditions-formset-__prefix__-applicable_duty": "test2",
+                "measure-conditions-formset-0-DELETE": "1",
+            },
+            True,
+        ),
+    ],
+)
+def test_formset_add_or_delete(data, exp):
+    assert formset_add_or_delete(["measure-conditions-formset"], data) == exp

--- a/common/tests/test_forms.py
+++ b/common/tests/test_forms.py
@@ -224,6 +224,21 @@ def test_radio_nested_form_nested_formset_cleaned_data():
                 },
             ],
         ),
+        (
+            {
+                "measure-conditions-formset-0-applicable_duty": "test1",
+                "measure-conditions-formset-__prefix__-applicable_duty": "test2",
+                "measure-conditions-formset-0-DELETE": "1",
+            },
+            [
+                {
+                    "applicable_duty": "test1",
+                },
+                {
+                    "applicable_duty": "test2",
+                },
+            ],
+        ),
     ],
 )
 def test_unprefix_formset_data(data, exp):

--- a/measures/forms.py
+++ b/measures/forms.py
@@ -73,6 +73,7 @@ class GeoAreaInitialDataMixin:
                 GROUP_EXCLUSIONS_FORMSET_PREFIX,
                 GEO_GROUP_FORMSET_PREFIX,
                 COUNTRY_REGION_FORMSET_PREFIX,
+                ERGA_OMNES_EXCLUSIONS_FORMSET_PREFIX,
             ],
             self.data,
         )

--- a/measures/forms.py
+++ b/measures/forms.py
@@ -49,7 +49,8 @@ from workbaskets.models import WorkBasket
 
 logger = logging.getLogger(__name__)
 
-
+MEASURE_CONDITIONS_FORMSET_PREFIX = "measure-conditions-formset"
+MEASURE_COMMODITIES_FORMSET_PREFIX = "measure_commodities_duties_formset"
 ERGA_OMNES_EXCLUSIONS_PREFIX = "erga_omnes_exclusions"
 ERGA_OMNES_EXCLUSIONS_FORMSET_PREFIX = (
     f"{ERGA_OMNES_EXCLUSIONS_PREFIX}_formset"  # /PS-IGNORE
@@ -507,6 +508,8 @@ class MeasureConditionsForm(MeasureConditionsFormMixin):
 
 
 class MeasureConditionsBaseFormSet(FormSet):
+    prefix = MEASURE_CONDITIONS_FORMSET_PREFIX
+
     def clean(self):
         """
         We get the cleaned_data from the forms in the formset if any of the
@@ -529,7 +532,6 @@ class MeasureConditionsBaseFormSet(FormSet):
 
 
 class MeasureConditionsFormSet(MeasureConditionsBaseFormSet):
-    prefix = "measure-conditions-formset"
     form = MeasureConditionsForm
 
 
@@ -871,7 +873,7 @@ class MeasureForm(
         )
         conditions_formset = MeasureConditionsFormSet(
             self.data,
-            {MeasureConditionsFormSet.prefix: initial},
+            initial=initial,
         )
         if not conditions_formset.is_valid():
             return False
@@ -1315,7 +1317,7 @@ class MeasureCommodityAndDutiesForm(forms.Form):
 
 MeasureCommodityAndDutiesBaseFormSet = formset_factory(
     MeasureCommodityAndDutiesForm,
-    prefix="measure_commodities_duties_formset",
+    prefix=MEASURE_COMMODITIES_FORMSET_PREFIX,
     formset=FormSet,
     min_num=1,
     max_num=99,

--- a/measures/forms.py
+++ b/measures/forms.py
@@ -26,17 +26,20 @@ from common.forms import FormSet
 from common.forms import RadioNested
 from common.forms import ValidityPeriodForm
 from common.forms import delete_form_for
+from common.forms import formset_add_or_delete
 from common.forms import formset_factory
+from common.forms import unprefix_formset_data
 from common.util import validity_range_contains_range
 from common.validators import SymbolValidator
 from common.validators import UpdateType
 from footnotes.models import Footnote
 from geo_areas.models import GeographicalArea
+from geo_areas.models import GeographicalMembership
 from geo_areas.validators import AreaCode
 from measures import models
 from measures.constants import MeasureEditSteps
+from measures.models import MeasureExcludedGeographicalArea
 from measures.parsers import DutySentenceParser
-from measures.patterns import MeasureCreationPattern
 from measures.util import diff_components
 from measures.validators import validate_conditions_formset
 from measures.validators import validate_duties
@@ -61,6 +64,53 @@ COUNTRY_REGION_PREFIX = "country_region"
 COUNTRY_REGION_FORMSET_PREFIX = f"{COUNTRY_REGION_PREFIX}_formset"
 
 
+class GeoAreaInitialDataMixin:
+    @property
+    def formset_submitted(self):
+        return formset_add_or_delete(
+            [
+                GROUP_EXCLUSIONS_FORMSET_PREFIX,
+                GEO_GROUP_FORMSET_PREFIX,
+                COUNTRY_REGION_FORMSET_PREFIX,
+            ],
+            self.data,
+        )
+
+    @property
+    def whole_form_submit(self):
+        return bool(self.data.get("submit"))
+
+    def get_geo_area_initial(self):
+        initial = {}
+        geo_area_type = self.initial.get(self.geo_area_field_name) or self.data.get(
+            self.geo_area_field_name,
+        )
+        if geo_area_type in [
+            GeoAreaType.GROUP.value,
+            GeoAreaType.ERGA_OMNES.value,
+        ]:
+            field_name = FIELD_NAME_MAPPING[geo_area_type]
+            prefix = FORMSET_PREFIX_MAPPING[geo_area_type]
+            initial_exclusions = []
+            if hasattr(self, "instance"):
+                initial_exclusions = [
+                    {field_name: exclusion.excluded_geographical_area}
+                    for exclusion in self.instance.exclusions.all()
+                ]
+            # if we just submitted the form, add the new data to initial
+            if self.formset_submitted or self.whole_form_submit:
+                new_data = unprefix_formset_data(prefix, self.data.copy())
+                for g in new_data:
+                    if g[field_name]:
+                        id = int(g[field_name])
+                        g[field_name] = GeographicalArea.objects.get(id=id)
+                initial_exclusions = new_data
+
+            initial[FORMSET_PREFIX_MAPPING[geo_area_type]] = initial_exclusions
+
+        return initial
+
+
 class GeoAreaType(TextChoices):
     ERGA_OMNES = "ERGA_OMNES", "All countries (erga omnes)"
     GROUP = "GROUP", "A group of countries"
@@ -72,15 +122,16 @@ SUBFORM_PREFIX_MAPPING = {
     GeoAreaType.COUNTRY: COUNTRY_REGION_FORMSET_PREFIX,
 }
 
-EXCLUSIONS_FORMSET_PREFIX_MAPPING = {
+FORMSET_PREFIX_MAPPING = {
     GeoAreaType.ERGA_OMNES: ERGA_OMNES_EXCLUSIONS_FORMSET_PREFIX,
     GeoAreaType.GROUP: GROUP_EXCLUSIONS_FORMSET_PREFIX,
-    GeoAreaType.COUNTRY: None,
+    GeoAreaType.COUNTRY: COUNTRY_REGION_FORMSET_PREFIX,
 }
 
 FIELD_NAME_MAPPING = {
     GeoAreaType.ERGA_OMNES: "erga_omnes_exclusion",
     GeoAreaType.GROUP: "geo_group_exclusion",
+    GeoAreaType.COUNTRY: "geographical_area_country_or_region",
 }
 
 
@@ -163,7 +214,7 @@ GeoGroupFormSet = formset_factory(
     formset=FormSet,
     min_num=1,
     max_num=2,
-    extra=1,
+    extra=0,
     validate_min=True,
     validate_max=True,
 )
@@ -173,8 +224,8 @@ ErgaOmnesExclusionsFormSet = formset_factory(
     prefix=ERGA_OMNES_EXCLUSIONS_FORMSET_PREFIX,
     formset=FormSet,
     min_num=0,
-    max_num=10,
-    extra=1,
+    max_num=100,
+    extra=0,
     validate_min=True,
     validate_max=True,
 )
@@ -184,8 +235,8 @@ GeoGroupExclusionsFormSet = formset_factory(
     prefix=GROUP_EXCLUSIONS_FORMSET_PREFIX,
     formset=FormSet,
     min_num=0,
-    max_num=10,
-    extra=1,
+    max_num=100,
+    extra=0,
     validate_min=True,
     validate_max=True,
 )
@@ -228,7 +279,7 @@ CountryRegionFormSet = formset_factory(
     formset=FormSet,
     min_num=1,
     max_num=2,
-    extra=1,
+    extra=0,
     validate_min=True,
     validate_max=True,
 )
@@ -524,7 +575,14 @@ class MeasureConditionsWizardStepFormSet(MeasureConditionsBaseFormSet):
     form = MeasureConditionsWizardStepForm
 
 
-class MeasureForm(ValidityPeriodForm, BindNestedFormMixin, forms.ModelForm):
+class MeasureForm(
+    GeoAreaInitialDataMixin,
+    ValidityPeriodForm,
+    BindNestedFormMixin,
+    forms.ModelForm,
+):
+    """Form used for editing individual Measures."""
+
     class Meta:
         model = models.Measure
         fields = (
@@ -535,6 +593,8 @@ class MeasureForm(ValidityPeriodForm, BindNestedFormMixin, forms.ModelForm):
             "additional_code",
             "order_number",
         )
+
+    geo_area_field_name = "geo_area"
 
     measure_type = AutoCompleteField(
         label="Measure type",
@@ -621,6 +681,8 @@ class MeasureForm(ValidityPeriodForm, BindNestedFormMixin, forms.ModelForm):
 
         nested_forms_initial = {**self.initial}
         nested_forms_initial["geographical_area"] = self.instance.geographical_area
+        geo_area_initial_data = self.get_geo_area_initial()
+        nested_forms_initial.update(geo_area_initial_data)
         kwargs.pop("initial")
         self.bind_nested_forms(*args, initial=nested_forms_initial, **kwargs)
 
@@ -657,15 +719,11 @@ class MeasureForm(ValidityPeriodForm, BindNestedFormMixin, forms.ModelForm):
             cleaned_data["geographical_area"] = geographical_area_fields[
                 geo_area_choice
             ]
-            exclusions = cleaned_data.get(
-                EXCLUSIONS_FORMSET_PREFIX_MAPPING[geo_area_choice],
-            )
+            exclusions = cleaned_data.get(FORMSET_PREFIX_MAPPING[geo_area_choice])
             if exclusions:
                 cleaned_data["exclusions"] = [
                     exclusion[FIELD_NAME_MAPPING[geo_area_choice]]
-                    for exclusion in cleaned_data[
-                        EXCLUSIONS_FORMSET_PREFIX_MAPPING[geo_area_choice]
-                    ]
+                    for exclusion in exclusions
                 ]
 
         cleaned_data["sid"] = self.instance.sid
@@ -683,23 +741,65 @@ class MeasureForm(ValidityPeriodForm, BindNestedFormMixin, forms.ModelForm):
 
         sid = instance.sid
 
-        measure_creation_pattern = MeasureCreationPattern(
-            workbasket=WorkBasket.current(self.request),
-            base_date=instance.valid_between.lower,
-            defaults={
-                "generating_regulation": self.cleaned_data["generating_regulation"],
-            },
-        )
-
         if self.cleaned_data.get("exclusions"):
-            for exclusion in self.cleaned_data.get("exclusions"):
-                pattern = (
-                    measure_creation_pattern.create_measure_excluded_geographical_areas(
-                        instance,
-                        exclusion,
+            exclusions = self.cleaned_data.get("exclusions")
+            valid_memberships = GeographicalMembership.objects.as_at(
+                instance.valid_between.lower,
+            )
+
+            # pull individual countries out of groups and add to the list
+            all_exclusions = []
+            for exclusion in exclusions:
+                if exclusion.area_code == AreaCode.GROUP:
+                    measure_origins = set(
+                        m.member
+                        for m in valid_memberships.filter(
+                            geo_group=instance.geographical_area,
+                        )
                     )
+                    for membership in valid_memberships.filter(geo_group=exclusion):
+                        if membership.member.sid in [m.sid for m in measure_origins]:
+                            all_exclusions.append(membership.member)
+                else:
+                    all_exclusions.append(exclusion)
+
+            for geo_area in all_exclusions:
+                existing_exclusion = (
+                    instance.exclusions.filter(excluded_geographical_area=geo_area)
+                    .current()
+                    .first()
                 )
-                [p for p in pattern]
+
+                if existing_exclusion:
+                    existing_exclusion.new_version(
+                        workbasket=WorkBasket.current(self.request),
+                        transaction=instance.transaction,
+                        modified_measure=instance,
+                    )
+                else:
+                    MeasureExcludedGeographicalArea.objects.create(
+                        modified_measure=instance,
+                        excluded_geographical_area=geo_area,
+                        update_type=UpdateType.CREATE,
+                        transaction=instance.transaction,
+                    )
+
+            removed_excluded_areas = {
+                e.excluded_geographical_area for e in instance.exclusions.current()
+            }.difference(set(self.cleaned_data["exclusions"]))
+
+            removed_exclusions = [
+                instance.exclusions.current().get(excluded_geographical_area__id=e.id)
+                for e in removed_excluded_areas
+            ]
+
+            for removed in removed_exclusions:
+                removed.new_version(
+                    update_type=UpdateType.DELETE,
+                    workbasket=WorkBasket.current(self.request),
+                    transaction=instance.transaction,
+                    modified_measure=instance,
+                )
 
         if (
             self.request.session[f"instance_duty_sentence_{self.instance.sid}"]
@@ -765,8 +865,14 @@ class MeasureForm(ValidityPeriodForm, BindNestedFormMixin, forms.ModelForm):
     def is_valid(self) -> bool:
         """Check that measure conditions data is valid before calling super() on
         the rest of the form data."""
-        conditions_formset = MeasureConditionsFormSet(self.data)
-
+        initial = unprefix_formset_data(
+            MeasureConditionsFormSet.prefix,
+            self.data.copy(),
+        )
+        conditions_formset = MeasureConditionsFormSet(
+            self.data,
+            {MeasureConditionsFormSet.prefix: initial},
+        )
         if not conditions_formset.is_valid():
             return False
 
@@ -975,7 +1081,18 @@ class MeasureQuotaOrderNumberForm(forms.Form):
         )
 
 
-class MeasureGeographicalAreaForm(BindNestedFormMixin, forms.Form):
+class MeasureGeographicalAreaForm(
+    GeoAreaInitialDataMixin,
+    BindNestedFormMixin,
+    forms.Form,
+):
+    """
+    Used in the MeasureCreateWizard.
+
+    Allows creation of multiple measures for multiple commodity codes and
+    countries.
+    """
+
     geo_area = RadioNested(
         label="",
         help_text=(
@@ -992,12 +1109,36 @@ class MeasureGeographicalAreaForm(BindNestedFormMixin, forms.Form):
         error_messages={"required": "A Geographical area must be selected"},
     )
 
+    @property
+    def geo_area_field_name(self):
+        return f"{self.prefix}-geo_area"
+
+    def get_countries_initial(self):
+        initial = {}
+
+        geo_area_type = self.initial.get(self.geo_area_field_name) or self.data.get(
+            self.geo_area_field_name,
+        )
+
+        if geo_area_type == GeoAreaType.COUNTRY.value:
+            field_name = FIELD_NAME_MAPPING[geo_area_type]
+            prefix = FORMSET_PREFIX_MAPPING[geo_area_type]
+            initial_countries = []
+            # if we just submitted the form, add the new data to initial
+            if self.formset_submitted or self.whole_form_submit:
+                new_data = unprefix_formset_data(prefix, self.data.copy())
+                for g in new_data:
+                    if g[field_name]:
+                        id = int(g[field_name])
+                        g[field_name] = GeographicalArea.objects.get(id=id)
+                initial_countries = new_data
+
+            initial[FORMSET_PREFIX_MAPPING[geo_area_type]] = initial_countries
+
+        return initial
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-
-        kwargs.pop("initial")
-
-        self.fields["geo_area"].initial = self.data.get(f"{self.prefix}-geo_area")
 
         geographical_area_fields = {
             GeoAreaType.ERGA_OMNES: self.erga_omnes_instance,
@@ -1007,6 +1148,8 @@ class MeasureGeographicalAreaForm(BindNestedFormMixin, forms.Form):
             ),
         }
 
+        self.fields["geo_area"].initial = self.data.get(f"{self.prefix}-geo_area")
+
         nested_forms_initial = {}
 
         if self.fields["geo_area"].initial:
@@ -1014,6 +1157,11 @@ class MeasureGeographicalAreaForm(BindNestedFormMixin, forms.Form):
                 self.fields["geo_area"].initial
             ]
 
+        geo_area_initial_data = self.get_geo_area_initial()
+        countries_initial_data = self.get_countries_initial()
+        nested_forms_initial.update(geo_area_initial_data)
+        nested_forms_initial.update(countries_initial_data)
+        kwargs.pop("initial")
         self.bind_nested_forms(*args, initial=nested_forms_initial, **kwargs)
 
         self.helper = FormHelper(self)
@@ -1044,7 +1192,7 @@ class MeasureGeographicalAreaForm(BindNestedFormMixin, forms.Form):
         }
 
         if geo_area_choice:
-            if not self.formset_submit():
+            if not self.formset_submitted:
                 if geo_area_choice == GeoAreaType.ERGA_OMNES:
                     cleaned_data["geo_area_list"] = [self.erga_omnes_instance]
 
@@ -1060,13 +1208,13 @@ class MeasureGeographicalAreaForm(BindNestedFormMixin, forms.Form):
                     ]
 
                 exclusions = cleaned_data.get(
-                    EXCLUSIONS_FORMSET_PREFIX_MAPPING[geo_area_choice],
+                    FORMSET_PREFIX_MAPPING[geo_area_choice],
                 )
                 if exclusions:
                     cleaned_data["geo_area_exclusions"] = [
                         exclusion[FIELD_NAME_MAPPING[geo_area_choice]]
                         for exclusion in cleaned_data[
-                            EXCLUSIONS_FORMSET_PREFIX_MAPPING[geo_area_choice]
+                            FORMSET_PREFIX_MAPPING[geo_area_choice]
                         ]
                     ]
 

--- a/measures/jinja2/measures/create-footnotes-formset.jinja
+++ b/measures/jinja2/measures/create-footnotes-formset.jinja
@@ -32,19 +32,19 @@
     {% endif %}
 {% endwith %}
 
-{{ crispy(formset.management_form, no_form_tags) }}
+{{ crispy(footnotes_formset.management_form, no_form_tags) }}
     <label class="govuk-label">Add a footnote</label>
     <div id="sort-code-hint" class="govuk-hint">Start typing the ID of the footnote or terms used in the description</div>
-    {% for form in formset %}
+    {% for form in footnotes_formset %}
         {{ crispy(form) }}
     {% endfor %}
 
-    {% if formset.data[formset.prefix ~ "-ADD"] %}
-        {{ crispy(formset.empty_form)|replace("__prefix__", formset.forms|length)|safe }}
+    {% if footnotes_formset.data[footnotes_formset.prefix ~ "-ADD"] %}
+        {{ crispy(footnotes_formset.empty_form)|replace("__prefix__", footnotes_formset.forms|length)|safe }}
     {% endif %}
 
     {% call govukFieldset({"legend": {}, "classes": "govuk-!-padding-top-3"}) %}
-        <button class="govuk-button govuk-button--secondary" data-module="govuk-button" value=1, name={{ formset.prefix ~ "-ADD" }}, formaction={{ object.get_url("edit-footnotes") }}>
+        <button class="govuk-button govuk-button--secondary" data-module="govuk-button" value=1, name={{ footnotes_formset.prefix ~ "-ADD" }}, formaction={{ object.get_url("edit-footnotes") }}>
             Add another footnote
         </button
        

--- a/measures/jinja2/measures/edit.jinja
+++ b/measures/jinja2/measures/edit.jinja
@@ -144,6 +144,8 @@
             {{ govukButton({
                 "text":"Save",
                 "preventDoubleClick": true,
+                "name": "submit",
+                "value": "submit",
             }) }}
         </div>
     </div>

--- a/measures/models.py
+++ b/measures/models.py
@@ -939,7 +939,7 @@ class MeasureExcludedGeographicalArea(TrackedModel):
 
     record_code = "430"
     subrecord_code = "15"
-
+    url_pattern_name_prefix = "geo_area"
     identifying_fields = ("modified_measure__sid", "excluded_geographical_area__sid")
 
     modified_measure = models.ForeignKey(
@@ -959,6 +959,12 @@ class MeasureExcludedGeographicalArea(TrackedModel):
         business_rules.ME68,
         UpdateValidity,
     )
+
+    def __str__(self):
+        return (
+            f"{self.excluded_geographical_area.get_area_code_display()} "
+            f"{self.excluded_geographical_area.structure_description} {self.excluded_geographical_area.area_id}"
+        )
 
 
 class FootnoteAssociationMeasure(TrackedModel):

--- a/measures/tests/test_forms.py
+++ b/measures/tests/test_forms.py
@@ -345,7 +345,7 @@ def test_measure_forms_geo_area_valid_data_countries_delete(erga_omnes):
         f"{GEO_AREA_FORM_PREFIX}-geo_area": forms.GeoAreaType.COUNTRY,
         "country_region_formset-0-geographical_area_country_or_region": geo_area1.pk,
         "country_region_formset-1-geographical_area_country_or_region": geo_area2.pk,
-        "country_region_formset-1-DELETE": "on",
+        "country_region_formset-DELETE": "on",
     }
     initial = [
         {"geographical_area_country_or_region": geo_area1.pk},
@@ -358,6 +358,8 @@ def test_measure_forms_geo_area_valid_data_countries_delete(erga_omnes):
             prefix=GEO_AREA_FORM_PREFIX,
         )
         assert not form.is_valid()
+        # when we submit ADD or DELETE no errors are raised
+        assert not form.errors
 
 
 def test_measure_forms_geo_area_valid_data_countries_add(erga_omnes):

--- a/measures/tests/test_views.py
+++ b/measures/tests/test_views.py
@@ -552,8 +552,7 @@ def test_measure_update_updates_footnote_association(measure_form, client, valid
 
 
 def test_measure_update_create_conditions(
-    client,
-    valid_user,
+    valid_user_client,
     measure_edit_conditions_data,
     duty_sentence_parser,
     erga_omnes,
@@ -568,8 +567,11 @@ def test_measure_update_create_conditions(
     """
     measure = Measure.objects.first()
     url = reverse("measure-ui-edit", args=(measure.sid,))
-    client.force_login(valid_user)
-    client.post(url, data=measure_edit_conditions_data)
+    response = valid_user_client.post(url, data=measure_edit_conditions_data)
+
+    assert response.status_code == 302
+    assert response.url == reverse("measure-ui-confirm-update", args=(measure.sid,))
+
     tx = Transaction.objects.last()
     updated_measure = Measure.objects.approved_up_to_transaction(tx).get(
         sid=measure.sid,
@@ -911,6 +913,7 @@ def test_measure_form_wizard_finish(
                 "measure_commodities_duties_formset-0-duties": "33 GBP/100kg",  # /PS-IGNORE
                 "measure_commodities_duties_formset-1-commodity": commodity2.pk,
                 "measure_commodities_duties_formset-1-duties": "40 GBP/100kg",
+                "submit": "submit",
             },
             "next_step": "additional_code",
         },

--- a/measures/tests/test_views.py
+++ b/measures/tests/test_views.py
@@ -816,6 +816,7 @@ def test_measure_update_group_exclusion(client, valid_user, erga_omnes):
             "start_date_2": start_date.year,
             "geo_area": "ERGA_OMNES",
             "erga_omnes_exclusions_formset-__prefix__-erga_omnes_exclusion": geo_group.pk,
+            "submit": "submit",
         },
     )
 
@@ -899,6 +900,7 @@ def test_measure_form_wizard_finish(
                 "measure_create_wizard-current_step": "geographical_area",
                 "geographical_area-geo_area": "ERGA_OMNES",
                 "erga_omnes_exclusions_formset-0-erga_omnes_exclusion": "",
+                "submit": "submit",
             },
             "next_step": "commodities",
         },
@@ -1275,8 +1277,14 @@ def test_measure_form_creates_exclusions(
     )
     exclusions_data = {
         "geo_area": "ERGA_OMNES",
+        "erga_omnes_exclusions_formset-TOTAL_FORMS": "2",
+        "erga_omnes_exclusions_formset-INITIAL_FORMS": "2",
+        "erga_omnes_exclusions_formset-MIN_NUM_FORMS": "0",
+        "erga_omnes_exclusions_formset-MAX_NUM_FORMS": "100",
         "erga_omnes_exclusions_formset-0-erga_omnes_exclusion": excluded_country1.pk,
         "erga_omnes_exclusions_formset-1-erga_omnes_exclusion": excluded_country2.pk,
+        "erga_omnes_exclusions_formset-__prefix__-erga_omnes_exclusion": "",
+        "submit": "submit",
     }
     data.update(exclusions_data)
     client.force_login(valid_user)

--- a/measures/views.py
+++ b/measures/views.py
@@ -709,18 +709,23 @@ class MeasureUpdate(
             f"formset_initial_{self.kwargs.get('sid')}",
             [],
         )
-        formset = forms.MeasureUpdateFootnotesFormSet()
-        formset.initial = initial
-        formset.form_kwargs = {"path": self.request.path}
-        context["formset"] = formset
+        footnotes_formset = forms.MeasureUpdateFootnotesFormSet()
+        footnotes_formset.initial = initial
+        footnotes_formset.form_kwargs = {"path": self.request.path}
+        context["footnotes_formset"] = footnotes_formset
         context["no_form_tags"] = FormHelper()
         context["no_form_tags"].form_tag = False
         context["footnotes"] = self.get_footnotes(context["measure"])
 
         if self.request.POST:
-            conditions_formset = forms.MeasureConditionsFormSet(self.request.POST)
+            conditions_formset = forms.MeasureConditionsFormSet(
+                self.request.POST,
+                prefix="measure-conditions-formset",
+            )
         else:
-            conditions_formset = forms.MeasureConditionsFormSet()
+            conditions_formset = forms.MeasureConditionsFormSet(
+                prefix="measure-conditions-formset",
+            )
         conditions = self.get_conditions(context["measure"])
         form_fields = conditions_formset.form.Meta.fields
         conditions_formset.initial = []

--- a/measures/views.py
+++ b/measures/views.py
@@ -25,6 +25,7 @@ from formtools.wizard.views import NamedUrlSessionWizardView
 from rest_framework import viewsets
 from rest_framework.reverse import reverse
 
+from common.forms import unprefix_formset_data
 from common.models import TrackedModel
 from common.serializers import AutoCompleteSerializer
 from common.util import TaricDateRange
@@ -37,6 +38,7 @@ from measures.constants import START
 from measures.constants import MeasureEditSteps
 from measures.filters import MeasureFilter
 from measures.filters import MeasureTypeFilterBackend
+from measures.forms import MEASURE_CONDITIONS_FORMSET_PREFIX
 from measures.models import FootnoteAssociationMeasure
 from measures.models import Measure
 from measures.models import MeasureActionPair
@@ -717,13 +719,21 @@ class MeasureUpdate(
         context["no_form_tags"].form_tag = False
         context["footnotes"] = self.get_footnotes(context["measure"])
 
+        conditions_initial = []
+
         if self.request.POST:
+            conditions_initial = unprefix_formset_data(
+                MEASURE_CONDITIONS_FORMSET_PREFIX,
+                self.request.POST.copy(),
+            )
             conditions_formset = forms.MeasureConditionsFormSet(
                 self.request.POST,
+                initial=conditions_initial,
                 prefix="measure-conditions-formset",
             )
         else:
             conditions_formset = forms.MeasureConditionsFormSet(
+                initial=conditions_initial,
                 prefix="measure-conditions-formset",
             )
         conditions = self.get_conditions(context["measure"])


### PR DESCRIPTION
# TP2000-477 Prepopulate geo exclusions
<!---
 * Include the JIRA ticket number, eg TP-123, to automatically link.
 * Use 50 characters maximum.
 * Do not end with a full-stop.
--->

## Why
<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Use as many lines as you like.
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions or deliberately ignored edge-cases.
--->
* When a single measure needed to be edited its geo area exclusions were not prepopulated meaning the user would have to fill these in again even if editing a different field on the measure. This was time consuming and error prone

## What
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Explain like I'm 5.
 * Use pictures if you can.
--->
* Updates the FormSet class and BindNestedForms mixin to properly add initial data to formsets
* Also updates the display of exclusions in the workbasket to show which area is excluded

<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
## Checklist
- Requires migrations?
- Requires dependency updates?
--->

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->

<img width="1221" alt="Screenshot 2023-04-25 at 10 49 12" src="https://user-images.githubusercontent.com/25905279/234240433-ef6b44cd-d523-4a26-910d-3b65ae6b2d5e.png">
<img width="840" alt="Screenshot 2023-04-25 at 10 49 28" src="https://user-images.githubusercontent.com/25905279/234240446-280ce9ea-126e-4bbd-8d54-eed1dccde993.png">

