### PR TITLE
TP2000-911: (Another) footnotes display fix

### DIFF
--- a/common/jinja2/macros/footnotes_display.jinja
+++ b/common/jinja2/macros/footnotes_display.jinja
@@ -1,0 +1,9 @@
+{% from 'macros/create_link.jinja' import create_link %}
+
+{% macro footnotes_display(footnotes) -%}
+{% if footnotes %}
+  {% for association in footnotes %}
+      {{ create_link(association.associated_footnote.get_url(), association.associated_footnote|string) }}{{ ", " if not loop.last else "" }}
+  {% endfor %}
+{% else %}-{% endif %}
+{% endmacro %}

--- a/measures/jinja2/includes/measures/list.jinja
+++ b/measures/jinja2/includes/measures/list.jinja
@@ -1,4 +1,5 @@
-{% from 'macros/create_link.jinja' import create_link %} 
+{% from 'macros/create_link.jinja' import create_link %}
+{% from 'macros/footnotes_display.jinja' import footnotes_display %}
 {% from "includes/measures/conditions.jinja" import conditions_list %}
 {% from "components/button/macro.njk" import govukButton %}
 {% from "components/warning-text/macro.njk" import govukWarningText %}
@@ -48,11 +49,6 @@
             {% set measure_link -%}
               <a class="govuk-link govuk-!-font-weight-bold" href="{{ measure.get_url() }}">{{measure.sid}}</a>
             {%- endset %}
-            {% set footnotes %}
-              {% for footnote in measure.footnoteassociationmeasure_set.current() %}
-                  {{ create_link(footnote.get_url(), footnote|string) }}{{ ", " if not loop.last else "" }}
-              {% endfor %}
-            {% endset %}
               {{ table_rows.append([
                 {"html": checkbox},
                 {"html": measure_link},
@@ -64,7 +60,7 @@
                 {"html": create_link(url("additional_code-ui-detail", kwargs={"sid": measure.additional_code.sid}), measure.additional_code.type.sid ~ measure.additional_code.code) if measure.additional_code else '-'},
                 {"html": create_link(url("geo_area-ui-detail", kwargs={"sid": measure.geographical_area.sid}), measure.geographical_area.area_id ~ " - " ~ measure.geographical_area.get_description().description) if measure.geographical_area else '-'},
                 {"text": create_link(measure.order_number.get_url(), measure.order_number.order_number) if measure.order_number else '-'},
-                {"text": footnotes if measure.footnoteassociationmeasure_set.current() else '-'},
+                {"text": footnotes_display(measure.footnoteassociationmeasure_set.current())},
                 {"text": conditions_list(measure) if measure.conditions.latest_approved() else "-", "classes": "govuk-!-width-one-quarter"},
               ]) or "" }} 
           {% endfor %}

--- a/measures/jinja2/includes/measures/workbasket-measures.jinja
+++ b/measures/jinja2/includes/measures/workbasket-measures.jinja
@@ -1,4 +1,5 @@
-{% from 'macros/create_link.jinja' import create_link %} 
+{% from 'macros/create_link.jinja' import create_link %}
+{% from 'macros/footnotes_display.jinja' import footnotes_display %}
 {% from "includes/measures/conditions.jinja" import conditions_list %}
 
 {% set table_rows = [] %}
@@ -6,11 +7,6 @@
   {% set measure_link -%}
     <a class="govuk-link govuk-!-font-weight-bold" href="{{ measure.get_url() }}">{{measure.sid}}</a>
   {%- endset %}
-  {% set footnotes %}
-    {% for footnote in measure.footnoteassociationmeasure_set.current() %}
-        {{ create_link(footnote.get_url(), footnote|string) }}{{ ", " if not loop.last else "" }}
-    {% endfor %}
-  {% endset %}
   {{ table_rows.append([
     {"html": measure_link},
     {"text": measure.measure_type.sid ~ " - " ~ measure.measure_type.description},
@@ -21,7 +17,7 @@
     {"html": create_link(url("additional_code-ui-detail", kwargs={"sid": measure.additional_code.sid}), measure.additional_code.type.sid ~ measure.additional_code.code) if measure.additional_code else '-'},
     {"html": create_link(url("geo_area-ui-detail", kwargs={"sid": measure.geographical_area.sid}), measure.geographical_area.area_id ~ " - " ~ measure.geographical_area.get_description().description) if measure.geographical_area else '-'},
     {"text": create_link(measure.order_number.get_url(), measure.order_number.order_number) if measure.order_number else '-'},
-    {"text": footnotes if measure.footnoteassociationmeasure_set.current() else '-'},
+    {"text": footnotes_display(measure.footnoteassociationmeasure_set.current())},
     {"text": conditions_list(measure) if measure.conditions.current() else "-"},
   ]) or "" }}
 {% endfor %}

--- a/measures/jinja2/measures/delete-multiple-measures.jinja
+++ b/measures/jinja2/measures/delete-multiple-measures.jinja
@@ -5,7 +5,8 @@
 {% from "components/inset-text/macro.njk" import govukInsetText %}
 {% from "components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
 
-{% from 'macros/create_link.jinja' import create_link %} 
+{% from 'macros/create_link.jinja' import create_link %}
+{% from 'macros/footnotes_display.jinja' import footnotes_display %}
 {% from "includes/measures/conditions.jinja" import conditions_list %}
 {% from "components/table/macro.njk" import govukTable %}
 
@@ -92,11 +93,6 @@
                 {% set measure_link -%}
                   <a class="govuk-link govuk-!-font-weight-bold" href="{{ measure.get_url() }}">{{measure.sid}}</a>
                 {%- endset %}
-                {% set footnotes %}
-                  {% for footnote in measure.footnoteassociationmeasure_set.current() %}
-                      {{ create_link(footnote.get_url(), footnote|string) }}{{ ", " if not loop.last else "" }}
-                  {% endfor %}
-                {% endset %}
                 {{ table_rows.append([
                   {"html": measure_link},
                   {"text": measure.measure_type.sid ~ " - " ~ measure.measure_type.description},
@@ -107,7 +103,7 @@
                   {"html": create_link(url("additional_code-ui-detail", kwargs={"sid": measure.additional_code.sid}), measure.additional_code.type.sid ~ measure.additional_code.code) if measure.additional_code else '-'},
                   {"html": create_link(url("geo_area-ui-detail", kwargs={"sid": measure.geographical_area.sid}), measure.geographical_area.area_id ~ " - " ~ measure.geographical_area.get_description().description) if measure.geographical_area else '-'},
                   {"text": create_link(measure.order_number.get_url(), measure.order_number.order_number) if measure.order_number else '-'},
-                  {"text": footnotes if measure.footnoteassociationmeasure_set.current() else '-'},
+                  {"text": footnotes_display(measure.footnoteassociationmeasure_set.current())},
                 ]) or "" }}
             {% endfor %}
             {{ govukTable({

--- a/measures/jinja2/measures/edit-multiple-measures-enddates.jinja
+++ b/measures/jinja2/measures/edit-multiple-measures-enddates.jinja
@@ -5,7 +5,8 @@
 {% from "components/inset-text/macro.njk" import govukInsetText %}
 {% from "components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
 
-{% from 'macros/create_link.jinja' import create_link %} 
+{% from 'macros/create_link.jinja' import create_link %}
+{% from 'macros/footnotes_display.jinja' import footnotes_display %}
 {% from "includes/measures/conditions.jinja" import conditions_list %}
 {% from "components/table/macro.njk" import govukTable %}
 
@@ -72,11 +73,6 @@
                 {% set measure_link -%}
                   <a class="govuk-link govuk-!-font-weight-bold" href="{{ measure.get_url() }}">{{measure.sid}}</a>
                 {%- endset %}
-                {% set footnotes %}
-                  {% for footnote in measure.footnoteassociationmeasure_set.current() %}
-                      {{ create_link(footnote.get_url(), footnote|string) }}{{ ", " if not loop.last else "" }}
-                  {% endfor %}
-                {% endset %}
                 {{ table_rows.append([
                   {"html": measure_link},
                   {"text": measure.measure_type.sid ~ " - " ~ measure.measure_type.description},
@@ -87,7 +83,7 @@
                   {"html": create_link(url("additional_code-ui-detail", kwargs={"sid": measure.additional_code.sid}), measure.additional_code.type.sid ~ measure.additional_code.code) if measure.additional_code else '-'},
                   {"html": create_link(url("geo_area-ui-detail", kwargs={"sid": measure.geographical_area.sid}), measure.geographical_area.area_id ~ " - " ~ measure.geographical_area.get_description().description) if measure.geographical_area else '-'},
                   {"text": create_link(measure.order_number.get_url(), measure.order_number.order_number) if measure.order_number else '-'},
-                  {"text": footnotes if measure.footnoteassociationmeasure_set.current() else '-'},
+                  {"text": footnotes_display(measure.footnoteassociationmeasure_set.current())},
                 ]) or "" }}
             {% endfor %}
             {{ govukTable({

--- a/measures/jinja2/measures/edit-multiple-start.jinja
+++ b/measures/jinja2/measures/edit-multiple-start.jinja
@@ -1,6 +1,7 @@
 
 {% extends "layouts/form.jinja" %}
 {% from 'macros/create_link.jinja' import create_link %}
+{% from 'macros/footnotes_display.jinja' import footnotes_display %}
 {% from "components/warning-text/macro.njk" import govukWarningText %}
 {% from "components/table/macro.njk" import govukTable %}
 
@@ -46,11 +47,6 @@
                 {% set measure_link -%}
                   <a class="govuk-link govuk-!-font-weight-bold" href="{{ measure.get_url() }}">{{measure.sid}}</a>
                 {%- endset %}
-                {% set footnotes %}
-                  {% for footnote in measure.footnoteassociationmeasure_set.current() %}
-                      {{ create_link(footnote.get_url(), footnote|string) }}{{ ", " if not loop.last else "" }}
-                  {% endfor %}
-                {% endset %}
                 {{ table_rows.append([
                   {"html": measure_link},
                   {"text": measure.measure_type.sid ~ " - " ~ measure.measure_type.description},
@@ -61,7 +57,7 @@
                   {"html": create_link(url("additional_code-ui-detail", kwargs={"sid": measure.additional_code.sid}), measure.additional_code.type.sid ~ measure.additional_code.code) if measure.additional_code else '-'},
                   {"html": create_link(url("geo_area-ui-detail", kwargs={"sid": measure.geographical_area.sid}), measure.geographical_area.area_id ~ " - " ~ measure.geographical_area.get_description().description) if measure.geographical_area else '-'},
                   {"text": create_link(measure.order_number.get_url(), measure.order_number.order_number) if measure.order_number else '-'},
-                  {"text": footnotes if measure.footnoteassociationmeasure_set.current() else '-'},
+                  {"text": footnotes_display(measure.footnoteassociationmeasure_set.current())},
                 ]) or "" }}
             {% endfor %}
             {{ govukTable({


### PR DESCRIPTION
# TP2000-911: (Another) footnotes display fix
<!---
 * Include the JIRA ticket number, eg TP-123, to automatically link.
 * Use 50 characters maximum.
 * Do not end with a full-stop.
--->

## Why
<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Use as many lines as you like.
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions or deliberately ignored edge-cases.
--->
* Some footnote display was wonky because we were using the footnote association object and not the footnote itself

## What
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Explain like I'm 5.
 * Use pictures if you can.
--->
* Uses association.associated_footnote to get the correct display for footnotes
* Also creates a reusable macro for this

<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
## Checklist
- Requires migrations?
- Requires dependency updates?
--->

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
