### PR TITLE
TP2000-923  Edit workbasket title and description

### DIFF
--- a/workbaskets/forms.py
+++ b/workbaskets/forms.py
@@ -60,6 +60,12 @@ class WorkbasketCreateForm(forms.ModelForm):
         fields = ("title", "reason")
 
 
+class WorkbasketUpdateForm(WorkbasketCreateForm):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.helper.layout[2].value = "Save"
+
+
 class SelectableObjectField(forms.BooleanField):
     """Associates an object instance with a BooleanField."""
 

--- a/workbaskets/jinja2/workbaskets/confirm_update.jinja
+++ b/workbaskets/jinja2/workbaskets/confirm_update.jinja
@@ -1,0 +1,39 @@
+{% extends "layouts/layout.jinja" %}
+
+{% from "components/panel/macro.njk" import govukPanel %}
+{% from "components/button/macro.njk" import govukButton %}
+
+{% set page_title = "Edit workbasket details" %}
+
+{% block breadcrumb %}
+  {{ breadcrumbs(request, [
+    {"text": page_title},
+    ])
+  }}
+{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      {{ govukPanel({
+        "titleText": object._meta.verbose_name|title ~ " " ~ object.id ~ " has been updated",
+        "text": "The details for this workbasket have been updated",
+        "classes": "govuk-!-margin-bottom-7"
+      }) }}
+
+      <h2 class="govuk-heading-m">Next steps</h2>
+      {{ govukButton({
+        "text": "Go to your workbasket summary",
+        "href": url("workbaskets:current-workbasket"),
+        "classes": "govuk-button--secondary"
+      }) }}
+      <ul class="govuk-list govuk-list-spaced">
+        {% block actions %}
+          <li><a class="govuk-link" href="{{ url("workbaskets:workbasket-ui-create") }}">Create a new workbasket</a></li>
+          <li><a href="{{ url("workbaskets:workbasket-ui-list") }}">Select an existing workbasket</a></li>
+        {% endblock %}
+        {% include "includes/common/main-menu-link.jinja" %}
+      </ul>
+    </div>
+  </div>
+{% endblock %}

--- a/workbaskets/jinja2/workbaskets/edit-details.jinja
+++ b/workbaskets/jinja2/workbaskets/edit-details.jinja
@@ -1,0 +1,15 @@
+{% extends "layouts/create.jinja" %}
+
+{% from "components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
+
+{% set page_title = "Edit workbasket details" %}
+
+{% block breadcrumb %}
+  {{ govukBreadcrumbs({
+    "items": [
+      {"text": "Home", "href": url("home")},
+      {"text": "Workbasket " ~ request.session.workbasket.id ~ " - Summary", "href": url("workbaskets:current-workbasket") },
+      {"text": page_title}
+    ]
+  }) }}
+{% endblock %}

--- a/workbaskets/jinja2/workbaskets/summary-workbasket.jinja
+++ b/workbaskets/jinja2/workbaskets/summary-workbasket.jinja
@@ -2,6 +2,7 @@
 
 {% from "components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
 {% from "components/button/macro.njk" import govukButton %}
+{% from "components/summary-list/macro.njk" import govukSummaryList %}
 {% from "includes/workbaskets/navigation.jinja" import navigation %}
 
 {% set page_title %}
@@ -134,12 +135,42 @@
   }}
 {% endblock %}
 
-
 {% block content %}
   <h1 class="govuk-heading-xl govuk-!-margin-bottom-3">
     {{ page_title }}
   </h1>
   {{ navigation(request, "summary") }}
+
+  {{ govukSummaryList({
+    "rows": [
+      {
+        "key": {"text": "TOPS/Jira number"},
+        "value": {"text": workbasket.title},
+        "actions": {
+          "items": [
+            {
+              "text": "Change",
+              "href": url("workbaskets:workbasket-ui-update"),
+              "attributes": {}
+            }
+          ]
+        }
+      },
+      {
+        "key": {"text": "Description"},
+        "value": {"text": workbasket.reason},
+        "actions": {
+          "items": [
+            {
+              "text": "Change",
+              "href": url("workbaskets:workbasket-ui-update"),
+              "attributes": {}
+            }
+          ]
+        }
+      },
+    ],
+    })}}
 
   {{ rule_check_block }}
 

--- a/workbaskets/tests/test_forms.py
+++ b/workbaskets/tests/test_forms.py
@@ -8,36 +8,6 @@ from workbaskets.forms import WorkbasketCreateForm
 pytestmark = pytest.mark.django_db
 
 
-def test_workbasket_form_validation():
-    form = WorkbasketCreateForm(
-        {
-            "title": "some title",
-            "reason": "",
-        },
-    )
-    assert not form.is_valid()
-    assert "title" in form.errors
-    assert "reason" in form.errors
-
-    form = WorkbasketCreateForm(
-        {
-            "title": "",
-            "reason": "some reason",
-        },
-    )
-    assert not form.is_valid()
-    assert "title" in form.errors
-
-    form = WorkbasketCreateForm(
-        {
-            "title": "some title",
-            "reason": "some reason",
-        },
-    )
-    assert not form.is_valid()
-    assert "title" in form.errors
-
-
 def test_workbasket_create_form_valid_data():
     """Test that WorkbasketCreateForm is valid when required fields in data."""
     data = {"title": "123", "reason": "testing testing"}
@@ -50,10 +20,21 @@ def test_workbasket_create_form_invalid_data():
     """Test that WorkbasketCreateForm is not valid when required fields not in
     data."""
     form = WorkbasketCreateForm(data={})
-
     assert not form.is_valid()
     assert "This field is required." in form.errors["title"]
     assert "This field is required." in form.errors["reason"]
+
+    form = WorkbasketCreateForm(data={"title": "abc", "reason": "test"})
+    assert not form.is_valid()
+    assert (
+        "Your TOPS/Jira number must only include numbers. You do not need to add ‘TOPS’ or ‘Jira’ in front of the number."
+        in form.errors["title"]
+    )
+
+    factories.WorkBasketFactory(title="123321")
+    form = WorkbasketCreateForm(data={"title": "123321", "reason": "test"})
+    assert not form.is_valid()
+    assert "Workbasket with this Title already exists." in form.errors["title"]
 
 
 def test_selectable_objects_form():

--- a/workbaskets/tests/test_views.py
+++ b/workbaskets/tests/test_views.py
@@ -81,6 +81,36 @@ def test_workbasket_create_without_permission(client):
     assert response.status_code == 403
 
 
+def test_workbasket_update_view_edits_workbasket_details(
+    valid_user_client,
+    session_workbasket,
+):
+    """Test that a workbasket's title and description can be edited."""
+    url = reverse("workbaskets:workbasket-ui-update")
+    new_title = "123321"
+    new_description = "Newly updated test description"
+    form_data = {
+        "title": new_title,
+        "reason": new_description,
+    }
+    assert not session_workbasket.title == new_title
+    assert not session_workbasket.reason == new_description
+
+    response = valid_user_client.get(url)
+    assert response.status_code == 200
+
+    response = valid_user_client.post(url, form_data)
+    assert response.status_code == 302
+    assert response.url == reverse(
+        "workbaskets:workbasket-ui-confirm-update",
+        kwargs={"pk": session_workbasket.pk},
+    )
+
+    session_workbasket.refresh_from_db()
+    assert session_workbasket.title == new_title
+    assert session_workbasket.reason == new_description
+
+
 def test_download(
     queued_workbasket,
     client,

--- a/workbaskets/urls.py
+++ b/workbaskets/urls.py
@@ -22,6 +22,11 @@ ui_patterns = [
         name="workbasket-ui-create",
     ),
     path(
+        "current/edit-details/",
+        ui_views.WorkBasketUpdate.as_view(),
+        name="workbasket-ui-update",
+    ),
+    path(
         "list-all/",
         ui_views.WorkBasketList.as_view(),
         name="workbasket-ui-list-all",
@@ -65,6 +70,11 @@ ui_patterns = [
         f"<pk>/confirm-create/",
         ui_views.WorkBasketConfirmCreate.as_view(),
         name="workbasket-ui-confirm-create",
+    ),
+    path(
+        f"<pk>/confirm-update/",
+        ui_views.WorkBasketConfirmUpdate.as_view(),
+        name="workbasket-ui-confirm-update",
     ),
     path(
         f"current/delete-changes-done/",

--- a/workbaskets/views/ui.py
+++ b/workbaskets/views/ui.py
@@ -18,6 +18,7 @@ from django.urls import reverse
 from django.urls import reverse_lazy
 from django.utils.decorators import method_decorator
 from django.views.generic import CreateView
+from django.views.generic import UpdateView
 from django.views.generic.base import TemplateResponseMixin
 from django.views.generic.base import TemplateView
 from django.views.generic.base import View
@@ -96,6 +97,29 @@ class WorkBasketCreate(PermissionRequiredMixin, CreateView):
         kwargs = super().get_form_kwargs()
         kwargs["request"] = self.request
         return kwargs
+
+
+@method_decorator(require_current_workbasket, name="dispatch")
+class WorkBasketUpdate(PermissionRequiredMixin, UpdateView):
+    """UI endpoint for editing a workbasket's title and description."""
+
+    permission_required = "workbaskets.add_workbasket"
+    template_name = "workbaskets/edit-details.jinja"
+    form_class = forms.WorkbasketUpdateForm
+
+    def get_object(self):
+        return WorkBasket.current(self.request)
+
+    def get_success_url(self):
+        return reverse(
+            "workbaskets:workbasket-ui-confirm-update",
+            kwargs={"pk": self.object.pk},
+        )
+
+
+class WorkBasketConfirmUpdate(DetailView):
+    template_name = "workbaskets/confirm_update.jinja"
+    model = WorkBasket
 
 
 class SelectWorkbasketView(PermissionRequiredMixin, WithPaginationListView):


### PR DESCRIPTION
# TP2000-923  Edit workbasket title and description

## Why
A workbasket's description cannot be filled at the start of the import journey because the details of an import aren't fully known at that time. It is therefore necessary to allow a workbasket's description to be updated after creation, following a successful import.

## What
- Adds an update view and form to allow changing a workbasket's title and description
- Displays in the workbasket summary tab the workbasket's current title and description with a link to edit these details
- Adds and updates tests

## Example
<img width="500" alt="Screenshot 2023-06-26 at 10 48 12" src="https://github.com/uktrade/tamato/assets/118175145/df4371fb-bbb2-46df-a401-49d3e4862391">
<img width="500" alt="Screenshot 2023-06-26 at 10 48 26" src="https://github.com/uktrade/tamato/assets/118175145/ba57cef3-98c6-4ae8-8bf2-c68b20316b64">
<img width="500" alt="Screenshot 2023-06-26 at 10 48 35" src="https://github.com/uktrade/tamato/assets/118175145/2c30ddd9-6709-4473-98b8-a30134baa603">
