### PR TITLE
TP2000-854: Measures on declarable commodities

### DIFF
--- a/commodities/jinja2/commodities/detail.jinja
+++ b/commodities/jinja2/commodities/detail.jinja
@@ -26,8 +26,13 @@
     },
     {
       "text": "Measures as defined",
-      "href": url('commodity-ui-detail-measures', args=[commodity.sid]),
-      "selected": selected_tab == "measures",
+      "href": url('commodity-ui-detail-measures-as-defined', args=[commodity.sid]),
+      "selected": selected_tab == "measures-defined",
+    },
+    {
+      "text": "Measures on declarable commodities",
+      "href": url('commodity-ui-detail-measures-declarable', args=[commodity.sid]),
+      "selected": selected_tab == "measures-declarable",
     },
     {
       "text": "Commodity hierarchy",

--- a/commodities/jinja2/commodities/measures-declarable.jinja
+++ b/commodities/jinja2/commodities/measures-declarable.jinja
@@ -1,4 +1,9 @@
+{% extends "commodities/detail.jinja" %}
 {% from "components/sort_by.jinja" import sort_by %}
+
+{% block tab_content %}
+
+<h2 class="govuk-heading-l">Measures on declarable commodities</h2>
 
 {% set table_rows = [] %}
 
@@ -8,12 +13,17 @@
     <a class="govuk-link govuk-!-font-weight-bold" href="{{ url('measure-ui-detail', kwargs={'sid': object.sid}) }}">{{ object.sid }}</a>
   {%- endset %}
 
+  {% set comm_code_link -%}
+    <a class="govuk-link govuk-!-font-weight-bold" href="{{ url('commodity-ui-detail', kwargs={'sid': object.goods_nomenclature.sid}) }}" title="{{ object.goods_nomenclature.get_description().description }}">{{ object.goods_nomenclature.code }}</a>
+  {%- endset %}
+
   {% set geo_area_link -%}
     <a class="govuk-link govuk-!-font-weight-bold" href="{{ url('geo_area-ui-detail', kwargs={'sid': object.geographical_area.sid}) }}">{{ object.geographical_area}} - {{ object.geographical_area.structure_description }}</a>
   {%- endset %}
 
   {{ table_rows.append([
     {"text": object_link },
+    {"text": comm_code_link },
     {"text": object.measure_type },
     {"text": geo_area_link },
     {"text": "{:%d %b %Y}".format(object.valid_between.lower) },
@@ -21,7 +31,11 @@
   ]) or "" }}
 {% endfor %}
 
-{% set base_url = url('commodity-ui-detail-measures', args=[commodity.sid]) %}
+{% set base_url = url('commodity-ui-detail-measures-declarable', args=[commodity.sid]) %}
+
+{% set comm_code %}
+  {{ sort_by(request, "commodity", "Commodity code", base_url) }}
+{% endset %}
 
 {% set measure_type %}
   {{ sort_by(request, "measure_type", "Measure type", base_url) }}
@@ -42,6 +56,7 @@
   {{ govukTable({
     "head": [
       {"text": "Measure SID" },
+      {"text": comm_code },
       {"text": measure_type},
       {"text": geo_area},
       {"text": start_date},
@@ -53,3 +68,5 @@
   <p class="govuk-body">There are no measures for this commodity code.</p>
 {% endif %}
 {% include "includes/common/pagination.jinja" %}
+
+{% endblock %}

--- a/commodities/jinja2/commodities/measures-defined.jinja
+++ b/commodities/jinja2/commodities/measures-defined.jinja
@@ -1,0 +1,62 @@
+{% extends "commodities/detail.jinja" %}
+{% from "components/sort_by.jinja" import sort_by %}
+
+{% block tab_content %}
+
+<h2 class="govuk-heading-l">Measures as defined</h2>
+
+{% set table_rows = [] %}
+
+{% for object in object_list %}
+
+  {% set object_link -%}
+    <a class="govuk-link govuk-!-font-weight-bold" href="{{ url('measure-ui-detail', kwargs={'sid': object.sid}) }}">{{ object.sid }}</a>
+  {%- endset %}
+
+  {% set geo_area_link -%}
+    <a class="govuk-link govuk-!-font-weight-bold" href="{{ url('geo_area-ui-detail', kwargs={'sid': object.geographical_area.sid}) }}">{{ object.geographical_area}} - {{ object.geographical_area.structure_description }}</a>
+  {%- endset %}
+
+  {{ table_rows.append([
+    {"text": object_link },
+    {"text": object.measure_type },
+    {"text": geo_area_link },
+    {"text": "{:%d %b %Y}".format(object.valid_between.lower) },
+    {"text": "{:%d %b %Y}".format(object.effective_end_date) if object.effective_end_date else "-"},
+  ]) or "" }}
+{% endfor %}
+
+{% set base_url = url('commodity-ui-detail-measures-as-defined', args=[commodity.sid]) %}
+
+{% set measure_type %}
+  {{ sort_by(request, "measure_type", "Measure type", base_url) }}
+{% endset %}
+
+{% set geo_area %}
+  {{ sort_by(request, "geo_area", "Geographical area", base_url) }}
+{% endset %}
+
+{% set start_date %}
+  {{ sort_by(request, "start_date", "Start date", base_url) }}
+{% endset %}
+
+{% if paginator.count > 0 %}
+  {% include "includes/common/pagination-list-summary.jinja" %}
+{% endif %}
+{% if object_list %}
+  {{ govukTable({
+    "head": [
+      {"text": "Measure SID" },
+      {"text": measure_type},
+      {"text": geo_area},
+      {"text": start_date},
+      {"text": "End date"},
+    ],
+    "rows": table_rows
+  }) }}
+{% else %}
+  <p class="govuk-body">There are no measures for this commodity code.</p>
+{% endif %}
+{% include "includes/common/pagination.jinja" %}
+
+{% endblock %}

--- a/commodities/jinja2/commodities/measures.jinja
+++ b/commodities/jinja2/commodities/measures.jinja
@@ -1,5 +1,0 @@
-{% extends "commodities/detail.jinja" %}
-
-{% block tab_content %}
-  {% include "includes/commodities/tabs/measures.jinja" %}
-{% endblock %}

--- a/commodities/tests/test_views.py
+++ b/commodities/tests/test_views.py
@@ -205,14 +205,19 @@ def measures(commodity):
     return [measure1, measure2, measure3]
 
 
-def test_commodity_measures(valid_user_client, commodity, measures):
-    url = reverse(
+@pytest.mark.parametrize(
+    "url_name",
+    [
         "commodity-ui-detail-measures-as-defined",
+        "commodity-ui-detail-measures-declarable",
+    ],
+)
+def test_commodity_measures(url_name, valid_user_client, commodity, measures):
+    url = reverse(
+        url_name,
         kwargs={"sid": commodity.sid},
     )
     response = valid_user_client.get(url)
-    assert response.status_code == 200
-
     soup = BeautifulSoup(response.content.decode(response.charset), "html.parser")
     table_rows = soup.select(".govuk-table tbody tr")
     assert len(table_rows) == 3
@@ -223,9 +228,33 @@ def test_commodity_measures(valid_user_client, commodity, measures):
     assert not measure_sids.difference(set([m.sid for m in measures]))
 
 
-def test_commodity_measures_no_measures(valid_user_client, commodity):
-    url = reverse(
+@pytest.mark.parametrize(
+    "url_name",
+    [
         "commodity-ui-detail-measures-as-defined",
+        "commodity-ui-detail-measures-declarable",
+        "commodity-ui-detail-hierarchy",
+    ],
+)
+def test_commodity_views_200(url_name, valid_user_client, commodity, measures):
+    url = reverse(
+        url_name,
+        kwargs={"sid": commodity.sid},
+    )
+    response = valid_user_client.get(url)
+    assert response.status_code == 200
+
+
+@pytest.mark.parametrize(
+    "url_name",
+    [
+        "commodity-ui-detail-measures-as-defined",
+        "commodity-ui-detail-measures-declarable",
+    ],
+)
+def test_commodity_measures_no_measures(url_name, valid_user_client, commodity):
+    url = reverse(
+        url_name,
         kwargs={"sid": commodity.sid},
     )
     response = valid_user_client.get(url)
@@ -236,9 +265,21 @@ def test_commodity_measures_no_measures(valid_user_client, commodity):
     assert len(table_rows) == 0
 
 
-def test_commodity_measures_sorting_geo_area(valid_user_client, commodity, measures):
-    url = reverse(
+@pytest.mark.parametrize(
+    "url_name",
+    [
         "commodity-ui-detail-measures-as-defined",
+        "commodity-ui-detail-measures-declarable",
+    ],
+)
+def test_commodity_measures_sorting_geo_area(
+    url_name,
+    valid_user_client,
+    commodity,
+    measures,
+):
+    url = reverse(
+        url_name,
         kwargs={"sid": commodity.sid},
     )
     response = valid_user_client.get(f"{url}?sort_by=geo_area&order=desc")
@@ -265,7 +306,15 @@ def test_commodity_measures_sorting_geo_area(valid_user_client, commodity, measu
     assert measure_sids == [m.sid for m in measures]
 
 
+@pytest.mark.parametrize(
+    "url_name",
+    [
+        "commodity-ui-detail-measures-as-defined",
+        "commodity-ui-detail-measures-declarable",
+    ],
+)
 def test_commodity_measures_sorting_start_date(
+    url_name,
     valid_user_client,
     date_ranges,
     commodity,
@@ -283,7 +332,7 @@ def test_commodity_measures_sorting_start_date(
         valid_between=date_ranges.starts_delta_no_end,
     )
     url = reverse(
-        "commodity-ui-detail-measures-as-defined",
+        url_name,
         kwargs={"sid": commodity.sid},
     )
     response = valid_user_client.get(f"{url}?sort_by=start_date&order=desc")
@@ -309,7 +358,15 @@ def test_commodity_measures_sorting_start_date(
     assert measure_sids == [measure1.sid, measure2.sid, measure3.sid]
 
 
+@pytest.mark.parametrize(
+    "url_name",
+    [
+        "commodity-ui-detail-measures-as-defined",
+        "commodity-ui-detail-measures-declarable",
+    ],
+)
 def test_commodity_measures_sorting_measure_type(
+    url_name,
     valid_user_client,
     date_ranges,
     commodity,
@@ -330,7 +387,7 @@ def test_commodity_measures_sorting_measure_type(
         measure_type=type3,
     )
     url = reverse(
-        "commodity-ui-detail-measures-as-defined",
+        url_name,
         kwargs={"sid": commodity.sid},
     )
     response = valid_user_client.get(f"{url}?sort_by=measure_type&order=desc")
@@ -354,9 +411,3 @@ def test_commodity_measures_sorting_measure_type(
         int(el.text) for el in soup.select(".govuk-table tbody tr td:first-child")
     ]
     assert measure_sids == [measure1.sid, measure2.sid, measure3.sid]
-
-
-def test_commodity_hierarchy(valid_user_client, commodity):
-    url = reverse("commodity-ui-detail-hierarchy", kwargs={"sid": commodity.sid})
-    response = valid_user_client.get(url)
-    assert response.status_code == 200

--- a/commodities/tests/test_views.py
+++ b/commodities/tests/test_views.py
@@ -206,7 +206,10 @@ def measures(commodity):
 
 
 def test_commodity_measures(valid_user_client, commodity, measures):
-    url = reverse("commodity-ui-detail-measures", kwargs={"sid": commodity.sid})
+    url = reverse(
+        "commodity-ui-detail-measures-as-defined",
+        kwargs={"sid": commodity.sid},
+    )
     response = valid_user_client.get(url)
     assert response.status_code == 200
 
@@ -221,7 +224,10 @@ def test_commodity_measures(valid_user_client, commodity, measures):
 
 
 def test_commodity_measures_no_measures(valid_user_client, commodity):
-    url = reverse("commodity-ui-detail-measures", kwargs={"sid": commodity.sid})
+    url = reverse(
+        "commodity-ui-detail-measures-as-defined",
+        kwargs={"sid": commodity.sid},
+    )
     response = valid_user_client.get(url)
     assert response.status_code == 200
 
@@ -231,7 +237,10 @@ def test_commodity_measures_no_measures(valid_user_client, commodity):
 
 
 def test_commodity_measures_sorting_geo_area(valid_user_client, commodity, measures):
-    url = reverse("commodity-ui-detail-measures", kwargs={"sid": commodity.sid})
+    url = reverse(
+        "commodity-ui-detail-measures-as-defined",
+        kwargs={"sid": commodity.sid},
+    )
     response = valid_user_client.get(f"{url}?sort_by=geo_area&order=desc")
     assert response.status_code == 200
 
@@ -242,7 +251,10 @@ def test_commodity_measures_sorting_geo_area(valid_user_client, commodity, measu
     measure_sids.reverse()
     assert measure_sids == [m.sid for m in measures]
 
-    url = reverse("commodity-ui-detail-measures", kwargs={"sid": commodity.sid})
+    url = reverse(
+        "commodity-ui-detail-measures-as-defined",
+        kwargs={"sid": commodity.sid},
+    )
     response = valid_user_client.get(f"{url}?sort_by=geo_area&order=asc")
     assert response.status_code == 200
 
@@ -270,7 +282,10 @@ def test_commodity_measures_sorting_start_date(
         goods_nomenclature=commodity,
         valid_between=date_ranges.starts_delta_no_end,
     )
-    url = reverse("commodity-ui-detail-measures", kwargs={"sid": commodity.sid})
+    url = reverse(
+        "commodity-ui-detail-measures-as-defined",
+        kwargs={"sid": commodity.sid},
+    )
     response = valid_user_client.get(f"{url}?sort_by=start_date&order=desc")
     assert response.status_code == 200
 
@@ -280,7 +295,10 @@ def test_commodity_measures_sorting_start_date(
     ]
     assert measure_sids == [measure3.sid, measure2.sid, measure1.sid]
 
-    url = reverse("commodity-ui-detail-measures", kwargs={"sid": commodity.sid})
+    url = reverse(
+        "commodity-ui-detail-measures-as-defined",
+        kwargs={"sid": commodity.sid},
+    )
     response = valid_user_client.get(f"{url}?sort_by=start_date&order=asc")
     assert response.status_code == 200
 
@@ -311,7 +329,10 @@ def test_commodity_measures_sorting_measure_type(
         goods_nomenclature=commodity,
         measure_type=type3,
     )
-    url = reverse("commodity-ui-detail-measures", kwargs={"sid": commodity.sid})
+    url = reverse(
+        "commodity-ui-detail-measures-as-defined",
+        kwargs={"sid": commodity.sid},
+    )
     response = valid_user_client.get(f"{url}?sort_by=measure_type&order=desc")
     assert response.status_code == 200
 
@@ -321,7 +342,10 @@ def test_commodity_measures_sorting_measure_type(
     ]
     assert measure_sids == [measure3.sid, measure2.sid, measure1.sid]
 
-    url = reverse("commodity-ui-detail-measures", kwargs={"sid": commodity.sid})
+    url = reverse(
+        "commodity-ui-detail-measures-as-defined",
+        kwargs={"sid": commodity.sid},
+    )
     response = valid_user_client.get(f"{url}?sort_by=measure_type&order=asc")
     assert response.status_code == 200
 

--- a/commodities/urls.py
+++ b/commodities/urls.py
@@ -25,13 +25,18 @@ urlpatterns = [
     ),
     path(
         f"commodities/<sid>/hierarchy/",
-        views.Commodityhierarchy.as_view(),
+        views.CommodityHierarchy.as_view(),
         name="commodity-ui-detail-hierarchy",
     ),
     path(
-        f"commodities/<sid>/measures/",
-        views.CommodityMeasuresList.as_view(),
-        name="commodity-ui-detail-measures",
+        f"commodities/<sid>/measures-on-declarable-commodities/",
+        views.MeasuresOnDeclarableCommoditiesList.as_view(),
+        name="commodity-ui-detail-measures-declarable",
+    ),
+    path(
+        f"commodities/<sid>/measures-as-defined/",
+        views.CommodityMeasuresAsDefinedList.as_view(),
+        name="commodity-ui-detail-measures-as-defined",
     ),
     path(
         f"commodities/<sid>/version/",


### PR DESCRIPTION
# TP2000-854: Measures on declarable commodities
<!---
 * Include the JIRA ticket number, eg TP-123, to automatically link.
 * Use 50 characters maximum.
 * Do not end with a full-stop.
--->

## Why
<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Use as many lines as you like.
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions or deliberately ignored edge-cases.
--->
* Users need to be able to see what measures apply to a given commodity when the measure has been defined on a commodity code higher in the tree

## What
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Explain like I'm 5.
 * Use pictures if you can.
--->
* Uses `MeasureSnapshot.get_applicable_measures` to return the list of measures that apply to a commodity for the commodity tree at a given moment in time
* Displays a sortable paginated list of measures like the Measures as defined tab
* Also tidies up some naming and template organisation

<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
## Checklist
- Requires migrations?
- Requires dependency updates?
--->

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->

<img width="1207" alt="Screenshot 2023-05-11 at 14 49 39" src="https://github.com/uktrade/tamato/assets/25905279/6fffcea7-c1c4-4979-ba61-e6c42d4d40c1">
