### PR TITLE
TP2000-884: Add quota edit form for validity period, category

### DIFF
--- a/quotas/forms.py
+++ b/quotas/forms.py
@@ -67,6 +67,12 @@ class QuotaDefinitionFilterForm(forms.Form):
 
 
 class QuotaUpdateForm(ValidityPeriodForm, forms.ModelForm):
+    CATEGORY_HELP_TEXT = "Categories are required for the TAP database but will not appear as a TARIC3 object in your workbasket"
+    SAFEGUARD_HELP_TEXT = (
+        "Once the quota category has been set as ‘Safeguard’, this cannot be changed"
+    )
+    START_DATE_HELP_TEXT = "If possible, avoid putting a start date in the past as this may cause issues with CDS downstream"
+
     class Meta:
         model = models.QuotaOrderNumber
         fields = [
@@ -75,7 +81,7 @@ class QuotaUpdateForm(ValidityPeriodForm, forms.ModelForm):
         ]
 
     category = forms.ChoiceField(
-        label="Category",
+        label="",
         choices=[],  # set in __init__
         error_messages={"invalid_choice": "Please select a valid category"},
     )
@@ -87,12 +93,13 @@ class QuotaUpdateForm(ValidityPeriodForm, forms.ModelForm):
                 attrs={"disabled": True},
                 choices=validators.QuotaCategory.choices,
             )
-            self.fields[
-                "category"
-            ].help_text = "Once safeguard has been set and published as the quota category, this can’t be changed"
+            self.fields["category"].help_text = self.SAFEGUARD_HELP_TEXT
         else:
             self.fields["category"].choices = validators.QuotaCategoryEditing.choices
+            self.fields["category"].help_text = self.CATEGORY_HELP_TEXT
+
         self.fields["category"].initial = self.instance.category
+        self.fields["start_date"].help_text = self.START_DATE_HELP_TEXT
 
         self.helper = FormHelper(self)
         self.helper.label_size = Size.SMALL

--- a/quotas/forms.py
+++ b/quotas/forms.py
@@ -1,12 +1,16 @@
 from crispy_forms_gds.helper import FormHelper
 from crispy_forms_gds.layout import HTML
+from crispy_forms_gds.layout import Accordion
+from crispy_forms_gds.layout import AccordionSection
 from crispy_forms_gds.layout import Button
 from crispy_forms_gds.layout import Field
 from crispy_forms_gds.layout import Layout
 from crispy_forms_gds.layout import Size
+from crispy_forms_gds.layout import Submit
 from django import forms
 from django.urls import reverse_lazy
 
+from common.forms import ValidityPeriodForm
 from common.forms import delete_form_for
 from quotas import models
 
@@ -57,5 +61,42 @@ class QuotaDefinitionFilterForm(forms.Form):
             Button("submit", "Apply"),
             HTML(
                 f'<a class="govuk-button govuk-button--secondary" href="{clear_url}">Restore defaults</a>',
+            ),
+        )
+
+
+class QuotaUpdateForm(ValidityPeriodForm, forms.ModelForm):
+    class Meta:
+        model = models.QuotaOrderNumber
+        fields = [
+            "valid_between",
+            "category",
+        ]
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self.helper = FormHelper(self)
+        self.helper.label_size = Size.SMALL
+        self.helper.legend_size = Size.SMALL
+
+        self.helper.layout = Layout(
+            Accordion(
+                AccordionSection(
+                    "Validity period",
+                    "start_date",
+                    "end_date",
+                ),
+                AccordionSection(
+                    "Category",
+                    "category",
+                ),
+                css_class="govuk-!-width-two-thirds",
+            ),
+            Submit(
+                "submit",
+                "Save",
+                data_module="govuk-button",
+                data_prevent_double_click="true",
             ),
         )

--- a/quotas/forms.py
+++ b/quotas/forms.py
@@ -88,9 +88,7 @@ class QuotaUpdateForm(ValidityPeriodForm, forms.ModelForm):
             )
             self.fields[
                 "category"
-            ].help_text = (
-                "Safeguard quotas cannot have their category edited after creation"
-            )
+            ].help_text = "Once safeguard has been set and published as the quota category, this can’t be changed"
         else:
             self.fields["category"].choices = validators.QuotaCategoryEditing.choices
         self.fields["category"].initial = self.instance.category

--- a/quotas/forms.py
+++ b/quotas/forms.py
@@ -13,6 +13,7 @@ from django.urls import reverse_lazy
 from common.forms import ValidityPeriodForm
 from common.forms import delete_form_for
 from quotas import models
+from quotas import validators
 
 
 class QuotaFilterForm(forms.Form):
@@ -73,8 +74,26 @@ class QuotaUpdateForm(ValidityPeriodForm, forms.ModelForm):
             "category",
         ]
 
+    category = forms.ChoiceField(
+        label="Category",
+        choices=[],  # set in __init__
+    )
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        if self.instance.category == validators.QuotaCategory.SAFEGUARD:
+            self.fields["category"].widget = forms.Select(
+                attrs={"disabled": True},
+                choices=validators.QuotaCategory.choices,
+            )
+            self.fields[
+                "category"
+            ].help_text = (
+                "Safeguard quotas cannot have their category edited after creation"
+            )
+        else:
+            self.fields["category"].choices = validators.QuotaCategoryEditing.choices
+        self.fields["category"].initial = self.instance.category
 
         self.helper = FormHelper(self)
         self.helper.label_size = Size.SMALL

--- a/quotas/forms.py
+++ b/quotas/forms.py
@@ -77,6 +77,7 @@ class QuotaUpdateForm(ValidityPeriodForm, forms.ModelForm):
     category = forms.ChoiceField(
         label="Category",
         choices=[],  # set in __init__
+        error_messages={"invalid_choice": "Please select a valid category"},
     )
 
     def __init__(self, *args, **kwargs):

--- a/quotas/jinja2/includes/quotas/actions.jinja
+++ b/quotas/jinja2/includes/quotas/actions.jinja
@@ -4,6 +4,10 @@
       <ul class="govuk-list govuk-!-font-size-16">
             <li><a class="govuk-link" href="{{ url('quota-definitions', args=[object.sid]) }}">View definition periods</a></li>
             <li><a class="govuk-link" href="{{ measures_url }}">View all measures</a></li>
+          {% set edit_url = object.get_url('edit') %}
+          {% if edit_url %}
+            <li><a class="govuk-link" href="{{ edit_url }}">Edit this {{object._meta.verbose_name}}</a></li>
+          {% endif %}
           {% set delete_url = object.get_url('delete') %}
           {% if delete_url %}
             <li><a class="govuk-link" href="{{ delete_url }}">Delete this {{object._meta.verbose_name}}</a></li>

--- a/quotas/jinja2/includes/quotas/tabs/core_data.jinja
+++ b/quotas/jinja2/includes/quotas/tabs/core_data.jinja
@@ -1,9 +1,15 @@
 {% set origins %}
     <ul class="govuk-table-list">
         {% for origin in object.quotaordernumberorigin_set.latest_approved().distinct('geographical_area') %}
-            <li>{{origin.geographical_area.area_id}} - {{origin.geographical_area.get_description().description}} </li>
+            <li><a href="{{ url('geo_area-ui-detail', args=[origin.geographical_area.sid]) }}" class="govuk-link">{{origin.geographical_area.area_id}} - {{origin.geographical_area.get_description().description}}</a></li>
         {% endfor %}
     </ul>
+{% endset %}
+{% set exclusions %}
+    {% for exclusion in object.geographical_exclusions %}
+        <a href="{{ url('geo_area-ui-detail', args=[exclusion.sid]) }}" class="govuk-link">{{ exclusion.area_id }} - {{ exclusion.get_description().description }}</a>
+        {% if not loop.last %}, {% endif %}
+    {% endfor %}
 {% endset %}
 
 <div class="quota__core-data govuk-grid-row">
@@ -23,7 +29,7 @@
             },
             {
                 "key": {"text": "Geographical area exclusions"},
-                "value": {"text": object.geographical_exclusion_descriptions|join(", ") if object.geographical_exclusion_descriptions else "-"},
+                "value": {"text": exclusions if object.geographical_exclusions else "-"},
                 "actions": {"items": []}
             },
             {

--- a/quotas/jinja2/includes/quotas/tabs/core_data.jinja
+++ b/quotas/jinja2/includes/quotas/tabs/core_data.jinja
@@ -1,7 +1,7 @@
 {% set origins %}
     <ul class="govuk-table-list">
-        {% for origin in object.origins.distinct().all() %}
-            <li>{{origin.area_id}} - {{origin.get_description().description}}</li>
+        {% for origin in object.quotaordernumberorigin_set.latest_approved().distinct('geographical_area') %}
+            <li>{{origin.geographical_area.area_id}} - {{origin.geographical_area.get_description().description}} </li>
         {% endfor %}
     </ul>
 {% endset %}

--- a/quotas/models.py
+++ b/quotas/models.py
@@ -126,13 +126,17 @@ class QuotaOrderNumber(TrackedModel, ValidityMixin):
         verbose_name = "quota"
 
 
-class QuotaOrderNumberOrigin(TrackedModel, ValidityMixin):
+class QuotaOrderNumberOrigin(GetTabURLMixin, TrackedModel, ValidityMixin):
     """The order number origin defines a quota as being available only to
     imports from a specific origin, usually a country or group of countries."""
 
     record_code = "360"
     subrecord_code = "10"
     identifying_fields = ("sid",)
+    url_pattern_name_prefix = "geo_area"
+    url_suffix = ""
+    url_relation_field = "geographical_area"
+
     sid = SignedIntSID(db_index=True)
     order_number = models.ForeignKey(QuotaOrderNumber, on_delete=models.PROTECT)
     geographical_area = models.ForeignKey(

--- a/quotas/models.py
+++ b/quotas/models.py
@@ -105,6 +105,23 @@ class QuotaOrderNumber(TrackedModel, ValidityMixin):
 
         return sorted(descriptions)
 
+    @property
+    def geographical_exclusions(self):
+        origin_ids = list(
+            self.quotaordernumberorigin_set.latest_approved().values_list(
+                "pk",
+                flat=True,
+            ),
+        )
+        exclusions = [
+            e.excluded_geographical_area
+            for e in QuotaOrderNumberOriginExclusion.objects.latest_approved().filter(
+                origin_id__in=origin_ids,
+            )
+        ]
+
+        return exclusions
+
     class Meta:
         verbose_name = "quota"
 

--- a/quotas/tests/test_forms.py
+++ b/quotas/tests/test_forms.py
@@ -1,0 +1,40 @@
+import pytest
+from bs4 import BeautifulSoup
+from django.urls import reverse
+
+from common.tests import factories
+from quotas import forms
+from quotas import validators
+
+pytestmark = pytest.mark.django_db
+
+
+def test_update_quota_form_safeguard_invalid():
+    """When a QuotaOrderNumber with the category safeguard is edited the
+    category cannot be changed."""
+    quota = factories.QuotaOrderNumberFactory.create(
+        category=validators.QuotaCategory.SAFEGUARD,
+    )
+    data = {
+        "category": validators.QuotaCategory.WTO.value,
+        "start_date_0": 1,
+        "start_date_1": 1,
+        "start_date_2": 2000,
+    }
+    form = forms.QuotaUpdateForm(data=data, instance=quota)
+    assert not form.is_valid()
+    assert "Please select a valid category" in form.errors["category"]
+
+
+def test_update_quota_form_safeguard_disabled(valid_user_client):
+    """When a QuotaOrderNumber with the category safeguard is edited the
+    category cannot be changed and the form field is disabled."""
+    quota = factories.QuotaOrderNumberFactory.create(
+        category=validators.QuotaCategory.SAFEGUARD,
+    )
+    response = valid_user_client.get(
+        reverse("quota-ui-edit", kwargs={"sid": quota.sid}),
+    )
+    html = response.content.decode(response.charset)
+    soup = BeautifulSoup(html, "html.parser")
+    assert "disabled" in soup.find(id="id_category").attrs.keys()

--- a/quotas/validators.py
+++ b/quotas/validators.py
@@ -33,6 +33,14 @@ class QuotaCategory(models.IntegerChoices):
     SAFEGUARD = 3, "Safeguard"
 
 
+class QuotaCategoryEditing(models.IntegerChoices):
+    """Quota category cannot be changed to safeguard when editing."""
+
+    WTO = 0, "WTO"
+    AUTONOMOUS = 1, "Autonomous"
+    PREFERENTIAL = 2, "Preferential"
+
+
 class SubQuotaType(models.TextChoices):
     EQUIVALENT = "EQ", "Equivalent to main quota"
     NORMAL = "NM", "Normal (restrictive to main quota)"

--- a/quotas/views.py
+++ b/quotas/views.py
@@ -8,6 +8,8 @@ from django.views.generic.list import ListView
 from rest_framework import permissions
 from rest_framework import viewsets
 
+from common.business_rules import UniqueIdentifyingFields
+from common.business_rules import UpdateValidity
 from common.serializers import AutoCompleteSerializer
 from common.tariffs_api import get_quota_data
 from common.tariffs_api import get_quota_definitions_data
@@ -23,11 +25,14 @@ from quotas import serializers
 from quotas.filters import OrderNumberFilterBackend
 from quotas.filters import QuotaFilter
 from quotas.forms import QuotaDefinitionFilterForm
+from quotas.forms import QuotaUpdateForm
 from quotas.models import QuotaAssociation
 from quotas.models import QuotaBlocking
 from quotas.models import QuotaSuspension
 from workbaskets.models import WorkBasket
 from workbaskets.views.generic import CreateTaricDeleteView
+from workbaskets.views.generic import CreateTaricUpdateView
+from workbaskets.views.generic import EditTaricView
 
 
 class QuotaOrderNumberViewset(viewsets.ReadOnlyModelViewSet):
@@ -85,7 +90,7 @@ class QuotaEventViewset(viewsets.ReadOnlyModelViewSet):
     permission_classes = [permissions.IsAuthenticated]
 
 
-class QuotaMixin:
+class QuotaOrderNumberMixin:
     model = models.QuotaOrderNumber
 
     def get_queryset(self):
@@ -93,14 +98,14 @@ class QuotaMixin:
         return models.QuotaOrderNumber.objects.approved_up_to_transaction(tx)
 
 
-class QuotaList(QuotaMixin, TamatoListView):
+class QuotaList(QuotaOrderNumberMixin, TamatoListView):
     """Returns a list of QuotaOrderNumber objects."""
 
     template_name = "quotas/list.jinja"
     filterset_class = QuotaFilter
 
 
-class QuotaDetail(QuotaMixin, TrackedModelDetailView, SortingMixin):
+class QuotaDetail(QuotaOrderNumberMixin, TrackedModelDetailView, SortingMixin):
     template_name = "quotas/detail.jinja"
     sort_by_fields = ["goods_nomenclature"]
 
@@ -217,8 +222,49 @@ class QuotaDefinitionList(FormMixin, SortingMixin, ListView):
         )
 
 
-class QuotaDelete(QuotaMixin, TrackedModelDetailMixin, CreateTaricDeleteView):
+class QuotaDelete(
+    QuotaOrderNumberMixin,
+    TrackedModelDetailMixin,
+    CreateTaricDeleteView,
+):
     form_class = forms.QuotaDeleteForm
     success_path = "list"
 
     validate_business_rules = (business_rules.ON11,)
+
+
+class QuotaUpdateMixin(
+    QuotaOrderNumberMixin,
+    TrackedModelDetailMixin,
+):
+    form_class = QuotaUpdateForm
+    permission_required = ["common.change_trackedmodel"]
+
+    validate_business_rules = (
+        business_rules.ON1,
+        business_rules.ON2,
+        # uncomment when we add geo area editing
+        # business_rules.ON4,
+        business_rules.ON9,
+        business_rules.ON11,
+        UniqueIdentifyingFields,
+        UpdateValidity,
+    )
+
+
+class QuotaUpdate(
+    QuotaUpdateMixin,
+    CreateTaricUpdateView,
+):
+    pass
+
+
+class QuotaEditUpdate(
+    QuotaUpdateMixin,
+    EditTaricView,
+):
+    pass
+
+
+class QuotaConfirmUpdate(QuotaOrderNumberMixin, TrackedModelDetailView):
+    template_name = "common/confirm_update.jinja"


### PR DESCRIPTION
# TP2000-884: Add quota edit form for validity period, category
<!---
 * Include the JIRA ticket number, eg TP-123, to automatically link.
 * Use 50 characters maximum.
 * Do not end with a full-stop.
--->

## Why
<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Use as many lines as you like.
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions or deliberately ignored edge-cases.
--->
* Users need a way to edit quota order numbers
* This lays the groundwork for editing certificates and geographical areas that will be done in another PR

## What
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Explain like I'm 5.
 * Use pictures if you can.
--->
* Adds an edit page and form for order numbers allowing users to change validity period and category

<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
## Checklist
- Requires migrations?
- Requires dependency updates?
--->

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->

<img width="884" alt="Screenshot 2023-05-30 at 14 16 04" src="https://github.com/uktrade/tamato/assets/25905279/c6da095c-ec49-471f-8cc3-f054abf4984a">
<img width="877" alt="Screenshot 2023-05-30 at 14 16 13" src="https://github.com/uktrade/tamato/assets/25905279/ee04b86c-dc51-423e-b32d-1dde022c5417">


