### PR TITLE
TP2000-872 Fix 'Add memberships' form error message alignment

### DIFF
--- a/geo_areas/forms.py
+++ b/geo_areas/forms.py
@@ -557,21 +557,18 @@ class GeographicalMembershipGroupForm(DateValidationMixin, ValidityPeriodForm):
         self.helper.layout = Layout(
             Fieldset(
                 Div(
-                    Div(
-                        Field("geo_group"),
-                        css_class="tap-column govuk-!-width-one-half",
-                    ),
-                    Div(
-                        Field("start_date"),
-                        css_class="tap-column",
-                    ),
-                    Div(
-                        Field("end_date"),
-                        css_class="tap-column",
-                    ),
-                    css_class="tap-row",
+                    Field("geo_group"),
+                    css_class="govuk-grid-column-one-half error-align",
                 ),
-                css_class="tap-inline",
+                Div(
+                    Field("start_date"),
+                    css_class="govuk-grid-column-one-quarter error-align",
+                ),
+                Div(
+                    Field("end_date"),
+                    css_class="govuk-grid-column-one-quarter error-align",
+                ),
+                css_class="membership-inline",
             ),
         )
 
@@ -649,21 +646,18 @@ class GeographicalMembershipMemberForm(DateValidationMixin, ValidityPeriodForm):
         self.helper.layout = Layout(
             Fieldset(
                 Div(
-                    Div(
-                        Field("member"),
-                        css_class="tap-column govuk-!-width-one-half",
-                    ),
-                    Div(
-                        Field("start_date"),
-                        css_class="tap-column",
-                    ),
-                    Div(
-                        Field("end_date"),
-                        css_class="tap-column",
-                    ),
-                    css_class="tap-row",
+                    Field("member"),
+                    css_class="govuk-grid-column-one-half error-align",
                 ),
-                css_class="tap-inline",
+                Div(
+                    Field("start_date"),
+                    css_class="govuk-grid-column-one-quarter error-align",
+                ),
+                Div(
+                    Field("end_date"),
+                    css_class="govuk-grid-column-one-quarter error-align",
+                ),
+                css_class="membership-inline",
             ),
         )
 

--- a/geo_areas/static/geo_areas/scss/_geo_areas.scss
+++ b/geo_areas/static/geo_areas/scss/_geo_areas.scss
@@ -14,3 +14,15 @@
     padding-top: govuk-spacing(4);
   }
 }
+
+.membership-inline {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+
+  .error-align {
+    align-self: flex-end;
+    padding-left: 0;
+    padding-right: 10px;
+  }
+}


### PR DESCRIPTION
# TP2000-872 Fix 'Add memberships' form error message alignment

## Why
On the Add memberships page (geographical-areas/\<sid\>/membership-create/), the layout goes a bit askew when a form field has an error message.

## What
- Adds a CSS class so that form input remain inline

##
Before:
<img width="500" alt="Screenshot 2023-05-09 at 15 46 18" src="https://github.com/uktrade/tamato/assets/118175145/3fc21e48-ceb7-440f-9b14-0bb6809b9644">


After:
<img width="500" alt="Screenshot 2023-05-10 at 17 27 41" src="https://github.com/uktrade/tamato/assets/118175145/52801d1d-e83c-4ee7-a784-cf8185036cec">


