### PR TITLE
 Edit Measure Conditions Fix

### DIFF
--- a/common/forms.py
+++ b/common/forms.py
@@ -580,7 +580,11 @@ class FormSet(forms.BaseFormSet):
         self.initial = initial
 
         if initial:
-            num_initial = len(initial)
+            num_initial = (
+                len(initial)
+                if len(initial) == len(formset_initial.values())
+                else len(formset_initial.values())
+            )
         else:
             num_initial = len(formset_initial.values())
 

--- a/measures/forms.py
+++ b/measures/forms.py
@@ -450,8 +450,8 @@ class MeasureConditionsFormMixin(forms.ModelForm):
             self.add_error(
                 None,
                 ValidationError(
-                    "If you action code is negative you do not need to enter ‘reference price or quantity’, ‘certificate, licence or document’ or ‘duty’.",
-                ),  #
+                    "If the action code is negative you do not need to enter ‘reference price or quantity’, ‘certificate, licence or document’ or ‘duty’.",
+                ),
             )
 
         price_errored = False

--- a/measures/forms.py
+++ b/measures/forms.py
@@ -404,7 +404,12 @@ class MeasureConditionsFormMixin(forms.ModelForm):
             ),
         )
 
-    def conditions_clean(self, cleaned_data, measure_start_date):
+    def conditions_clean(
+        self,
+        cleaned_data,
+        measure_start_date,
+        is_negative_action_code=False,
+    ):
         """
         We get the reference_price from cleaned_data and the measure_start_date
         from the form's initial data.
@@ -415,17 +420,38 @@ class MeasureConditionsFormMixin(forms.ModelForm):
         are dealing with a simple duty (i.e. only one component). We then update
         cleaned_data with key-value pairs created from this single, unsaved
         component.
+
+        Args:
+            cleaned_data the cleaned data submitted in the form,
+            measure_start_date the start date set for the measure,
+            is_negative_action_code is a boolean by default false and is used to
+            carry out different validation depending on the action code type
+        Returns:
+            returns cleaned_data
         """
         price = cleaned_data.get("reference_price")
         certificate = cleaned_data.get("required_certificate")
+        applicable_duty = cleaned_data.get("applicable_duty")
 
-        # Price or certificate must be present but no both
-        if (not price and not certificate) or (price and certificate):
+        # Price or certificate must be present but no both; if the action code is not negative
+        if (
+            not is_negative_action_code
+            and (not price and not certificate)
+            or (price and certificate)
+        ):
             self.add_error(
                 None,
                 ValidationError(
                     "For each condition you must complete either ‘reference price or quantity’ or ‘certificate, licence or document’.",
                 ),
+            )
+
+        if is_negative_action_code and (price or certificate or applicable_duty):
+            self.add_error(
+                None,
+                ValidationError(
+                    "If you action code is negative you do not need to enter ‘reference price or quantity’, ‘certificate, licence or document’ or ‘duty’.",
+                ),  #
             )
 
         price_errored = False
@@ -464,6 +490,14 @@ class MeasureConditionsFormMixin(forms.ModelForm):
 
 
 class MeasureConditionsForm(MeasureConditionsFormMixin):
+    # override action queryset for edit form, gets all actions
+    action = forms.ModelChoiceField(
+        label="Action code",
+        queryset=models.MeasureAction.objects.latest_approved(),
+        empty_label="-- Please select an action code --",
+        error_messages={"required": "An action code is required."},
+    )
+
     def get_start_date(self, data):
         """Validates that the day, month, and year start_date fields are present
         in data and then returns the start_date datetime object."""
@@ -505,7 +539,15 @@ class MeasureConditionsForm(MeasureConditionsFormMixin):
         cleaned_data = super().clean()
         measure_start_date = self.get_start_date(self.data)
 
-        return self.conditions_clean(cleaned_data, measure_start_date)
+        # Check if the action code set for the form is
+        is_negative_action_code = models.MeasureActionPair.objects.filter(
+            negative_action=cleaned_data.get("action"),
+        ).exists()
+        return self.conditions_clean(
+            cleaned_data,
+            measure_start_date,
+            is_negative_action_code=is_negative_action_code,
+        )
 
 
 class MeasureConditionsBaseFormSet(FormSet):

--- a/measures/forms.py
+++ b/measures/forms.py
@@ -567,7 +567,12 @@ class MeasureConditionsBaseFormSet(FormSet):
         if any(self.errors):
             # Don't bother validating the formset unless each form is valid on its own
             return
-        cleaned_data = super().cleaned_data
+
+        cleaned_data = []
+        for form in self.forms:
+            if self.can_delete and self._should_delete_form(form):
+                continue
+            cleaned_data += [form.cleaned_data]
 
         validate_conditions_formset(cleaned_data)
 

--- a/measures/jinja2/measures/create-conditions-formset.jinja
+++ b/measures/jinja2/measures/create-conditions-formset.jinja
@@ -1,5 +1,7 @@
 {% from "layouts/form.jinja" import errors with context %}
 
+{% from "components/error-summary/macro.njk" import govukErrorSummary %}
+
 {{ crispy(conditions_formset.management_form, no_form_tags) }}
     <p class="govuk-body">
         You can edit these conditions by selecting a new condition code and filling in the details.
@@ -7,6 +9,19 @@
         <br>
         Any changes you make will take effect when you press save.
     </p>
+    {% if conditions_formset.non_form_errors() %}
+        {% set error_list = [] %}
+        {% for error in conditions_formset.non_form_errors() %}
+            {{ error_list.append({
+                "html": '<p class="govuk-error-message">' ~ error ~ '</p>',
+            }) or "" }}
+        {% endfor %}
+
+        {{ govukErrorSummary({
+        "titleText": "There is a problem",
+        "errorList": error_list
+        }) }}
+    {% endif %}
     {% for form in conditions_formset %}
         {% if form.errors %}
             {{ errors(form) }}

--- a/measures/tests/conftest.py
+++ b/measures/tests/conftest.py
@@ -522,6 +522,33 @@ def measure_edit_conditions_data(measure_form_data):
 
 
 @pytest.fixture
+def measure_edit_conditions_and_negative_action_data(measure_edit_conditions_data):
+    # set up second condition with negative action
+    negative_action = factories.MeasureActionFactory.create()
+    positive_action = MeasureAction.objects.get(
+        pk=measure_edit_conditions_data[
+            f"{MEASURE_CONDITIONS_FORMSET_PREFIX}-0-action"
+        ],
+    )
+    factories.MeasureActionPairFactory(
+        positive_action=positive_action,
+        negative_action=negative_action,
+    )
+
+    edit_data = {k: v for k, v in measure_edit_conditions_data.items() if v is not None}
+    edit_data[
+        f"{MEASURE_CONDITIONS_FORMSET_PREFIX}-1-condition_code"
+    ] = measure_edit_conditions_data[
+        f"{MEASURE_CONDITIONS_FORMSET_PREFIX}-0-condition_code"
+    ]
+    edit_data[f"{MEASURE_CONDITIONS_FORMSET_PREFIX}-1-action"] = negative_action.pk
+    edit_data[f"{MEASURE_CONDITIONS_FORMSET_PREFIX}-TOTAL_FORMS"] = 2
+    edit_data[f"{MEASURE_CONDITIONS_FORMSET_PREFIX}-INITIAL_FORMS"] = 2
+
+    return edit_data
+
+
+@pytest.fixture
 def measure_form(measure_form_data, session_with_workbasket, erga_omnes):
     with override_current_transaction(Transaction.objects.last()):
         return MeasureForm(

--- a/measures/tests/conftest.py
+++ b/measures/tests/conftest.py
@@ -17,6 +17,7 @@ from common.util import TaricDateRange
 from common.validators import ApplicabilityCode
 from common.validators import UpdateType
 from geo_areas.validators import AreaCode
+from measures.forms import MEASURE_CONDITIONS_FORMSET_PREFIX
 from measures.forms import MeasureForm
 from measures.models import DutyExpression
 from measures.models import Measure
@@ -502,14 +503,20 @@ def measure_edit_conditions_data(measure_form_data):
     action = factories.MeasureActionFactory.create()
     edit_data = {k: v for k, v in measure_form_data.items() if v is not None}
     edit_data["update_type"] = 1
-    edit_data["measure-conditions-formset-TOTAL_FORMS"] = 1
-    edit_data["measure-conditions-formset-INITIAL_FORMS"] = 1
-    edit_data["measure-conditions-formset-MIN_NUM_FORMS"] = 0
-    edit_data["measure-conditions-formset-MAX_NUM_FORMS"] = 1000
-    edit_data["measure-conditions-formset-0-condition_code"] = condition_code.pk
-    edit_data["measure-conditions-formset-0-required_certificate"] = certificate.pk
-    edit_data["measure-conditions-formset-0-action"] = action.pk
-    edit_data["measure-conditions-formset-0-applicable_duty"] = "3.5% + 11 GBP / 100 kg"
+    edit_data[f"{MEASURE_CONDITIONS_FORMSET_PREFIX}-TOTAL_FORMS"] = 1
+    edit_data[f"{MEASURE_CONDITIONS_FORMSET_PREFIX}-INITIAL_FORMS"] = 1
+    edit_data[f"{MEASURE_CONDITIONS_FORMSET_PREFIX}-MIN_NUM_FORMS"] = 0
+    edit_data[f"{MEASURE_CONDITIONS_FORMSET_PREFIX}-MAX_NUM_FORMS"] = 1000
+    edit_data[
+        f"{MEASURE_CONDITIONS_FORMSET_PREFIX}-0-condition_code"
+    ] = condition_code.pk
+    edit_data[
+        f"{MEASURE_CONDITIONS_FORMSET_PREFIX}-0-required_certificate"
+    ] = certificate.pk
+    edit_data[f"{MEASURE_CONDITIONS_FORMSET_PREFIX}-0-action"] = action.pk
+    edit_data[
+        f"{MEASURE_CONDITIONS_FORMSET_PREFIX}-0-applicable_duty"
+    ] = "3.5% + 11 GBP / 100 kg"
 
     return edit_data
 

--- a/measures/tests/test_forms.py
+++ b/measures/tests/test_forms.py
@@ -1322,9 +1322,12 @@ def test_measure_formset_invalid_duplicate_certs(date_ranges, duty_sentence_pars
         )
 
 
-def test_measure_formset_conditions_field_queryset(
+def test_measure_formset_conditions_action_field_queryset(
     date_ranges,
 ):
+    """Tests measure actions select field for create & edit measure conditons
+    Create measure conditions should not return negative action codes While Edit
+    measure conditions should return all aciton codes."""
     (
         positive_action,
         negative_action,
@@ -1347,3 +1350,14 @@ def test_measure_formset_conditions_field_queryset(
     assert positive_action in form["action"].field.queryset
     assert single_action in form["action"].field.queryset
     assert negative_action not in form["action"].field.queryset
+
+    edit_form = forms.MeasureConditionsForm(
+        data={},
+        prefix=MEASURE_CONDITIONS_FORMSET_PREFIX,
+        instance=None,
+    )
+
+    assert edit_form
+    assert positive_action in edit_form["action"].field.queryset
+    assert single_action in edit_form["action"].field.queryset
+    assert negative_action in edit_form["action"].field.queryset

--- a/measures/tests/test_forms.py
+++ b/measures/tests/test_forms.py
@@ -1251,7 +1251,7 @@ def measure_conditions_incorrect_order_data():
         (
             measure_conditions_different_actions_data,
             True,
-            "All conditions of the same condition code must have the same resulting action.",
+            "All conditions of the same condition code must have the same resulting action, except for the negative action code pair.",
         ),
         (
             measure_conditions_duplicate_price_data,

--- a/measures/tests/test_views.py
+++ b/measures/tests/test_views.py
@@ -860,7 +860,6 @@ def test_measure_update_invalid_conditions_invalid_actions(
 ):
     # set up invalid action under the same condition code
     single_action = factories.MeasureActionFactory.create()
-
     measure_edit_conditions_data[
         f"{MEASURE_CONDITIONS_FORMSET_PREFIX}-1-condition_code"
     ] = measure_edit_conditions_data[
@@ -870,7 +869,7 @@ def test_measure_update_invalid_conditions_invalid_actions(
         f"{MEASURE_CONDITIONS_FORMSET_PREFIX}-1-required_certificate"
     ] = measure_edit_conditions_data[
         f"{MEASURE_CONDITIONS_FORMSET_PREFIX}-0-required_certificate"
-    ]  # factories.CertificateFactory.create().pk
+    ]
     measure_edit_conditions_data[
         f"{MEASURE_CONDITIONS_FORMSET_PREFIX}-1-action"
     ] = single_action.pk
@@ -894,8 +893,6 @@ def test_measure_update_invalid_conditions_invalid_actions(
         features="lxml",
     )
     a_tags = page.select("ul.govuk-list.govuk-error-summary__list a")
-
-    print(a_tags)
 
     assert a_tags[0].attrs["href"] == f"#{MEASURE_CONDITIONS_FORMSET_PREFIX}-__all__"
     assert (

--- a/measures/tests/test_views.py
+++ b/measures/tests/test_views.py
@@ -28,8 +28,10 @@ from common.views import TrackedModelDetailMixin
 from measures.business_rules import ME70
 from measures.constants import START
 from measures.constants import MeasureEditSteps
+from measures.forms import MEASURE_CONDITIONS_FORMSET_PREFIX
 from measures.models import FootnoteAssociationMeasure
 from measures.models import Measure
+from measures.models import MeasureAction
 from measures.models import MeasureCondition
 from measures.models import MeasureConditionComponent
 from measures.models import MeasureExcludedGeographicalArea
@@ -583,17 +585,19 @@ def test_measure_update_create_conditions(
 
     assert (
         condition.condition_code.pk
-        == measure_edit_conditions_data["measure-conditions-formset-0-condition_code"]
+        == measure_edit_conditions_data[
+            f"{MEASURE_CONDITIONS_FORMSET_PREFIX}-0-condition_code"
+        ]
     )
     assert (
         condition.required_certificate.pk
         == measure_edit_conditions_data[
-            "measure-conditions-formset-0-required_certificate"
+            f"{MEASURE_CONDITIONS_FORMSET_PREFIX}-0-required_certificate"
         ]
     )
     assert (
         condition.action.pk
-        == measure_edit_conditions_data["measure-conditions-formset-0-action"]
+        == measure_edit_conditions_data[f"{MEASURE_CONDITIONS_FORMSET_PREFIX}-0-action"]
     )
     assert condition.update_type == UpdateType.CREATE
 
@@ -632,11 +636,13 @@ def test_measure_update_edit_conditions(
     )
     previous_condition = measure_with_condition.conditions.last()
     measure_edit_conditions_data[
-        "measure-conditions-formset-0-required_certificate"
+        f"{MEASURE_CONDITIONS_FORMSET_PREFIX}-0-required_certificate"
     ] = ""
-    measure_edit_conditions_data["measure-conditions-formset-0-reference_price"] = "3%"
     measure_edit_conditions_data[
-        "measure-conditions-formset-0-applicable_duty"
+        f"{MEASURE_CONDITIONS_FORMSET_PREFIX}-0-reference_price"
+    ] = "3%"
+    measure_edit_conditions_data[
+        f"{MEASURE_CONDITIONS_FORMSET_PREFIX}-0-applicable_duty"
     ] = "10 GBP / 100 kg"
     client.post(url, data=measure_edit_conditions_data)
     tx = Transaction.objects.last()
@@ -717,20 +723,26 @@ def test_measure_update_remove_conditions(
     url = reverse("measure-ui-edit", args=(measure.sid,))
     client.force_login(valid_user)
     client.post(url, data=measure_edit_conditions_data)
-    measure_edit_conditions_data["measure-conditions-formset-0-DELETE"] = 1
+    measure_edit_conditions_data[f"{MEASURE_CONDITIONS_FORMSET_PREFIX}-0-DELETE"] = 1
     response = client.post(url, data=measure_edit_conditions_data)
 
     assert response.status_code == 200
 
-    measure_edit_conditions_data["measure-conditions-formset-TOTAL_FORMS"] = 0
-    measure_edit_conditions_data["measure-conditions-formset-INITIAL_FORMS"] = 0
-    measure_edit_conditions_data["measure-conditions-formset-0-condition_code"] = ""
+    measure_edit_conditions_data[f"{MEASURE_CONDITIONS_FORMSET_PREFIX}-TOTAL_FORMS"] = 0
     measure_edit_conditions_data[
-        "measure-conditions-formset-0-required_certificate"
+        f"{MEASURE_CONDITIONS_FORMSET_PREFIX}-INITIAL_FORMS"
+    ] = 0
+    measure_edit_conditions_data[
+        f"{MEASURE_CONDITIONS_FORMSET_PREFIX}-0-condition_code"
     ] = ""
-    measure_edit_conditions_data["measure-conditions-formset-0-action"] = ""
-    measure_edit_conditions_data["measure-conditions-formset-0-applicable_duty"] = ""
-    del measure_edit_conditions_data["measure-conditions-formset-0-DELETE"]
+    measure_edit_conditions_data[
+        f"{MEASURE_CONDITIONS_FORMSET_PREFIX}-0-required_certificate"
+    ] = ""
+    measure_edit_conditions_data[f"{MEASURE_CONDITIONS_FORMSET_PREFIX}-0-action"] = ""
+    measure_edit_conditions_data[
+        f"{MEASURE_CONDITIONS_FORMSET_PREFIX}-0-applicable_duty"
+    ] = ""
+    del measure_edit_conditions_data[f"{MEASURE_CONDITIONS_FORMSET_PREFIX}-0-DELETE"]
     transaction_count = Transaction.objects.count()
     response = client.post(url, data=measure_edit_conditions_data)
 
@@ -753,15 +765,53 @@ def test_measure_update_invalid_conditions(
     duty_sentence_parser,
     erga_omnes,
 ):
-    """Tests that html contains appropriate form validation errors after posting
-    to measure edit endpoint with compound reference_price and an invalid
-    applicable_duty string."""
+    """
+    Tests that html contains appropriate form validation errors after posting to
+    measure edit endpoint with compound reference_price and an invalid
+    applicable_duty string.
+
+    Also tests form validation on negative action code's checking that
+    reference_price, required_certificate & applicable_duty must be empty
+    """
     measure_edit_conditions_data[
-        "measure-conditions-formset-0-reference_price"
+        f"{MEASURE_CONDITIONS_FORMSET_PREFIX}-0-reference_price"
     ] = "3.5% + 11 GBP / 100 kg"
     measure_edit_conditions_data[
-        "measure-conditions-formset-0-applicable_duty"
+        f"{MEASURE_CONDITIONS_FORMSET_PREFIX}-0-applicable_duty"
     ] = "invalid"
+
+    # set up second condition with negative action
+    negative_action = factories.MeasureActionFactory.create()
+    positive_action = MeasureAction.objects.get(
+        pk=measure_edit_conditions_data[
+            f"{MEASURE_CONDITIONS_FORMSET_PREFIX}-0-action"
+        ],
+    )
+    factories.MeasureActionPairFactory(
+        positive_action=positive_action,
+        negative_action=negative_action,
+    )
+    measure_edit_conditions_data[
+        f"{MEASURE_CONDITIONS_FORMSET_PREFIX}-1-condition_code"
+    ] = measure_edit_conditions_data[
+        f"{MEASURE_CONDITIONS_FORMSET_PREFIX}-0-condition_code"
+    ]
+    measure_edit_conditions_data[
+        f"{MEASURE_CONDITIONS_FORMSET_PREFIX}-1-required_certificate"
+    ] = measure_edit_conditions_data[
+        f"{MEASURE_CONDITIONS_FORMSET_PREFIX}-0-required_certificate"
+    ]
+    measure_edit_conditions_data[
+        f"{MEASURE_CONDITIONS_FORMSET_PREFIX}-1-action"
+    ] = negative_action.pk
+    measure_edit_conditions_data[
+        f"{MEASURE_CONDITIONS_FORMSET_PREFIX}-1-applicable_duty"
+    ] = "3.5% + 11 GBP / 100 kg"
+    measure_edit_conditions_data[f"{MEASURE_CONDITIONS_FORMSET_PREFIX}-TOTAL_FORMS"] = 2
+    measure_edit_conditions_data[
+        f"{MEASURE_CONDITIONS_FORMSET_PREFIX}-INITIAL_FORMS"
+    ] = 2
+
     measure = Measure.objects.first()
     url = reverse("measure-ui-edit", args=(measure.sid,))
     client.force_login(valid_user)
@@ -775,18 +825,82 @@ def test_measure_update_invalid_conditions(
     )
     a_tags = page.select("ul.govuk-list.govuk-error-summary__list a")
 
-    assert a_tags[0].attrs["href"] == "#measure-conditions-formset-0-applicable_duty"
+    assert (
+        a_tags[0].attrs["href"]
+        == f"#{MEASURE_CONDITIONS_FORMSET_PREFIX}-0-applicable_duty"
+    )
     assert a_tags[0].text == "Enter a valid duty sentence."
 
-    assert a_tags[1].attrs["href"] == "#measure-conditions-formset-0-__all__"
+    assert a_tags[1].attrs["href"] == f"#{MEASURE_CONDITIONS_FORMSET_PREFIX}-0-__all__"
     assert (
         a_tags[1].text
         == "For each condition you must complete either ‘reference price or quantity’ or ‘certificate, licence or document’."
     )
-    assert a_tags[2].attrs["href"] == "#measure-conditions-formset-0-reference_price"
+    assert (
+        a_tags[2].attrs["href"]
+        == f"#{MEASURE_CONDITIONS_FORMSET_PREFIX}-0-reference_price"
+    )
     assert (
         a_tags[2].text
         == "A MeasureCondition cannot be created with a compound reference price (e.g. 3.5% + 11 GBP / 100 kg)"
+    )
+
+    assert a_tags[3].attrs["href"] == f"#{MEASURE_CONDITIONS_FORMSET_PREFIX}-1-__all__"
+    assert (
+        a_tags[3].text
+        == "If you action code is negative you do not need to enter ‘reference price or quantity’, ‘certificate, licence or document’ or ‘duty’."
+    )
+
+
+def test_measure_update_invalid_conditions_invalid_actions(
+    client,
+    valid_user,
+    measure_edit_conditions_data,
+    duty_sentence_parser,
+):
+    # set up invalid action under the same condition code
+    single_action = factories.MeasureActionFactory.create()
+
+    measure_edit_conditions_data[
+        f"{MEASURE_CONDITIONS_FORMSET_PREFIX}-1-condition_code"
+    ] = measure_edit_conditions_data[
+        f"{MEASURE_CONDITIONS_FORMSET_PREFIX}-0-condition_code"
+    ]
+    measure_edit_conditions_data[
+        f"{MEASURE_CONDITIONS_FORMSET_PREFIX}-1-required_certificate"
+    ] = measure_edit_conditions_data[
+        f"{MEASURE_CONDITIONS_FORMSET_PREFIX}-0-required_certificate"
+    ]  # factories.CertificateFactory.create().pk
+    measure_edit_conditions_data[
+        f"{MEASURE_CONDITIONS_FORMSET_PREFIX}-1-action"
+    ] = single_action.pk
+    measure_edit_conditions_data[
+        f"{MEASURE_CONDITIONS_FORMSET_PREFIX}-1-applicable_duty"
+    ] = "3.5% + 11 GBP / 100 kg"
+    measure_edit_conditions_data[f"{MEASURE_CONDITIONS_FORMSET_PREFIX}-TOTAL_FORMS"] = 2
+    measure_edit_conditions_data[
+        f"{MEASURE_CONDITIONS_FORMSET_PREFIX}-INITIAL_FORMS"
+    ] = 2
+
+    measure = Measure.objects.first()
+    url = reverse("measure-ui-edit", args=(measure.sid,))
+    client.force_login(valid_user)
+    response = client.post(url, data=measure_edit_conditions_data)
+
+    assert response.status_code == 200
+
+    page = BeautifulSoup(
+        response.content.decode(response.charset),
+        features="lxml",
+    )
+    a_tags = page.select("ul.govuk-list.govuk-error-summary__list a")
+
+    print(a_tags)
+
+    assert a_tags[0].attrs["href"] == f"#{MEASURE_CONDITIONS_FORMSET_PREFIX}-__all__"
+    assert (
+        a_tags[0].text
+        == "All conditions of the same condition code must have the same resulting action."
     )
 
 

--- a/measures/tests/test_views.py
+++ b/measures/tests/test_views.py
@@ -819,7 +819,7 @@ def test_measure_update_invalid_conditions(
     assert a_tags[3].attrs["href"] == f"#{MEASURE_CONDITIONS_FORMSET_PREFIX}-1-__all__"
     assert (
         a_tags[3].text
-        == "If you action code is negative you do not need to enter ‘reference price or quantity’, ‘certificate, licence or document’ or ‘duty’."
+        == "If the action code is negative you do not need to enter ‘reference price or quantity’, ‘certificate, licence or document’ or ‘duty’."
     )
 
 

--- a/measures/validators.py
+++ b/measures/validators.py
@@ -140,6 +140,8 @@ def validate_conditions_formset(cleaned_data):
     condition_duty_amounts = []
     # list of condition codes
     condition_codes = []
+    # list of condition code tuples containing conditions & True/False depending on if it's a positive negative action
+    condition_negative_action_bool = []
     # list of tuples of condition code and it's action code
     condition_action_tuple = []
     for condition in cleaned_data:
@@ -156,6 +158,17 @@ def validate_conditions_formset(cleaned_data):
             condition_certificates.append(
                 (condition["condition_code"], condition["required_certificate"]),
             )
+
+        condition_negative_action_bool.append(
+            (
+                condition["condition_code"],
+                not (
+                    bool(condition["reference_price"])
+                    | bool(condition["required_certificate"])
+                    | bool(condition["applicable_duty"])
+                ),
+            ),
+        )
         condition_action_tuple.append(
             (condition["condition_code"], condition["action"]),
         )
@@ -163,8 +176,8 @@ def validate_conditions_formset(cleaned_data):
 
     num_unique_certificates = len(set(condition_certificates))
     num_unique_duty_amounts = len(set(condition_duty_amounts))
-    num_unique_conditions = len(set(condition_codes))
     num_unique_condition_action_codes = len(set(condition_action_tuple))
+    num_unique_condition_negative_action_bool = len(set(condition_negative_action_bool))
     ordered_condition_codes = sorted(condition_codes)
 
     # for the number of certificates the number of unique certificate, condition code tuples
@@ -184,9 +197,7 @@ def validate_conditions_formset(cleaned_data):
 
     # for all unique condition codes the number of unique action codes will be equal
     # if the form is valid
-    print(num_unique_conditions)
-    print(num_unique_condition_action_codes)
-    if num_unique_conditions != num_unique_condition_action_codes:
+    if num_unique_condition_negative_action_bool != num_unique_condition_action_codes:
         errors_list.append(
             ValidationError(
                 "All conditions of the same condition code must have the same resulting action.",
@@ -201,7 +212,6 @@ def validate_conditions_formset(cleaned_data):
             ),
         )
     if errors_list:
-        print("rasing error")
         raise ValidationError(errors_list)
 
 

--- a/measures/validators.py
+++ b/measures/validators.py
@@ -200,7 +200,7 @@ def validate_conditions_formset(cleaned_data):
     if num_unique_condition_negative_action_bool != num_unique_condition_action_codes:
         errors_list.append(
             ValidationError(
-                "All conditions of the same condition code must have the same resulting action.",
+                "All conditions of the same condition code must have the same resulting action, except for the negative action code pair.",
             ),
         )
 

--- a/measures/validators.py
+++ b/measures/validators.py
@@ -184,6 +184,8 @@ def validate_conditions_formset(cleaned_data):
 
     # for all unique condition codes the number of unique action codes will be equal
     # if the form is valid
+    print(num_unique_conditions)
+    print(num_unique_condition_action_codes)
     if num_unique_conditions != num_unique_condition_action_codes:
         errors_list.append(
             ValidationError(
@@ -199,6 +201,7 @@ def validate_conditions_formset(cleaned_data):
             ),
         )
     if errors_list:
+        print("rasing error")
         raise ValidationError(errors_list)
 
 


### PR DESCRIPTION
# TP2000-856 Edit Measure Conditions Fix


## Why
When we automated the creation of the negative action code for use in the Create Measures journey, we removed the negative actions from the UI menu.
Unfortunately this has also removed them from the Edit Measures journey, meaning that a user can’t complete the journey as the required UI setting is missing.

## What

- Edit Measure condition form - field action - queryset updated to include all actions
- New validation for edit measure condition forms that checks that all fields are blank when a negative action code is selected.
- formset errors now appear in edit formset for conditions
- Formset validation now counts negative actions seperately so the form can successfully submit when editting negative actions too

