### PR TITLE
TP2000-861 Fix footnote delete button on measure edit view

### DIFF
--- a/common/paths.py
+++ b/common/paths.py
@@ -10,22 +10,22 @@ logger = logging.getLogger(__name__)
 
 BULK_ACTIONS = {
     "List": "",
-    "Create": "create",
+    "Create": "create/",
 }
 """Map of view class name suffixes to URL path action names, used to handle
 class-level actions."""
 
 
 OBJECT_ACTIONS = {
-    "ConfirmCreate": "confirm-create",
+    "ConfirmCreate": "confirm-create/",
     "Detail": "",
-    "Update": "edit",
-    "ConfirmUpdate": "confirm-update",
-    "Delete": "delete",
-    "DescriptionCreate": "description-create",
+    "Update": "edit/",
+    "ConfirmUpdate": "confirm-update/",
+    "Delete": "delete/",
+    "DescriptionCreate": "description-create/",
     # Edits on taric objects that are in a WorkBasket with status=EDITING.
-    "EditCreate": "edit-create",
-    "EditUpdate": "edit-update",
+    "EditCreate": "edit-create/",
+    "EditUpdate": "edit-update/",
 }
 """Map of view class name suffixes to URL path action names, used to handle
 object-level actions."""
@@ -107,7 +107,7 @@ def get_ui_paths(
             view = getattr(views, classname)
             name = (
                 f"{app_name_singular}-ui-"
-                f"{pathname if pathname else class_suffix.lower()}"
+                f"{pathname[:-1] if pathname else class_suffix.lower()}"
             )
             url = detail_pattern + ("/" if detail_pattern else "") + pathname
 

--- a/measures/forms.py
+++ b/measures/forms.py
@@ -1406,7 +1406,7 @@ class MeasureUpdateFootnotesForm(MeasureFootnotesForm):
     def __init__(self, *args, **kwargs):
         path = kwargs.pop("path")
         if "edit" in path:
-            self.path = path[:-1] + "-footnotes/"
+            self.path = path + "-footnotes/"
 
         super().__init__(*args, **kwargs)
 

--- a/measures/forms.py
+++ b/measures/forms.py
@@ -1412,7 +1412,7 @@ class MeasureUpdateFootnotesForm(MeasureFootnotesForm):
     def __init__(self, *args, **kwargs):
         path = kwargs.pop("path")
         if "edit" in path:
-            self.path = path + "-footnotes/"
+            self.path = path[:-1] + "-footnotes/"
 
         super().__init__(*args, **kwargs)
 


### PR DESCRIPTION
# TP2000-861 Fix footnote delete button on measure edit view

## Why
On the measure edit view, the delete button for the footnote form redirects the user to /measures/<sid\>/**edi-footnotes**  causing a page not found (404) error.

## What
- Fix `self.path` so that "-footnotes/" is appended to an unsliced `path` (e.g /measures/<sid\>/edit).

