### PR TITLE
 Exclusion created on Single Geo area selection Fix

### DIFF
--- a/measures/forms.py
+++ b/measures/forms.py
@@ -130,6 +130,12 @@ FORMSET_PREFIX_MAPPING = {
     GeoAreaType.COUNTRY: COUNTRY_REGION_FORMSET_PREFIX,
 }
 
+EXCLUSIONS_FORMSET_PREFIX_MAPPING = {
+    GeoAreaType.ERGA_OMNES: ERGA_OMNES_EXCLUSIONS_FORMSET_PREFIX,
+    GeoAreaType.GROUP: GROUP_EXCLUSIONS_FORMSET_PREFIX,
+    GeoAreaType.COUNTRY: None,
+}
+
 FIELD_NAME_MAPPING = {
     GeoAreaType.ERGA_OMNES: "erga_omnes_exclusion",
     GeoAreaType.GROUP: "geo_group_exclusion",
@@ -1211,13 +1217,13 @@ class MeasureGeographicalAreaForm(
                     ]
 
                 exclusions = cleaned_data.get(
-                    FORMSET_PREFIX_MAPPING[geo_area_choice],
+                    EXCLUSIONS_FORMSET_PREFIX_MAPPING[geo_area_choice],
                 )
                 if exclusions:
                     cleaned_data["geo_area_exclusions"] = [
                         exclusion[FIELD_NAME_MAPPING[geo_area_choice]]
                         for exclusion in cleaned_data[
-                            FORMSET_PREFIX_MAPPING[geo_area_choice]
+                            EXCLUSIONS_FORMSET_PREFIX_MAPPING[geo_area_choice]
                         ]
                     ]
 

--- a/measures/tests/test_forms.py
+++ b/measures/tests/test_forms.py
@@ -334,6 +334,8 @@ def test_measure_forms_geo_area_valid_data_countries_submit(erga_omnes):
         )
         assert form.is_valid()
         assert form.cleaned_data["geo_area_list"] == [geo_area1, geo_area2]
+        # specific country selection should have empty exclusions
+        assert not form.cleaned_data.get("geo_area_exclusions")
 
 
 def test_measure_forms_geo_area_valid_data_countries_delete(erga_omnes):


### PR DESCRIPTION
# TP2000-862 Exclusion created on Single Geo area selection Fix


## Why
When selecting a single country as the geographical area, TAP is assigning the selection as both the area to be selected and the geographical exclusion.

## What
Re added the exclusion specific Mapping constant as the select specific geo area does not have an exclusions field.

Previous PR: https://github.com/uktrade/tamato/pull/889
