### PR TITLE
TP2000-857  Implement geo area create journey

### DIFF
--- a/common/jinja2/includes/common/tabs/descriptions.jinja
+++ b/common/jinja2/includes/common/tabs/descriptions.jinja
@@ -23,7 +23,7 @@
     {% endfor %}
 
     <h2 class="govuk-heading-l">Descriptions</h2>
-    <p><a class="govuk-link" href={{object.get_url("description-create")}}>Create a new description</a></p>
+    <p class="govuk-body"><a class="govuk-link" href={{object.get_url("description-create")}}>Create a new description</a></p>
     {% set head = [
       {"text": "Start date", "classes":  "govuk-!-width-one-eighth"},
       {"text": "Description"},

--- a/common/static/common/js/addNewForm.js
+++ b/common/static/common/js/addNewForm.js
@@ -10,15 +10,18 @@ const addNewForm = (event) => {
     let newForm = fieldset.cloneNode(true);
 
     newForm.innerHTML = newForm.innerHTML.replaceAll("-0-", "-" + numForms + "-");
-    newForm.querySelector(".autocomplete").removeAttribute("data-original-value");
+    if (newForm.querySelector(".autocomplete"))
+      newForm.querySelector(".autocomplete").removeAttribute("data-original-value");
 
     let formFields = newForm.querySelectorAll("input");
     for (let field of formFields.values()) {
       field.value = "";
     }
 
-    newForm.querySelector(".autocomplete__wrapper").remove();
-    autoCompleteElement(newForm.querySelector(".autocomplete"));
+    if (newForm.querySelector(".autocomplete__wrapper")) {
+      newForm.querySelector(".autocomplete__wrapper").remove();
+      autoCompleteElement(newForm.querySelector(".autocomplete"));
+    }
 
     let buttonGroup = document.querySelector(".govuk-button-group");
     formset.insertBefore(newForm, buttonGroup);

--- a/geo_areas/forms.py
+++ b/geo_areas/forms.py
@@ -538,8 +538,8 @@ class GeographicalMembershipGroupForm(ValidityPeriodForm):
         queryset=None,  # populated in __init__
     )
 
-    def __init__(self, *args, geo_area, **kwargs):
-        self.geo_area = geo_area
+    def __init__(self, *args, **kwargs):
+        self.geo_area = kwargs.pop("geo_area", None)
         super().__init__(*args, **kwargs)
 
         current_memberships = self.geo_area.groups.values_list("geo_group", flat=True)
@@ -632,8 +632,8 @@ class GeographicalMembershipMemberForm(ValidityPeriodForm):
         queryset=None,  # populated in __init__
     )
 
-    def __init__(self, *args, geo_area, **kwargs):
-        self.geo_area = geo_area
+    def __init__(self, *args, **kwargs):
+        self.geo_area = kwargs.pop("geo_area", None)
         super().__init__(*args, **kwargs)
 
         current_memberships = self.geo_area.memberships.all()
@@ -727,15 +727,9 @@ class GeographicalMembershipBaseFormSet(FormSet):
     validate_min = True
     validate_max = True
 
-    def __init__(self, *args, geo_area, **kwargs):
+    def __init__(self, *args, **kwargs):
         self.instance = kwargs.pop("instance", None)
-        self.geo_area = geo_area
         super().__init__(*args, **kwargs)
-
-    def get_form_kwargs(self, index):
-        kwargs = super().get_form_kwargs(index)
-        kwargs["geo_area"] = self.geo_area
-        return kwargs
 
 
 class GeographicalMembershipGroupFormSet(GeographicalMembershipBaseFormSet):

--- a/geo_areas/forms.py
+++ b/geo_areas/forms.py
@@ -28,6 +28,7 @@ from geo_areas.models import GeographicalArea
 from geo_areas.models import GeographicalAreaDescription
 from geo_areas.models import GeographicalMembership
 from geo_areas.validators import AreaCode
+from geo_areas.validators import area_id_validator
 from geo_areas.validators import validate_dates
 from quotas.models import QuotaOrderNumberOrigin
 from workbaskets.models import WorkBasket
@@ -430,6 +431,24 @@ class GeographicalAreaEditForm(
 
 
 class GeographicalAreaCreateForm(ValidityPeriodForm):
+    area_code = forms.ChoiceField(
+        label="Area code",
+        help_text="Select if the new geographical area is a country, area group or region from the dropdown.",
+        choices=AreaCode.choices,
+        error_messages={"required": "Select an area code from the dropdown."},
+    )
+
+    area_id = forms.CharField(
+        label="Area ID",
+        help_text="For a country or region, the area ID is 2 upper-case letters, like AZ. For an area group, the area ID is 4 digits, like 1234.",
+        widget=forms.TextInput,
+        validators=[area_id_validator],
+        error_messages={
+            "required": "Enter a geographical area ID.",
+            "invalid": "Enter a geographical area ID in the correct format.",
+        },
+    )
+
     description = forms.CharField(
         label="Description",
         help_text="The name of the country, area group or region.",
@@ -440,23 +459,6 @@ class GeographicalAreaCreateForm(ValidityPeriodForm):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-
-        self.fields["area_code"].label = "Area code"
-        self.fields[
-            "area_code"
-        ].help_text = "Select if the new geographical area is a country, area group or region from the dropdown."
-        self.fields["area_code"].error_messages = {
-            "required": "Select an area code from the dropdown.",
-        }
-
-        self.fields["area_id"].label = "Area ID"
-        self.fields[
-            "area_id"
-        ].help_text = "For a country or region, the area ID is 2 upper-case letters, like AZ. For an area group, the area ID is 4 digits, like 1234."
-        self.fields["area_id"].error_messages = {
-            "required": "Enter a geographical area ID.",
-            "invalid": "Enter a geographical area ID in the correct format.",
-        }
 
         self.fields[
             "end_date"

--- a/geo_areas/forms.py
+++ b/geo_areas/forms.py
@@ -28,8 +28,8 @@ from geo_areas.models import GeographicalArea
 from geo_areas.models import GeographicalAreaDescription
 from geo_areas.models import GeographicalMembership
 from geo_areas.validators import AreaCode
+from geo_areas.validators import DateValidationMixin
 from geo_areas.validators import area_id_validator
-from geo_areas.validators import validate_dates
 from quotas.models import QuotaOrderNumberOrigin
 from workbaskets.models import WorkBasket
 
@@ -167,6 +167,7 @@ class GeographicalMembershipValidityPeriodForm(forms.ModelForm):
 
 class GeographicalMembershipAddForm(
     BindNestedFormMixin,
+    DateValidationMixin,
     GeographicalMembershipValidityPeriodForm,
 ):
     geo_group = forms.ModelChoiceField(
@@ -247,14 +248,12 @@ class GeographicalMembershipAddForm(
                     "new_membership_start_date",
                     "A start date is required.",
                 )
-            validate_dates(
-                form=self,
+            self.validate_dates(
                 field="new_membership_start_date",
                 start_date=start_date,
                 container_start_date=area_group.valid_between.lower,
             )
-            validate_dates(
-                form=self,
+            self.validate_dates(
                 field="new_membership_end_date",
                 start_date=start_date,
                 end_date=end_date,
@@ -268,7 +267,11 @@ class GeographicalMembershipAddForm(
         fields = ["geo_group", "member"]
 
 
-class GeographicalMembershipEditForm(BindNestedFormMixin, forms.Form):
+class GeographicalMembershipEditForm(
+    BindNestedFormMixin,
+    DateValidationMixin,
+    forms.Form,
+):
     membership = forms.ModelChoiceField(
         label="",
         queryset=None,  # populated in __init__
@@ -310,26 +313,12 @@ class GeographicalMembershipEditForm(BindNestedFormMixin, forms.Form):
         end_date = cleaned_data.get("membership_end_date")
 
         if membership and action == GeoMembershipAction.END_DATE:
-            validate_dates(
-                form=self.fields["action"].nested_forms["END DATE"][0],
-                field="membership_end_date",
-                end_date=end_date,
-                container_end_date=membership.geo_group.valid_between.upper,
-            )
-            validate_dates(
-                form=self,
+            self.validate_dates(
                 field="",
                 end_date=end_date,
                 container_end_date=membership.geo_group.valid_between.upper,
             )
-            validate_dates(
-                form=self.fields["action"].nested_forms["END DATE"][0],
-                field="membership_end_date",
-                end_date=end_date,
-                container_start_date=membership.geo_group.valid_between.lower,
-            )
-            validate_dates(
-                form=self,
+            self.validate_dates(
                 field="",
                 end_date=end_date,
                 container_start_date=membership.geo_group.valid_between.lower,
@@ -531,7 +520,7 @@ class GeographicalAreaEditCreateForm(GeographicalAreaCreateForm):
         )
 
 
-class GeographicalMembershipGroupForm(ValidityPeriodForm):
+class GeographicalMembershipGroupForm(DateValidationMixin, ValidityPeriodForm):
     geo_group = forms.ModelChoiceField(
         label="Area group",
         help_text="Select an area group to add this country or region to from the dropdown.",
@@ -591,27 +580,23 @@ class GeographicalMembershipGroupForm(ValidityPeriodForm):
         if geo_group:
             start_date = cleaned_data["valid_between"].lower
             end_date = cleaned_data["valid_between"].upper
-            validate_dates(
-                form=self,
+            self.validate_dates(
                 field="start_date",
                 start_date=start_date,
                 container_start_date=geo_group.valid_between.lower,
             )
-            validate_dates(
-                form=self,
+            self.validate_dates(
                 field="start_date",
                 start_date=start_date,
                 container="country or region",
                 container_start_date=self.geo_area.valid_between.lower,
             )
-            validate_dates(
-                form=self,
+            self.validate_dates(
                 field="end_date",
                 end_date=end_date,
                 container_end_date=geo_group.valid_between.upper,
             )
-            validate_dates(
-                form=self,
+            self.validate_dates(
                 field="end_date",
                 end_date=end_date,
                 container="country or region",
@@ -625,7 +610,7 @@ class GeographicalMembershipGroupForm(ValidityPeriodForm):
         fields = ["valid_between", "geo_group"]
 
 
-class GeographicalMembershipMemberForm(ValidityPeriodForm):
+class GeographicalMembershipMemberForm(DateValidationMixin, ValidityPeriodForm):
     member = forms.ModelChoiceField(
         label="Country or region",
         help_text="Select a country or region to add to this area group from the dropdown.",
@@ -687,27 +672,23 @@ class GeographicalMembershipMemberForm(ValidityPeriodForm):
         if member:
             start_date = cleaned_data["valid_between"].lower
             end_date = cleaned_data["valid_between"].upper
-            validate_dates(
-                form=self,
+            self.validate_dates(
                 field="start_date",
                 start_date=start_date,
                 container_start_date=self.geo_area.valid_between.lower,
             )
-            validate_dates(
-                form=self,
+            self.validate_dates(
                 field="start_date",
                 start_date=start_date,
                 container="country or region",
                 container_start_date=member.valid_between.lower,
             )
-            validate_dates(
-                form=self,
+            self.validate_dates(
                 field="end_date",
                 end_date=end_date,
                 container_end_date=self.geo_area.valid_between.upper,
             )
-            validate_dates(
-                form=self,
+            self.validate_dates(
                 field="end_date",
                 end_date=end_date,
                 container="country or region",

--- a/geo_areas/forms.py
+++ b/geo_areas/forms.py
@@ -357,9 +357,10 @@ class GeographicalAreaEndDateForm(ValidityPeriodForm):
                     not origin.valid_between.upper
                     or origin.valid_between.upper < end_date
                 ):
-                    self.add_error(
-                        "end_date",
-                        "The end date must span the validity period of the quota order number origin that specifies this geographical area.",
+                    raise ValidationError(
+                        {
+                            "end_date": "The end date must span the validity period of the quota order number origin that specifies this geographical area.",
+                        },
                     )
         return super().clean()
 

--- a/geo_areas/forms.py
+++ b/geo_areas/forms.py
@@ -163,10 +163,6 @@ class GeographicalMembershipValidityPeriodForm(forms.ModelForm):
 
         return cleaned_data
 
-    class Meta:
-        model = GeographicalMembership
-        fields = ["valid_between"]
-
 
 class GeographicalMembershipAddForm(
     BindNestedFormMixin,

--- a/geo_areas/forms.py
+++ b/geo_areas/forms.py
@@ -423,3 +423,103 @@ class GeographicalAreaEditForm(
                 data_prevent_double_click="true",
             ),
         )
+
+
+class GeographicalAreaCreateForm(ValidityPeriodForm):
+    description = forms.CharField(
+        label="Description",
+        help_text="The name of the country, area group or region.",
+        widget=forms.Textarea,
+        validators=[SymbolValidator],
+        error_messages={"required": "Enter a geographical area description."},
+    )
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self.fields["area_code"].label = "Area code"
+        self.fields[
+            "area_code"
+        ].help_text = "Select if the new geographical area is a country, area group or region from the dropdown."
+        self.fields["area_code"].error_messages = {
+            "required": "Select an area code from the dropdown.",
+        }
+
+        self.fields["area_id"].label = "Area ID"
+        self.fields[
+            "area_id"
+        ].help_text = "For a country or region, the area ID is 2 upper-case letters, like AZ. For an area group, the area ID is 4 digits, like 1234."
+        self.fields["area_id"].error_messages = {
+            "required": "Enter a geographical area ID.",
+            "invalid": "Enter a geographical area ID in the correct format.",
+        }
+
+        self.fields[
+            "end_date"
+        ].help_text = (
+            "Leave empty if the geographical area is needed for an unlimited time."
+        )
+
+        self.helper = FormHelper(self)
+        self.helper.label_size = Size.SMALL
+        self.helper.legend_size = Size.SMALL
+
+        self.helper.layout = Layout(
+            "area_code",
+            Field(
+                "area_id",
+                css_class="govuk-input govuk-input--width-4",
+                maxlength="4",
+            ),
+            "start_date",
+            "end_date",
+            Field.textarea("description", label_size=Size.SMALL, rows=3),
+            Submit(
+                "submit",
+                "Save",
+                data_module="govuk-button",
+                data_prevent_double_click="true",
+            ),
+        )
+
+    def clean(self):
+        cleaned_data = super().clean()
+
+        cleaned_data["geographical_area_description"] = GeographicalAreaDescription(
+            description=cleaned_data.get("description"),
+            validity_start=cleaned_data["valid_between"].lower,
+        )
+
+        return cleaned_data
+
+    class Meta:
+        model = GeographicalArea
+        fields = ["valid_between", "area_id", "area_code"]
+
+
+class GeographicalAreaEditCreateForm(GeographicalAreaCreateForm):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self.fields["description"].required = False
+
+        self.helper = FormHelper(self)
+        self.helper.label_size = Size.SMALL
+        self.helper.legend_size = Size.SMALL
+
+        self.helper.layout = Layout(
+            "area_code",
+            Field(
+                "area_id",
+                css_class="govuk-input govuk-input--width-4",
+                maxlength="4",
+            ),
+            "start_date",
+            "end_date",
+            Submit(
+                "submit",
+                "Save",
+                data_module="govuk-button",
+                data_prevent_double_click="true",
+            ),
+        )

--- a/geo_areas/forms.py
+++ b/geo_areas/forms.py
@@ -11,6 +11,7 @@ from crispy_forms_gds.layout import Layout
 from crispy_forms_gds.layout import Size
 from crispy_forms_gds.layout import Submit
 from django import forms
+from django.core.exceptions import ValidationError
 from django.db.models import TextChoices
 from django.forms import ValidationError
 

--- a/geo_areas/jinja2/geo_areas/confirm-create-membership.jinja
+++ b/geo_areas/jinja2/geo_areas/confirm-create-membership.jinja
@@ -1,0 +1,11 @@
+{% extends "common/confirm_create.jinja" %}
+
+{% set page_title = "Add memberships" %}
+
+{% block panel %}
+  {{ govukPanel({
+    "titleText": "Membership associations for " ~ object._meta.verbose_name|title ~ " " ~ object|string ~ " have been created",
+    "text": "These new membership associations have been added to your workbasket",
+    "classes": "govuk-!-margin-bottom-7"
+  }) }}
+{% endblock %}

--- a/geo_areas/jinja2/geo_areas/confirm-create.jinja
+++ b/geo_areas/jinja2/geo_areas/confirm-create.jinja
@@ -1,0 +1,34 @@
+{% extends "layouts/confirm.jinja" %}
+
+{% set page_title = "Create a new " ~ object._meta.verbose_name %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      {% block panel %}
+        {{ govukPanel({
+          "titleText": object._meta.verbose_name|title ~ " " ~ object|string ~ " has been created",
+          "text": "This new " ~ object._meta.verbose_name ~ " has been added to your workbasket",
+          "classes": "govuk-!-margin-bottom-7"
+        }) }}
+      {% endblock %}
+      <h2 class="govuk-heading-m">Next steps</h2>
+      {#
+      <p class="govuk-body">
+        You can now <a class="govuk-link" href={{ url("geo_area-ui-membership-create", kwargs={"sid": object.sid}) }} >edit memberships for this geographical area.</a>
+      </p>
+      #}
+      <p class="govuk-body">To complete your task you must publish your change.</p>
+      {{ govukButton({
+        "text": "Go to your workbasket summary",
+        "href": url("workbaskets:current-workbasket"),
+        "classes": "govuk-button--secondary"
+      }) }}
+      <ul class="govuk-list govuk-list-spaced">
+        <li><a class="govuk-link" href="{{ object.get_url() }}">View {{ object._meta.verbose_name }} {{ object|string }}</a></li>
+        <li><a href="{{ object.get_url("list") }}">Find and edit {{ object._meta.verbose_name_plural }}</a></li>
+        {% include "includes/common/main-menu-link.jinja" %}
+      </ul>
+    </div>
+  </div>
+{% endblock %}

--- a/geo_areas/jinja2/geo_areas/confirm-create.jinja
+++ b/geo_areas/jinja2/geo_areas/confirm-create.jinja
@@ -13,11 +13,9 @@
         }) }}
       {% endblock %}
       <h2 class="govuk-heading-m">Next steps</h2>
-      {#
       <p class="govuk-body">
-        You can now <a class="govuk-link" href={{ url("geo_area-ui-membership-create", kwargs={"sid": object.sid}) }} >edit memberships for this geographical area.</a>
+        You can now <a class="govuk-link" href={{ url("geo_area-ui-membership-create", kwargs={"sid": object.sid}) }} >add memberships for this geographical area.</a>
       </p>
-      #}
       <p class="govuk-body">To complete your task you must publish your change.</p>
       {{ govukButton({
         "text": "Go to your workbasket summary",

--- a/geo_areas/jinja2/geo_areas/create-membership-formset.jinja
+++ b/geo_areas/jinja2/geo_areas/create-membership-formset.jinja
@@ -3,6 +3,7 @@
 {% from "components/fieldset/macro.njk" import govukFieldset %}
 {% from "components/error-summary/macro.njk" import govukErrorSummary %}
 
+{% set page_title = "Add memberships" %}
 {% set area_code = " (" ~ geo_area.get_area_code_display() ~ ")" %}
 {% set geo_area_title = "Geographical area: " ~  geo_area.area_id ~ area_code %}
 

--- a/geo_areas/jinja2/geo_areas/create-membership-formset.jinja
+++ b/geo_areas/jinja2/geo_areas/create-membership-formset.jinja
@@ -19,6 +19,10 @@
   <p class="govuk-body">
     Create new geographical membership associations for  {{ geo_area|string }}.
   </p>
+  <p class="govuk-body">
+    Learn more about
+    <a class="govuk-link" href="https://data-services-help.trade.gov.uk/tariff-application-platform/data-structures/geographical-areas/">geographical area memberships</a>.
+  </p>
   {% set formset = form %}
   {{ crispy(formset.management_form) }}
 

--- a/geo_areas/jinja2/geo_areas/create-membership-formset.jinja
+++ b/geo_areas/jinja2/geo_areas/create-membership-formset.jinja
@@ -1,0 +1,62 @@
+{% extends 'layouts/form.jinja' %}
+
+{% from "components/fieldset/macro.njk" import govukFieldset %}
+{% from "components/error-summary/macro.njk" import govukErrorSummary %}
+
+{% set area_code = " (" ~ geo_area.get_area_code_display() ~ ")" %}
+{% set geo_area_title = "Geographical area: " ~  geo_area.area_id ~ area_code %}
+
+{% block breadcrumb %}
+  {% if request.path != "/" %}
+    {{ breadcrumbs(request, [
+      {"text": geo_area_title, "href": url("geo_area-ui-detail", args=[geo_area.sid])},
+      {"text": page_title}
+    ]) }}
+  {% endif %}
+{% endblock %}
+
+{% block form %}
+  <p class="govuk-body">
+    Create new geographical membership associations for  {{ geo_area|string }}.
+  </p>
+  {% set formset = form %}
+  {{ crispy(formset.management_form) }}
+
+  {% if formset.non_form_errors() %}
+    {% set error_list = [] %}
+    {% for error in formset.non_form_errors() %}
+      {{ error_list.append({
+        "html": '<p class="govuk-error-message">' ~ error ~ '</p>',
+      }) or "" }}
+    {% endfor %}
+
+    {{ govukErrorSummary({
+      "titleText": "There is a problem",
+      "errorList": error_list
+    }) }}
+  {% endif %}
+
+  {% call django_form(action=url("geo_area-ui-membership-create", kwargs={"sid": geo_area.sid})) %}
+    {% for form in formset %}
+      {{ crispy(form) }}
+    {% endfor %}
+
+    {% if formset.data[formset.prefix ~ "-ADD"] %}
+      {{ crispy(formset.empty_form)|replace("__prefix__", formset.forms|length)|safe }}
+    {% endif %}
+
+    <div class="govuk-button-group">
+      {{ govukButton({"text": "Save"}) }}
+
+    {% if formset.total_form_count() + 1 < formset.max_num %}
+      {{ govukButton({
+        "text": "Add new",
+        "attributes": {"id": "add-new"},
+        "classes": "govuk-button--secondary",
+        "value": "1",
+        "name": formset.prefix ~ "-ADD",
+      }) }}
+    {% endif %}
+    </div>
+  {% endcall %}
+{% endblock %}

--- a/geo_areas/jinja2/geo_areas/create.jinja
+++ b/geo_areas/jinja2/geo_areas/create.jinja
@@ -1,5 +1,7 @@
 {% extends 'layouts/form.jinja' %}
 
+{% set page_title = "Create a new geographical area" %}
+
 {% block content %}
   <h1 class="govuk-heading-xl">{{ page_title }}</h1>
   {% if page_label %}

--- a/geo_areas/jinja2/geo_areas/create.jinja
+++ b/geo_areas/jinja2/geo_areas/create.jinja
@@ -1,0 +1,20 @@
+{% extends 'layouts/form.jinja' %}
+
+{% block content %}
+  <h1 class="govuk-heading-xl">{{ page_title }}</h1>
+  {% if page_label %}
+    <div class="govuk-hint"> {{ page_label }}</div>
+  {% endif %}
+  <p class="govuk-body">
+    Find out more about <a class="govuk-link" href="https://data-services-help.trade.gov.uk/tariff-application-platform/data-structures/geographical-areas/">geographical areas</a>.
+  </p>
+  {% block form %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      {% call django_form() %}
+        {{ crispy(form) }}
+      {% endcall %}
+    </div>
+  </div>
+  {% endblock %}
+{% endblock %}

--- a/geo_areas/jinja2/includes/geo_areas/tabs/memberships.jinja
+++ b/geo_areas/jinja2/includes/geo_areas/tabs/memberships.jinja
@@ -1,6 +1,7 @@
 <div class="geo_areas__memberships govuk-grid-row">
   <div class="geo_areas__memberships__content govuk-grid-column-three-quarters">
     <h2 class="govuk-heading-l">Memberships</h2>
+    <p class="govuk-body"><a class="govuk-link" href="{{ url("geo_area-ui-membership-create", kwargs={"sid": object.sid}) }}">Create a new membership</a></p>
     {% if object.get_area_code_display() in ["Country", "Region"] %}
       <p class="govuk-body">This {{ object.get_area_code_display().lower() }} is a member of:</p>
     {% else %}

--- a/geo_areas/tests/test_forms.py
+++ b/geo_areas/tests/test_forms.py
@@ -457,7 +457,7 @@ def test_geographical_membership_group_formset_same_selection(date_ranges):
     with override_current_transaction(Transaction.objects.last()):
         formset = forms.GeographicalMembershipGroupFormSet(
             data=form_data,
-            geo_area=country,
+            form_kwargs={"geo_area": country},
         )
         assert not formset.is_valid()
         assert (
@@ -546,7 +546,7 @@ def test_geographical_membership_member_formset_same_selection(date_ranges):
     with override_current_transaction(Transaction.objects.last()):
         formset = forms.GeographicalMembershipMemberFormSet(
             data=form_data,
-            geo_area=area_group,
+            form_kwargs={"geo_area": area_group},
         )
         assert not formset.is_valid()
         assert (

--- a/geo_areas/tests/test_views.py
+++ b/geo_areas/tests/test_views.py
@@ -66,6 +66,7 @@ def test_geographical_area_detail_views(
     areas and don't return an error."""
     model_overrides = {
         "geo_areas.views.GeoAreaDescriptionCreate": GeographicalArea,
+        "geo_areas.views.GeographicalMembershipCreate": GeographicalArea,
     }
 
     assert_model_view_renders(view, url_pattern, valid_user_client, model_overrides)

--- a/geo_areas/tests/test_views.py
+++ b/geo_areas/tests/test_views.py
@@ -66,7 +66,7 @@ def test_geographical_area_detail_views(
     areas and don't return an error."""
     model_overrides = {
         "geo_areas.views.GeoAreaDescriptionCreate": GeographicalArea,
-        "geo_areas.views.GeographicalMembershipCreate": GeographicalArea,
+        "geo_areas.views.GeographicalMembershipsCreate": GeographicalArea,
     }
 
     assert_model_view_renders(view, url_pattern, valid_user_client, model_overrides)

--- a/geo_areas/tests/test_views.py
+++ b/geo_areas/tests/test_views.py
@@ -3,11 +3,14 @@ from bs4 import BeautifulSoup
 from django.core.exceptions import ValidationError
 from rest_framework.reverse import reverse
 
+from common.models.transactions import Transaction
 from common.models.utils import override_current_transaction
 from common.tests import factories
 from common.tests.util import assert_model_view_renders
 from common.tests.util import assert_read_only_model_view_returns_list
+from common.tests.util import date_post_data
 from common.tests.util import get_class_based_view_urls_matching_url
+from common.tests.util import raises_if
 from common.tests.util import view_is_subclass
 from common.tests.util import view_urlpattern_ids
 from common.validators import UpdateType
@@ -365,3 +368,52 @@ def test_geo_area_update_view_membership_deletion(
     )
     for membership in workbasket:
         assert membership.update_type == UpdateType.DELETE
+
+
+def test_geo_area_create_view(valid_user_client, session_workbasket, date_ranges):
+    """Tests that a geographical area can be created."""
+    form_data = {
+        "area_code": AreaCode.COUNTRY,
+        "area_id": "TC",
+        "start_date_0": date_ranges.normal.lower.day,
+        "start_date_1": date_ranges.normal.lower.month,
+        "start_date_2": date_ranges.normal.lower.year,
+        "end_date_0": date_ranges.normal.upper.day,
+        "end_date_1": date_ranges.normal.upper.month,
+        "end_date_2": date_ranges.normal.upper.year,
+        "description": "Test country",
+    }
+    expected_valid_between = date_ranges.normal
+
+    url = reverse("geo_area-ui-create")
+    response = valid_user_client.post(url, form_data)
+    assert response.status_code == 302
+
+    with override_current_transaction(Transaction.objects.last()):
+        geo_area = GeographicalArea.objects.get(
+            transaction__workbasket=session_workbasket,
+        )
+        assert geo_area.update_type == UpdateType.CREATE
+        assert geo_area.area_code == form_data["area_code"]
+        assert geo_area.area_id == form_data["area_id"]
+        assert geo_area.valid_between == expected_valid_between
+        assert geo_area.get_description().description == form_data["description"]
+
+
+def test_geo_area_edit_create_view(
+    valid_user_client,
+    session_workbasket,
+    date_ranges,
+    use_edit_view,
+):
+    """Tests that geographical area CREATE instances can be edited."""
+    geo_area = factories.GeographicalAreaFactory.create(
+        area_code=AreaCode.REGION,
+        area_id="TR",
+        valid_between=date_ranges.no_end,
+        transaction=session_workbasket.new_transaction(),
+    )
+
+    data_changes = {**date_post_data("end_date", date_ranges.normal.upper)}
+    with raises_if(ValidationError, not True):
+        use_edit_view(geo_area, data_changes)

--- a/geo_areas/urls.py
+++ b/geo_areas/urls.py
@@ -12,6 +12,19 @@ detail = "<sid:sid>"
 description_detail = "<sid:described_geographicalarea__sid>/description/<sid:sid>"
 ui_patterns = get_ui_paths(views, detail, description=description_detail)
 
+ui_patterns += [
+    path(
+        "<sid:sid>/membership-create",
+        views.GeographicalMembershipCreate.as_view(),
+        name="geo_area-ui-membership-create",
+    ),
+    path(
+        "<sid:sid>/membership/confirm-create",
+        views.GeographicalMembershipConfirmCreate.as_view(),
+        name="geo_area-ui-membership-confirm-create",
+    ),
+]
+
 
 urlpatterns = [
     path("geographical-areas/", include(ui_patterns)),

--- a/geo_areas/urls.py
+++ b/geo_areas/urls.py
@@ -14,12 +14,12 @@ ui_patterns = get_ui_paths(views, detail, description=description_detail)
 
 ui_patterns += [
     path(
-        "<sid:sid>/membership-create",
+        "<sid:sid>/membership-create/",
         views.GeographicalMembershipCreate.as_view(),
         name="geo_area-ui-membership-create",
     ),
     path(
-        "<sid:sid>/membership/confirm-create",
+        "<sid:sid>/membership/confirm-create/",
         views.GeographicalMembershipConfirmCreate.as_view(),
         name="geo_area-ui-membership-confirm-create",
     ),

--- a/geo_areas/urls.py
+++ b/geo_areas/urls.py
@@ -15,7 +15,7 @@ ui_patterns = get_ui_paths(views, detail, description=description_detail)
 ui_patterns += [
     path(
         "<sid:sid>/membership-create/",
-        views.GeographicalMembershipCreate.as_view(),
+        views.GeographicalMembershipsCreate.as_view(),
         name="geo_area-ui-membership-create",
     ),
     path(

--- a/geo_areas/validators.py
+++ b/geo_areas/validators.py
@@ -17,15 +17,15 @@ def validate_dates(
     field,
     start_date=None,
     end_date=None,
-    group_start_date=None,
-    group_end_date=None,
+    container="area group",
+    container_start_date=None,
+    container_end_date=None,
 ):
     """
-    Adds an error message to a form field if a start and end date is not within
-    a Geographical Area Group's start and end date.
+    Adds an error message to a form field if either the start or end date is not
+    within the container's start and end date.
 
-    Used by forms in GeographicalAreaEditForm for creating and updating
-    Geographical Memberships.
+    Used by forms for creating and updating Geographical Memberships.
     """
 
     if end_date and start_date and end_date < start_date:
@@ -34,27 +34,27 @@ def validate_dates(
             "The end date must be the same as or after the start date.",
         )
 
-    if start_date and group_start_date and start_date < group_start_date:
+    if start_date and container_start_date and start_date < container_start_date:
         form.add_error(
             field,
-            "The start date must be the same as or after the area group's start date.",
+            f"The start date must be the same as or after the {container}'s start date.",
         )
 
-    if start_date and group_end_date and start_date > group_end_date:
+    if start_date and container_end_date and start_date > container_end_date:
         form.add_error(
             field,
-            "The start date must be the same as or before the area group's end date.",
+            f"The start date must be the same as or before the {container}'s end date.",
         )
 
-    if end_date and group_start_date and end_date < group_start_date:
+    if end_date and container_start_date and end_date < container_start_date:
         form.add_error(
             field,
-            "The end date must be the same as or after the area group's start date.",
+            f"The end date must be the same as or after the {container}'s start date.",
         )
 
-    if group_end_date:
-        if end_date and end_date > group_end_date or not end_date:
+    if container_end_date:
+        if end_date and end_date > container_end_date or not end_date:
             form.add_error(
                 field,
-                "The end date must be the same as or before the area group's end date.",
+                f"The end date must be the same as or before the {container}'s end date.",
             )

--- a/geo_areas/validators.py
+++ b/geo_areas/validators.py
@@ -12,49 +12,46 @@ class AreaCode(models.IntegerChoices):
     REGION = 2, "Region"
 
 
-def validate_dates(
-    form,
-    field,
-    start_date=None,
-    end_date=None,
-    container="area group",
-    container_start_date=None,
-    container_end_date=None,
-):
-    """
-    Adds an error message to a form field if either the start or end date is not
-    within the container's start and end date.
+class DateValidationMixin:
+    def validate_dates(
+        self,
+        field,
+        start_date=None,
+        end_date=None,
+        container="area group",
+        container_start_date=None,
+        container_end_date=None,
+    ):
+        """Adds an error message to a form field if either the start or end date
+        is not within the container's start and end date."""
 
-    Used by forms for creating and updating Geographical Memberships.
-    """
-
-    if end_date and start_date and end_date < start_date:
-        form.add_error(
-            field,
-            "The end date must be the same as or after the start date.",
-        )
-
-    if start_date and container_start_date and start_date < container_start_date:
-        form.add_error(
-            field,
-            f"The start date must be the same as or after the {container}'s start date.",
-        )
-
-    if start_date and container_end_date and start_date > container_end_date:
-        form.add_error(
-            field,
-            f"The start date must be the same as or before the {container}'s end date.",
-        )
-
-    if end_date and container_start_date and end_date < container_start_date:
-        form.add_error(
-            field,
-            f"The end date must be the same as or after the {container}'s start date.",
-        )
-
-    if container_end_date:
-        if end_date and end_date > container_end_date or not end_date:
-            form.add_error(
+        if end_date and start_date and end_date < start_date:
+            self.add_error(
                 field,
-                f"The end date must be the same as or before the {container}'s end date.",
+                "The end date must be the same as or after the start date.",
             )
+
+        if start_date and container_start_date and start_date < container_start_date:
+            self.add_error(
+                field,
+                f"The start date must be the same as or after the {container}'s start date.",
+            )
+
+        if start_date and container_end_date and start_date > container_end_date:
+            self.add_error(
+                field,
+                f"The start date must be the same as or before the {container}'s end date.",
+            )
+
+        if end_date and container_start_date and end_date < container_start_date:
+            self.add_error(
+                field,
+                f"The end date must be the same as or after the {container}'s start date.",
+            )
+
+        if container_end_date:
+            if end_date and end_date > container_end_date or not end_date:
+                self.add_error(
+                    field,
+                    f"The end date must be the same as or before the {container}'s end date.",
+                )

--- a/geo_areas/views.py
+++ b/geo_areas/views.py
@@ -230,7 +230,7 @@ class GeoAreaEditUpdate(
 class GeoAreaCreate(GeoAreaMixin, CreateTaricCreateView):
     """UI endpoint for creating Geographical Area CREATE instances."""
 
-    template_name = "layouts/create.jinja"
+    template_name = "geo_areas/create.jinja"
     form_class = forms.GeographicalAreaCreateForm
 
     validate_business_rules = (

--- a/geo_areas/views.py
+++ b/geo_areas/views.py
@@ -297,7 +297,7 @@ class GeographicalMembershipsCreate(
 
     def get_form_kwargs(self):
         kwargs = super().get_form_kwargs()
-        kwargs["geo_area"] = self.instance
+        kwargs["form_kwargs"] = {"geo_area": self.instance}
         return kwargs
 
     def create_memberships(self, form):

--- a/geo_areas/views.py
+++ b/geo_areas/views.py
@@ -1,5 +1,7 @@
 from typing import Type
 
+from django.shortcuts import redirect
+from django.urls import reverse
 from rest_framework import permissions
 from rest_framework import viewsets
 
@@ -274,3 +276,87 @@ class GeoAreaConfirmCreate(
     TrackedModelDetailView,
 ):
     template_name = "geo_areas/confirm-create.jinja"
+
+
+class GeographicalMembershipCreate(
+    TrackedModelDetailMixin,
+    CreateTaricCreateView,
+):
+    template_name = "geo_areas/create-membership-formset.jinja"
+
+    @property
+    def instance(self):
+        return GeographicalArea.objects.current().get(sid=self.kwargs.get("sid"))
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        geo_area = self.instance
+        context.update(
+            {
+                "geo_area": geo_area,
+                "page_title": "Add memberships",
+            },
+        )
+        return context
+
+    def get_form(self):
+        if self.instance.is_group():
+            return super().get_form(forms.GeographicalMembershipMemberFormSet)
+        else:
+            return super().get_form(forms.GeographicalMembershipGroupFormSet)
+
+    def get_form_kwargs(self):
+        kwargs = super().get_form_kwargs()
+        kwargs["geo_area"] = self.instance
+        return kwargs
+
+    def create_memberships(self, form):
+        geo_area = self.instance
+
+        validity_periods = [
+            d["valid_between"] for d in form.cleaned_data if "valid_between" in d
+        ]
+        members = [d["member"] for d in form.cleaned_data if "member" in d]
+        geo_groups = [d["geo_group"] for d in form.cleaned_data if "geo_group" in d]
+
+        tx = WorkBasket.get_current_transaction(self.request)
+
+        if members:
+            for member, valid_between in zip(members, validity_periods):
+                membership = GeographicalMembership(
+                    geo_group=geo_area,
+                    member=member,
+                    valid_between=valid_between,
+                    transaction=tx,
+                    update_type=UpdateType.CREATE,
+                )
+                membership.save()
+
+        if geo_groups:
+            for geo_group, valid_between in zip(geo_groups, validity_periods):
+                membership = GeographicalMembership(
+                    geo_group=geo_group,
+                    member=geo_area,
+                    valid_between=valid_between,
+                    transaction=tx,
+                    update_type=UpdateType.CREATE,
+                )
+                membership.save()
+
+        return geo_area
+
+    def form_valid(self, form):
+        self.create_memberships(form)
+        return redirect(
+            reverse(
+                "geo_area-ui-membership-confirm-create",
+                kwargs={"sid": self.instance.sid},
+            ),
+        )
+
+
+class GeographicalMembershipConfirmCreate(
+    GeoAreaMixin,
+    TrackedModelDetailView,
+):
+    template_name = "geo_areas/confirm-create-membership.jinja"

--- a/geo_areas/views.py
+++ b/geo_areas/views.py
@@ -238,11 +238,6 @@ class GeoAreaCreate(GeoAreaMixin, CreateTaricCreateView):
         business_rules.GA7,
     )
 
-    def get_context_data(self, **kwargs):
-        context = super().get_context_data(**kwargs)
-        context["page_title"] = "Create a new geographical area"
-        return context
-
     def get_result_object(self, form):
         geo_area = super().get_result_object(form)
         description = form.cleaned_data["geographical_area_description"]
@@ -291,12 +286,7 @@ class GeographicalMembershipCreate(
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         geo_area = self.instance
-        context.update(
-            {
-                "geo_area": geo_area,
-                "page_title": "Add memberships",
-            },
-        )
+        context.update({"geo_area": geo_area})
         return context
 
     def get_form(self):

--- a/geo_areas/views.py
+++ b/geo_areas/views.py
@@ -273,7 +273,7 @@ class GeoAreaConfirmCreate(
     template_name = "geo_areas/confirm-create.jinja"
 
 
-class GeographicalMembershipCreate(
+class GeographicalMembershipsCreate(
     TrackedModelDetailMixin,
     CreateTaricCreateView,
 ):

--- a/geo_areas/views.py
+++ b/geo_areas/views.py
@@ -223,3 +223,54 @@ class GeoAreaEditUpdate(
     EditTaricView,
 ):
     """UI endpoint to edit geo area UPDATE instances."""
+
+
+class GeoAreaCreate(GeoAreaMixin, CreateTaricCreateView):
+    """UI endpoint for creating Geographical Area CREATE instances."""
+
+    template_name = "layouts/create.jinja"
+    form_class = forms.GeographicalAreaCreateForm
+
+    validate_business_rules = (
+        business_rules.GA1,
+        business_rules.GA7,
+    )
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["page_title"] = "Create a new geographical area"
+        return context
+
+    def get_result_object(self, form):
+        geo_area = super().get_result_object(form)
+        description = form.cleaned_data["geographical_area_description"]
+        description.described_geographicalarea = geo_area
+        description.update_type = UpdateType.CREATE
+        description.transaction = geo_area.transaction
+        description.save()
+
+        return geo_area
+
+
+class GeoAreaEditCreate(
+    GeoAreaMixin,
+    TrackedModelDetailMixin,
+    EditTaricView,
+):
+    """UI endpoint for editing Geographical Area CREATE instances."""
+
+    template_name = "layouts/create.jinja"
+    form_class = forms.GeographicalAreaEditCreateForm
+
+    validate_business_rules = (
+        business_rules.GA1,
+        business_rules.GA3,
+        business_rules.GA7,
+    )
+
+
+class GeoAreaConfirmCreate(
+    GeoAreaMixin,
+    TrackedModelDetailView,
+):
+    template_name = "geo_areas/confirm-create.jinja"

--- a/workbaskets/jinja2/workbaskets/edit-workbasket.jinja
+++ b/workbaskets/jinja2/workbaskets/edit-workbasket.jinja
@@ -77,6 +77,11 @@
       <h2 class="govuk-heading-m">Geographical areas</h2>
       <ul class="govuk-list">
         <li>
+          <a class="govuk-link" href="{{ url('geo_area-ui-create') }}">
+            Create a new geographical area
+          </a>
+        </li>
+        <li>
           <a class="govuk-link" href="{{ url('geo_area-ui-list') }}">
             Find and edit geographical areas
           </a>


### PR DESCRIPTION
# TP2000-857  Implement geo area create journey

## Why
Now that the ‘Edit Geographical area’ journey has been implemented, we should complete the final journey, ‘Create a new geographical area’, which will allow users to create their own geographical areas without the need to involve data engineers.

## What
- Adds `GeoAreaCreate` view and `GeographicalAreaCreateForm`, enabling users to create new geo areas
- Adds `GeographicalMembershipCreate` view and `GeographicalMembershipBaseFormSet`, enabling users to create multiple new memberships for a geo area (TP2000-858)
- Adds 'create a new geo area' link to workbasket menu
- Adds 'create a new membership' link to memberships tab of a geo area
- Adds view and form unit tests

##

<img width="250" alt="Screenshot 2023-05-02 at 10 49 58" src="https://user-images.githubusercontent.com/118175145/235635193-d3ed96c9-3a5a-43d0-a75d-0eeab2c29217.png">

<img width="250" alt="Screenshot 2023-04-28 at 10 16 39" src="https://user-images.githubusercontent.com/118175145/235636242-152c3167-5ec9-4dfa-8363-65704e0e4bb9.png">

<img width="250" alt="Screenshot 2023-05-02 at 10 50 20" src="https://user-images.githubusercontent.com/118175145/235635241-cd5c19de-beff-4006-8db8-de3f5ab42bba.png">

<img width="250" alt="Screenshot 2023-04-28 at 10 30 37" src="https://user-images.githubusercontent.com/118175145/235111253-498202ae-d1ad-441b-bf25-1f398550dabd.png">

<img width="250" alt="Screenshot 2023-04-28 at 10 27 46" src="https://user-images.githubusercontent.com/118175145/235111277-c1c616e9-f0cc-41a7-8372-2c1248b3154b.png">