### PR TITLE
TP2000-891 Multi-version + same transaction indent causes ME32

### DIFF
--- a/commodities/models/dc.py
+++ b/commodities/models/dc.py
@@ -584,7 +584,7 @@ class CommodityTreeSnapshot(CommodityTreeBase):
 
         NOTE: This methods is invoked by __post_init__ and should not be called directly.
 
-        The commodity collection is sorted on code, suffix and indent.
+        The commodity collection is sorted on code and suffix.
         Note that since this is a commodity tree snapshot,
         multiple versions of the same commodity are not possible.
         """

--- a/commodities/models/dc.py
+++ b/commodities/models/dc.py
@@ -491,32 +491,32 @@ class CommodityTreeSnapshot(CommodityTreeBase):
         *commodities: Commodity,
         as_at: Optional[date] = NOT_PROVIDED,
     ) -> MeasuresQuerySet:
-        filter = Q()
+        goods_sid_query = Q()
         for commodity in commodities:
             if commodity not in self.commodities:
                 logger.warning(f"Commodity {commodity} not found in this snapshot.")
                 continue
 
-            filter |= Q(goods_nomenclature__sid=commodity.obj.sid)
+            goods_sid_query |= Q(goods_nomenclature__sid=commodity.obj.sid)
 
-        qs = Measure.objects.filter(filter)
+        measure_qs = Measure.objects.filter(goods_sid_query)
 
         if self.moment.clock_type.is_transaction_clock:
-            qs = qs.approved_up_to_transaction(self.moment.transaction)
+            measure_qs = measure_qs.approved_up_to_transaction(self.moment.transaction)
         else:
-            qs = qs.latest_approved()
+            measure_qs = measure_qs.latest_approved()
 
         if as_at is not None and as_at is not NOT_PROVIDED:
-            qs = qs.with_effective_valid_between().filter(
+            measure_qs = measure_qs.with_effective_valid_between().filter(
                 Q(db_effective_valid_between__contains=as_at)
                 | Q(valid_between__startswith__gte=as_at),
             )
         elif as_at is NOT_PROVIDED and self.moment.clock_type.is_calendar_clock:
-            qs = qs.with_effective_valid_between().filter(
+            measure_qs = measure_qs.with_effective_valid_between().filter(
                 db_effective_valid_between__contains=self.moment.date,
             )
 
-        return qs
+        return measure_qs
 
     def is_declarable(self, commodity: Commodity) -> bool:
         return (

--- a/commodities/models/dc.py
+++ b/commodities/models/dc.py
@@ -1604,7 +1604,7 @@ class CommodityCollectionLoader:
             .with_end_date()
             .filter(indented_goods_nomenclature__sid__in=goods_sids)
             .annotate(goods_sid=F("indented_goods_nomenclature__sid"))
-            .order_by("transaction")
+            .order_by("transaction", "validity_start")
         )
 
         goods_sid_to_indents: Dict[str, List] = {}

--- a/settings/common.py
+++ b/settings/common.py
@@ -689,9 +689,9 @@ else:
 
 
 # ClamAV
-CLAM_AV_USERNAME = os.environ.get("CLAM_AV_USERNAME")
-CLAM_AV_PASSWORD = os.environ.get("CLAM_AV_PASSWORD")
-CLAM_AV_DOMAIN = os.environ.get("CLAM_AV_DOMAIN")
+CLAM_AV_USERNAME = os.environ.get("CLAM_AV_USERNAME", "")
+CLAM_AV_PASSWORD = os.environ.get("CLAM_AV_PASSWORD", "")
+CLAM_AV_DOMAIN = os.environ.get("CLAM_AV_DOMAIN", "")
 
 
 FILE_UPLOAD_HANDLERS = (

--- a/workbaskets/tasks.py
+++ b/workbaskets/tasks.py
@@ -62,4 +62,5 @@ def check_workbasket_sync(workbasket: WorkBasket):
 @app.task(bind=True)
 def call_check_workbasket_sync(self, workbasket_id: int):
     workbasket: WorkBasket = WorkBasket.objects.get(pk=workbasket_id)
+    workbasket.delete_checks()
     check_workbasket_sync(workbasket)


### PR DESCRIPTION
# TP2000-891 Multi-version + same transaction indent causes ME32
<!---
 * Include the JIRA ticket number, eg TP-123, to automatically link.
 * Use 50 characters maximum.
 * Do not end with a full-stop.
--->

## Why
<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Use as many lines as you like.
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions or deliberately ignored edge-cases.
--->
As per TARIC3, it's valid to have multiple instances of an indent that provide different start dates within the same transaction. This arrangement of indents in TAP data isn't catered for in commodity tree snapshot code, causing incorrect commodity extent values and therefore ancestor commodities within the tree.

## What
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Explain like I'm 5.
 * Use pictures if you can.
--->
In addition to ordering indents by transaction when loading the commodity collection, also apply a secondary ordering of `start_date`. This ensures correct indent selection when constructing a commodity tree snapshot.

<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
--->
## Checklist
- Requires migrations? No
- Requires dependency updates? No

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
