### PR TITLE
Fix autocomplete TypeError

### DIFF
--- a/common/static/common/js/addNewForm.js
+++ b/common/static/common/js/addNewForm.js
@@ -31,7 +31,9 @@ const addNewForm = (event) => {
 
     let dutiesInput = newForm.querySelector("input.duties");
     let copyButton = newForm.querySelector("button.tap-copy-down");
-    setupClickHandler(dutiesInput, copyButton);
+    if (dutiesInput && copyButton) {
+      setupClickHandler(dutiesInput, copyButton);
+    }
 
     let totalForms = document.querySelector('[id$="-TOTAL_FORMS"]');
     let numTotalForms = Number(totalForms.value);

--- a/common/static/common/js/autocomplete.js
+++ b/common/static/common/js/autocomplete.js
@@ -42,7 +42,7 @@ const autoCompleteElement = (element, includeNameAttr=true) => {
         .catch(err => console.log(err));
     },
     minLength: element.dataset.minLength ? element.dataset.minLength : 0,
-    defaultValue: removeNewLine(element.dataset.originalValue),
+    defaultValue: element.dataset.originalValue && removeNewLine(element.dataset.originalValue),
     name: "",
     templates: {
       inputValue: template,


### PR DESCRIPTION
# Fix autocomplete TypeError

## Why
A TypeError introduced by https://github.com/uktrade/tamato/pull/932, caused by attempting to remove new line characters from an undefined value, is preventing the Add new button from working when the autocomplete field is empty. 

## What
- Attempts to remove new line characters only if original value is not null
- Fixes unrelated TypeError spotted when trying to add a new form for forms without duties input

<img width="588" alt="Screenshot 2023-06-12 at 09 23 26" src="https://github.com/uktrade/tamato/assets/118175145/53018c63-de55-4aac-80f4-80f594ee7d8d">

<img width="551" alt="Screenshot 2023-06-12 at 09 26 40" src="https://github.com/uktrade/tamato/assets/118175145/54954ffa-5989-48cb-bfbd-c12eefa469fe">
