### PR TITLE
TP2000-870 Superuser rule check violation override

### DIFF
--- a/workbaskets/jinja2/workbaskets/violation_detail.jinja
+++ b/workbaskets/jinja2/workbaskets/violation_detail.jinja
@@ -1,7 +1,9 @@
 {% extends "layouts/layout.jinja" %}
 
 {% from "components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
+{% from "components/button/macro.njk" import govukButton %}
 {% from "components/table/macro.njk" import govukTable %}
+{% from "components/warning-text/macro.njk" import govukWarningText %}
 {% from "includes/workbaskets/navigation.jinja" import navigation %}
 
 {% set page_title %}Workbasket {{ workbasket.id if workbasket else request.session.workbasket.id }} - Rule violation
@@ -46,6 +48,23 @@ details
     <hr class="govuk-section-break govuk-section-break--s govuk-section-break--visible">
 
     {# <a href="#" class="govuk-button govuk-button-primary">Review violation</a> #}
+    {% if request.user.is_superuser %}
+      <form method="post">
+        <input type="hidden" name="csrfmiddlewaretoken" value="{{ csrf_token }}">
+
+        {{ govukWarningText({
+          "text": "Be sure that you understand the reasons and implications of
+          this violation before choosing to override it."
+        }) }}
+
+        {{ govukButton({
+          "text": "Override rule violation",
+          "classes": "govuk-button--warning",
+          "name": "action",
+          "value": "delete"
+        }) }}
+      </form>
+    {% endif %}
   </div>
 </div>
 

--- a/workbaskets/views/ui.py
+++ b/workbaskets/views/ui.py
@@ -518,3 +518,33 @@ class WorkBasketViolationDetail(DetailView):
 
     def get_context_data(self, **kwargs):
         return super().get_context_data(workbasket=self.workbasket, **kwargs)
+
+    def override_violation(self):
+        """
+        Override the `TrackedModelCheck` instance for this rules check
+        violation, setting its `successful` value to True.
+
+        If there are no other failing `TrackedModelCheck` instances on the
+        associated `TransactionCheck` instance, then also set its `successful`
+        value to True.
+        """
+
+        model_check = TrackedModelCheck.objects.get(pk=self.kwargs["pk"])
+        model_check.successful = True
+        model_check.save()
+
+        transaction_check = model_check.transaction_check
+        # Only clear the associated transcation check if model_check
+        # was the last and only other failing model check.
+        other_model_checks = transaction_check.model_checks.filter(successful=False)
+        if not other_model_checks:
+            transaction_check.successful = True
+            transaction_check.save()
+
+    def post(self, request, *args, **kwargs):
+        if request.POST.get("action", None) == "delete" and request.user.is_superuser:
+            self.override_violation()
+
+        return redirect(
+            "workbaskets:workbasket-ui-violations",
+        )


### PR DESCRIPTION
# TP2000-870 Superuser rule check violation override
<!---
 * Include the JIRA ticket number, eg TP-123, to automatically link.
 * Use 50 characters maximum.
 * Do not end with a full-stop.
--->

## Why
<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Use as many lines as you like.
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions or deliberately ignored edge-cases.
--->
TAP is generating false (incorrect) violations during rule checking around commodities with a specific indent arrangement.

At least one comm code (code: 0406901300, suffix: 80) has multiple indents with historic indent creation, all within the same transaction. When a measure is applied to the comm code, indent selection can be incorrect.

The root cause requires a fix. In the interim, a rule check override that is accessible only to users with superuser status needs to be made available.

## What
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Explain like I'm 5.
 * Use pictures if you can.
--->
This PR implements a capability, only available to users with superuser status, to override failing rules checks.

<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
--->
## Checklist
- Requires migrations?
- Requires dependency updates?

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
