### PR TITLE
TP2000-682  Add password policy validator

### DIFF
--- a/common/tests/test_validators.py
+++ b/common/tests/test_validators.py
@@ -6,6 +6,7 @@ from common.validators import EnvelopeIdValidator
 from common.validators import NumberRangeValidator
 from common.validators import NumericSIDValidator
 from common.validators import NumericValidator
+from common.validators import PasswordPolicyValidator
 from common.validators import SymbolValidator
 
 
@@ -96,3 +97,21 @@ def test_symbol_validator(value, expected_valid):
 )
 def test_numeric_validator(value, expected_valid):
     check_validator(NumericValidator, value, expected_valid)
+
+
+@pytest.mark.parametrize(
+    ("value", "expected_valid"),
+    [
+        ("123", False),
+        ("lower", False),
+        ("lower123", False),
+        ("lower123!", False),
+        ("Capital", False),
+        ("Capital123", False),
+        ("Capital!", False),
+        ("Capital123!", True),
+    ],
+)
+def test_password_policy_validator(value, expected_valid):
+    validator = PasswordPolicyValidator()
+    check_validator(validator.validate, value, expected_valid)

--- a/common/tests/test_validators.py
+++ b/common/tests/test_validators.py
@@ -109,6 +109,7 @@ def test_numeric_validator(value, expected_valid):
         ("Capital", False),
         ("Capital123", False),
         ("Capital!", False),
+        ("CAPITAL123!", False),
         ("Capital123!", True),
     ],
 )

--- a/common/validators.py
+++ b/common/validators.py
@@ -89,15 +89,16 @@ SymbolValidator = RegexValidator(
 
 class PasswordPolicyValidator:
     """Validate whether the password contains at least 1 capital letter, 1
-    number and a special character."""
+    lowercase letter, 1 number and a special character."""
 
-    HELP_TEXT = "Your password must contain at least 1 capital letter, 1 number and a special character."
+    HELP_TEXT = "Your password must contain at least 1 capital letter, 1 lowercase letter, 1 number and a special character."
 
     def validate(self, password, user=None):
         if (
             password.isalnum()
             or not any(c.isdigit() for c in password)
             or not any(c.isupper() for c in password)
+            or not any(c.islower() for c in password)
         ):
             raise ValidationError(self.HELP_TEXT, code="password_missing_characters")
 

--- a/common/validators.py
+++ b/common/validators.py
@@ -85,3 +85,24 @@ SymbolValidator = RegexValidator(
     r"^[0-9A-Za-z\s.',()&£$%@!/\+-]*$",
     ValidationError("Only symbols .,/()&£$@!+-% are allowed."),
 )
+
+
+class PasswordPolicyValidator:
+    """Validate whether the password contains at least 1 capital letter, 1
+    number and a special character."""
+
+    def validate(self, password, user=None):
+        if (
+            password.isalnum()
+            or not any(c.isdigit() for c in password)
+            or not any(c.isupper() for c in password)
+        ):
+            raise ValidationError(
+                (
+                    "This password must contain at least 1 capital letter, 1 number and a special character."
+                ),
+                code="password_missing_characters",
+            )
+
+    def get_help_text(self):
+        return "Your password must contain at least 1 capital letter, 1 number and a special character."

--- a/common/validators.py
+++ b/common/validators.py
@@ -91,18 +91,15 @@ class PasswordPolicyValidator:
     """Validate whether the password contains at least 1 capital letter, 1
     number and a special character."""
 
+    HELP_TEXT = "Your password must contain at least 1 capital letter, 1 number and a special character."
+
     def validate(self, password, user=None):
         if (
             password.isalnum()
             or not any(c.isdigit() for c in password)
             or not any(c.isupper() for c in password)
         ):
-            raise ValidationError(
-                (
-                    "This password must contain at least 1 capital letter, 1 number and a special character."
-                ),
-                code="password_missing_characters",
-            )
+            raise ValidationError(self.HELP_TEXT, code="password_missing_characters")
 
     def get_help_text(self):
-        return "Your password must contain at least 1 capital letter, 1 number and a special character."
+        return self.HELP_TEXT

--- a/settings/common.py
+++ b/settings/common.py
@@ -221,6 +221,9 @@ if DEBUG is False:
         {
             "NAME": "django.contrib.auth.password_validation.CommonPasswordValidator",
         },
+        {
+            "NAME": "common.validators.PasswordPolicyValidator",
+        },
     ]
 
 if SSO_ENABLED:


### PR DESCRIPTION
# TP2000-682  Add password policy validator

## Why
Password validation in the admin (applies only to local, non-SSO created accounts) must take into account password policy.

## What
- Adds `PasswordPolicyValidator` that is used in addition to existing password validators.
- Adds test
