### PR TITLE
TP2000-864 ME32 failing on multi-versioned indents

### DIFF
--- a/commodities/models/dc.py
+++ b/commodities/models/dc.py
@@ -1604,6 +1604,7 @@ class CommodityCollectionLoader:
             .with_end_date()
             .filter(indented_goods_nomenclature__sid__in=goods_sids)
             .annotate(goods_sid=F("indented_goods_nomenclature__sid"))
+            .order_by("transaction")
         )
 
         goods_sid_to_indents: Dict[str, List] = {}


### PR DESCRIPTION
# TP2000-864 ME32 failing on multi-versioned indents
<!---
 * Include the JIRA ticket number, eg TP-123, to automatically link.
 * Use 50 characters maximum.
 * Do not end with a full-stop.
--->

## Why
<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Use as many lines as you like.
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions or deliberately ignored edge-cases.
--->
ME32 rule checks run against a measure whose attached commodity code has multiple indents within the same version group, can occasionally and randomly fail.

Currently when multiple versions of an indent exist against a commodity, the one selected within the `CommodityCollection` instance is non-deterministic. This is because no ordering is placed on the indents when querying the database.

## What
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Explain like I'm 5.
 * Use pictures if you can.
--->
Apply an `order_by("transaction")` to the query that loads indents during `CommodityCollection` loading. This ensures the latest version of an indent is selected when many are available.

<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
--->
## Checklist
- Requires migrations? No
- Requires dependency updates? No

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
