### PR TITLE
Handle currently processing state

### DIFF
--- a/publishing/models/tap_api_envelope.py
+++ b/publishing/models/tap_api_envelope.py
@@ -118,6 +118,7 @@ class ApiEnvelopeQuerySet(QuerySet):
             self.failed_publishing_staging()
             | self.failed_publishing_production()
             | self.awaiting_publishing()
+            | self.currently_publishing()
         )
 
     def currently_publishing(self):

--- a/publishing/tariff_api/client.py
+++ b/publishing/tariff_api/client.py
@@ -2,7 +2,8 @@ import requests
 from django.conf import settings
 from requests import Response
 
-from publishing.models import Envelope
+from publishing.models.envelope import Envelope
+from publishing.models.envelope import EnvelopeId
 
 
 class TariffAPIClient:
@@ -10,8 +11,34 @@ class TariffAPIClient:
         self.api_host_staging = settings.API_HOST_STAGING
         self.api_host_prod = settings.API_HOST_PROD
         self.api_url_path = settings.API_URL_PATH
+
+        self.api_key_staging_get = settings.API_KEY_STAGING_GET
+        self.api_key_prod_get = settings.API_KEY_PROD_GET
+
         self.api_key_staging_post = settings.API_KEY_STAGING_POST
         self.api_key_prod_post = settings.API_KEY_PROD_POST
+
+    def get_envelope_staging(self, envelope_id: EnvelopeId) -> Response:
+        """Get envelope from Tariff API staging environment."""
+        full_api_url = self.api_host_staging + self.api_url_path + envelope_id
+
+        headers = {
+            "X-API-KEY": self.api_key_staging_get,
+        }
+
+        response = requests.get(full_api_url, headers=headers, timeout=60)
+        return response
+
+    def get_envelope_production(self, envelope_id: EnvelopeId) -> Response:
+        """Get envelope from Tariff API production environment."""
+        full_api_url = self.api_host_prod + self.api_url_path + envelope_id
+
+        headers = {
+            "X-API-KEY": self.api_key_staging_get,
+        }
+
+        response = requests.get(full_api_url, headers=headers, timeout=60)
+        return response
 
     def post_envelope_staging(self, envelope: Envelope) -> Response:
         """Upload envelope to Tariff API staging environment."""

--- a/publishing/tariff_api/interface.py
+++ b/publishing/tariff_api/interface.py
@@ -3,11 +3,20 @@ from abc import abstractmethod
 
 from requests import Response
 
-from publishing.models import Envelope
+from publishing.models.envelope import Envelope
+from publishing.models.envelope import EnvelopeId
 from publishing.tariff_api.client import TariffAPIClient
 
 
 class TariffAPIBase(ABC):
+    @abstractmethod
+    def get_envelope_staging(self, envelope_id: EnvelopeId) -> Response:
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_envelope_production(self, envelope_id: EnvelopeId) -> Response:
+        raise NotImplementedError
+
     @abstractmethod
     def post_envelope_staging(self, envelope: Envelope) -> Response:
         raise NotImplementedError
@@ -18,7 +27,19 @@ class TariffAPIBase(ABC):
 
 
 class TariffAPIStubbed(TariffAPIBase):
-    def stubbed_post_response(self, envelope: Envelope) -> Response:
+    def stubbed_get_response(self, envelope_id: EnvelopeId = None) -> Response:
+        response = Response()
+        if not envelope_id:
+            response.reason = "404 Taric file does not exist"
+            response.status_code = 404
+        elif not isinstance(envelope_id, EnvelopeId):
+            response.reason = "400 Bad request [invalid seq]"
+            response.status_code = 400
+        else:
+            response.status_code = 200
+        return response
+
+    def stubbed_post_response(self, envelope: Envelope = None) -> Response:
         response = Response()
 
         if not envelope:
@@ -29,11 +50,19 @@ class TariffAPIStubbed(TariffAPIBase):
             response.reason = "200 OK File uploaded"
         return response
 
-    def post_envelope_staging(self, envelope: Envelope) -> Response:
+    def get_envelope_staging(self, envelope_id: EnvelopeId = None) -> Response:
+        """Get envelope from Tariff API staging environment."""
+        return self.stubbed_get_response(envelope_id=envelope_id)
+
+    def get_envelope_production(self, envelope_id: EnvelopeId = None) -> Response:
+        """Get envelope from Tariff API production environment."""
+        return self.stubbed_get_response(envelope_id=envelope_id)
+
+    def post_envelope_staging(self, envelope: Envelope = None) -> Response:
         """Upload envelope to Tariff API staging environment."""
         return self.stubbed_post_response(envelope=envelope)
 
-    def post_envelope_production(self, envelope: Envelope) -> Response:
+    def post_envelope_production(self, envelope: Envelope = None) -> Response:
         """Upload envelope to Tariff API production environment."""
         return self.stubbed_post_response(envelope=envelope)
 
@@ -42,6 +71,14 @@ class TariffAPI(TariffAPIBase):
     def __init__(self):
         super().__init__()
         self.client = TariffAPIClient()
+
+    def get_envelope_staging(self, envelope_id: EnvelopeId) -> Response:
+        """Get envelope from Tariff API staging environment."""
+        return self.client.get_envelope_staging(envelope_id=envelope_id)
+
+    def get_envelope_production(self, envelope_id: EnvelopeId) -> Response:
+        """Get envelope from Tariff API production environment."""
+        return self.client.get_envelope_production(envelope_id=envelope_id)
 
     def post_envelope_staging(self, envelope: Envelope) -> Response:
         """Upload envelope to Tariff API staging environment."""

--- a/publishing/tests/test_tasks.py
+++ b/publishing/tests/test_tasks.py
@@ -370,8 +370,8 @@ def test_publish_to_api_has_been_published_production(
     envelope.refresh_from_db()
 
     assert envelope.publishing_state == ApiPublishingState.SUCCESSFULLY_PUBLISHED
-    assert envelope.staging_published == published_date
-    assert envelope.production_published == published_date
+    assert envelope.staging_published
+    assert envelope.production_published
 
 
 def test_publish_to_api_published_in_sequence(successful_envelope_factory, settings):

--- a/publishing/tests/test_tasks.py
+++ b/publishing/tests/test_tasks.py
@@ -1,5 +1,6 @@
 import re
 from datetime import datetime
+from datetime import timezone
 from unittest import mock
 
 import pytest
@@ -227,8 +228,8 @@ def test_publish_to_api_failed_publishing_staging_to_successfully_published(
     successful_envelope_factory,
     settings,
 ):
-    """Test that an envelope with state FAILED_PUBLISHING_STAGING can be
-    published to the Tariff API."""
+    """Test that an envelope in state FAILED_PUBLISHING_STAGING can be published
+    to the Tariff API."""
 
     settings.ENABLE_PACKAGING_NOTIFICATIONS = False
     successful_envelope_factory()
@@ -255,7 +256,7 @@ def test_publish_to_api_failed_publishing_production_to_successfully_published(
     successful_envelope_factory,
     settings,
 ):
-    """Test that an envelope with state FAILED_PUBLISHING_PRODUCTION can be
+    """Test that an envelope in state FAILED_PUBLISHING_PRODUCTION can be
     published to the Tariff API."""
 
     settings.ENABLE_PACKAGING_NOTIFICATIONS = False
@@ -278,6 +279,99 @@ def test_publish_to_api_failed_publishing_production_to_successfully_published(
     assert envelope[0].publishing_state == ApiPublishingState.SUCCESSFULLY_PUBLISHED
     assert envelope[0].production_published
     assert pwb.envelope.published_to_tariffs_api
+
+
+def test_publish_to_api_currently_publishing_to_successfully_published(
+    successful_envelope_factory,
+    settings,
+):
+    """Test that an envelope in state CURRENTLY_PUBLISHING can be published to
+    the Tariff API."""
+
+    settings.ENABLE_PACKAGING_NOTIFICATIONS = False
+    successful_envelope_factory()
+
+    envelope = TAPApiEnvelope.objects.all()
+    assert envelope.count() == 1
+
+    envelope[0].begin_publishing()
+    assert envelope[0].publishing_state == ApiPublishingState.CURRENTLY_PUBLISHING
+
+    publish_to_api()
+    envelope[0].refresh_from_db()
+
+    assert envelope[0].publishing_state == ApiPublishingState.SUCCESSFULLY_PUBLISHED
+    assert envelope[0].production_published
+
+
+def test_publish_to_api_has_been_published_staging(
+    successful_envelope_factory,
+    settings,
+):
+    """Test that an envelope that has already been published to staging but is
+    stuck in state CURRENTLY_PUBLISHING can be published to production and
+    updated accordingly."""
+
+    settings.ENABLE_PACKAGING_NOTIFICATIONS = False
+    successful_envelope_factory()
+
+    envelope = TAPApiEnvelope.objects.first()
+
+    envelope.begin_publishing()
+    assert envelope.publishing_state == ApiPublishingState.CURRENTLY_PUBLISHING
+
+    published_date = datetime(2023, 1, 1, tzinfo=timezone.utc)
+    envelope.staging_published = published_date
+    envelope.save(update_fields=["staging_published"])
+
+    response = Response()
+    response.status_code = 200
+    with mock.patch.object(
+        TariffAPIStubbed,
+        "get_envelope_staging",
+        return_value=response,
+    ):
+        publish_to_api()
+    envelope.refresh_from_db()
+
+    assert envelope.publishing_state == ApiPublishingState.SUCCESSFULLY_PUBLISHED
+    assert envelope.staging_published == published_date
+    assert envelope.production_published
+
+
+def test_publish_to_api_has_been_published_production(
+    successful_envelope_factory,
+    settings,
+):
+    """Test that an envelope that has already been published to production but
+    is stuck in state CURRENTLY_PUBLISHING can be updated accordingly."""
+
+    settings.ENABLE_PACKAGING_NOTIFICATIONS = False
+    successful_envelope_factory()
+
+    envelope = TAPApiEnvelope.objects.first()
+
+    envelope.begin_publishing()
+    assert envelope.publishing_state == ApiPublishingState.CURRENTLY_PUBLISHING
+
+    published_date = datetime(2023, 1, 1, tzinfo=timezone.utc)
+    envelope.staging_published = published_date
+    envelope.production_published = published_date
+    envelope.save(update_fields=["staging_published", "production_published"])
+
+    response = Response()
+    response.status_code = 200
+    with mock.patch.object(
+        TariffAPIStubbed,
+        "get_envelope_production",
+        return_value=response,
+    ):
+        publish_to_api()
+    envelope.refresh_from_db()
+
+    assert envelope.publishing_state == ApiPublishingState.SUCCESSFULLY_PUBLISHED
+    assert envelope.staging_published == published_date
+    assert envelope.production_published == published_date
 
 
 def test_publish_to_api_published_in_sequence(successful_envelope_factory, settings):

--- a/sample.env
+++ b/sample.env
@@ -34,6 +34,8 @@ TARIFF_API_INTERFACE=publishing.tariff_api.interface.TariffAPIStubbed
 API_HOST_STAGING=http://tariffs-api-staging/
 API_HOST_PROD=http://tariffs-api-production/
 API_URL_PATH=api/v1/taricfiles/
+API_KEY_STAGING_GET=api_key_staging_get
+API_KEY_PROD_GET=api_key_prod_get
 API_KEY_STAGING_POST=api_key_staging_post
 API_KEY_PROD_POST=api_key_prod_post
 

--- a/settings/common.py
+++ b/settings/common.py
@@ -453,6 +453,8 @@ TARIFF_API_INTERFACE = os.environ.get(
 API_HOST_STAGING = os.environ.get("API_HOST_STAGING", "")
 API_HOST_PROD = os.environ.get("API_HOST_PROD", "")
 API_URL_PATH = os.environ.get("API_URL_PATH", "api/v1/taricfiles/")
+API_KEY_STAGING_GET = os.environ.get("API_KEY_STAGING_GET", "")
+API_KEY_PROD_GET = os.environ.get("API_KEY_PROD_GET", "")
 API_KEY_STAGING_POST = os.environ.get("API_KEY_STAGING_POST", "")
 API_KEY_PROD_POST = os.environ.get("API_KEY_PROD_POST", "")
 


### PR DESCRIPTION
# Handle currently processing state

## Why
An envelope becomes "stuck" in currently processing state if the previous publishing task fails to transition it to a new publishing state and/or set any published timestamps.

## What
- Extends API Client to include GET request for an envelope
- Handles API envelope stuck in currently processing state
- Adds tests

TP2000-777
