### PR TITLE
TP2000-860 Sqlite dump and upload failing

### DIFF
--- a/measures/migrations/0014_action_pair_data_migration.py
+++ b/measures/migrations/0014_action_pair_data_migration.py
@@ -26,6 +26,17 @@ def generate_action_pairs(apps, schema_editor):
 
     MeasureAction = apps.get_model("measures", "MeasureAction")
     MeasureActionPair = apps.get_model("measures", "MeasureActionPair")
+
+    if not MeasureAction.objects.all():
+        # The Sqlite dump task, export_and_upload_sqlite, runs migrations before
+        # populating the database. Because no MeasureAction instances are
+        # available in the DB at this point, this data migration has nothing to
+        # do and would in fact fail. However, since MeasureActionPair is soley
+        # used to enable a UI provision in the Tamato application, instances of
+        # MeasureActionPair and its data migrations, are not required as part of
+        # the Sqlite export.
+        return
+
     for positive, negative in action_code_mappings:
         positive_action = MeasureAction.objects.get(code=positive)
         negative_action = MeasureAction.objects.get(code=negative)

--- a/settings/common.py
+++ b/settings/common.py
@@ -455,7 +455,7 @@ CELERY_WORKER_POOL_RESTARTS = True  # Restart worker if it dies
 CELERY_BEAT_SCHEDULE = {
     "sqlite_export": {
         "task": "exporter.sqlite.tasks.export_and_upload_sqlite",
-        "schedule": crontab(hour=4, minute=10),
+        "schedule": crontab(hour=3, minute=5),
     },
 }
 


### PR DESCRIPTION
# TP2000-860 Sqlite dump and upload failing
<!---
 * Include the JIRA ticket number, eg TP-123, to automatically link.
 * Use 50 characters maximum.
 * Do not end with a full-stop.
--->

## Why
<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Use as many lines as you like.
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions or deliberately ignored edge-cases.
--->
The scheduled sqlite dump of TAP data is failing due to a data migration failure. Migrations are run as part of the sqlite database creation process, before it has been populated with data. The migration failure causes the dump to fail.

## What
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Explain like I'm 5.
 * Use pictures if you can.
--->
This PR guards against using non-existent data in the data migration `measures.migrations/0014_action_pair_data_migration.py`, preventing a failure within the Sqlite dump process.

<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
--->
## Checklist
- Requires migrations? No
- Requires dependency updates? No

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
