### PR TITLE
TP2000-909: Multiple quota order number origin edits

### DIFF
--- a/common/jinja2/layouts/confirm.jinja
+++ b/common/jinja2/layouts/confirm.jinja
@@ -24,8 +24,10 @@
         "classes": "govuk-button--secondary"
       }) }}
       <ul class="govuk-list govuk-list-spaced">
+        {% block actions %}
         <li><a class="govuk-link" href="{{ object.get_url() }}">View {{ object._meta.verbose_name }} {{ object|string }}</a></li>
         <li><a href="{{ object.get_url("list") }}">Find and edit {{ object._meta.verbose_name_plural }}</a></li>
+        {% endblock %}
         {% include "includes/common/main-menu-link.jinja" %}
       </ul>
     </div>

--- a/common/models/trackedmodel.py
+++ b/common/models/trackedmodel.py
@@ -647,16 +647,10 @@ class TrackedModel(PolymorphicModel):
                 elif self.update_type == UpdateType.UPDATE:
                     action += "-update"
 
-            if action == "detail":
-                url = reverse(
-                    f"{self.get_url_pattern_name_prefix()}-ui-{action}",
-                    kwargs=kwargs,
-                )
-            else:
-                url = reverse(
-                    f"{self.slugify_model_name()}-ui-{action}",
-                    kwargs=kwargs,
-                )
+            url = reverse(
+                f"{self.get_url_pattern_name_prefix()}-ui-{action}",
+                kwargs=kwargs,
+            )
             return f"{url}{self.url_suffix}"
         except NoReverseMatch:
             return None
@@ -673,9 +667,5 @@ class TrackedModel(PolymorphicModel):
         """
         prefix = getattr(cls, "url_pattern_name_prefix", None)
         if not prefix:
-            prefix = cls.slugify_model_name()
+            prefix = cls._meta.verbose_name.replace(" ", "_")
         return prefix
-
-    @classmethod
-    def slugify_model_name(cls):
-        return cls._meta.verbose_name.replace(" ", "_")

--- a/common/models/trackedmodel.py
+++ b/common/models/trackedmodel.py
@@ -647,10 +647,16 @@ class TrackedModel(PolymorphicModel):
                 elif self.update_type == UpdateType.UPDATE:
                     action += "-update"
 
-            url = reverse(
-                f"{self.get_url_pattern_name_prefix()}-ui-{action}",
-                kwargs=kwargs,
-            )
+            if action == "detail":
+                url = reverse(
+                    f"{self.get_url_pattern_name_prefix()}-ui-{action}",
+                    kwargs=kwargs,
+                )
+            else:
+                url = reverse(
+                    f"{self.slugify_model_name()}-ui-{action}",
+                    kwargs=kwargs,
+                )
             return f"{url}{self.url_suffix}"
         except NoReverseMatch:
             return None
@@ -667,5 +673,9 @@ class TrackedModel(PolymorphicModel):
         """
         prefix = getattr(cls, "url_pattern_name_prefix", None)
         if not prefix:
-            prefix = cls._meta.verbose_name.replace(" ", "_")
+            prefix = cls.slugify_model_name()
         return prefix
+
+    @classmethod
+    def slugify_model_name(cls):
+        return cls._meta.verbose_name.replace(" ", "_")

--- a/common/tests/factories.py
+++ b/common/tests/factories.py
@@ -739,7 +739,7 @@ class QuotaOrderNumberFactory(TrackedModelMixin, ValidityFactoryMixin):
     order_number = string_sequence(6, characters=string.digits)
     mechanism = 0
     category = 1
-    valid_between = date_ranges("normal")
+    valid_between = date_ranges("big_no_end")
 
     origin = factory.RelatedFactory(
         "common.tests.factories.QuotaOrderNumberOriginFactory",

--- a/common/tests/util.py
+++ b/common/tests/util.py
@@ -650,6 +650,7 @@ class Dates:
             relativedelta(years=+1, months=+2),
         ),
         "big": (relativedelta(years=-2), relativedelta(years=+2, days=+1)),
+        "big_no_end": (relativedelta(years=-2), None),
         "adjacent": (relativedelta(days=+1), relativedelta(months=+1)),
         "adjacent_earlier": (relativedelta(months=-1), relativedelta(days=-1)),
         "adjacent_later": (relativedelta(months=+1, days=+1), relativedelta(months=+2)),

--- a/geo_areas/tests/test_utils.py
+++ b/geo_areas/tests/test_utils.py
@@ -59,6 +59,9 @@ def test_get_all_members(date_ranges):
     )
 
     with override_current_transaction(origin.transaction):
-        all_geo_areas = get_all_members_of_geo_groups(origin, [country4, area_group2])
+        all_geo_areas = get_all_members_of_geo_groups(
+            origin.valid_between,
+            [country4, area_group2],
+        )
 
         assert not set(all_geo_areas).difference({country1, country2, country4})

--- a/geo_areas/utils.py
+++ b/geo_areas/utils.py
@@ -3,7 +3,7 @@ from geo_areas.models import GeographicalMembership
 from geo_areas.validators import AreaCode
 
 
-def get_all_members_of_geo_groups(instance, geo_areas):
+def get_all_members_of_geo_groups(validity, geo_areas):
     all_members = []
     for geo_area in geo_areas:
         if geo_area.area_code == AreaCode.GROUP:
@@ -12,7 +12,7 @@ def get_all_members_of_geo_groups(instance, geo_areas):
                 for member in GeographicalMembership.objects.filter(
                     geo_group=geo_area,
                 )
-                if date_ranges_overlap(member.valid_between, instance.valid_between)
+                if date_ranges_overlap(member.valid_between, validity)
             ]
             origins = set(m.member for m in valid_memberships)
             for membership in valid_memberships:

--- a/measures/forms.py
+++ b/measures/forms.py
@@ -603,7 +603,10 @@ class MeasureForm(
         if self.cleaned_data.get("exclusions"):
             exclusions = self.cleaned_data.get("exclusions")
 
-            all_exclusions = get_all_members_of_geo_groups(instance, exclusions)
+            all_exclusions = get_all_members_of_geo_groups(
+                instance.valid_between,
+                exclusions,
+            )
 
             for geo_area in all_exclusions:
                 existing_exclusion = (

--- a/quotas/forms.py
+++ b/quotas/forms.py
@@ -13,11 +13,9 @@ from django.template.loader import render_to_string
 from django.urls import reverse_lazy
 
 from common.forms import BindNestedFormMixin
-from common.forms import DateInputFieldFixed
 from common.forms import FormSet
 from common.forms import FormSetField
 from common.forms import FormSetSubmitMixin
-from common.forms import GovukDateRangeField
 from common.forms import ValidityPeriodForm
 from common.forms import delete_form_for
 from common.forms import formset_factory
@@ -112,9 +110,7 @@ QuotaOriginExclusionsFormSet = formset_factory(
 
 
 class QuotaUpdateForm(
-    FormSetSubmitMixin,
     ValidityPeriodForm,
-    BindNestedFormMixin,
     forms.ModelForm,
 ):
     CATEGORY_HELP_TEXT = "Categories are required for the TAP database but will not appear as a TARIC3 object in your workbasket"
@@ -136,90 +132,14 @@ class QuotaUpdateForm(
         error_messages={"invalid_choice": "Please select a valid category"},
     )
 
-    origin_start_date = DateInputFieldFixed(label="Start date")
-    origin_end_date = DateInputFieldFixed(
-        label="End date",
-        required=False,
-    )
-    origin_valid_between = GovukDateRangeField(required=False)
-
-    geographical_area = forms.ModelChoiceField(
-        label="Geographical area",
-        help_text="Add a geographical area",
-        queryset=GeographicalArea.objects.all(),
-    )
-
-    exclusions = FormSetField(
-        label="Geographical area exclusions",
-        nested_forms=[QuotaOriginExclusionsFormSet],
-        required=False,
-    )
-
-    existing_origin = forms.ModelChoiceField(
-        queryset=models.QuotaOrderNumberOrigin.objects.all(),
-        widget=forms.HiddenInput(),
-    )
-
-    @property
-    def origin(self):
-        return (
-            self.instance.quotaordernumberorigin_set.current()
-            .filter(order_number=self.instance)
-            .first()
-        )
-
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.init_fields()
         self.set_initial_data(*args, **kwargs)
         self.init_layout()
 
-    def clean(self):
-        cleaned_data = super().clean()
-        self.clean_validity_period(
-            cleaned_data,
-            valid_between_field_name="origin_valid_between",
-            start_date_field_name="origin_start_date",
-            end_date_field_name="origin_end_date",
-        )
-        return cleaned_data
-
     def set_initial_data(self, *args, **kwargs):
         self.fields["category"].initial = self.instance.category
-        self.fields["existing_origin"].initial = self.origin
-        self.fields["origin_start_date"].initial = self.origin.valid_between.lower
-        self.fields["origin_end_date"].initial = self.origin.valid_between.upper
-        self.fields["geographical_area"].initial = self.origin.geographical_area
-        nested_forms_initial = {**self.initial}
-        nested_forms_initial["geographical_area"] = self.origin.geographical_area
-        nested_forms_initial.update(self.get_geo_area_initial())
-        kwargs.pop("initial")
-        self.bind_nested_forms(*args, initial=nested_forms_initial, **kwargs)
-
-    def get_geo_area_initial(self):
-        field_name = "exclusion"
-        initial = {}
-        initial_exclusions = []
-        if hasattr(self, "instance"):
-            initial_exclusions = [
-                {field_name: exclusion.excluded_geographical_area}
-                for exclusion in self.origin.quotaordernumberoriginexclusion_set.current()
-            ]
-        # if we just submitted the form, add the new data to initial
-        if self.formset_submitted or self.whole_form_submit:
-            new_data = unprefix_formset_data(
-                QUOTA_ORIGIN_EXCLUSIONS_FORMSET_PREFIX,
-                self.data.copy(),
-            )
-            for g in new_data:
-                if g[field_name]:
-                    id = int(g[field_name])
-                    g[field_name] = GeographicalArea.objects.get(id=id)
-            initial_exclusions = new_data
-
-        initial[QUOTA_ORIGIN_EXCLUSIONS_FORMSET_PREFIX] = initial_exclusions
-
-        return initial
 
     def init_fields(self):
         if self.instance.category == validators.QuotaCategory.SAFEGUARD:
@@ -233,15 +153,6 @@ class QuotaUpdateForm(
             self.fields["category"].help_text = self.CATEGORY_HELP_TEXT
 
         self.fields["start_date"].help_text = self.START_DATE_HELP_TEXT
-        self.fields["geographical_area"].queryset = (
-            GeographicalArea.objects.current()
-            .with_latest_description()
-            .as_at_today()
-            .order_by("description")
-        )
-        self.fields[
-            "geographical_area"
-        ].label_from_instance = lambda obj: f"{obj.area_id} - {obj.description}"
 
     def init_layout(self):
         self.helper = FormHelper(self)
@@ -255,35 +166,6 @@ class QuotaUpdateForm(
             },
         )
 
-        if len(self.instance.quotaordernumberorigin_set.current()) > 1:
-            origin_fields = [
-                "Quota origins",
-                Div(
-                    HTML(origins_html),
-                ),
-            ]
-        else:
-            origin_fields = [
-                "Quota origin",
-                Div(
-                    "existing_origin",
-                    Div(
-                        "origin_start_date",
-                        "origin_end_date",
-                        css_class="govuk-grid-column-one-half",
-                    ),
-                    Div(
-                        "geographical_area",
-                        css_class="govuk-grid-column-one-half",
-                    ),
-                    Div(
-                        "exclusions",
-                        css_class="govuk-grid-column-full",
-                    ),
-                    css_class="govuk-grid-row",
-                ),
-            ]
-
         self.helper.layout = Layout(
             Div(
                 Accordion(
@@ -296,7 +178,12 @@ class QuotaUpdateForm(
                         "Category",
                         "category",
                     ),
-                    AccordionSection(*origin_fields),
+                    AccordionSection(
+                        "Quota origins",
+                        Div(
+                            HTML(origins_html),
+                        ),
+                    ),
                     css_class="govuk-grid-column-two-thirds",
                 ),
                 css_class="govuk-grid-row",
@@ -383,6 +270,7 @@ class QuotaOrderNumberOriginUpdateForm(
                 "end_date",
                 "geographical_area",
                 "exclusions",
+                css_class="govuk-!-width-two-thirds",
             ),
             Submit(
                 "submit",

--- a/quotas/jinja2/includes/quotas/quota-edit-origins.jinja
+++ b/quotas/jinja2/includes/quotas/quota-edit-origins.jinja
@@ -1,0 +1,12 @@
+{% from "quota-origins/macros/origin_display.jinja" import origin_display %}
+
+<div class="govuk-grid-row">
+  {% for origin in object.quotaordernumberorigin_set.current() %}
+  <div class="govuk-grid-column-three-quarters">
+    {{ origin_display(origin) }}
+  </div>
+  <div class="govuk-grid-column-one-quarter">
+    <a class="govuk-link" href="{{ url('quota_order_number_origin-ui-edit', args=[origin.sid]) }}">Edit this origin</a>
+  </div>
+  {% endfor %}
+</div>

--- a/quotas/jinja2/includes/quotas/tabs/core_data.jinja
+++ b/quotas/jinja2/includes/quotas/tabs/core_data.jinja
@@ -1,56 +1,8 @@
-{% from "components/details/macro.njk" import govukDetails %}
-
-{% set exclusions %}
-    {% for exclusion in object.geographical_exclusions %}
-        <a href="{{ url('geo_area-ui-detail', args=[exclusion.sid]) }}" class="govuk-link">{{ exclusion.area_id }} - {{ exclusion.get_description().description }}</a>
-        {% if not loop.last %}, {% endif %}
-    {% endfor %}
-{% endset %}
+{% from "quota-origins/macros/origin_display.jinja" import origin_display %}
 
 {% set origins %}
     {% for origin in object.quotaordernumberorigin_set.current() %}
-        {% set geo_area_name -%}
-            {{ origin.geographical_area.area_id  ~ " - " ~ origin.geographical_area.get_description().description }}
-        {% endset %}
-        {% set geo_area_summary -%}
-            {{ geo_area_name }}
-            {% if object.geographical_exclusions %} (with exclusions){% endif %}
-        {% endset %}
-        {% set origin_link -%}
-            <a href="{{ url('geo_area-ui-detail', args=[origin.geographical_area.sid]) }}" class="govuk-link">{{ geo_area_name }}</a>
-        {% endset %}
-        {% set end_date -%}
-        {{"{:%d %b %Y}".format(object.valid_between.upper) if object.valid_between.upper else "—"}}
-        {% endset %}
-        {% set validity -%}
-        {{"{:%d %b %Y}".format(object.valid_between.lower) ~ " " ~ end_date }}
-        {% endset %}
-        {% set summary_list %}
-            {{ govukSummaryList({
-                "rows": [
-                    {
-                        "key": {"text": "Geographical area"},
-                        "value": {"text": origin_link},
-                        "actions": {"items": []},
-                    },
-                    {
-                        "key": {"text": "Geographical area exclusions"},
-                        "value": {"text": exclusions if object.geographical_exclusions else "-"},
-                        "actions": {"items": []},
-                    },
-                    {
-                        "key": {"text": "Validity"},
-                        "value": {"text": validity},
-                        "actions": {"items": []},
-                    },
-                ]
-            })
-            }}
-        {% endset %}
-        {{ govukDetails({
-            "summaryText": geo_area_summary,
-            "html": summary_list
-            }) }}
+        {{ origin_display(origin) }}
     {% endfor %}
 {% endset %}
 

--- a/quotas/jinja2/quota-origins/confirm-update.jinja
+++ b/quotas/jinja2/quota-origins/confirm-update.jinja
@@ -1,0 +1,20 @@
+{% extends "common/confirm_update.jinja" %}
+{% from "components/breadcrumbs.jinja" import breadcrumbs %}
+
+{% set page_title = "Edit quota order number origin details" %}
+
+{% block breadcrumb %}
+  {{ breadcrumbs(request, [
+      {"text": "Find and edit quotas", "href": url("quota-ui-list")},
+      {"text": object.order_number._meta.verbose_name|capitalize ~ ": " ~ object.order_number|string, "href": object.order_number.get_url()},
+      {"text": "Edit quota details", "href": object.order_number.get_url("edit")},
+      {"text": page_title}
+    ])
+  }}
+{% endblock %}
+
+
+{% block actions %}
+<li><a class="govuk-link" href="{{ object.order_number.get_url() }}">View this origin's quota order number</a></li>
+<li><a href="{{ object.order_number.get_url('list') }}">Find and edit quotas</a></li>
+{% endblock %}

--- a/quotas/jinja2/quota-origins/edit.jinja
+++ b/quotas/jinja2/quota-origins/edit.jinja
@@ -1,0 +1,11 @@
+{% extends "common/edit.jinja" %}
+
+{% block breadcrumb %}
+  {{ breadcrumbs(request, [
+      {"text": "Find and edit quotas", "href": url("quota-ui-list")},
+      {"text": object.order_number._meta.verbose_name|capitalize ~ ": " ~ object.order_number|string, "href": object.order_number.get_url()},
+      {"text": "Edit quota details", "href": object.order_number.get_url("edit")},
+      {"text": page_title}
+    ])
+  }}
+{% endblock %}

--- a/quotas/jinja2/quota-origins/macros/origin_display.jinja
+++ b/quotas/jinja2/quota-origins/macros/origin_display.jinja
@@ -1,0 +1,53 @@
+{% from "components/details/macro.njk" import govukDetails %}
+{% from "components/summary-list/macro.njk" import govukSummaryList %}
+
+{% macro origin_display(object) -%}
+    {% set exclusions %}
+        {% for exclusion in object.quotaordernumberoriginexclusion_set.current() %}
+            <a href="{{ url('geo_area-ui-detail', args=[exclusion.excluded_geographical_area.sid]) }}" class="govuk-link">{{ exclusion.excluded_geographical_area.area_id }} - {{ exclusion.excluded_geographical_area.get_description().description }}</a>
+            {% if not loop.last %}, {% endif %}
+        {% endfor %}
+    {% endset %}
+  {% set geo_area_name -%}
+      {{ object.geographical_area.area_id  ~ " - " ~ object.geographical_area.get_description().description }}
+  {% endset %}
+  {% set geo_area_summary -%}
+      {{ geo_area_name }}
+      {% if object.geographical_exclusions %} (with exclusions){% endif %}
+  {% endset %}
+  {% set origin_link -%}
+      <a href="{{ url('geo_area-ui-detail', args=[object.geographical_area.sid]) }}" class="govuk-link">{{ geo_area_name }}</a>
+  {% endset %}
+  {% set end_date -%}
+  {{" - {:%d %b %Y}".format(object.valid_between.upper) if object.valid_between.upper else " —"}}
+  {% endset %}
+  {% set validity -%}
+  {{"{:%d %b %Y}".format(object.valid_between.lower) ~ end_date }}
+  {% endset %}
+  {% set summary_list %}
+      {{ govukSummaryList({
+          "rows": [
+              {
+                  "key": {"text": "Geographical area"},
+                  "value": {"text": origin_link},
+                  "actions": {"items": []},
+              },
+              {
+                  "key": {"text": "Geographical area exclusions"},
+                  "value": {"text": exclusions if object.quotaordernumberoriginexclusion_set.current() else "-"},
+                  "actions": {"items": []},
+              },
+              {
+                  "key": {"text": "Validity"},
+                  "value": {"text": validity},
+                  "actions": {"items": []},
+              },
+          ]
+      })
+      }}
+  {% endset %}
+  {{ govukDetails({
+      "summaryText": geo_area_summary,
+      "html": summary_list
+      }) }}
+{% endmacro %}

--- a/quotas/models.py
+++ b/quotas/models.py
@@ -126,7 +126,7 @@ class QuotaOrderNumber(TrackedModel, ValidityMixin):
         verbose_name = "quota"
 
 
-class QuotaOrderNumberOrigin(GetTabURLMixin, TrackedModel, ValidityMixin):
+class QuotaOrderNumberOrigin(TrackedModel, ValidityMixin):
     """The order number origin defines a quota as being available only to
     imports from a specific origin, usually a country or group of countries."""
 

--- a/quotas/tests/test_views.py
+++ b/quotas/tests/test_views.py
@@ -694,9 +694,7 @@ def test_quota_edit_origin_exclusions(
 
     tx = Transaction.objects.last()
 
-    origin = models.QuotaOrderNumberOrigin.objects.approved_up_to_transaction(
-        tx,
-    ).get(
+    origin = models.QuotaOrderNumberOrigin.objects.approved_up_to_transaction(tx).get(
         sid=origin.sid,
     )
 

--- a/quotas/tests/test_views.py
+++ b/quotas/tests/test_views.py
@@ -665,29 +665,28 @@ def test_quota_edit_origin_exclusions(
     country1,
     country2,
     country3,
+    date_ranges,
 ):
     """Checks that members of geo groups are added individually as
     exclusions."""
-    quota = factories.QuotaOrderNumberFactory.create(transaction=approved_transaction)
+    quota = factories.QuotaOrderNumberFactory.create(
+        valid_between=date_ranges.no_end,
+        transaction=approved_transaction,
+    )
 
     origin = models.QuotaOrderNumberOrigin.objects.last()
 
     form_data = {
-        "category": validators.QuotaCategory.AUTONOMOUS.value,
-        "start_date_0": 1,
-        "start_date_1": 1,
-        "start_date_2": 2000,
-        "existing_origin": origin.id,
-        "origin_start_date_0": 1,
-        "origin_start_date_1": 1,
-        "origin_start_date_2": 2000,
+        "start_date_0": origin.valid_between.lower.day,
+        "start_date_1": origin.valid_between.lower.month,
+        "start_date_2": origin.valid_between.lower.year,
         "geographical_area": geo_group1.id,
         "quota-origin-exclusions-formset-__prefix__-exclusion": geo_group2.id,
         "submit": "Save",
     }
 
     response = valid_user_client.post(
-        reverse("quota-ui-edit", kwargs={"sid": quota.sid}),
+        reverse("quota_order_number_origin-ui-edit", kwargs={"sid": origin.sid}),
         form_data,
     )
 
@@ -695,13 +694,10 @@ def test_quota_edit_origin_exclusions(
 
     tx = Transaction.objects.last()
 
-    quota = models.QuotaOrderNumber.objects.approved_up_to_transaction(tx).get(
-        sid=quota.sid,
-    )
-    origins = models.QuotaOrderNumberOrigin.objects.approved_up_to_transaction(
+    origin = models.QuotaOrderNumberOrigin.objects.approved_up_to_transaction(
         tx,
-    ).filter(
-        order_number=quota,
+    ).get(
+        sid=origin.sid,
     )
 
     # geo_group1 contains country1, country2, country3
@@ -710,13 +706,13 @@ def test_quota_edit_origin_exclusions(
     # we're excluding geo_group2 from geo_group1
     # geo_group2 has 2 members
     # so we should have 2 exclusions
-    assert origins.first().excluded_areas.all().count() == 2
+    assert origin.excluded_areas.all().count() == 2
 
     # if we exclude geo_group2
     # we exclude country1 and country2
-    assert country1 in origins.first().excluded_areas.all()
-    assert country2 in origins.first().excluded_areas.all()
-    assert country3 not in origins.first().excluded_areas.all()
+    assert country1 in origin.excluded_areas.all()
+    assert country2 in origin.excluded_areas.all()
+    assert country3 not in origin.excluded_areas.all()
 
 
 def test_quota_edit_origin_exclusions_remove(
@@ -724,12 +720,14 @@ def test_quota_edit_origin_exclusions_remove(
     approved_transaction,
     geo_group1,
     country1,
+    date_ranges,
 ):
     """Checks that exclusions are removed from a quota origin."""
 
     origin = factories.QuotaOrderNumberOriginFactory.create(
         transaction=approved_transaction,
         geographical_area=geo_group1,
+        valid_between=date_ranges.normal,
     )
     factories.QuotaOrderNumberOriginExclusionFactory.create(
         transaction=approved_transaction,
@@ -739,21 +737,16 @@ def test_quota_edit_origin_exclusions_remove(
     quota = models.QuotaOrderNumber.objects.last()
 
     form_data = {
-        "category": validators.QuotaCategory.AUTONOMOUS.value,
-        "start_date_0": 1,
-        "start_date_1": 1,
-        "start_date_2": 2000,
-        "existing_origin": origin.id,
-        "origin_start_date_0": 1,
-        "origin_start_date_1": 1,
-        "origin_start_date_2": 2000,
+        "start_date_0": origin.valid_between.lower.day,
+        "start_date_1": origin.valid_between.lower.month,
+        "start_date_2": origin.valid_between.lower.year,
         "geographical_area": geo_group1.id,
         "quota-origin-exclusions-formset-__prefix__-exclusion": "",
         "submit": "Save",
     }
 
     response = valid_user_client.post(
-        reverse("quota-ui-edit", kwargs={"sid": quota.sid}),
+        reverse("quota_order_number_origin-ui-edit", kwargs={"sid": origin.sid}),
         form_data,
     )
 
@@ -764,17 +757,20 @@ def test_quota_edit_origin_exclusions_remove(
     updated_quota = models.QuotaOrderNumber.objects.approved_up_to_transaction(tx).get(
         sid=quota.sid,
     )
-    updated_origins = (
+    updated_origin = (
         updated_quota.quotaordernumberorigin_set.approved_up_to_transaction(tx)
-    )
+    ).first()
 
     assert (
-        updated_origins.first()
-        .quotaordernumberoriginexclusion_set.approved_up_to_transaction(tx)
-        .count()
+        updated_origin.quotaordernumberoriginexclusion_set.approved_up_to_transaction(
+            tx,
+        ).count()
         == 0
     )
 
-    assert country1 not in updated_origins.first().quotaordernumberoriginexclusion_set.approved_up_to_transaction(
-        tx,
+    assert (
+        country1
+        not in updated_origin.quotaordernumberoriginexclusion_set.approved_up_to_transaction(
+            tx,
+        )
     )

--- a/quotas/urls.py
+++ b/quotas/urls.py
@@ -49,5 +49,20 @@ urlpatterns = [
         views.QuotaDefinitionList.as_view(),
         name="quota-definitions",
     ),
+    path(
+        f"quota_order_number_origins/<sid>/edit/",
+        views.QuotaOrderNumberOriginUpdate.as_view(),
+        name="quota_order_number_origin-ui-edit",
+    ),
+    path(
+        f"quota_order_number_origins/<sid>/edit/",
+        views.QuotaOrderNumberOriginUpdate.as_view(),
+        name="quota_order_number_origin-ui-edit-update",
+    ),
+    path(
+        f"quota_order_number_origins/<sid>/confirm-update/",
+        views.QuotaOrderNumberOriginConfirmUpdate.as_view(),
+        name="quota_order_number_origin-ui-confirm-update",
+    ),
     path("api/", include(api_router.urls)),
 ]


### PR DESCRIPTION
# TP2000-909: Multiple quota order number origin edits
<!---
 * Include the JIRA ticket number, eg TP-123, to automatically link.
 * Use 50 characters maximum.
 * Do not end with a full-stop.
--->

## Why
<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Use as many lines as you like.
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions or deliberately ignored edge-cases.
--->
* Users need to be able to edit multiple quota origins to support upcoming tariff changes

## What
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Explain like I'm 5.
 * Use pictures if you can.
--->
* Uses the single origin edit form added previously
* On the quota order number edit form page, multiple origins are listed with links to their own separate edit forms where these can be edited individually

<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
## Checklist
- Requires migrations?
- Requires dependency updates?
--->

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->

<img width="830" alt="Screenshot 2023-06-13 at 11 57 06" src="https://github.com/uktrade/tamato/assets/25905279/c6e29092-ffbe-45f2-baa4-57180c2546ba">
<img width="975" alt="Screenshot 2023-06-13 at 11 57 40" src="https://github.com/uktrade/tamato/assets/25905279/58229fbe-fbf8-4110-b30d-b255dd6537af">
<img width="955" alt="Screenshot 2023-06-13 at 11 58 01" src="https://github.com/uktrade/tamato/assets/25905279/3b638e81-4093-4dd6-a34f-bb85ebec01c8">
