### PR TITLE
TP2000-894: Quota origin edits

### DIFF
--- a/common/forms.py
+++ b/common/forms.py
@@ -38,8 +38,7 @@ class BindNestedFormMixin:
     in order to instantiate and validate nested forms.
     """
 
-    def get_nested_forms(self, form_class, args, kwargs):
-        nested_forms = []
+    def get_bound_form(self, form_class, *args, **kwargs):
         if issubclass(form_class, FormSet):
             formset_kwargs = kwargs.copy()
             if "initial" in formset_kwargs:
@@ -57,8 +56,7 @@ class BindNestedFormMixin:
             )
         else:
             bound_form = form_class(*args, **kwargs)
-        nested_forms.append(bound_form)
-        return nested_forms
+        return bound_form
 
     def bind_nested_forms(self, *args, **kwargs):
         if kwargs.get("instance"):
@@ -71,14 +69,16 @@ class BindNestedFormMixin:
                     nested_forms = []
 
                     for form_class in form_list:
-                        nested_forms = self.get_nested_forms(form_class, args, kwargs)
+                        nested_forms.append(
+                            self.get_bound_form(form_class, *args, **kwargs),
+                        )
                     all_forms[choice] = nested_forms
                 field.bind_nested_forms(all_forms)
 
             elif isinstance(field, FormSetField):
                 for form_class in field.nested_forms:
-                    nested_forms = self.get_nested_forms(form_class, args, kwargs)
-                field.bind_nested_forms(nested_forms)
+                    bound_form = self.get_bound_form(form_class, *args, **kwargs)
+                field.bind_nested_forms(bound_form)
 
     def formset_submit(self):
         nested_formset_submit = [

--- a/common/forms.py
+++ b/common/forms.py
@@ -794,3 +794,13 @@ def formset_add_or_delete(data):
     if len(formset_data) > 0:
         return True
     return False
+
+
+class FormSetSubmitMixin:
+    @property
+    def formset_submitted(self):
+        return formset_add_or_delete(self.data)
+
+    @property
+    def whole_form_submit(self):
+        return bool(self.data.get("submit"))

--- a/common/forms.py
+++ b/common/forms.py
@@ -76,9 +76,11 @@ class BindNestedFormMixin:
                 field.bind_nested_forms(all_forms)
 
             elif isinstance(field, FormSetField):
+                bound_forms = []
                 for form_class in field.nested_forms:
                     bound_form = self.get_bound_form(form_class, *args, **kwargs)
-                field.bind_nested_forms(bound_form)
+                    bound_forms.append(bound_form)
+                field.bind_nested_forms(bound_forms)
 
     def formset_submit(self):
         nested_formset_submit = [

--- a/common/templates/common/widgets/formset_field.html
+++ b/common/templates/common/widgets/formset_field.html
@@ -1,0 +1,58 @@
+{% load crispy_forms_tags crispy_forms_gds crispy_forms_utils %}
+
+{% if widget.nested_forms %}
+<div class="govuk-form-group" id="{{ widget.attrs.id }}">
+
+	{% for nested_form in widget.nested_forms %}
+    <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">{{nested_form.legend}}</legend>
+
+		{% with nested_form.management_form as form %}
+			{% if form_show_errors %}
+				{% if form.non_field_errors %}
+				<div class="alert alert-block alert-danger">
+					{% if form_error_title %}<h4 class="alert-heading">{{ form_error_title }}</h4>{% endif %}
+					<ul>
+						{{ form.non_field_errors|unordered_list }}
+					</ul>
+				</div>
+				{% endif %}
+			{% endif %}
+
+			{% for field in form %}
+				{% include "gds/field.html" %}
+			{% endfor %}
+		{% endwith %}
+
+		{% if nested_form.is_formset %}
+			{% if nested_form.initial|length == nested_form.max_num %}
+				<p class="govuk-hint">You can only select up to {{ nested_form.max_num }} at this time.</p>
+			{% endif %}
+
+			{% for form in nested_form %}
+				{% for field in form %}
+					{% include "gds/field.html" %}
+					{% include "common/widgets/formset_delete_button.html" with prefix=form.prefix %}
+				{% endfor %}
+			{% endfor %}
+
+			{% if nested_form.initial|length < nested_form.max_num %}
+				{% for field in nested_form.empty_form %}
+					{% include "gds/field.html" %}
+				{% endfor %}
+
+				{% include "common/widgets/formset_add_button.html" with prefix=nested_form.prefix %}
+
+			{% endif %}
+
+		{% else %}
+			{% with nested_form as form %}
+				{% for field in form %}
+					{% include "gds/field.html" with field=field %}
+				{% endfor %}
+			{% endwith %}
+		{% endif %}
+
+
+	{% endfor %}
+</div>
+{% endif %}

--- a/common/tests/test_forms.py
+++ b/common/tests/test_forms.py
@@ -313,4 +313,4 @@ def test_unprefix_formset_data(data, exp):
     ],
 )
 def test_formset_add_or_delete(data, exp):
-    assert formset_add_or_delete(["measure-conditions-formset"], data) == exp
+    assert formset_add_or_delete(data) == exp

--- a/common/widgets.py
+++ b/common/widgets.py
@@ -22,3 +22,16 @@ class RadioNestedWidget(RadioSelect):
 
     def bind_nested_forms(self, forms):
         self.nested_forms = forms
+
+
+class FormSetFieldWidget(widgets.Widget):
+    template_name = "common/widgets/formset_field.html"
+    input_type = ""
+
+    def bind_nested_forms(self, forms):
+        self.nested_forms = forms
+
+    def get_context(self, name, value, attrs):
+        context = super().get_context(name, value, attrs)
+        context["widget"]["nested_forms"] = self.nested_forms
+        return context

--- a/geo_areas/constants.py
+++ b/geo_areas/constants.py
@@ -1,0 +1,45 @@
+from django.db import models
+
+
+class GeoAreaType(models.TextChoices):
+    ERGA_OMNES = "ERGA_OMNES", "All countries (erga omnes)"
+    GROUP = "GROUP", "A group of countries"
+    COUNTRY = "COUNTRY", "Specific countries or regions"
+
+
+ERGA_OMNES_EXCLUSIONS_PREFIX = "erga_omnes_exclusions"
+ERGA_OMNES_EXCLUSIONS_FORMSET_PREFIX = (
+    f"{ERGA_OMNES_EXCLUSIONS_PREFIX}_formset"  # /PS-IGNORE
+)
+GROUP_EXCLUSIONS_PREFIX = "geo_group_exclusions"
+GROUP_EXCLUSIONS_FORMSET_PREFIX = f"{GROUP_EXCLUSIONS_PREFIX}_formset"
+
+GEO_GROUP_PREFIX = "geographical_area_group"
+GEO_GROUP_FORMSET_PREFIX = f"{GEO_GROUP_PREFIX}_formset"
+
+COUNTRY_REGION_PREFIX = "country_region"
+COUNTRY_REGION_FORMSET_PREFIX = f"{COUNTRY_REGION_PREFIX}_formset"
+
+
+SUBFORM_PREFIX_MAPPING = {
+    GeoAreaType.GROUP: GEO_GROUP_PREFIX,
+    GeoAreaType.COUNTRY: COUNTRY_REGION_FORMSET_PREFIX,
+}
+
+FORMSET_PREFIX_MAPPING = {
+    GeoAreaType.ERGA_OMNES: ERGA_OMNES_EXCLUSIONS_FORMSET_PREFIX,
+    GeoAreaType.GROUP: GROUP_EXCLUSIONS_FORMSET_PREFIX,
+    GeoAreaType.COUNTRY: COUNTRY_REGION_FORMSET_PREFIX,
+}
+
+EXCLUSIONS_FORMSET_PREFIX_MAPPING = {
+    GeoAreaType.ERGA_OMNES: ERGA_OMNES_EXCLUSIONS_FORMSET_PREFIX,
+    GeoAreaType.GROUP: GROUP_EXCLUSIONS_FORMSET_PREFIX,
+    GeoAreaType.COUNTRY: None,
+}
+
+FIELD_NAME_MAPPING = {
+    GeoAreaType.ERGA_OMNES: "erga_omnes_exclusion",
+    GeoAreaType.GROUP: "geo_group_exclusion",
+    GeoAreaType.COUNTRY: "geographical_area_country_or_region",
+}

--- a/geo_areas/tests/test_utils.py
+++ b/geo_areas/tests/test_utils.py
@@ -61,4 +61,4 @@ def test_get_all_members(date_ranges):
     with override_current_transaction(origin.transaction):
         all_geo_areas = get_all_members_of_geo_groups(origin, [country4, area_group2])
 
-        assert not all_geo_areas.difference({country1, country2, country4})
+        assert not set(all_geo_areas).difference({country1, country2, country4})

--- a/geo_areas/tests/test_utils.py
+++ b/geo_areas/tests/test_utils.py
@@ -1,0 +1,64 @@
+import pytest
+
+from common.models.utils import override_current_transaction
+from common.tests import factories
+from geo_areas.utils import get_all_members_of_geo_groups
+from geo_areas.validators import AreaCode
+
+pytestmark = pytest.mark.django_db
+
+
+def test_get_all_members(date_ranges):
+    area_group = factories.GeographicalAreaFactory.create(
+        area_code=AreaCode.GROUP,
+        valid_between=date_ranges.no_end,
+    )
+    (
+        country1,
+        country2,
+        country3,
+        country4,
+    ) = factories.GeographicalAreaFactory.create_batch(
+        4,
+        area_code=AreaCode.COUNTRY,
+        valid_between=date_ranges.no_end,
+    )
+    factories.GeographicalMembershipFactory.create(
+        geo_group=area_group,
+        member=country1,
+        valid_between=date_ranges.no_end,
+    )
+    factories.GeographicalMembershipFactory.create(
+        geo_group=area_group,
+        member=country2,
+        valid_between=date_ranges.no_end,
+    )
+    factories.GeographicalMembershipFactory.create(
+        geo_group=area_group,
+        member=country3,
+        valid_between=date_ranges.no_end,
+    )
+    area_group2 = factories.GeographicalAreaFactory.create(
+        area_code=AreaCode.GROUP,
+        valid_between=date_ranges.no_end,
+    )
+    factories.GeographicalMembershipFactory.create(
+        geo_group=area_group2,
+        member=country1,
+        valid_between=date_ranges.no_end,
+    )
+    factories.GeographicalMembershipFactory.create(
+        geo_group=area_group2,
+        member=country2,
+        valid_between=date_ranges.no_end,
+    )
+
+    origin = factories.QuotaOrderNumberOriginFactory.create(
+        geographical_area=area_group,
+        valid_between=date_ranges.no_end,
+    )
+
+    with override_current_transaction(origin.transaction):
+        all_geo_areas = get_all_members_of_geo_groups(origin, [country4, area_group2])
+
+        assert not all_geo_areas.difference({country1, country2, country4})

--- a/geo_areas/utils.py
+++ b/geo_areas/utils.py
@@ -1,0 +1,25 @@
+from geo_areas.models import GeographicalMembership
+from geo_areas.validators import AreaCode
+
+
+def get_all_members_of_geo_groups(instance, geo_areas):
+    valid_memberships = GeographicalMembership.objects.as_at(
+        instance.valid_between.lower,
+    )
+
+    all_exclusions = []
+    for exclusion in geo_areas:
+        if exclusion.area_code == AreaCode.GROUP:
+            measure_origins = set(
+                m.member
+                for m in valid_memberships.filter(
+                    geo_group=instance.geographical_area,
+                )
+            )
+            for membership in valid_memberships.filter(geo_group=exclusion):
+                if membership.member.sid in [m.sid for m in measure_origins]:
+                    all_exclusions.append(membership.member)
+        else:
+            all_exclusions.append(exclusion)
+
+    return set(all_exclusions)

--- a/measures/forms.py
+++ b/measures/forms.py
@@ -32,7 +32,7 @@ from common.util import validity_range_contains_range
 from common.validators import SymbolValidator
 from common.validators import UpdateType
 from footnotes.models import Footnote
-from geo_areas.constants import *
+from geo_areas import constants
 from geo_areas.forms import CountryRegionForm
 from geo_areas.forms import CountryRegionFormSet
 from geo_areas.forms import ErgaOmnesExclusionsFormSet
@@ -64,11 +64,11 @@ class MeasureGeoAreaInitialDataMixin(FormSetSubmitMixin):
             self.geo_area_field_name,
         )
         if geo_area_type in [
-            GeoAreaType.GROUP.value,
-            GeoAreaType.ERGA_OMNES.value,
+            constants.GeoAreaType.GROUP.value,
+            constants.GeoAreaType.ERGA_OMNES.value,
         ]:
-            field_name = FIELD_NAME_MAPPING[geo_area_type]
-            prefix = FORMSET_PREFIX_MAPPING[geo_area_type]
+            field_name = constants.FIELD_NAME_MAPPING[geo_area_type]
+            prefix = constants.FORMSET_PREFIX_MAPPING[geo_area_type]
             initial_exclusions = []
             if hasattr(self, "instance"):
                 initial_exclusions = [
@@ -84,7 +84,9 @@ class MeasureGeoAreaInitialDataMixin(FormSetSubmitMixin):
                         g[field_name] = GeographicalArea.objects.get(id=id)
                 initial_exclusions = new_data
 
-            initial[FORMSET_PREFIX_MAPPING[geo_area_type]] = initial_exclusions
+            initial[
+                constants.FORMSET_PREFIX_MAPPING[geo_area_type]
+            ] = initial_exclusions
 
         return initial
 
@@ -487,11 +489,14 @@ class MeasureForm(
     )
     geo_area = RadioNested(
         label="Geographical area",
-        choices=GeoAreaType.choices,
+        choices=constants.GeoAreaType.choices,
         nested_forms={
-            GeoAreaType.ERGA_OMNES.value: [ErgaOmnesExclusionsFormSet],
-            GeoAreaType.GROUP.value: [GeoGroupForm, GeoGroupExclusionsFormSet],
-            GeoAreaType.COUNTRY.value: [CountryRegionForm],
+            constants.GeoAreaType.ERGA_OMNES.value: [ErgaOmnesExclusionsFormSet],
+            constants.GeoAreaType.GROUP.value: [
+                GeoGroupForm,
+                GeoGroupExclusionsFormSet,
+            ],
+            constants.GeoAreaType.COUNTRY.value: [CountryRegionForm],
         },
         error_messages={"required": "A Geographical area must be selected"},
     )
@@ -508,13 +513,13 @@ class MeasureForm(
         ] = self.instance.duty_sentence
 
         if self.instance.geographical_area.is_all_countries():
-            self.initial["geo_area"] = GeoAreaType.ERGA_OMNES.value
+            self.initial["geo_area"] = constants.GeoAreaType.ERGA_OMNES.value
 
         elif self.instance.geographical_area.is_group():
-            self.initial["geo_area"] = GeoAreaType.GROUP.value
+            self.initial["geo_area"] = constants.GeoAreaType.GROUP.value
 
         else:
-            self.initial["geo_area"] = GeoAreaType.COUNTRY.value
+            self.initial["geo_area"] = constants.GeoAreaType.COUNTRY.value
 
         # If no footnote keys are stored in the session for a measure,
         # store all the pks of a measure's footnotes on the session, using the measure sid as key
@@ -559,9 +564,9 @@ class MeasureForm(
         )
 
         geographical_area_fields = {
-            GeoAreaType.ERGA_OMNES: erga_omnes_instance,
-            GeoAreaType.GROUP: cleaned_data.get("geographical_area_group"),
-            GeoAreaType.COUNTRY: cleaned_data.get(
+            constants.GeoAreaType.ERGA_OMNES: erga_omnes_instance,
+            constants.GeoAreaType.GROUP: cleaned_data.get("geographical_area_group"),
+            constants.GeoAreaType.COUNTRY: cleaned_data.get(
                 "geographical_area_country_or_region",
             ),
         }
@@ -942,11 +947,14 @@ class MeasureGeographicalAreaForm(
             "This can be a specific country or a group of countries, and exclusions can be specified. "
             "The measure will only apply to imports from or exports to the selected area."
         ),
-        choices=GeoAreaType.choices,
+        choices=constants.GeoAreaType.choices,
         nested_forms={
-            GeoAreaType.ERGA_OMNES.value: [ErgaOmnesExclusionsFormSet],
-            GeoAreaType.GROUP.value: [GeoGroupForm, GeoGroupExclusionsFormSet],
-            GeoAreaType.COUNTRY.value: [CountryRegionFormSet],
+            constants.GeoAreaType.ERGA_OMNES.value: [ErgaOmnesExclusionsFormSet],
+            constants.GeoAreaType.GROUP.value: [
+                GeoGroupForm,
+                GeoGroupExclusionsFormSet,
+            ],
+            constants.GeoAreaType.COUNTRY.value: [CountryRegionFormSet],
         },
         error_messages={"required": "A Geographical area must be selected"},
     )
@@ -962,9 +970,9 @@ class MeasureGeographicalAreaForm(
             self.geo_area_field_name,
         )
 
-        if geo_area_type == GeoAreaType.COUNTRY.value:
-            field_name = FIELD_NAME_MAPPING[geo_area_type]
-            prefix = FORMSET_PREFIX_MAPPING[geo_area_type]
+        if geo_area_type == constants.GeoAreaType.COUNTRY.value:
+            field_name = constants.FIELD_NAME_MAPPING[geo_area_type]
+            prefix = constants.FORMSET_PREFIX_MAPPING[geo_area_type]
             initial_countries = []
             # if we just submitted the form, add the new data to initial
             if self.formset_submitted or self.whole_form_submit:
@@ -975,7 +983,7 @@ class MeasureGeographicalAreaForm(
                         g[field_name] = GeographicalArea.objects.get(id=id)
                 initial_countries = new_data
 
-            initial[FORMSET_PREFIX_MAPPING[geo_area_type]] = initial_countries
+            initial[constants.FORMSET_PREFIX_MAPPING[geo_area_type]] = initial_countries
 
         return initial
 
@@ -983,9 +991,11 @@ class MeasureGeographicalAreaForm(
         super().__init__(*args, **kwargs)
 
         geographical_area_fields = {
-            GeoAreaType.ERGA_OMNES: self.erga_omnes_instance,
-            GeoAreaType.GROUP: self.data.get(f"{self.prefix}-geographical_area_group"),
-            GeoAreaType.COUNTRY: self.data.get(
+            constants.GeoAreaType.ERGA_OMNES: self.erga_omnes_instance,
+            constants.GeoAreaType.GROUP: self.data.get(
+                f"{self.prefix}-geographical_area_group",
+            ),
+            constants.GeoAreaType.COUNTRY: self.data.get(
                 f"{self.prefix}-geographical_area_country_or_region",
             ),
         }
@@ -1029,34 +1039,34 @@ class MeasureGeographicalAreaForm(
         geo_area_choice = self.cleaned_data.get("geo_area")
 
         geographical_area_fields = {
-            GeoAreaType.GROUP: "geographical_area_group",
-            GeoAreaType.COUNTRY: "geographical_area_country_or_region",
+            constants.GeoAreaType.GROUP: "geographical_area_group",
+            constants.GeoAreaType.COUNTRY: "geographical_area_country_or_region",
         }
 
         if geo_area_choice:
             if not self.formset_submitted:
-                if geo_area_choice == GeoAreaType.ERGA_OMNES:
+                if geo_area_choice == constants.GeoAreaType.ERGA_OMNES:
                     cleaned_data["geo_area_list"] = [self.erga_omnes_instance]
 
-                elif geo_area_choice == GeoAreaType.GROUP:
-                    data_key = SUBFORM_PREFIX_MAPPING[geo_area_choice]
+                elif geo_area_choice == constants.GeoAreaType.GROUP:
+                    data_key = constants.SUBFORM_PREFIX_MAPPING[geo_area_choice]
                     cleaned_data["geo_area_list"] = [cleaned_data[data_key]]
 
-                elif geo_area_choice == GeoAreaType.COUNTRY:
+                elif geo_area_choice == constants.GeoAreaType.COUNTRY:
                     field_name = geographical_area_fields[geo_area_choice]
-                    data_key = SUBFORM_PREFIX_MAPPING[geo_area_choice]
+                    data_key = constants.SUBFORM_PREFIX_MAPPING[geo_area_choice]
                     cleaned_data["geo_area_list"] = [
                         geo_area[field_name] for geo_area in cleaned_data[data_key]
                     ]
 
                 exclusions = cleaned_data.get(
-                    EXCLUSIONS_FORMSET_PREFIX_MAPPING[geo_area_choice],
+                    constants.EXCLUSIONS_FORMSET_PREFIX_MAPPING[geo_area_choice],
                 )
                 if exclusions:
                     cleaned_data["geo_area_exclusions"] = [
-                        exclusion[FIELD_NAME_MAPPING[geo_area_choice]]
+                        exclusion[constants.FIELD_NAME_MAPPING[geo_area_choice]]
                         for exclusion in cleaned_data[
-                            EXCLUSIONS_FORMSET_PREFIX_MAPPING[geo_area_choice]
+                            constants.EXCLUSIONS_FORMSET_PREFIX_MAPPING[geo_area_choice]
                         ]
                     ]
 

--- a/measures/forms.py
+++ b/measures/forms.py
@@ -576,10 +576,12 @@ class MeasureForm(
             cleaned_data["geographical_area"] = geographical_area_fields[
                 geo_area_choice
             ]
-            exclusions = cleaned_data.get(FORMSET_PREFIX_MAPPING[geo_area_choice])
+            exclusions = cleaned_data.get(
+                constants.FORMSET_PREFIX_MAPPING[geo_area_choice],
+            )
             if exclusions:
                 cleaned_data["exclusions"] = [
-                    exclusion[FIELD_NAME_MAPPING[geo_area_choice]]
+                    exclusion[constants.FIELD_NAME_MAPPING[geo_area_choice]]
                     for exclusion in exclusions
                 ]
 

--- a/measures/tests/test_forms.py
+++ b/measures/tests/test_forms.py
@@ -9,6 +9,7 @@ from common.models.transactions import Transaction
 from common.models.utils import override_current_transaction
 from common.tests import factories
 from common.util import TaricDateRange
+from geo_areas import constants
 from geo_areas.validators import AreaCode
 from measures import forms
 from measures.forms import MEASURE_COMMODITIES_FORMSET_PREFIX
@@ -161,7 +162,7 @@ def test_measure_forms_quota_order_number_valid_data(quota_order_number):
 
 def test_measure_forms_geo_area_valid_data_erga_omnes(erga_omnes):
     data = {
-        f"{GEO_AREA_FORM_PREFIX}-geo_area": forms.GeoAreaType.ERGA_OMNES,
+        f"{GEO_AREA_FORM_PREFIX}-geo_area": constants.GeoAreaType.ERGA_OMNES,
     }
     with override_current_transaction(Transaction.objects.last()):
         form = forms.MeasureGeographicalAreaForm(
@@ -178,7 +179,7 @@ def test_measure_forms_geo_area_valid_data_erga_omnes_exclusions(erga_omnes):
     geo_area2 = factories.GeographicalAreaFactory.create()
     formset_prefix = "erga_omnes_exclusions_formset"
     data = {
-        f"{GEO_AREA_FORM_PREFIX}-geo_area": forms.GeoAreaType.ERGA_OMNES,
+        f"{GEO_AREA_FORM_PREFIX}-geo_area": constants.GeoAreaType.ERGA_OMNES,
         "erga_omnes_exclusions_formset-0-erga_omnes_exclusion": geo_area1.pk,
         "erga_omnes_exclusions_formset-1-erga_omnes_exclusion": geo_area2.pk,
         "erga_omnes_exclusions_formset-__prefix__-erga_omnes_exclusion": "",
@@ -207,7 +208,7 @@ def test_measure_forms_geo_area_valid_data_erga_omnes_exclusions_delete(erga_omn
     FormSet.is_valid()."""
     geo_area1 = factories.GeographicalAreaFactory.create()
     data = {
-        f"{GEO_AREA_FORM_PREFIX}-geo_area": forms.GeoAreaType.ERGA_OMNES,
+        f"{GEO_AREA_FORM_PREFIX}-geo_area": constants.GeoAreaType.ERGA_OMNES,
         "erga_omnes_exclusions_formset-0-erga_omnes_exclusion": geo_area1.pk,
         "erga_omnes_exclusions_formset-0-DELETE": "1",
         "submit": "submit",
@@ -230,7 +231,7 @@ def test_measure_forms_geo_area_valid_data_geo_group_exclusions(erga_omnes):
     geo_group = factories.GeographicalAreaFactory.create(area_code=AreaCode.GROUP)
     geo_area1 = factories.GeographicalAreaFactory.create()
     data = {
-        f"{GEO_AREA_FORM_PREFIX}-geo_area": forms.GeoAreaType.GROUP,
+        f"{GEO_AREA_FORM_PREFIX}-geo_area": constants.GeoAreaType.GROUP,
         f"{GEO_AREA_FORM_PREFIX}-geographical_area_group": geo_group.pk,
         "geo_group_exclusions_formset-0-geo_group_exclusion": geo_area1.pk,
         "submit": "submit",
@@ -256,7 +257,7 @@ def test_measure_forms_geo_area_valid_data_geo_group_exclusions_delete(erga_omne
     geo_area1 = factories.GeographicalAreaFactory.create()
     geo_group = factories.GeographicalAreaFactory.create(area_code=AreaCode.GROUP)
     data = {
-        f"{GEO_AREA_FORM_PREFIX}-geo_area": forms.GeoAreaType.GROUP,
+        f"{GEO_AREA_FORM_PREFIX}-geo_area": constants.GeoAreaType.GROUP,
         "geographical_area_group-geographical_area_group": geo_group.pk,
         "geo_group_exclusions_formset-0-geo_group_exclusion": geo_area1.pk,
         "geo_group_exclusions_formset-0-DELETE": "1",
@@ -281,7 +282,7 @@ def test_measure_forms_geo_area_valid_data_erga_omnes_exclusions_add(erga_omnes)
     FormSet.is_valid()."""
     geo_area1 = factories.GeographicalAreaFactory.create()
     data = {
-        "geo_area": forms.GeoAreaType.ERGA_OMNES,
+        "geo_area": constants.GeoAreaType.ERGA_OMNES,
         "erga_omnes_exclusions_formset-__prefix__-erga_omnes_exclusion": geo_area1.pk,
         "erga_omnes_exclusions_formset-ADD": "1",
         "submit": "submit",
@@ -298,7 +299,7 @@ def test_measure_forms_geo_area_valid_data_erga_omnes_exclusions_add(erga_omnes)
 def test_measure_forms_geo_area_valid_data_geo_group(erga_omnes):
     geo_group = factories.GeographicalAreaFactory.create(area_code=AreaCode.GROUP)
     data = {
-        f"{GEO_AREA_FORM_PREFIX}-geo_area": forms.GeoAreaType.GROUP,
+        f"{GEO_AREA_FORM_PREFIX}-geo_area": constants.GeoAreaType.GROUP,
         f"{GEO_AREA_FORM_PREFIX}-geographical_area_group": geo_group.pk,
         "submit": "submit",
     }
@@ -317,7 +318,7 @@ def test_measure_forms_geo_area_valid_data_countries_submit(erga_omnes):
     geo_area1 = factories.GeographicalAreaFactory.create()
     geo_area2 = factories.GeographicalAreaFactory.create()
     data = {
-        f"{GEO_AREA_FORM_PREFIX}-geo_area": forms.GeoAreaType.COUNTRY,
+        f"{GEO_AREA_FORM_PREFIX}-geo_area": constants.GeoAreaType.COUNTRY,
         "country_region_formset-0-geographical_area_country_or_region": geo_area1.pk,
         "country_region_formset-1-geographical_area_country_or_region": geo_area2.pk,
         "submit": "submit",
@@ -344,7 +345,7 @@ def test_measure_forms_geo_area_valid_data_countries_delete(erga_omnes):
     geo_area1 = factories.GeographicalAreaFactory.create()
     geo_area2 = factories.GeographicalAreaFactory.create()
     data = {
-        f"{GEO_AREA_FORM_PREFIX}-geo_area": forms.GeoAreaType.COUNTRY,
+        f"{GEO_AREA_FORM_PREFIX}-geo_area": constants.GeoAreaType.COUNTRY,
         "country_region_formset-0-geographical_area_country_or_region": geo_area1.pk,
         "country_region_formset-1-geographical_area_country_or_region": geo_area2.pk,
         "country_region_formset-DELETE": "on",
@@ -369,7 +370,7 @@ def test_measure_forms_geo_area_valid_data_countries_add(erga_omnes):
     FormSet.is_valid()."""
     geo_area1 = factories.GeographicalAreaFactory.create()
     data = {
-        f"{GEO_AREA_FORM_PREFIX}-geo_area": forms.GeoAreaType.COUNTRY,
+        f"{GEO_AREA_FORM_PREFIX}-geo_area": constants.GeoAreaType.COUNTRY,
         "country_region_formset-0-geographical_area_country_or_region": geo_area1.pk,
         "country_region_formset-ADD": "1",
         "submit": "submit",
@@ -387,7 +388,7 @@ def test_measure_forms_geo_area_invalid_data_geo_group_missing_field(erga_omnes)
     """Test that GeoGroupForm raises a field required error when null value is
     passed to geographical_area_group field."""
     data = {
-        f"{GEO_AREA_FORM_PREFIX}-geo_area": forms.GeoAreaType.GROUP,
+        f"{GEO_AREA_FORM_PREFIX}-geo_area": constants.GeoAreaType.GROUP,
         "geographical_area-geographical_area_group": None,
         "submit": "submit",
     }
@@ -406,7 +407,7 @@ def test_measure_forms_geo_area_invalid_data_geo_group_invalid_choice(erga_omnes
     whose area_code is not AreaCode.GROUP."""
     geo_area1 = factories.GeographicalAreaFactory.create(area_code=AreaCode.REGION)
     data = {
-        f"{GEO_AREA_FORM_PREFIX}-geo_area": forms.GeoAreaType.GROUP,
+        f"{GEO_AREA_FORM_PREFIX}-geo_area": constants.GeoAreaType.GROUP,
         "geographical_area-geographical_area_group": geo_area1.pk,
         "submit": "submit",
     }
@@ -428,7 +429,7 @@ def test_measure_forms_geo_area_invalid_data_geo_group_invalid_choice(erga_omnes
     [
         (
             {
-                f"{GEO_AREA_FORM_PREFIX}-geo_area": forms.GeoAreaType.COUNTRY,
+                f"{GEO_AREA_FORM_PREFIX}-geo_area": constants.GeoAreaType.COUNTRY,
                 "country_region_formset-0-geographical_area_country_or_region": "",
                 "submit": "submit",
             },

--- a/quotas/constants.py
+++ b/quotas/constants.py
@@ -1,0 +1,1 @@
+QUOTA_ORIGIN_EXCLUSIONS_FORMSET_PREFIX = "quota-origin-exclusions-formset"

--- a/quotas/forms.py
+++ b/quotas/forms.py
@@ -3,6 +3,7 @@ from crispy_forms_gds.layout import HTML
 from crispy_forms_gds.layout import Accordion
 from crispy_forms_gds.layout import AccordionSection
 from crispy_forms_gds.layout import Button
+from crispy_forms_gds.layout import Div
 from crispy_forms_gds.layout import Field
 from crispy_forms_gds.layout import Layout
 from crispy_forms_gds.layout import Size
@@ -10,10 +11,20 @@ from crispy_forms_gds.layout import Submit
 from django import forms
 from django.urls import reverse_lazy
 
+from common.forms import BindNestedFormMixin
+from common.forms import DateInputFieldFixed
+from common.forms import FormSet
+from common.forms import FormSetField
+from common.forms import FormSetSubmitMixin
+from common.forms import GovukDateRangeField
 from common.forms import ValidityPeriodForm
 from common.forms import delete_form_for
+from common.forms import formset_factory
+from common.forms import unprefix_formset_data
+from geo_areas.models import GeographicalArea
 from quotas import models
 from quotas import validators
+from quotas.constants import QUOTA_ORIGIN_EXCLUSIONS_FORMSET_PREFIX
 
 
 class QuotaFilterForm(forms.Form):
@@ -66,7 +77,45 @@ class QuotaDefinitionFilterForm(forms.Form):
         )
 
 
-class QuotaUpdateForm(ValidityPeriodForm, forms.ModelForm):
+class QuotaOriginExclusionsForm(forms.Form):
+    exclusion = forms.ModelChoiceField(
+        label="",
+        queryset=GeographicalArea.objects.all(),  # modified in __init__
+        help_text="Select a country to be excluded:",
+        required=False,
+    )
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.fields["exclusion"].queryset = (
+            GeographicalArea.objects.current()
+            .with_latest_description()
+            .as_at_today()
+            .order_by("description")
+        )
+        self.fields[
+            "exclusion"
+        ].label_from_instance = lambda obj: f"{obj.area_id} - {obj.description}"
+
+
+QuotaOriginExclusionsFormSet = formset_factory(
+    QuotaOriginExclusionsForm,
+    prefix=QUOTA_ORIGIN_EXCLUSIONS_FORMSET_PREFIX,
+    formset=FormSet,
+    min_num=0,
+    max_num=10,
+    extra=0,
+    validate_min=True,
+    validate_max=True,
+)
+
+
+class QuotaUpdateForm(
+    FormSetSubmitMixin,
+    ValidityPeriodForm,
+    BindNestedFormMixin,
+    forms.ModelForm,
+):
     CATEGORY_HELP_TEXT = "Categories are required for the TAP database but will not appear as a TARIC3 object in your workbasket"
     SAFEGUARD_HELP_TEXT = (
         "Once the quota category has been set as ‘Safeguard’, this cannot be changed"
@@ -86,8 +135,88 @@ class QuotaUpdateForm(ValidityPeriodForm, forms.ModelForm):
         error_messages={"invalid_choice": "Please select a valid category"},
     )
 
+    origin_start_date = DateInputFieldFixed(label="Start date")
+    origin_end_date = DateInputFieldFixed(
+        label="End date",
+        required=False,
+    )
+    origin_valid_between = GovukDateRangeField(required=False)
+
+    geographical_area = forms.ModelChoiceField(
+        label="Geographical area",
+        help_text="Add a geographical area",
+        queryset=GeographicalArea.objects.all(),
+    )
+
+    exclusions = FormSetField(
+        label="Geographical area exclusions",
+        nested_forms=[QuotaOriginExclusionsFormSet],
+        required=False,
+    )
+
+    existing_origin = forms.ModelChoiceField(
+        queryset=models.QuotaOrderNumberOrigin.objects.all(),
+        widget=forms.HiddenInput(),
+    )
+
+    @property
+    def origin(self):
+        return self.instance.quotaordernumberorigin_set.current().first()
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        self.init_fields()
+        self.set_initial_data(*args, **kwargs)
+        self.init_layout()
+
+    def clean(self):
+        cleaned_data = super().clean()
+        self.clean_validity_period(
+            cleaned_data,
+            valid_between_field_name="origin_valid_between",
+            start_date_field_name="origin_start_date",
+            end_date_field_name="origin_end_date",
+        )
+        return cleaned_data
+
+    def set_initial_data(self, *args, **kwargs):
+        self.fields["category"].initial = self.instance.category
+        self.fields["existing_origin"].initial = self.origin
+        self.fields["origin_start_date"].initial = self.origin.valid_between.lower
+        self.fields["origin_end_date"].initial = self.origin.valid_between.upper
+        self.fields["geographical_area"].initial = self.origin.geographical_area
+        nested_forms_initial = {**self.initial}
+        nested_forms_initial["geographical_area"] = self.origin.geographical_area
+        nested_forms_initial.update(self.get_geo_area_initial())
+        kwargs.pop("initial")
+        self.bind_nested_forms(*args, initial=nested_forms_initial, **kwargs)
+
+    def get_geo_area_initial(self):
+        field_name = "exclusion"
+        initial = {}
+        initial_exclusions = []
+        if hasattr(self, "instance"):
+            initial_exclusions = [
+                {field_name: exclusion}
+                for exclusion in self.origin.excluded_areas.all()
+            ]
+        # if we just submitted the form, add the new data to initial
+        if self.formset_submitted or self.whole_form_submit:
+            new_data = unprefix_formset_data(
+                QUOTA_ORIGIN_EXCLUSIONS_FORMSET_PREFIX,
+                self.data.copy(),
+            )
+            for g in new_data:
+                if g[field_name]:
+                    id = int(g[field_name])
+                    g[field_name] = GeographicalArea.objects.get(id=id)
+            initial_exclusions = new_data
+
+        initial[QUOTA_ORIGIN_EXCLUSIONS_FORMSET_PREFIX] = initial_exclusions
+
+        return initial
+
+    def init_fields(self):
         if self.instance.category == validators.QuotaCategory.SAFEGUARD:
             self.fields["category"].widget = forms.Select(
                 attrs={"disabled": True},
@@ -98,25 +227,65 @@ class QuotaUpdateForm(ValidityPeriodForm, forms.ModelForm):
             self.fields["category"].choices = validators.QuotaCategoryEditing.choices
             self.fields["category"].help_text = self.CATEGORY_HELP_TEXT
 
-        self.fields["category"].initial = self.instance.category
         self.fields["start_date"].help_text = self.START_DATE_HELP_TEXT
+        self.fields["geographical_area"].queryset = (
+            GeographicalArea.objects.current()
+            .with_latest_description()
+            .as_at_today()
+            .order_by("description")
+        )
+        self.fields[
+            "geographical_area"
+        ].label_from_instance = lambda obj: f"{obj.area_id} - {obj.description}"
 
+    def init_layout(self):
         self.helper = FormHelper(self)
         self.helper.label_size = Size.SMALL
         self.helper.legend_size = Size.SMALL
 
+        if len(self.instance.quotaordernumberorigin_set.current()) > 1:
+            origin_fields = [
+                HTML.warning(
+                    "Editing of quota order numbers with multiple origins is not supported at this time",
+                ),
+            ]
+        else:
+            origin_fields = [
+                Div(
+                    "existing_origin",
+                    Div(
+                        "origin_start_date",
+                        "origin_end_date",
+                        css_class="govuk-grid-column-one-half",
+                    ),
+                    Div(
+                        "geographical_area",
+                        css_class="govuk-grid-column-one-half",
+                    ),
+                    Div(
+                        "exclusions",
+                        css_class="govuk-grid-column-full",
+                    ),
+                    css_class="govuk-grid-row",
+                ),
+            ]
+
         self.helper.layout = Layout(
-            Accordion(
-                AccordionSection(
-                    "Validity period",
-                    "start_date",
-                    "end_date",
+            Div(
+                Accordion(
+                    AccordionSection(
+                        "Validity period",
+                        "start_date",
+                        "end_date",
+                    ),
+                    AccordionSection(
+                        "Category",
+                        "category",
+                    ),
+                    AccordionSection("Quota origin", *origin_fields),
+                    css_class="govuk-grid-column-two-thirds",
                 ),
-                AccordionSection(
-                    "Category",
-                    "category",
-                ),
-                css_class="govuk-!-width-two-thirds",
+                css_class="govuk-grid-row",
             ),
             Submit(
                 "submit",

--- a/quotas/forms.py
+++ b/quotas/forms.py
@@ -80,16 +80,19 @@ class QuotaDefinitionFilterForm(forms.Form):
 class QuotaOriginExclusionsForm(forms.Form):
     exclusion = forms.ModelChoiceField(
         label="",
-        queryset=GeographicalArea.objects.current()
-        .with_latest_description()
-        .as_at_today()
-        .order_by("description"),
+        queryset=GeographicalArea.objects.all(),  # modified in __init__
         help_text="Select a country to be excluded:",
         required=False,
     )
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        self.fields["exclusion"].queryset = (
+            GeographicalArea.objects.current()
+            .with_latest_description()
+            .as_at_today()
+            .order_by("description")
+        )
         self.fields[
             "exclusion"
         ].label_from_instance = lambda obj: f"{obj.area_id} - {obj.description}"

--- a/quotas/forms.py
+++ b/quotas/forms.py
@@ -80,19 +80,16 @@ class QuotaDefinitionFilterForm(forms.Form):
 class QuotaOriginExclusionsForm(forms.Form):
     exclusion = forms.ModelChoiceField(
         label="",
-        queryset=GeographicalArea.objects.all(),  # modified in __init__
+        queryset=GeographicalArea.objects.current()
+        .with_latest_description()
+        .as_at_today()
+        .order_by("description"),
         help_text="Select a country to be excluded:",
         required=False,
     )
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.fields["exclusion"].queryset = (
-            GeographicalArea.objects.current()
-            .with_latest_description()
-            .as_at_today()
-            .order_by("description")
-        )
         self.fields[
             "exclusion"
         ].label_from_instance = lambda obj: f"{obj.area_id} - {obj.description}"

--- a/quotas/forms.py
+++ b/quotas/forms.py
@@ -162,13 +162,12 @@ class QuotaUpdateForm(
     @property
     def origin(self):
         return (
-            self.instance.quotaordernumberorigin_set.approved_up_to_transaction(self.tx)
+            self.instance.quotaordernumberorigin_set.current()
             .filter(order_number=self.instance)
             .first()
         )
 
     def __init__(self, *args, **kwargs):
-        self.tx = kwargs.pop("tx")
         super().__init__(*args, **kwargs)
         self.init_fields()
         self.set_initial_data(*args, **kwargs)

--- a/quotas/forms.py
+++ b/quotas/forms.py
@@ -158,9 +158,14 @@ class QuotaUpdateForm(
 
     @property
     def origin(self):
-        return self.instance.quotaordernumberorigin_set.current().first()
+        return (
+            self.instance.quotaordernumberorigin_set.approved_up_to_transaction(self.tx)
+            .filter(order_number=self.instance)
+            .first()
+        )
 
     def __init__(self, *args, **kwargs):
+        self.tx = kwargs.pop("tx")
         super().__init__(*args, **kwargs)
         self.init_fields()
         self.set_initial_data(*args, **kwargs)
@@ -195,7 +200,7 @@ class QuotaUpdateForm(
         if hasattr(self, "instance"):
             initial_exclusions = [
                 {field_name: exclusion}
-                for exclusion in self.origin.excluded_areas.all()
+                for exclusion in self.origin.quotaordernumberoriginexclusion_set.current().all()
             ]
         # if we just submitted the form, add the new data to initial
         if self.formset_submitted or self.whole_form_submit:

--- a/quotas/jinja2/includes/quotas/tabs/core_data.jinja
+++ b/quotas/jinja2/includes/quotas/tabs/core_data.jinja
@@ -1,6 +1,6 @@
 {% set origins %}
     <ul class="govuk-table-list">
-        {% for origin in object.quotaordernumberorigin_set.latest_approved().distinct('geographical_area') %}
+        {% for origin in object.quotaordernumberorigin_set.current() %}
             <li><a href="{{ url('geo_area-ui-detail', args=[origin.geographical_area.sid]) }}" class="govuk-link">{{origin.geographical_area.area_id}} - {{origin.geographical_area.get_description().description}}</a></li>
         {% endfor %}
     </ul>

--- a/quotas/jinja2/includes/quotas/tabs/core_data.jinja
+++ b/quotas/jinja2/includes/quotas/tabs/core_data.jinja
@@ -14,7 +14,7 @@
         {% endset %}
         {% set geo_area_summary -%}
             {{ geo_area_name }}
-            {% if origin.excluded_areas.all() %} (with exclusions){% endif %}
+            {% if object.geographical_exclusions %} (with exclusions){% endif %}
         {% endset %}
         {% set origin_link -%}
             <a href="{{ url('geo_area-ui-detail', args=[origin.geographical_area.sid]) }}" class="govuk-link">{{ geo_area_name }}</a>

--- a/quotas/jinja2/includes/quotas/tabs/core_data.jinja
+++ b/quotas/jinja2/includes/quotas/tabs/core_data.jinja
@@ -9,7 +9,13 @@
 
 {% set origins %}
     {% for origin in object.quotaordernumberorigin_set.current() %}
-        {% set geo_area_name -%}{{origin.geographical_area.area_id}} - {{origin.geographical_area.get_description().description}}{% endset %}
+        {% set geo_area_name -%}
+            {{ origin.geographical_area.area_id  ~ " - " ~ origin.geographical_area.get_description().description }}
+        {% endset %}
+        {% set geo_area_summary -%}
+            {{ geo_area_name }}
+            {% if origin.excluded_areas.all() %} (with exclusions){% endif %}
+        {% endset %}
         {% set origin_link -%}
             <a href="{{ url('geo_area-ui-detail', args=[origin.geographical_area.sid]) }}" class="govuk-link">{{ geo_area_name }}</a>
         {% endset %}
@@ -42,7 +48,7 @@
             }}
         {% endset %}
         {{ govukDetails({
-            "summaryText": geo_area_name,
+            "summaryText": geo_area_summary,
             "html": summary_list
             }) }}
     {% endfor %}

--- a/quotas/jinja2/includes/quotas/tabs/core_data.jinja
+++ b/quotas/jinja2/includes/quotas/tabs/core_data.jinja
@@ -1,14 +1,50 @@
-{% set origins %}
-    <ul class="govuk-table-list">
-        {% for origin in object.quotaordernumberorigin_set.current() %}
-            <li><a href="{{ url('geo_area-ui-detail', args=[origin.geographical_area.sid]) }}" class="govuk-link">{{origin.geographical_area.area_id}} - {{origin.geographical_area.get_description().description}}</a></li>
-        {% endfor %}
-    </ul>
-{% endset %}
+{% from "components/details/macro.njk" import govukDetails %}
+
 {% set exclusions %}
     {% for exclusion in object.geographical_exclusions %}
         <a href="{{ url('geo_area-ui-detail', args=[exclusion.sid]) }}" class="govuk-link">{{ exclusion.area_id }} - {{ exclusion.get_description().description }}</a>
         {% if not loop.last %}, {% endif %}
+    {% endfor %}
+{% endset %}
+
+{% set origins %}
+    {% for origin in object.quotaordernumberorigin_set.current() %}
+        {% set geo_area_name -%}{{origin.geographical_area.area_id}} - {{origin.geographical_area.get_description().description}}{% endset %}
+        {% set origin_link -%}
+            <a href="{{ url('geo_area-ui-detail', args=[origin.geographical_area.sid]) }}" class="govuk-link">{{ geo_area_name }}</a>
+        {% endset %}
+        {% set end_date -%}
+        {{"{:%d %b %Y}".format(object.valid_between.upper) if object.valid_between.upper else "—"}}
+        {% endset %}
+        {% set validity -%}
+        {{"{:%d %b %Y}".format(object.valid_between.lower) ~ " " ~ end_date }}
+        {% endset %}
+        {% set summary_list %}
+            {{ govukSummaryList({
+                "rows": [
+                    {
+                        "key": {"text": "Geographical area"},
+                        "value": {"text": origin_link},
+                        "actions": {"items": []},
+                    },
+                    {
+                        "key": {"text": "Geographical area exclusions"},
+                        "value": {"text": exclusions if object.geographical_exclusions else "-"},
+                        "actions": {"items": []},
+                    },
+                    {
+                        "key": {"text": "Validity"},
+                        "value": {"text": validity},
+                        "actions": {"items": []},
+                    },
+                ]
+            })
+            }}
+        {% endset %}
+        {{ govukDetails({
+            "summaryText": geo_area_name,
+            "html": summary_list
+            }) }}
     {% endfor %}
 {% endset %}
 
@@ -23,13 +59,8 @@
                 "actions": {"items": []}
             },
             {
-                "key": {"text": "Geographical area"},
+                "key": {"text": "Origins"},
                 "value": {"text": origins if object.origins.all() else "-"},
-                "actions": {"items": []}
-            },
-            {
-                "key": {"text": "Geographical area exclusions"},
-                "value": {"text": exclusions if object.geographical_exclusions else "-"},
                 "actions": {"items": []}
             },
             {

--- a/quotas/models.py
+++ b/quotas/models.py
@@ -108,14 +108,14 @@ class QuotaOrderNumber(TrackedModel, ValidityMixin):
     @property
     def geographical_exclusions(self):
         origin_ids = list(
-            self.quotaordernumberorigin_set.latest_approved().values_list(
+            self.quotaordernumberorigin_set.current().values_list(
                 "pk",
                 flat=True,
             ),
         )
         exclusions = [
             e.excluded_geographical_area
-            for e in QuotaOrderNumberOriginExclusion.objects.latest_approved().filter(
+            for e in QuotaOrderNumberOriginExclusion.objects.current().filter(
                 origin_id__in=origin_ids,
             )
         ]

--- a/quotas/models.py
+++ b/quotas/models.py
@@ -167,10 +167,21 @@ class QuotaOrderNumberOrigin(GetTabURLMixin, TrackedModel, ValidityMixin):
     def order_number_in_use(self, transaction):
         return self.order_number.in_use(transaction)
 
+    @property
+    def structure_description(self):
+        return (
+            f"{self.geographical_area.get_area_code_display()} - "
+            f"{self.geographical_area.structure_description} ({self.geographical_area.area_id})"
+        )
 
-class QuotaOrderNumberOriginExclusion(TrackedModel):
+
+class QuotaOrderNumberOriginExclusion(GetTabURLMixin, TrackedModel):
     """Origin exclusions specify countries (or groups of countries, or other
     origins) to exclude from the quota number origin."""
+
+    url_pattern_name_prefix = "geo_area"
+    url_suffix = ""
+    url_relation_field = "excluded_geographical_area"
 
     record_code = "360"
     subrecord_code = "15"
@@ -187,6 +198,13 @@ class QuotaOrderNumberOriginExclusion(TrackedModel):
         business_rules.ON14,
         UpdateValidity,
     )
+
+    @property
+    def structure_description(self):
+        return (
+            f"{self.excluded_geographical_area.get_area_code_display()} - "
+            f"{self.excluded_geographical_area.structure_description} ({self.excluded_geographical_area.area_id})"
+        )
 
 
 class QuotaDefinition(GetTabURLMixin, TrackedModel, ValidityMixin):

--- a/quotas/tests/test_forms.py
+++ b/quotas/tests/test_forms.py
@@ -2,6 +2,7 @@ import pytest
 from bs4 import BeautifulSoup
 from django.urls import reverse
 
+from common.models.utils import override_current_transaction
 from common.tests import factories
 from quotas import forms
 from quotas import validators
@@ -21,9 +22,10 @@ def test_update_quota_form_safeguard_invalid():
         "start_date_1": 1,
         "start_date_2": 2000,
     }
-    form = forms.QuotaUpdateForm(data=data, instance=quota)
-    assert not form.is_valid()
-    assert "Please select a valid category" in form.errors["category"]
+    with override_current_transaction(quota.transaction):
+        form = forms.QuotaUpdateForm(data=data, instance=quota, initial={})
+        assert not form.is_valid()
+        assert "Please select a valid category" in form.errors["category"]
 
 
 def test_update_quota_form_safeguard_disabled(valid_user_client):

--- a/quotas/tests/test_views.py
+++ b/quotas/tests/test_views.py
@@ -17,11 +17,79 @@ from common.tests.util import view_urlpattern_ids
 from common.validators import UpdateType
 from common.views import TamatoListView
 from common.views import TrackedModelDetailMixin
+from geo_areas.validators import AreaCode
 from quotas import models
 from quotas import validators
 from quotas.views import QuotaList
 
 pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def country1(date_ranges):
+    return factories.GeographicalAreaFactory.create(
+        area_code=AreaCode.COUNTRY,
+        valid_between=date_ranges.no_end,
+    )
+
+
+@pytest.fixture
+def country2(date_ranges):
+    return factories.GeographicalAreaFactory.create(
+        area_code=AreaCode.COUNTRY,
+        valid_between=date_ranges.no_end,
+    )
+
+
+@pytest.fixture
+def country3(date_ranges):
+    return factories.GeographicalAreaFactory.create(
+        area_code=AreaCode.COUNTRY,
+        valid_between=date_ranges.no_end,
+    )
+
+
+@pytest.fixture
+def geo_group1(country1, country2, country3, date_ranges):
+    geo_group1 = factories.GeographicalAreaFactory.create(
+        area_code=AreaCode.GROUP,
+        valid_between=date_ranges.no_end,
+    )
+    factories.GeographicalMembershipFactory.create(
+        geo_group=geo_group1,
+        member=country1,
+        valid_between=date_ranges.no_end,
+    )
+    factories.GeographicalMembershipFactory.create(
+        geo_group=geo_group1,
+        member=country2,
+        valid_between=date_ranges.no_end,
+    )
+    factories.GeographicalMembershipFactory.create(
+        geo_group=geo_group1,
+        member=country3,
+        valid_between=date_ranges.no_end,
+    )
+    return geo_group1
+
+
+@pytest.fixture
+def geo_group2(date_ranges, country1, country2):
+    geo_group2 = factories.GeographicalAreaFactory.create(
+        area_code=AreaCode.GROUP,
+        valid_between=date_ranges.no_end,
+    )
+    factories.GeographicalMembershipFactory.create(
+        geo_group=geo_group2,
+        member=country1,
+        valid_between=date_ranges.no_end,
+    )
+    factories.GeographicalMembershipFactory.create(
+        geo_group=geo_group2,
+        member=country2,
+        valid_between=date_ranges.no_end,
+    )
+    return geo_group2
 
 
 @pytest.mark.parametrize(
@@ -587,3 +655,66 @@ def test_quota_edit_origin_new_versions(valid_user_client):
     assert origins.exists()
     assert origins.count() == 1
     assert origins.first().version_group != quota.version_group
+
+
+def test_quota_edit_origin_exclusions(
+    valid_user_client,
+    date_ranges,
+    approved_transaction,
+    geo_group1,
+    geo_group2,
+    country1,
+    country2,
+    country3,
+):
+    """Checks that members of geo groups are added individually as
+    exclusions."""
+    quota = factories.QuotaOrderNumberFactory.create(transaction=approved_transaction)
+
+    origin = models.QuotaOrderNumberOrigin.objects.last()
+
+    form_data = {
+        "category": validators.QuotaCategory.AUTONOMOUS.value,
+        "start_date_0": 1,
+        "start_date_1": 1,
+        "start_date_2": 2000,
+        "existing_origin": origin.id,
+        "origin_start_date_0": 1,
+        "origin_start_date_1": 1,
+        "origin_start_date_2": 2000,
+        "geographical_area": geo_group1.id,
+        "quota-origin-exclusions-formset-__prefix__-exclusion": geo_group2.id,
+        "submit": "Save",
+    }
+
+    response = valid_user_client.post(
+        reverse("quota-ui-edit", kwargs={"sid": quota.sid}),
+        form_data,
+    )
+
+    assert response.status_code == 302
+
+    tx = Transaction.objects.last()
+
+    quota = models.QuotaOrderNumber.objects.approved_up_to_transaction(tx).get(
+        sid=quota.sid,
+    )
+    origins = models.QuotaOrderNumberOrigin.objects.approved_up_to_transaction(
+        tx,
+    ).filter(
+        order_number=quota,
+    )
+
+    # geo_group1 contains country1, country2, country3
+    # geo_group2 contains country1, country2
+
+    # we're excluding geo_group2 from geo_group1
+    # geo_group2 has 2 members
+    # so we should have 2 exclusions
+    assert origins.first().excluded_areas.all().count() == 2
+
+    # if we exclude geo_group2
+    # we exclude country1 and country2
+    assert country1 in origins.first().excluded_areas.all()
+    assert country2 in origins.first().excluded_areas.all()
+    assert country3 not in origins.first().excluded_areas.all()

--- a/quotas/views.py
+++ b/quotas/views.py
@@ -254,11 +254,6 @@ class QuotaUpdateMixin(
         UpdateValidity,
     )
 
-    def get_form_kwargs(self):
-        kwargs = super().get_form_kwargs()
-        kwargs["tx"] = WorkBasket.get_current_transaction(self.request)
-        return kwargs
-
     @transaction.atomic
     def get_result_object(self, form):
         object = super().get_result_object(form)

--- a/quotas/views.py
+++ b/quotas/views.py
@@ -270,8 +270,6 @@ class QuotaUpdateMixin(
             for item in form.cleaned_data[QUOTA_ORIGIN_EXCLUSIONS_FORMSET_PREFIX]
         ]
 
-        print("form_exclusions", form_exclusions)
-
         existing_origins = (
             models.QuotaOrderNumberOrigin.objects.approved_up_to_transaction(
                 object.transaction,
@@ -289,8 +287,6 @@ class QuotaUpdateMixin(
         )
 
         all_new_exclusions = get_all_members_of_geo_groups(new_origin, form_exclusions)
-
-        print("all_new_exclusions", all_new_exclusions)
 
         for geo_area in all_new_exclusions:
             existing_exclusion = (

--- a/quotas/views.py
+++ b/quotas/views.py
@@ -254,6 +254,11 @@ class QuotaUpdateMixin(
         UpdateValidity,
     )
 
+    def get_form_kwargs(self):
+        kwargs = super().get_form_kwargs()
+        kwargs["tx"] = WorkBasket.get_current_transaction(self.request)
+        return kwargs
+
     @transaction.atomic
     def get_result_object(self, form):
         object = super().get_result_object(form)
@@ -299,7 +304,7 @@ class QuotaUpdateMixin(
             if existing_exclusion:
                 existing_exclusion.new_version(
                     workbasket=WorkBasket.current(self.request),
-                    transaction=new_origin.transaction,
+                    transaction=object.transaction,
                     origin=new_origin,
                 )
             else:
@@ -307,7 +312,7 @@ class QuotaUpdateMixin(
                     origin=new_origin,
                     excluded_geographical_area=geo_area,
                     update_type=UpdateType.CREATE,
-                    transaction=new_origin.transaction,
+                    transaction=object.transaction,
                 )
 
         removed_excluded_areas = {
@@ -326,7 +331,7 @@ class QuotaUpdateMixin(
             removed.new_version(
                 update_type=UpdateType.DELETE,
                 workbasket=WorkBasket.current(self.request),
-                transaction=new_origin.transaction,
+                transaction=object.transaction,
                 origin=new_origin,
             )
 


### PR DESCRIPTION
# TP2000-894: Quota origin edits
<!---
 * Include the JIRA ticket number, eg TP-123, to automatically link.
 * Use 50 characters maximum.
 * Do not end with a full-stop.
--->

## Why
<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Use as many lines as you like.
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions or deliberately ignored edge-cases.
--->
* Users need to be able to edit quota origins for some upcoming policy implementation

## What
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Explain like I'm 5.
 * Use pictures if you can.
--->
* Adds an origin section to the quota edit form
* Allows editing of the origin validity, geographical area and exclusions
* Currently it's only possible to edit quotas with one origin, not multiple
* Also updates the quota detail UI to better represent quota origin data

<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
## Checklist
- Requires migrations?
- Requires dependency updates?
--->

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
![FireShot Capture 059 - Edit quota details - Manage Trade Tariffs - localhost](https://github.com/uktrade/tamato/assets/25905279/86836588-a56f-4676-9220-ab30e3292082)

<img width="912" alt="Screenshot 2023-06-05 at 11 35 35" src="https://github.com/uktrade/tamato/assets/25905279/7ccc2132-6b49-42fc-99b3-a99191f80647">
<img width="912" alt="Screenshot 2023-06-05 at 11 35 47" src="https://github.com/uktrade/tamato/assets/25905279/4358c7bd-c035-4054-9a42-f1a86996e2ce">
<img width="834" alt="Screenshot 2023-06-07 at 13 20 21" src="https://github.com/uktrade/tamato/assets/25905279/013593c5-915e-4b9d-ba18-5d05a59b5d38">

