### PR TITLE
Updated ME67 and added additional unit tests

### DIFF
--- a/measures/business_rules.py
+++ b/measures/business_rules.py
@@ -1231,30 +1231,55 @@ class ME66(ExclusionMembership):
 
 
 class ME67(BusinessRule):
-    """The membership period of the excluded geographical area must span the
-    valid period of the measure."""
+    """
+    The membership period of the excluded geographical area must span the valid
+    period of the measure.
+
+    interpretation:
+    When a measure has a geo-area exclusion, the valid between date range of the measure is used to check the existence
+    of the excluded geo area in the geo group the measure is linked to (a member of the geo area group), if the members
+    validity date range does not match or extend beyond the measures valid between date range then the change is
+    considered invalid and a violation should be raised.
+    """
 
     def validate(self, exclusion):
-        GeographicalMembership = type(
-            exclusion.excluded_geographical_area,
-        ).memberships.through
+        measure = exclusion.modified_measure
 
-        geo_group = exclusion.modified_measure.geographical_area
-        excluded = exclusion.excluded_geographical_area
+        geo_area = measure.geographical_area
+        members = geo_area.members.approved_up_to_transaction(
+            self.transaction,
+        )
 
-        if (
-            not GeographicalMembership.objects.approved_up_to_transaction(
-                self.transaction,
+        matching_members_to_exclusion_period = members.filter(
+            Q(
+                member__area_id=exclusion.excluded_geographical_area.area_id,
+                valid_between__startswith__lte=measure.valid_between.lower,
+            ),
+        )
+        if measure.valid_between.upper is None:
+            matching_members_to_exclusion_period = (
+                matching_members_to_exclusion_period.filter(
+                    valid_between__endswith__isnull=True,
+                )
             )
-            .as_at(
-                exclusion.modified_measure.effective_valid_between,
+        else:
+            # Because the top of the date range is open - comparisons performed with less-than don't include
+            # the top value
+            # e.g. if a date range is 1/1/2020 to 31/1/2020, in the database the upper will be stored as 1/2/2020
+            # which means we must use gt rather than gte here. See the tests for ME67 for clarity - they all work
+            # correctly and the queried dates are all exactly within the ranges, no days space so we can be
+            # confident this rule is behaving as expected.
+            matching_members_to_exclusion_period = (
+                matching_members_to_exclusion_period.filter(
+                    Q(valid_between__endswith__isnull=True)
+                    | Q(
+                        valid_between__endswith__isnull=False,
+                        valid_between__endswith__gt=measure.valid_between.upper,
+                    ),
+                )
             )
-            .filter(
-                geo_group__version_group=geo_group.version_group,
-                member__version_group=excluded.version_group,
-            )
-            .exists()
-        ):
+
+        if not matching_members_to_exclusion_period.exists():
             raise self.violation(exclusion)
 
 

--- a/measures/tests/test_buinsess_rules/test_ME67.py
+++ b/measures/tests/test_buinsess_rules/test_ME67.py
@@ -1,0 +1,234 @@
+from datetime import date
+
+import pytest
+
+from common.business_rules import BusinessRuleViolation
+from common.tests import factories
+from common.tests.util import raises_if
+from common.util import TaricDateRange
+from measures import business_rules
+
+pytestmark = pytest.mark.django_db
+
+
+def test_ME67(spanning_dates):
+    """The membership period of the excluded geographical area must span the
+    validity period of the measure."""
+    membership_period, measure_period, fully_spans = spanning_dates
+
+    membership = factories.GeographicalMembershipFactory.create(
+        valid_between=membership_period,
+    )
+    exclusion = factories.MeasureExcludedGeographicalAreaFactory.create(
+        excluded_geographical_area=membership.member,
+        modified_measure__geographical_area=membership.geo_group,
+        modified_measure__valid_between=measure_period,
+    )
+    with raises_if(BusinessRuleViolation, not fully_spans):
+        business_rules.ME67(exclusion.transaction).validate(exclusion)
+
+
+def test_ME67_multiple_member_periods():
+    """This test verifies that when a member is added and removed multiple
+    times, that the rule performs correctly."""
+    TaricDateRange(date(2020, 1, 1), date(2020, 12, 31))
+
+    # membership periods
+    membership_1_valid_between = TaricDateRange(
+        date(2020, 1, 1),
+        date(2020, 5, 31),
+    )  # full first included period
+
+    membership_2_valid_between = TaricDateRange(
+        date(2020, 7, 1),
+        date(2020, 12, 31),
+    )  # full last included period
+
+    # valid exclusion periods
+    exclusion_valid_1_valid_between = TaricDateRange(
+        date(2020, 1, 1),
+        date(2020, 5, 31),
+    )  # full first included period
+
+    exclusion_valid_2_valid_between = TaricDateRange(
+        date(2020, 7, 1),
+        date(2020, 12, 31),
+    )  # full last included period
+
+    exclusion_valid_3_valid_between = TaricDateRange(
+        date(2020, 1, 5),
+        date(2020, 5, 26),
+    )  # inside first period
+
+    exclusion_valid_4_valid_between = TaricDateRange(
+        date(2020, 7, 5),
+        date(2020, 12, 26),
+    )  # inside second period
+
+    # invalid exclusion periods
+    exclusion_invalid_1_valid_between = TaricDateRange(
+        date(2020, 1, 1),
+        date(2020, 6, 1),
+    )  # overlap on upper by one day
+
+    exclusion_invalid_2_valid_between = TaricDateRange(
+        date(2020, 6, 30),
+        date(2020, 12, 31),
+    )  # overlap on lower by one day
+
+    exclusion_invalid_3_valid_between = TaricDateRange(
+        date(2020, 6, 1),
+        date(2020, 6, 30),
+    )  # mirror missing member period
+
+    exclusion_invalid_4_valid_between = TaricDateRange(
+        date(2020, 6, 5),
+        date(2020, 6, 25),
+    )  # inside missing member period
+
+    exclusion_invalid_5_valid_between = TaricDateRange(
+        date(2020, 6, 5),
+    )  # no end date
+
+    # member kenya is available between 1/1/2020 and 31/5/2020 and then 1/7/2020 to 31/12/2020,
+    # leaving 1 month (june) without kenya as a member
+    membership_1 = factories.GeographicalMembershipFactory.create(
+        valid_between=membership_1_valid_between,
+    )
+
+    factories.GeographicalMembershipFactory.create(
+        valid_between=membership_2_valid_between,
+        member=membership_1.member,
+        geo_group=membership_1.geo_group,
+    )
+
+    exclusion_1_pass = factories.MeasureExcludedGeographicalAreaFactory.create(
+        excluded_geographical_area=membership_1.member,
+        modified_measure__geographical_area=membership_1.geo_group,
+        modified_measure__valid_between=exclusion_valid_1_valid_between,
+    )
+
+    exclusion_2_pass = factories.MeasureExcludedGeographicalAreaFactory.create(
+        excluded_geographical_area=membership_1.member,
+        modified_measure__geographical_area=membership_1.geo_group,
+        modified_measure__valid_between=exclusion_valid_2_valid_between,
+    )
+
+    exclusion_3_pass = factories.MeasureExcludedGeographicalAreaFactory.create(
+        excluded_geographical_area=membership_1.member,
+        modified_measure__geographical_area=membership_1.geo_group,
+        modified_measure__valid_between=exclusion_valid_3_valid_between,
+    )
+
+    exclusion_4_pass = factories.MeasureExcludedGeographicalAreaFactory.create(
+        excluded_geographical_area=membership_1.member,
+        modified_measure__geographical_area=membership_1.geo_group,
+        modified_measure__valid_between=exclusion_valid_4_valid_between,
+    )
+
+    exclusion_1_fail = factories.MeasureExcludedGeographicalAreaFactory.create(
+        excluded_geographical_area=membership_1.member,
+        modified_measure__geographical_area=membership_1.geo_group,
+        modified_measure__valid_between=exclusion_invalid_1_valid_between,
+    )
+
+    exclusion_2_fail = factories.MeasureExcludedGeographicalAreaFactory.create(
+        excluded_geographical_area=membership_1.member,
+        modified_measure__geographical_area=membership_1.geo_group,
+        modified_measure__valid_between=exclusion_invalid_2_valid_between,
+    )
+
+    exclusion_3_fail = factories.MeasureExcludedGeographicalAreaFactory.create(
+        excluded_geographical_area=membership_1.member,
+        modified_measure__geographical_area=membership_1.geo_group,
+        modified_measure__valid_between=exclusion_invalid_3_valid_between,
+    )
+
+    exclusion_4_fail = factories.MeasureExcludedGeographicalAreaFactory.create(
+        excluded_geographical_area=membership_1.member,
+        modified_measure__geographical_area=membership_1.geo_group,
+        modified_measure__valid_between=exclusion_invalid_4_valid_between,
+    )
+
+    exclusion_5_fail = factories.MeasureExcludedGeographicalAreaFactory.create(
+        excluded_geographical_area=membership_1.member,
+        modified_measure__geographical_area=membership_1.geo_group,
+        modified_measure__valid_between=exclusion_invalid_5_valid_between,
+    )
+
+    business_rules.ME67(exclusion_1_pass.transaction).validate(exclusion_1_pass)
+    business_rules.ME67(exclusion_2_pass.transaction).validate(exclusion_2_pass)
+    business_rules.ME67(exclusion_2_pass.transaction).validate(exclusion_3_pass)
+    business_rules.ME67(exclusion_2_pass.transaction).validate(exclusion_4_pass)
+
+    with pytest.raises(BusinessRuleViolation) as e:
+        business_rules.ME67(exclusion_1_fail.transaction).validate(exclusion_1_fail)
+        assert str(e) == "<ExceptionInfo for raises contextmanager>"
+
+    with pytest.raises(BusinessRuleViolation) as e:
+        business_rules.ME67(exclusion_2_fail.transaction).validate(exclusion_2_fail)
+        assert str(e) == "<ExceptionInfo for raises contextmanager>"
+
+    with pytest.raises(BusinessRuleViolation) as e:
+        business_rules.ME67(exclusion_3_fail.transaction).validate(exclusion_3_fail)
+        assert str(e) == "<ExceptionInfo for raises contextmanager>"
+
+    with pytest.raises(BusinessRuleViolation) as e:
+        business_rules.ME67(exclusion_4_fail.transaction).validate(exclusion_4_fail)
+        assert str(e) == "<ExceptionInfo for raises contextmanager>"
+
+    with pytest.raises(BusinessRuleViolation) as e:
+        business_rules.ME67(exclusion_5_fail.transaction).validate(exclusion_5_fail)
+        assert str(e) == "<ExceptionInfo for raises contextmanager>"
+
+
+def test_ME67_with_end_dates_in_range():
+    """This test verifies that when queried, null values for end dates are not
+    an issue."""
+
+    # membership periods
+    valid_between_no_end_date = TaricDateRange(
+        date(2020, 1, 1),
+    )
+
+    valid_between_with_end_date = TaricDateRange(
+        date(2020, 1, 1),
+        date(2020, 3, 1),
+    )
+
+    geo_membership_no_end_date = factories.GeographicalMembershipFactory.create(
+        valid_between=valid_between_no_end_date,
+    )
+
+    exclusion_for_no_end_date_measure = (
+        factories.MeasureExcludedGeographicalAreaFactory.create(
+            excluded_geographical_area=geo_membership_no_end_date.member,
+            modified_measure__geographical_area=geo_membership_no_end_date.geo_group,
+            modified_measure__valid_between=valid_between_no_end_date,
+        )
+    )
+
+    exclusion_for_end_dated_measure = (
+        factories.MeasureExcludedGeographicalAreaFactory.create(
+            excluded_geographical_area=geo_membership_no_end_date.member,
+            modified_measure__geographical_area=geo_membership_no_end_date.geo_group,
+            modified_measure__valid_between=valid_between_with_end_date,
+        )
+    )
+
+    business_rules.ME67(exclusion_for_no_end_date_measure.transaction).validate(
+        exclusion_for_no_end_date_measure,
+    )
+    business_rules.ME67(exclusion_for_end_dated_measure.transaction).validate(
+        exclusion_for_end_dated_measure,
+    )
+
+
+#  business_rules.ME67(exclusion_1_pass.transaction).validate(exclusion_1_pass)
+#
+#
+#  with pytest.raises(BusinessRuleViolation) as e:
+#      business_rules.ME67(exclusion_1_fail.transaction).validate(exclusion_1_fail)
+#      assert str(e) == "<ExceptionInfo for raises contextmanager>"
+#
+#

--- a/measures/tests/test_business_rules.py
+++ b/measures/tests/test_business_rules.py
@@ -1667,23 +1667,6 @@ def test_ME66():
         business_rules.ME66(exclusion.transaction).validate(exclusion)
 
 
-def test_ME67(spanning_dates):
-    """The membership period of the excluded geographical area must span the
-    validity period of the measure."""
-    membership_period, measure_period, fully_spans = spanning_dates
-
-    membership = factories.GeographicalMembershipFactory.create(
-        valid_between=membership_period,
-    )
-    exclusion = factories.MeasureExcludedGeographicalAreaFactory.create(
-        excluded_geographical_area=membership.member,
-        modified_measure__geographical_area=membership.geo_group,
-        modified_measure__valid_between=measure_period,
-    )
-    with raises_if(BusinessRuleViolation, not fully_spans):
-        business_rules.ME67(exclusion.transaction).validate(exclusion)
-
-
 def test_ME68():
     """The same geographical area can only be excluded once by the same
     measure."""


### PR DESCRIPTION
BUG FIX applied and tested for checks against NULL measure end dates 

added tests to verify the change not only passes existing tests but extends and verifies and passes additional scenarios that were incorrectly failed in production previously

# TP2000-914 fix ME67

## Why
 * ME67 did not pass in valid scenarios.
 * Unit test coverage missed some data configurations that were valid.
 * Bug fix for measures that do not have an end date - which caused an invalid query

## What
 * Updated the logic for ME67 to verify the date range of the change against the data
 * Added tests to cover additional scenarios, observed as incorrectly raising violations in production

## Checklist
- Requires migrations? NO
- Requires dependency updates? NO


Links to relevant material
See: [Description](https://uktrade.atlassian.net/browse/TP2000-914)
