### PR TITLE
TP2000-514 Add commodity links in find and edit, review measures views

### DIFF
--- a/measures/jinja2/includes/measures/list.jinja
+++ b/measures/jinja2/includes/measures/list.jinja
@@ -57,7 +57,7 @@
                 {"html": checkbox},
                 {"html": measure_link},
                 {"text": measure.measure_type.sid ~ " - " ~ measure.measure_type.description},
-                {"text": measure.goods_nomenclature.item_id|wordwrap(2)|replace("\n", " ") if measure.goods_nomenclature else '-', "classes": "govuk-!-width-one-eighth"},
+                {"text": create_link(url("commodity-ui-detail", kwargs={"sid": measure.goods_nomenclature.sid}), measure.goods_nomenclature.item_id) if measure.goods_nomenclature else '-', "classes": "govuk-!-width-one-eighth"},
                 {"text": "{:%d %b %Y}".format(measure.effective_valid_between.lower) if measure.effective_valid_between.lower else '-' },
                 {"text": "{:%d %b %Y}".format(measure.effective_valid_between.upper) if measure.effective_valid_between.upper else '-' },
                 {"text": measure.duty_sentence if measure.duty_sentence else '-'},

--- a/measures/jinja2/includes/measures/tabs/core_data.jinja
+++ b/measures/jinja2/includes/measures/tabs/core_data.jinja
@@ -1,4 +1,5 @@
 {%- extends "includes/common/tabs/core_data.jinja" -%}
+{% from "macros/create_link.jinja" import create_link %}
 
 {% set geographical_exclusions %}
 {% if object.exclusions.current() %}
@@ -28,7 +29,7 @@
         },
         {
             "key": {"text": "Commodity code"},
-            "value": {"text": object.goods_nomenclature.item_id if object.goods_nomenclature else "-"},
+            "value": {"text": create_link(url("commodity-ui-detail", kwargs={"sid": object.goods_nomenclature.sid}), object.goods_nomenclature.item_id) if object.goods_nomenclature else "-"},
             "actions": {"items": []}
         },
         {

--- a/measures/jinja2/includes/measures/workbasket-measures.jinja
+++ b/measures/jinja2/includes/measures/workbasket-measures.jinja
@@ -14,7 +14,7 @@
   {{ table_rows.append([
     {"html": measure_link},
     {"text": measure.measure_type.sid ~ " - " ~ measure.measure_type.description},
-    {"text": measure.goods_nomenclature.item_id|wordwrap(2)|replace("\n", " ") if measure.goods_nomenclature else '-', "classes": "govuk-!-width-one-eighth"},
+    {"text": create_link(url("commodity-ui-detail", kwargs={"sid": measure.goods_nomenclature.sid}), measure.goods_nomenclature.item_id) if measure.goods_nomenclature else '-', "classes": "govuk-!-width-one-eighth"},
     {"text": measure.duty_sentence if measure.duty_sentence else '-'},
     {"text": "{:%d %b %Y}".format(measure.valid_between.lower) },
     {"text": "{:%d %b %Y}".format(measure.effective_end_date) if measure.effective_end_date else "-" },

--- a/workbaskets/tests/test_views.py
+++ b/workbaskets/tests/test_views.py
@@ -400,12 +400,18 @@ def test_workbasket_measures_review(valid_user_client):
     assert table_measure_sids == measure_sids
     assert set(measure_sids).difference(non_workbasket_measures_sids)
 
+    # 3rd column is commodity
+    table_commodity_links = {e.a for e in soup.select("table tr td:nth-child(3)")}
+    for link in table_commodity_links:
+        assert link["class"][0] == "govuk-link" and "/commodities/" in link["href"]
+
     # 5th column is start date
     table_start_dates = {e.text for e in soup.select("table tr td:nth-child(5)")}
     measure_start_dates = {
         f"{m.valid_between.lower:%d %b %Y}" for m in workbasket_measures
     }
     assert not measure_start_dates.difference(table_start_dates)
+
     # 6th column is end date
     table_end_dates = {e.text for e in soup.select("table tr td:nth-child(6)")}
     measure_end_dates = {


### PR DESCRIPTION
# TP2000-514 Add commodity links in find and edit, review measures views


## Why
To provide a richer data experience to users, links could be added to commodity codes on the following: find and edit measures view, workbasket measure review view and measure details view.

## What
- Hyperlinks commodities to their respective commodity detail view on the above views

##
Find and edit measures search results view:
<img width="450" alt="Screenshot 2023-06-13 at 14 32 36" src="https://github.com/uktrade/tamato/assets/118175145/50117a8c-387c-4607-befd-f38e3ae763d1">

Workbasket review measures view:
<img width="450" alt="Screenshot 2023-06-13 at 14 32 11" src="https://github.com/uktrade/tamato/assets/118175145/0f254cd8-d32d-4406-bc47-950d5152c1ab">

Measure details view:
<img width="300" alt="Screenshot 2023-06-13 at 14 32 54" src="https://github.com/uktrade/tamato/assets/118175145/52a54ac9-4d4a-4dac-9dd8-9d99d5cb3211">

