### PR TITLE
TP2000-915 Redirect imports with completed status to workbasket

### DIFF
--- a/importer/jinja2/includes/taric_importer_list.jinja
+++ b/importer/jinja2/includes/taric_importer_list.jinja
@@ -6,10 +6,12 @@
   {%- endset -%}
 
   {%- set object_link -%}
-    <a
-      class="govuk-link"
-      href="{{ url('commodity_importer-ui-detail-url-resolver', kwargs={'pk': object.pk}) }}"
-    >Resume</a>
+  <form action="{{ url("workbaskets:workbasket-ui-list") }}" method="post">
+    <input type="hidden" name="csrfmiddlewaretoken" value="{{ csrf_token }}">
+    <input type="hidden" name="workbasket" value="{{ object.workbasket.pk }}">
+    <input type="hidden" name="workbasket-tab" value="review-goods">
+    <input type="submit" class="button-link" name="submit" value="Edit/View workbasket">
+  </form>
   {%- endset -%}
 
   {%- set author -%}
@@ -31,7 +33,7 @@
     {"text": "{:%d %b %Y}".format(object.created_at)},
     {"text": author},
     {"text": object_status},
-    {"html": object_link},
+    {"html": object_link if object.status == "COMPLETED" else " "},
   ]) or "" }}
 {% endfor %}
 

--- a/importer/urls.py
+++ b/importer/urls.py
@@ -17,11 +17,6 @@ general_importer_urlpatterns = [
 
 commodity_importer_urlpatterns = [
     path(
-        "commodity-importer/<pk>/detail/",
-        views.CommodityImportDetailURLResolverView.as_view(),
-        name="commodity_importer-ui-detail-url-resolver",
-    ),
-    path(
         "commodity-importer/",
         views.CommodityImportListView.as_view(),
         name="commodity_importer-ui-list",

--- a/importer/views.py
+++ b/importer/views.py
@@ -98,20 +98,18 @@ class CommodityImportDetailURLResolverView(RedirectView):
                 "path_name": "commodity_importer-ui-list",
                 "kwargs": {},
             },
-            # TODO: which workbasket view? workbasket:workbasket-ui-changes (pk=import.workbasket.pk)?
-            models.ImportBatchStatus.COMPLETED: {
-                "path_name": "commodity_importer-ui-list",
-                "kwargs": {},
-            },
             # TODO: will there be a view for failed imports?
             models.ImportBatchStatus.FAILED: {
                 "path_name": "commodity_importer-ui-list",
                 "kwargs": {},
             },
         }
-
-        location = status_to_location_map[import_batch.status]
-        return reverse(location["path_name"], kwargs=location["kwargs"])
+        if import_batch.status == models.ImportBatchStatus.COMPLETED:
+            import_batch.workbasket.save_to_session(self.request.session)
+            return reverse("workbaskets:workbasket-ui-review-goods")
+        else:
+            location = status_to_location_map[import_batch.status]
+            return reverse(location["path_name"], kwargs=location["kwargs"])
 
 
 class CommodityImportCreateView(

--- a/importer/views.py
+++ b/importer/views.py
@@ -6,7 +6,6 @@ from django.urls import reverse
 from django.urls import reverse_lazy
 from django.views.generic import DetailView
 from django.views.generic import FormView
-from django.views.generic.base import RedirectView
 
 from common.views import RequiresSuperuserMixin
 from common.views import WithPaginationListView
@@ -69,47 +68,6 @@ class CommodityImportListView(
     queryset = models.ImportBatch.objects.order_by("-created_at")
     template_name = "eu-importer/select-imports.jinja"
     filterset_class = TaricImportFilter
-
-
-class CommodityImportDetailURLResolverView(RedirectView):
-    """URL resolver view used to redirect to the appropriate 'detail' view for
-    an ImportBatch instance at run-time."""
-
-    def get_redirect_url(self, *args, **kwargs):
-        # Fetch the import_batch to get the related workbasket.
-        import_batch = models.ImportBatch.objects.get(pk=kwargs["pk"])
-
-        status_to_location_map = {
-            models.ImportBatchStatus.UPLOADING: {
-                "path_name": "commodity_importer-ui-create-success",
-                "kwargs": {
-                    "pk": str(import_batch.pk),
-                },
-            },
-            # TODO: is the IMPORTED status required or should a successful import transition directly to REVIEW?
-            models.ImportBatchStatus.IMPORTED: {
-                "path_name": "commodity_importer-ui-create-success",
-                "kwargs": {
-                    "pk": str(import_batch.pk),
-                },
-            },
-            # TODO: workbasket:workbasket-ui-goods-changes (pk=import.workbasket.pk)?
-            models.ImportBatchStatus.REVIEW: {
-                "path_name": "commodity_importer-ui-list",
-                "kwargs": {},
-            },
-            # TODO: will there be a view for failed imports?
-            models.ImportBatchStatus.FAILED: {
-                "path_name": "commodity_importer-ui-list",
-                "kwargs": {},
-            },
-        }
-        if import_batch.status == models.ImportBatchStatus.COMPLETED:
-            import_batch.workbasket.save_to_session(self.request.session)
-            return reverse("workbaskets:workbasket-ui-review-goods")
-        else:
-            location = status_to_location_map[import_batch.status]
-            return reverse(location["path_name"], kwargs=location["kwargs"])
 
 
 class CommodityImportCreateView(

--- a/workbaskets/tests/test_views.py
+++ b/workbaskets/tests/test_views.py
@@ -245,6 +245,36 @@ def test_select_workbasket_with_errored_status(valid_user_client):
 
 
 @pytest.mark.parametrize(
+    "workbasket_tab, expected_url",
+    [
+        ("view-summary", "workbaskets:current-workbasket"),
+        ("add-edit-items", "workbaskets:edit-workbasket"),
+        ("view-violations", "workbaskets:workbasket-ui-violations"),
+        ("review-measures", "workbaskets:review-workbasket"),
+        ("review-goods", "workbaskets:workbasket-ui-review-goods"),
+        ("", "workbaskets:current-workbasket"),
+    ],
+)
+def test_select_workbasket_redirects_to_tab(
+    valid_user_client,
+    workbasket_tab,
+    expected_url,
+):
+    """Test that SelectWorkbasketView redirects to a specific tab on the
+    selected workbasket if a tab has been provided."""
+    workbasket = factories.WorkBasketFactory.create()
+    response = valid_user_client.post(
+        reverse("workbaskets:workbasket-ui-list"),
+        {
+            "workbasket": workbasket.id,
+            "workbasket-tab": workbasket_tab,
+        },
+    )
+    assert response.status_code == 302
+    assert response.url == reverse(expected_url)
+
+
+@pytest.mark.parametrize(
     "form_action, url_name",
     [
         ("remove-selected", "workbaskets:workbasket-ui-delete-changes"),

--- a/workbaskets/views/ui.py
+++ b/workbaskets/views/ui.py
@@ -116,20 +116,40 @@ class SelectWorkbasketView(PermissionRequiredMixin, WithPaginationListView):
 
     def post(self, request, *args, **kwargs):
         workbasket_pk = request.POST.get("workbasket")
-        if workbasket_pk:
-            workbasket = WorkBasket.objects.get(pk=workbasket_pk)
+        workbasket_tab = request.POST.get("workbasket-tab")
 
-            if workbasket:
-                if workbasket.status == WorkflowStatus.ERRORED:
-                    workbasket.restore()
-                    workbasket.save()
+        workbasket_tab_map = {
+            "view-summary": {
+                "path_name": "workbaskets:current-workbasket",
+            },
+            "add-edit-items": {
+                "path_name": "workbaskets:edit-workbasket",
+            },
+            "view-violations": {
+                "path_name": "workbaskets:workbasket-ui-violations",
+            },
+            "review-measures": {
+                "path_name": "workbaskets:review-workbasket",
+            },
+            "review-goods": {
+                "path_name": "workbaskets:workbasket-ui-review-goods",
+            },
+        }
 
-                workbasket.save_to_session(request.session)
-                redirect_url = reverse(
-                    "workbaskets:current-workbasket",
-                )
+        workbasket = WorkBasket.objects.get(pk=workbasket_pk) if workbasket_pk else None
 
-                return redirect(redirect_url)
+        if workbasket:
+            if workbasket.status == WorkflowStatus.ERRORED:
+                workbasket.restore()
+                workbasket.save()
+
+            workbasket.save_to_session(request.session)
+
+            if workbasket_tab:
+                view = workbasket_tab_map[workbasket_tab]
+                return redirect(reverse(view["path_name"]))
+            else:
+                return redirect(reverse("workbaskets:current-workbasket"))
 
         return redirect(reverse("workbaskets:workbasket-ui-list"))
 


### PR DESCRIPTION
# TP2000-915 Redirect imports with completed status to workbasket

## Why
A link on the import list view should redirect the user to an import's workbasket if the import has status 'COMPLETED'.

## What
- Extends `SelectWorkbasketView` to allow specifying which tab to redirect to in a workbasket view
- Adds test
- Shows a link (to import's workbasket) for completed imports only
- Removes `CommodityImportDetailURLResolverView` since we no longer need dynamic linking for imports of varying status

## Example
<img width="500" alt="Screenshot 2023-06-21 at 17 57 39" src="https://github.com/uktrade/tamato/assets/118175145/3ac28fa5-37c6-45be-bdba-66b3e4ae2356">

