### PR TITLE
TP2000-905  Remove newline characters from autocomplete results

### DIFF
--- a/common/static/common/js/autocomplete.js
+++ b/common/static/common/js/autocomplete.js
@@ -47,7 +47,7 @@ const autoCompleteElement = (element, includeNameAttr=true) => {
     templates: {
       inputValue: template,
       suggestion: template
-    },±
+    },
     onConfirm: value => {
       const autocomplete = document.querySelector(`#${hiddenInput.id}_autocomplete`);
       if (value && typeof value == "object") {

--- a/common/static/common/js/autocomplete.js
+++ b/common/static/common/js/autocomplete.js
@@ -4,6 +4,21 @@ const template = (result) => result && result.label
 
 let aborter = null;
 
+const newLine  = /\n/g;
+const removeNewLine = (str) => str.replace(newLine, "")
+
+const cleanResults = (results) => {
+  /*
+  Results which contain new line characters are considered as a new query when
+  selected, causing results to be repopulated unnecessarily. To prevent this,
+  we can remove new line characters from results since they're unimportant here.
+  */
+  for(let i = 0, len = results.length; i < len; i++) {
+    results[i].label = removeNewLine(results[i].label);
+  }
+  return results
+}
+
 
 const autoCompleteElement = (element, includeNameAttr=true) => {
   const hiddenInput = element.querySelector("input[type=hidden]");
@@ -22,11 +37,11 @@ const autoCompleteElement = (element, includeNameAttr=true) => {
       const signal = aborter.signal
       fetch(`${source_url}?${searchParams}`, {signal})
         .then(response => response.json())
-        .then(data => populateResults(data.results))
+        .then(data => populateResults(cleanResults(data.results)))
         .catch(err => console.log(err));
     },
     minLength: element.dataset.minLength ? element.dataset.minLength : 0,
-    defaultValue: element.dataset.originalValue,
+    defaultValue: removeNewLine(element.dataset.originalValue),
     name: "",
     templates: {
       inputValue: template,

--- a/common/static/common/js/autocomplete.js
+++ b/common/static/common/js/autocomplete.js
@@ -1,6 +1,7 @@
 import accessibleAutocomplete from 'accessible-autocomplete'
 
-const template = (result) => result && result.label
+// Only a new result has a label, else result is the original result's label
+const template = (result) => typeof result == "object" ? result.label : result
 
 let aborter = null;
 
@@ -46,10 +47,11 @@ const autoCompleteElement = (element, includeNameAttr=true) => {
     templates: {
       inputValue: template,
       suggestion: template
-    },
+    },±
     onConfirm: value => {
       const autocomplete = document.querySelector(`#${hiddenInput.id}_autocomplete`);
-      if (value) {
+      if (value && typeof value == "object") {
+        // value is new
         hiddenInput.value = value.value;
       } else if (!autocomplete.value) {
         hiddenInput.value = "";


### PR DESCRIPTION
# TP2000-905  Remove newline characters from autocomplete results

## Why
Autocomplete doesn't handle results which contain new lines characters consistently. Results which contain new line characters (for example, the descriptions for commodity codes 8708942000 & 8414302030) are considered as a new query when selected, causing results to be repopulated again unnecessarily through an additional fetch request. 

If a user selects one of the results and submits a form before the fetch request has resolved, then the user's selection can sometimes be "forgotten" by the server. This intermittent issue can be seen occurring during the create a new measure (TP2000-823) and multiple measure edit journeys (TP2000-905). 

## What
- Adds a new function to remove new line characters from autocomplete results
- Fixes another issue with autocomplete where a previously selected result shows as undefined

## Examples
Problematic, superfluous request:
<img width="600" alt="Screenshot 2023-06-09 at 12 50 41" src="https://github.com/uktrade/tamato/assets/118175145/9320d444-ef86-4c78-a465-06bb04f79374">

Undefined error:
<img width="150" alt="Screenshot 2023-06-09 at 12 53 05" src="https://github.com/uktrade/tamato/assets/118175145/8d8bb95f-702f-4e6a-a6d0-92f20f292dbc">



