### PR TITLE
TP2000-888  Add ME40 validation to create a new measure journey

### DIFF
--- a/measures/forms.py
+++ b/measures/forms.py
@@ -1297,6 +1297,7 @@ class MeasureReviewForm(forms.Form):
             commodities_data=self.commodities_data,
             conditions_data=self.conditions_data,
         )
+        return super().clean()
 
 
 MeasureDeleteForm = delete_form_for(models.Measure)

--- a/measures/forms.py
+++ b/measures/forms.py
@@ -391,7 +391,7 @@ class MeasureConditionsFormSet(MeasureConditionsBaseFormSet):
 class MeasureConditionsWizardStepForm(MeasureConditionsFormMixin):
     # override methods that use form kwargs
     def __init__(self, *args, **kwargs):
-        self.measure_start_date = kwargs.pop("measure_start_date")
+        self.measure_start_date = kwargs.pop("measure_start_date", None)
         self.measure_type = kwargs.pop("measure_type", None)
         super().__init__(*args, **kwargs)
 

--- a/measures/forms.py
+++ b/measures/forms.py
@@ -45,6 +45,7 @@ from measures.constants import MeasureEditSteps
 from measures.models import MeasureExcludedGeographicalArea
 from measures.parsers import DutySentenceParser
 from measures.util import diff_components
+from measures.validators import validate_components_applicability
 from measures.validators import validate_conditions_formset
 from measures.validators import validate_duties
 from quotas.models import QuotaOrderNumber
@@ -391,6 +392,7 @@ class MeasureConditionsWizardStepForm(MeasureConditionsFormMixin):
     # override methods that use form kwargs
     def __init__(self, *args, **kwargs):
         self.measure_start_date = kwargs.pop("measure_start_date")
+        self.measure_type = kwargs.pop("measure_type", None)
         super().__init__(*args, **kwargs)
 
     def clean_applicable_duty(self):
@@ -402,6 +404,15 @@ class MeasureConditionsWizardStepForm(MeasureConditionsFormMixin):
         string.
         """
         applicable_duty = self.cleaned_data["applicable_duty"]
+
+        if (
+            applicable_duty
+            and self.measure_type
+            and self.measure_type.components_not_permitted
+        ):
+            raise ValidationError(
+                f"Duties cannot be added to a condition for measure type {self.measure_type}",
+            )
 
         if applicable_duty and self.measure_start_date is not None:
             try:
@@ -1123,7 +1134,8 @@ class MeasureCommodityAndDutiesForm(forms.Form):
 
     def __init__(self, *args, **kwargs):
         # remove measure_start_date from kwargs here because superclass will not be expecting it
-        self.measure_start_date = kwargs.pop("measure_start_date")
+        self.measure_start_date = kwargs.pop("measure_start_date", None)
+        self.measure_type = kwargs.pop("measure_type", None)
         super().__init__(*args, **kwargs)
 
         delete_button = (
@@ -1159,6 +1171,12 @@ class MeasureCommodityAndDutiesForm(forms.Form):
     def clean(self):
         cleaned_data = super().clean()
         duties = cleaned_data.get("duties", "")
+        if duties and self.measure_type and self.measure_type.components_not_permitted:
+            raise ValidationError(
+                {
+                    "duties": f"Duties cannot be added to a commodity for measure type {self.measure_type}",
+                },
+            )
         try:
             validate_duties(duties, self.measure_start_date)
         except ValidationError as e:
@@ -1267,7 +1285,18 @@ class MeasureUpdateFootnotesFormSet(FormSet):
 
 
 class MeasureReviewForm(forms.Form):
-    pass
+    def __init__(self, *args, **kwargs):
+        self.measure_type = kwargs.pop("measure_type", None)
+        self.commodities_data = kwargs.pop("commodities_data", None)
+        self.conditions_data = kwargs.pop("conditions_data", None)
+        super().__init__(*args, **kwargs)
+
+    def clean(self):
+        validate_components_applicability(
+            measure_type=self.measure_type,
+            commodities_data=self.commodities_data,
+            conditions_data=self.conditions_data,
+        )
 
 
 MeasureDeleteForm = delete_form_for(models.Measure)

--- a/measures/jinja2/measures/create-review.jinja
+++ b/measures/jinja2/measures/create-review.jinja
@@ -113,7 +113,7 @@
             ("Condition code", item.condition_code),
             ("Required certificate or amount", requirement(item)),
             ("Action", item.action.description),
-            ("Applicable duties", item.duty_sentence if item.duty_sentence else "-"),
+            ("Applicable duties", item.applicable_duty if item.applicable_duty else "-"),
           ]) }}
         {% endif %}
       {% endfor %}

--- a/measures/tests/test_views.py
+++ b/measures/tests/test_views.py
@@ -22,6 +22,7 @@ from common.tests.util import raises_if
 from common.tests.util import view_is_subclass
 from common.tests.util import view_urlpattern_ids
 from common.util import TaricDateRange
+from common.validators import ApplicabilityCode
 from common.validators import UpdateType
 from common.views import TamatoListView
 from common.views import TrackedModelDetailMixin
@@ -939,12 +940,15 @@ def test_measure_form_wizard_start(valid_user_client):
 def test_measure_form_wizard_finish(
     mock_duty_sentence_parser,
     valid_user_client,
-    measure_type,
     regulation,
     quota_order_number,
     duty_sentence_parser,
     erga_omnes,
 ):
+    measure_type = factories.MeasureTypeFactory.create(
+        measure_component_applicability_code=ApplicabilityCode.PERMITTED,
+        valid_between=TaricDateRange(datetime.date(2020, 1, 1), None, "[)"),
+    )
     commodity1, commodity2 = factories.GoodsNomenclatureFactory.create_batch(2)
 
     mock_duty_sentence_parser.return_value = duty_sentence_parser
@@ -1340,7 +1344,9 @@ def test_measure_create_wizard_get_form_kwargs(
     form_kwargs = wizard.get_form_kwargs(step)
 
     assert "measure_start_date" in form_kwargs["form_kwargs"]
+    assert "measure_type" in form_kwargs["form_kwargs"]
     assert form_kwargs["form_kwargs"]["measure_start_date"] == date(2021, 4, 2)
+    assert form_kwargs["form_kwargs"]["measure_type"] == measure_type
 
 
 def test_measure_form_creates_exclusions(

--- a/measures/validators.py
+++ b/measures/validators.py
@@ -215,6 +215,26 @@ def validate_conditions_formset(cleaned_data):
         raise ValidationError(errors_list)
 
 
+def validate_components_applicability(measure_type, commodities_data, conditions_data):
+    """Validate measure component and measure condition component applicability
+    for measure type according to business rule ME40."""
+
+    has_measure_components = any(data["duties"] for data in commodities_data)
+    has_condition_components = any(data["applicable_duty"] for data in conditions_data)
+
+    if measure_type.components_mandatory and not (
+        has_measure_components or has_condition_components
+    ):
+        raise ValidationError(
+            f"You must specify at least one duty on either a commodity or a condition for measure type {measure_type}",
+        )
+
+    if has_measure_components and has_condition_components:
+        raise ValidationError(
+            "A duty cannot be specified on both commodities and conditions",
+        )
+
+
 validate_reduction_indicator = NumberRangeValidator(1, 9)
 
 validate_component_sequence_number = NumberRangeValidator(1, 999)

--- a/measures/views.py
+++ b/measures/views.py
@@ -621,18 +621,33 @@ class MeasureCreateWizard(
         if step == self.COMMODITIES:
             min_commodity_count = self.get_cleaned_data_for_step(
                 self.MEASURE_DETAILS,
-            ).get(
-                "min_commodity_count",
-            )
+            ).get("min_commodity_count")
             kwargs.update({"min_commodity_count": min_commodity_count})
 
         if step == self.COMMODITIES or step == self.CONDITIONS:
+            measure_details = self.get_cleaned_data_for_step(self.MEASURE_DETAILS)
             # duty sentence validation requires the measure start date so pass it to form kwargs here
-            valid_between = self.get_cleaned_data_for_step(self.MEASURE_DETAILS).get(
-                "valid_between",
-            )
+            valid_between = measure_details.get("valid_between")
+            measure_type = measure_details.get("measure_type")
             # commodities/duties step is a formset which expects form_kwargs to pass kwargs to its child forms
-            kwargs["form_kwargs"] = {"measure_start_date": valid_between.lower}
+            kwargs["form_kwargs"] = {
+                "measure_start_date": valid_between.lower,
+                "measure_type": measure_type,
+            }
+
+        if step == self.SUMMARY:
+            measure_type = self.get_cleaned_data_for_step(self.MEASURE_DETAILS).get(
+                "measure_type",
+            )
+            kwargs.update(
+                {
+                    "measure_type": measure_type,
+                    "commodities_data": self.get_cleaned_data_for_step(
+                        self.COMMODITIES,
+                    ),
+                    "conditions_data": self.get_cleaned_data_for_step(self.CONDITIONS),
+                },
+            )
 
         return kwargs
 


### PR DESCRIPTION
# TP2000-888  Add ME40 validation to create a new measure journey

## Why
Create a new measure journey lacks validation to prevent ME40 violations.

## What
- Fixes the displaying of duties under conditions on the review page
- Commodities and conditions forms check if duties are permitted for the selected measure type
- Review form checks if mandatory duties are missing for the selected measure type
- Updates and adds tests

#
<img width="450" alt="Screenshot 2023-06-13 at 09 30 08" src="https://github.com/uktrade/tamato/assets/118175145/8071588a-5c73-493b-b66c-2b191f27c951">

<img width="450" alt="Screenshot 2023-06-13 at 09 25 33" src="https://github.com/uktrade/tamato/assets/118175145/806da3e6-a5c8-4087-93a9-9af733953294">

<img width="450" alt="Screenshot 2023-06-13 at 09 28 15" src="https://github.com/uktrade/tamato/assets/118175145/3e187159-44db-4463-880b-1b1f7a86c2a5">

