### PR TITLE
TP2000-921 transition import status to succeeded and failed

### DIFF
--- a/importer/jinja2/eu-importer/import-success.jinja
+++ b/importer/jinja2/eu-importer/import-success.jinja
@@ -23,7 +23,7 @@
   <div class="govuk-grid-column-two-thirds">
       {{ govukPanel({
         "titleText": "TARIC ID " ~ object.name ~ " has been uploaded",
-        "text": "TODO: content here",
+        "text": "You can view " ~ object.name ~ " import progress from the import list.",
         "classes": "govuk-!-margin-bottom-7"
       }) }}
 

--- a/importer/models.py
+++ b/importer/models.py
@@ -109,6 +109,8 @@ class ImportBatch(TimestampedMixin):
 
     @property
     def ready_chunks(self):
+        """Return a QuerySet of chunks that have neither a status of DONE
+        or ERRORED - i.e. they have a status of WAITING or RUNNING."""
         return self.chunks.exclude(
             Q(status=ImporterChunkStatus.DONE) | Q(status=ImporterChunkStatus.ERRORED),
         ).defer("chunk_text")

--- a/importer/models.py
+++ b/importer/models.py
@@ -1,3 +1,5 @@
+from logging import getLogger
+
 from django.conf import settings
 from django.db import models
 from django.db.models import Q
@@ -6,6 +8,10 @@ from django_fsm import FSMField
 from django_fsm import transition
 
 from common.models import TimestampedMixin
+from workbaskets.util import clear_workbasket
+from workbaskets.validators import WorkflowStatus
+
+logger = getLogger(__name__)
 
 
 class ImporterChunkStatus(models.IntegerChoices):
@@ -97,6 +103,19 @@ class ImportBatch(TimestampedMixin):
     )
     def succeeded(self):
         """The import process completed and was successful."""
+        logger.info(f"Transitioning status of import pk={self.pk} to SUCCEEDED.")
+
+        if (
+            not self.workbasket.tracked_models.exists()
+            and self.workbasket.status == WorkflowStatus.EDITING
+        ):
+            # Successful imports with an empty workbasket are archived.
+            logger.info(
+                f"Archiving empty workbasket pk={self.workbasket.pk} "
+                f"associated with SUCCEEDED import pk={self.pk}.",
+            )
+            self.workbasket.archive()
+            self.workbasket.save()
 
     @transition(
         field=status,
@@ -106,6 +125,22 @@ class ImportBatch(TimestampedMixin):
     )
     def failed(self):
         """The import process completed with an error condition."""
+        logger.info(f"Transitioning status of import pk={self.pk} to FAILED.")
+
+        if self.workbasket.tracked_models.exists():
+            logger.info(
+                f"Clearing workbasket pk={self.workbasket.pk} contents "
+                f"associated with FAILED import pk={self.pk}.",
+            )
+            clear_workbasket(self.workbasket)
+
+        if self.workbasket.status == WorkflowStatus.EDITING:
+            logger.info(
+                f"Archiving workbasket pk={self.workbasket.pk} "
+                f"associated with FAILED import pk={self.pk}.",
+            )
+            self.workbasket.archive()
+            self.workbasket.save()
 
     @property
     def ready_chunks(self):


### PR DESCRIPTION
# TP2000-921 transition import status to succeeded and failed
<!---
 * Include the JIRA ticket number, eg TP-123, to automatically link.
 * Use 50 characters maximum.
 * Do not end with a full-stop.
--->

## Why
<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Use as many lines as you like.
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions or deliberately ignored edge-cases.
--->
When the parser has completed its work it must, depending on its whether it has succeeded or failed, transition the related ImportBatch instance status to SUCCEEDED or FAILED.

## What
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Explain like I'm 5.
 * Use pictures if you can.
--->
Upon the parser completing it correctly transitions the `ImportBatch.status` via the `succeeded()` and `failed()` transition functions. The workbasket associated with the import is also managed correctly, transitioning its state depending upon the outcome of the import. Info log messages have also been added to help with any debugging / investigation where necessary.

Comments also added to the parser code while exploring required work.

<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
--->
## Checklist
- Requires migrations? No
- Requires dependency updates? No

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
