### PR TITLE
TP2000-853 Fix for measures as defined tab

### DIFF
--- a/commodities/views.py
+++ b/commodities/views.py
@@ -134,7 +134,7 @@ class CommodityMeasuresList(SortingMixin, WithPaginationListMixin, ListView):
         commodity = (
             GoodsNomenclature.objects.filter(sid=self.kwargs["sid"]).current().first()
         )
-        queryset = commodity.measures.as_at_today()
+        queryset = commodity.measures.current()
         if ordering:
             if isinstance(ordering, str):
                 ordering = (ordering,)


### PR DESCRIPTION
# TP2000-853 Fix for measures as defined tab
<!---
 * Include the JIRA ticket number, eg TP-123, to automatically link.
 * Use 50 characters maximum.
 * Do not end with a full-stop.
--->

## Why
<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Use as many lines as you like.
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions or deliberately ignored edge-cases.
--->
* Old query was not showing the correct version of measures that had an end date of December 2020

## What
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Explain like I'm 5.
 * Use pictures if you can.
--->
* Uses current() instead of as_at_today() for the measures queryset

<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
## Checklist
- Requires migrations?
- Requires dependency updates?
--->

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
