### PR TITLE
Tp2000 780  separate rule check worker

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,4 +1,4 @@
 web: gunicorn wsgi --bind 0.0.0.0:$PORT --timeout 1000 --worker-class=gevent --worker-connections=1000 --workers 9
 worker: celery -A common.celery worker -O fair -l info -Q standard
 beat: celery -A common.celery beat
-worker: celery -A common.celery worker -O fair -l info -Q rule-check
+rule-check-worker: celery -A common.celery worker -O fair -l info -Q rule-check

--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,4 @@
 web: gunicorn wsgi --bind 0.0.0.0:$PORT --timeout 1000 --worker-class=gevent --worker-connections=1000 --workers 9
-worker: celery -A common.celery worker -O fair -l info
+worker: celery -A common.celery worker -O fair -l info -Q standard
 beat: celery -A common.celery beat
+rule-check-worker: celery -A common.celery worker -O fair -l info -Q rule-check

--- a/Procfile
+++ b/Procfile
@@ -1,4 +1,4 @@
 web: gunicorn wsgi --bind 0.0.0.0:$PORT --timeout 1000 --worker-class=gevent --worker-connections=1000 --workers 9
 # worker: celery -A common.celery worker -O fair -l info -Q standard
 beat: celery -A common.celery beat
-rule-check-worker: celery -A common.celery worker -O fair -l info -Q rule-check
+worker: celery -A common.celery worker -O fair -l info -Q rule-check

--- a/Procfile
+++ b/Procfile
@@ -1,4 +1,4 @@
 web: gunicorn wsgi --bind 0.0.0.0:$PORT --timeout 1000 --worker-class=gevent --worker-connections=1000 --workers 9
-worker: celery -A common.celery worker -O fair -l info -Q standard --hostname worker@%h
+# worker: celery -A common.celery worker -O fair -l info -Q standard
 beat: celery -A common.celery beat
-rule-check-worker: celery -A common.celery worker -O fair -l info -Q rule-check --hostname rule-check-worker@%h
+rule-check-worker: celery -A common.celery worker -O fair -l info -Q rule-check

--- a/Procfile
+++ b/Procfile
@@ -1,4 +1,4 @@
 web: gunicorn wsgi --bind 0.0.0.0:$PORT --timeout 1000 --worker-class=gevent --worker-connections=1000 --workers 9
-# worker: celery -A common.celery worker -O fair -l info -Q standard
+worker: celery -A common.celery worker -O fair -l info -Q standard
 beat: celery -A common.celery beat
-rule-worker: celery -A common.celery worker -O fair -l info -Q rule-check
+worker: celery -A common.celery worker -O fair -l info -Q rule-check

--- a/Procfile
+++ b/Procfile
@@ -1,4 +1,4 @@
 web: gunicorn wsgi --bind 0.0.0.0:$PORT --timeout 1000 --worker-class=gevent --worker-connections=1000 --workers 9
-worker: celery -A common.celery worker -O fair -l info -Q standard
+worker: celery -A common.celery worker -O fair -l info -Q standard --hostname worker@%h
 beat: celery -A common.celery beat
-rule-check-worker: celery -A common.celery worker -O fair -l info -Q rule-check
+rule-check-worker: celery -A common.celery worker -O fair -l info -Q rule-check --hostname rule-check-worker@%h

--- a/Procfile
+++ b/Procfile
@@ -1,4 +1,4 @@
 web: gunicorn wsgi --bind 0.0.0.0:$PORT --timeout 1000 --worker-class=gevent --worker-connections=1000 --workers 9
 # worker: celery -A common.celery worker -O fair -l info -Q standard
 beat: celery -A common.celery beat
-worker: celery -A common.celery worker -O fair -l info -Q rule-check
+rule-worker: celery -A common.celery worker -O fair -l info -Q rule-check

--- a/README.rst
+++ b/README.rst
@@ -435,5 +435,4 @@ You may get a message like ``There are no running instances of this process.`` I
 
 .. code:: sh
 
-    cf scale <space> --process <process_name> -i <number_of_instances> -m 1G
-    
+    cf scale <space> --process <process_name> -i <number_of_instances> -m <memory>

--- a/README.rst
+++ b/README.rst
@@ -410,29 +410,3 @@ environment database with ``cf conduit tamato-dev-db -- psql``.
 
 .. |codecov| image:: https://codecov.io/gh/uktrade/tamato/branch/master/graph/badge.svg
    :target: https://codecov.io/gh/uktrade/tamato
-
-Scaling Celery workers in GOV.UK PaaS
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Then you need to login to the DIT GOV.UK PaaS:
-
-.. code:: sh
-
-    cf login --sso -s <space>
-
-Where ``<space>`` is one of ``tariffs-dev``, ``tariffs-staging``,
-``tariffs-training`` or ``tariffs-uat``.
-
-Once you are logged in, you can list the application hosted in the space and their resources with
-
-.. code:: sh
-
-    cf apps
-    cf scale <space>
-
-You may notice that the celery worker isn't running or running with the resources you'd like.
-You may get a message like ``There are no running instances of this process.`` In this case you should scale the worker with
-
-.. code:: sh
-
-    cf scale <space> --process <process_name> -i <number_of_instances> -m <memory> -d <disk>

--- a/README.rst
+++ b/README.rst
@@ -435,4 +435,4 @@ You may get a message like ``There are no running instances of this process.`` I
 
 .. code:: sh
 
-    cf scale <space> --process <process_name> -i <number_of_instances> -m <memory>
+    cf scale <space> --process <process_name> -i <number_of_instances> -m <memory> -d <disk>

--- a/README.rst
+++ b/README.rst
@@ -281,7 +281,10 @@ Open another terminal and start a Celery worker:
 
 .. code:: sh
 
-    celery -A common.celery worker --loglevel=info
+    celery -A common.celery worker --loglevel=info -Q standard,rule-check
+    # The celery worker can be run as two workers for each queue 
+    celery -A common.celery worker --loglevel=info -Q standard
+    celery -A common.celery worker --loglevel=info -Q rule-check
 
 To monitor celery workers or individual tasks run:
 
@@ -407,3 +410,30 @@ environment database with ``cf conduit tamato-dev-db -- psql``.
 
 .. |codecov| image:: https://codecov.io/gh/uktrade/tamato/branch/master/graph/badge.svg
    :target: https://codecov.io/gh/uktrade/tamato
+
+Scaling Celery workers in GOV.UK PaaS
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Then you need to login to the DIT GOV.UK PaaS:
+
+.. code:: sh
+
+    cf login --sso -s <space>
+
+Where ``<space>`` is one of ``tariffs-dev``, ``tariffs-staging``,
+``tariffs-training`` or ``tariffs-uat``.
+
+Once you are logged in, you can list the application hosted in the space and their resources with
+
+.. code:: sh
+
+    cf apps
+    cf scale <space>
+
+You may notice that the celery worker isn't running or running with the resources you'd like.
+You may get a message like ``There are no running instances of this process.`` In this case you should scale the worker with
+
+.. code:: sh
+
+    cf scale <space> --process <process_name> -i <number_of_instances> -m 1G
+    

--- a/common/celery.py
+++ b/common/celery.py
@@ -17,6 +17,6 @@ app.config_from_object("django.conf:settings", namespace="CELERY")
 # Load task modules from all registered Django app configs.
 app.autodiscover_tasks()
 
-# this *shouldn't* need to be applied directly but
-# automatically configured via ^^ config_from_object
+# this should be automactically configured via ^^ config_from_object
+# but it isn't so here it's configured here
 app.conf.task_routes = settings.CELERY_ROUTES

--- a/common/celery.py
+++ b/common/celery.py
@@ -1,6 +1,7 @@
 import os
 
 from celery import Celery
+from django.conf import settings
 
 # set the default Django settings module for the 'celery' program.
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "settings")
@@ -15,3 +16,7 @@ app.config_from_object("django.conf:settings", namespace="CELERY")
 
 # Load task modules from all registered Django app configs.
 app.autodiscover_tasks()
+
+# this *shouldn't* need to be applied directly but
+# automatically configured via ^^ config_from_object
+app.conf.task_routes = settings.CELERY_ROUTES

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,7 +41,27 @@ services:
         - "ENV=${ENV:-prod}"
     volumes:
       - ./:/app/
-    command: ["celery", "-A" , "common.celery" ,"worker", "-O", "fair", "-l", "info"]
+    command: 
+      [
+        "celery", "-A" , "common.celery" ,"worker", "-O", "fair", "-l", "info", "-Q", "standard" 
+      ]
+    env_file: 
+      - .env
+      - settings/envs/docker.env
+    restart: "${DOCKER_RESTART_POLICY:-unless-stopped}"
+    depends_on:
+      - celery-redis
+    networks:
+      - inside
+
+  rule-check-celery:
+    build:
+      context: .
+      args:
+        - "ENV=${ENV:-prod}"
+    volumes:
+      - ./:/app/
+    command: ["celery", "-A" , "common.celery" ,"worker", "-O", "fair", "-l", "info", "-Q", "rule-check"]
     env_file: 
       - .env
       - settings/envs/docker.env

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,7 +1,6 @@
 ---
 applications:
   - buildpacks:
-      - https://github.com/cloudfoundry/apt-buildpack.git#v0.2.13
       - nodejs_buildpack
       - python_buildpack
     memory: 6G

--- a/manifest.yml
+++ b/manifest.yml
@@ -8,5 +8,7 @@ applications:
       memory: 1G
     - type: worker
       memory: 4G
-    - type: worker
+      health_check_type: process
+    - type: rule-check-worker
       memory: 6G
+      health_check_type: process

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,6 +1,7 @@
 ---
 applications:
   - buildpacks:
+      - https://github.com/cloudfoundry/apt-buildpack.git#v0.2.13
       - nodejs_buildpack
       - python_buildpack
     memory: 6G

--- a/manifest.yml
+++ b/manifest.yml
@@ -3,7 +3,6 @@ applications:
   - buildpacks:
       - nodejs_buildpack
       - python_buildpack
-      - https://github.com/cloudfoundry/apt-buildpack.git#v0.2.2
     processes:
     - type: web
       memory: 1G

--- a/manifest.yml
+++ b/manifest.yml
@@ -6,7 +6,7 @@ applications:
     processes:
     - type: web
       memory: 1G
-    # - type: worker
-    #   memory: 4G
-    - type: rule-worker
+    - type: worker
+      memory: 4G
+    - type: worker
       memory: 6G

--- a/manifest.yml
+++ b/manifest.yml
@@ -3,13 +3,10 @@ applications:
   - buildpacks:
       - nodejs_buildpack
       - python_buildpack
-    memory: 6G
     processes:
     - type: web
       memory: 1G
     - type: worker
       memory: 4G
-      health_check_type: process
     - type: rule-check-worker
       memory: 6G
-      health_check_type: process

--- a/manifest.yml
+++ b/manifest.yml
@@ -8,5 +8,5 @@ applications:
       memory: 1G
     # - type: worker
     #   memory: 4G
-    - type: rule-check-worker
+    - type: worker
       memory: 6G

--- a/manifest.yml
+++ b/manifest.yml
@@ -3,6 +3,7 @@ applications:
   - buildpacks:
       - nodejs_buildpack
       - python_buildpack
+    memory: 6G
     processes:
     - type: web
       memory: 1G

--- a/manifest.yml
+++ b/manifest.yml
@@ -8,5 +8,5 @@ applications:
       memory: 1G
     # - type: worker
     #   memory: 4G
-    - type: worker
+    - type: rule-worker
       memory: 6G

--- a/manifest.yml
+++ b/manifest.yml
@@ -6,7 +6,7 @@ applications:
     processes:
     - type: web
       memory: 1G
-    - type: worker
-      memory: 4G
+    # - type: worker
+    #   memory: 4G
     - type: rule-check-worker
       memory: 6G

--- a/manifest.yml
+++ b/manifest.yml
@@ -7,4 +7,6 @@ applications:
     - type: web
       memory: 1G
     - type: worker
-      memory: 8G
+      memory: 4G
+    - type: rule-check-worker
+      memory: 6G

--- a/manifest.yml
+++ b/manifest.yml
@@ -3,6 +3,7 @@ applications:
   - buildpacks:
       - nodejs_buildpack
       - python_buildpack
+      - https://github.com/cloudfoundry/apt-buildpack.git#v0.2.2
     processes:
     - type: web
       memory: 1G

--- a/settings/common.py
+++ b/settings/common.py
@@ -469,14 +469,10 @@ CELERY_ROUTES = {
     "workbaskets.tasks.transition": {
         "queue": "standard",
     },
-    re.compile(
-        r"(checks)\.tasks\..*",
-    ): {
+    re.compile(r"(checks)\.tasks\..*"): {
         "queue": "rule-check",
     },
-    re.compile(
-        r"(exporter|importer|notifications|publishing)\.tasks\..*",
-    ): {
+    re.compile(r"(exporter|importer|notifications|publishing)\.tasks\..*"): {
         "queue": "standard",
     },
 }

--- a/settings/common.py
+++ b/settings/common.py
@@ -460,8 +460,10 @@ CELERY_BEAT_SCHEDULE = {
 }
 
 CELERY_ROUTES = {
-    re.compile(r"(checks|workbaskets)\.tasks\..*"): {"queue": "rule-check"},
-    re.compile(r"(exporter|importer|notifications|publishing)\.tasks\..*"): {
+    re.compile(r"(checks)\.tasks\..*"): {"queue": "rule-check"},
+    re.compile(
+        r"(exporter|importer|notifications|publishing|workbaskets)\.tasks\..*",
+    ): {
         "queue": "standard",
     },
 }

--- a/settings/common.py
+++ b/settings/common.py
@@ -466,13 +466,13 @@ CELERY_ROUTES = {
     "workbaskets.tasks.check_workbasket": {
         "queue": "rule-check",
     },
+    "workbaskets.tasks.transition": {
+        "queue": "standard",
+    },
     re.compile(
         r"(checks)\.tasks\..*",
     ): {
         "queue": "rule-check",
-    },
-    "workbaskets.tasks.transition": {
-        "queue": "standard",
     },
     re.compile(
         r"(exporter|importer|notifications|publishing)\.tasks\..*",

--- a/settings/common.py
+++ b/settings/common.py
@@ -459,6 +459,14 @@ CELERY_BEAT_SCHEDULE = {
     },
 }
 
+CELERY_ROUTES = {
+    re.compile(r"(checks|workbaskets)\.tasks\..*"): {"queue": "rule-check"},
+    re.compile(r"(exporter|importer|notifications|publishing)\.tasks\..*"): {
+        "queue": "standard",
+    },
+}
+
+
 SQLITE_EXCLUDED_APPS = [
     "checks",
 ]

--- a/settings/common.py
+++ b/settings/common.py
@@ -460,9 +460,12 @@ CELERY_BEAT_SCHEDULE = {
 }
 
 CELERY_ROUTES = {
+    "workbaskets.tasks.call_check_workbasket_sync": {"queue": "rule-check"},
+    "workbaskets.tasks.check_workbasket": {"queue": "rule-check"},
     re.compile(r"(checks)\.tasks\..*"): {"queue": "rule-check"},
+    "workbaskets.tasks.transition": {"queue": "standard"},
     re.compile(
-        r"(exporter|importer|notifications|publishing|workbaskets)\.tasks\..*",
+        r"(exporter|importer|notifications|publishing)\.tasks\..*",
     ): {
         "queue": "standard",
     },

--- a/settings/common.py
+++ b/settings/common.py
@@ -471,7 +471,6 @@ CELERY_ROUTES = {
     },
 }
 
-
 SQLITE_EXCLUDED_APPS = [
     "checks",
 ]

--- a/settings/common.py
+++ b/settings/common.py
@@ -460,10 +460,16 @@ CELERY_BEAT_SCHEDULE = {
 }
 
 CELERY_ROUTES = {
-    "workbaskets.tasks.call_check_workbasket_sync": {"queue": "rule-check"},
-    "workbaskets.tasks.check_workbasket": {"queue": "rule-check"},
+    "workbaskets.tasks.call_check_workbasket_sync": {
+        "queue": "rule-check",
+    },
+    "workbaskets.tasks.check_workbasket": {
+        "queue": "rule-check",
+    },
     re.compile(r"(checks)\.tasks\..*"): {"queue": "rule-check"},
-    "workbaskets.tasks.transition": {"queue": "standard"},
+    "workbaskets.tasks.transition": {
+        "queue": "standard",
+    },
     re.compile(
         r"(exporter|importer|notifications|publishing)\.tasks\..*",
     ): {

--- a/settings/common.py
+++ b/settings/common.py
@@ -466,7 +466,11 @@ CELERY_ROUTES = {
     "workbaskets.tasks.check_workbasket": {
         "queue": "rule-check",
     },
-    re.compile(r"(checks)\.tasks\..*"): {"queue": "rule-check"},
+    re.compile(
+        r"(checks)\.tasks\..*",
+    ): {
+        "queue": "rule-check",
+    },
     "workbaskets.tasks.transition": {
         "queue": "standard",
     },


### PR DESCRIPTION
# TP2000-780  Separate rule check worker

## Why
- CPU usage on a single worker is exceeding over 100% in production so load should be reduced
- The rule check can execute multiple tasks and can be log running seperating out the worker ensure that these tasks will not hold up other tasks or vise versa

## What
- Celery routing updated to route to specific queue's standard & rule-check
- This routing is then set up locally using multiple docker instances each running a different queue
- Procfile updated to include new worker (will not run until scaled)
- Updating this page with infrastructure details https://readme.trade.gov.uk/docs/playbooks/trade-tariff-management.html

