### PR TITLE
TP2000-884: Add quota edit form for validity period, category

### DIFF
--- a/quotas/forms.py
+++ b/quotas/forms.py
@@ -1,12 +1,16 @@
 from crispy_forms_gds.helper import FormHelper
 from crispy_forms_gds.layout import HTML
+from crispy_forms_gds.layout import Accordion
+from crispy_forms_gds.layout import AccordionSection
 from crispy_forms_gds.layout import Button
 from crispy_forms_gds.layout import Field
 from crispy_forms_gds.layout import Layout
 from crispy_forms_gds.layout import Size
+from crispy_forms_gds.layout import Submit
 from django import forms
 from django.urls import reverse_lazy
 
+from common.forms import ValidityPeriodForm
 from common.forms import delete_form_for
 from quotas import models
 
@@ -57,5 +61,42 @@ class QuotaDefinitionFilterForm(forms.Form):
             Button("submit", "Apply"),
             HTML(
                 f'<a class="govuk-button govuk-button--secondary" href="{clear_url}">Restore defaults</a>',
+            ),
+        )
+
+
+class QuotaUpdateForm(ValidityPeriodForm, forms.ModelForm):
+    class Meta:
+        model = models.QuotaOrderNumber
+        fields = [
+            "valid_between",
+            "category",
+        ]
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self.helper = FormHelper(self)
+        self.helper.label_size = Size.SMALL
+        self.helper.legend_size = Size.SMALL
+
+        self.helper.layout = Layout(
+            Accordion(
+                AccordionSection(
+                    "Validity period",
+                    "start_date",
+                    "end_date",
+                ),
+                AccordionSection(
+                    "Category",
+                    "category",
+                ),
+                css_class="govuk-!-width-two-thirds",
+            ),
+            Submit(
+                "submit",
+                "Save",
+                data_module="govuk-button",
+                data_prevent_double_click="true",
             ),
         )

--- a/quotas/forms.py
+++ b/quotas/forms.py
@@ -88,9 +88,7 @@ class QuotaUpdateForm(ValidityPeriodForm, forms.ModelForm):
             )
             self.fields[
                 "category"
-            ].help_text = (
-                "Safeguard quotas cannot have their category edited after creation"
-            )
+            ].help_text = "Once safeguard has been set and published as the quota category, this can’t be changed"
         else:
             self.fields["category"].choices = validators.QuotaCategoryEditing.choices
         self.fields["category"].initial = self.instance.category

--- a/quotas/forms.py
+++ b/quotas/forms.py
@@ -13,6 +13,7 @@ from django.urls import reverse_lazy
 from common.forms import ValidityPeriodForm
 from common.forms import delete_form_for
 from quotas import models
+from quotas import validators
 
 
 class QuotaFilterForm(forms.Form):
@@ -73,8 +74,26 @@ class QuotaUpdateForm(ValidityPeriodForm, forms.ModelForm):
             "category",
         ]
 
+    category = forms.ChoiceField(
+        label="Category",
+        choices=[],  # set in __init__
+    )
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        if self.instance.category == validators.QuotaCategory.SAFEGUARD:
+            self.fields["category"].widget = forms.Select(
+                attrs={"disabled": True},
+                choices=validators.QuotaCategory.choices,
+            )
+            self.fields[
+                "category"
+            ].help_text = (
+                "Safeguard quotas cannot have their category edited after creation"
+            )
+        else:
+            self.fields["category"].choices = validators.QuotaCategoryEditing.choices
+        self.fields["category"].initial = self.instance.category
 
         self.helper = FormHelper(self)
         self.helper.label_size = Size.SMALL

--- a/quotas/jinja2/includes/quotas/actions.jinja
+++ b/quotas/jinja2/includes/quotas/actions.jinja
@@ -4,6 +4,10 @@
       <ul class="govuk-list govuk-!-font-size-16">
             <li><a class="govuk-link" href="{{ url('quota-definitions', args=[object.sid]) }}">View definition periods</a></li>
             <li><a class="govuk-link" href="{{ measures_url }}">View all measures</a></li>
+          {% set edit_url = object.get_url('edit') %}
+          {% if edit_url %}
+            <li><a class="govuk-link" href="{{ edit_url }}">Edit this {{object._meta.verbose_name}}</a></li>
+          {% endif %}
           {% set delete_url = object.get_url('delete') %}
           {% if delete_url %}
             <li><a class="govuk-link" href="{{ delete_url }}">Delete this {{object._meta.verbose_name}}</a></li>

--- a/quotas/validators.py
+++ b/quotas/validators.py
@@ -33,6 +33,14 @@ class QuotaCategory(models.IntegerChoices):
     SAFEGUARD = 3, "Safeguard"
 
 
+class QuotaCategoryEditing(models.IntegerChoices):
+    """Quota category cannot be changed to safeguard when editing."""
+
+    WTO = 0, "WTO"
+    AUTONOMOUS = 1, "Autonomous"
+    PREFERENTIAL = 2, "Preferential"
+
+
 class SubQuotaType(models.TextChoices):
     EQUIVALENT = "EQ", "Equivalent to main quota"
     NORMAL = "NM", "Normal (restrictive to main quota)"

--- a/quotas/views.py
+++ b/quotas/views.py
@@ -8,6 +8,8 @@ from django.views.generic.list import ListView
 from rest_framework import permissions
 from rest_framework import viewsets
 
+from common.business_rules import UniqueIdentifyingFields
+from common.business_rules import UpdateValidity
 from common.serializers import AutoCompleteSerializer
 from common.tariffs_api import get_quota_data
 from common.tariffs_api import get_quota_definitions_data
@@ -23,11 +25,14 @@ from quotas import serializers
 from quotas.filters import OrderNumberFilterBackend
 from quotas.filters import QuotaFilter
 from quotas.forms import QuotaDefinitionFilterForm
+from quotas.forms import QuotaUpdateForm
 from quotas.models import QuotaAssociation
 from quotas.models import QuotaBlocking
 from quotas.models import QuotaSuspension
 from workbaskets.models import WorkBasket
 from workbaskets.views.generic import CreateTaricDeleteView
+from workbaskets.views.generic import CreateTaricUpdateView
+from workbaskets.views.generic import EditTaricView
 
 
 class QuotaOrderNumberViewset(viewsets.ReadOnlyModelViewSet):
@@ -85,7 +90,7 @@ class QuotaEventViewset(viewsets.ReadOnlyModelViewSet):
     permission_classes = [permissions.IsAuthenticated]
 
 
-class QuotaMixin:
+class QuotaOrderNumberMixin:
     model = models.QuotaOrderNumber
 
     def get_queryset(self):
@@ -93,14 +98,14 @@ class QuotaMixin:
         return models.QuotaOrderNumber.objects.approved_up_to_transaction(tx)
 
 
-class QuotaList(QuotaMixin, TamatoListView):
+class QuotaList(QuotaOrderNumberMixin, TamatoListView):
     """Returns a list of QuotaOrderNumber objects."""
 
     template_name = "quotas/list.jinja"
     filterset_class = QuotaFilter
 
 
-class QuotaDetail(QuotaMixin, TrackedModelDetailView, SortingMixin):
+class QuotaDetail(QuotaOrderNumberMixin, TrackedModelDetailView, SortingMixin):
     template_name = "quotas/detail.jinja"
     sort_by_fields = ["goods_nomenclature"]
 
@@ -217,8 +222,49 @@ class QuotaDefinitionList(FormMixin, SortingMixin, ListView):
         )
 
 
-class QuotaDelete(QuotaMixin, TrackedModelDetailMixin, CreateTaricDeleteView):
+class QuotaDelete(
+    QuotaOrderNumberMixin,
+    TrackedModelDetailMixin,
+    CreateTaricDeleteView,
+):
     form_class = forms.QuotaDeleteForm
     success_path = "list"
 
     validate_business_rules = (business_rules.ON11,)
+
+
+class QuotaUpdateMixin(
+    QuotaOrderNumberMixin,
+    TrackedModelDetailMixin,
+):
+    form_class = QuotaUpdateForm
+    permission_required = ["common.change_trackedmodel"]
+
+    validate_business_rules = (
+        business_rules.ON1,
+        business_rules.ON2,
+        # uncomment when we add geo area editing
+        # business_rules.ON4,
+        business_rules.ON9,
+        business_rules.ON11,
+        UniqueIdentifyingFields,
+        UpdateValidity,
+    )
+
+
+class QuotaUpdate(
+    QuotaUpdateMixin,
+    CreateTaricUpdateView,
+):
+    pass
+
+
+class QuotaEditUpdate(
+    QuotaUpdateMixin,
+    EditTaricView,
+):
+    pass
+
+
+class QuotaConfirmUpdate(QuotaOrderNumberMixin, TrackedModelDetailView):
+    template_name = "common/confirm_update.jinja"


### PR DESCRIPTION
# TP2000-884: Add quota edit form for validity period, category
<!---
 * Include the JIRA ticket number, eg TP-123, to automatically link.
 * Use 50 characters maximum.
 * Do not end with a full-stop.
--->

## Why
<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Use as many lines as you like.
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions or deliberately ignored edge-cases.
--->
* Users need a way to edit quota order numbers
* This lays the groundwork for editing certificates and geographical areas that will be done in another PR

## What
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Explain like I'm 5.
 * Use pictures if you can.
--->
* Adds an edit page and form for order numbers allowing users to change validity period and category

<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
## Checklist
- Requires migrations?
- Requires dependency updates?
--->

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
<img width="822" alt="Screenshot 2023-05-22 at 12 06 30" src="https://github.com/uktrade/tamato/assets/25905279/903720d5-80be-494f-a7a4-a051acbf407e">
<img width="857" alt="Screenshot 2023-05-22 at 12 06 40" src="https://github.com/uktrade/tamato/assets/25905279/fd87cf0e-5a0b-4ff2-a58a-7ba600bbbf91">

<img width="824" alt="Screenshot 2023-05-22 at 12 30 14" src="https://github.com/uktrade/tamato/assets/25905279/fe7aee18-3542-4e97-8cf5-62848436acc9">

