### PR TITLE
Add missing env variables to sample.env for local development setup

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -337,6 +337,12 @@ Mocking s3 upload with minio
    this will be SQLITE_STORAGE_BUCKET_NAME, SQLITE_S3_ACCESS_KEY_ID, SQLITE_S3_SECRET_ACCESS_KEY,
    SQLITE_S3_ENDPOINT_URL, and SQLITE_STORAGE_DIRECTORY), setting s3 endpoint url to 
    http://localhost:9003/
+6. Alternatively, export all environment variables temporarily to an environment such as Bash
+   (useful when running a local development instance of a Celery worker):
+
+   .. code:: sh
+
+    set -a && source .env && set +a
 
 Virus Scan and running locally
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/sample.env
+++ b/sample.env
@@ -1,5 +1,5 @@
-# To export settings in this file to an environment such as Bash, which is
-# useful when running a local development instance of a Celery worker), do:
+# To export settings in this file to an environment such as Bash
+# (useful when running a local development instance of a Celery worker), do:
 #   $ set -a && source .env && set +a
 
 DEBUG=True
@@ -21,6 +21,9 @@ HMRC_PACKAGING_SEED_ENVELOPE_ID=0001
 HMRC_PACKAGING_STORAGE_BUCKET_NAME=hmrc-packaging
 HMRC_ENVELOPE_STORAGE_DIRECTORY=envelope/
 HMRC_LOADING_REPORTS_STORAGE_DIRECTORY=loading-reports/
+S3_ACCESS_KEY_ID=minio_access_key
+S3_SECRET_ACCESS_KEY=minio_access_key
+S3_ENDPOINT_URL=http://localhost:9003
 
 # S3 Bucket for SQLite uploads.
 SQLITE_STORAGE_BUCKET_NAME=sqlite


### PR DESCRIPTION
# Add missing env variables to sample.env for local development setup

## Why
When copying from sample.env to set up local dev environment, packaging automation fails to run locally because some environment variables that are needed to mock s3 upload with minio are missing.

## What
- Adds `S3_ACCESS_KEY_ID`, `S3_SECRET_ACCESS_KEY`  and `S3_ENDPOINT_URL` to sample.env

