### PR TITLE
TP2000-929  Fix quota form geo area member exclusions

### DIFF
--- a/geo_areas/tests/test_utils.py
+++ b/geo_areas/tests/test_utils.py
@@ -1,5 +1,6 @@
 import pytest
 
+from common.models.transactions import Transaction
 from common.models.utils import override_current_transaction
 from common.tests import factories
 from geo_areas.utils import get_all_members_of_geo_groups
@@ -36,7 +37,7 @@ def test_get_all_members(date_ranges):
     factories.GeographicalMembershipFactory.create(
         geo_group=area_group,
         member=country3,
-        valid_between=date_ranges.no_end,
+        valid_between=date_ranges.starts_2_months_ago_to_1_month_ago,
     )
     area_group2 = factories.GeographicalAreaFactory.create(
         area_code=AreaCode.GROUP,
@@ -53,15 +54,10 @@ def test_get_all_members(date_ranges):
         valid_between=date_ranges.no_end,
     )
 
-    origin = factories.QuotaOrderNumberOriginFactory.create(
-        geographical_area=area_group,
-        valid_between=date_ranges.no_end,
-    )
-
-    with override_current_transaction(origin.transaction):
+    with override_current_transaction(Transaction.objects.last()):
         all_geo_areas = get_all_members_of_geo_groups(
-            origin.valid_between,
-            [country4, area_group2],
+            date_ranges.no_end,
+            [area_group, area_group2, country4],
         )
-
-        assert not set(all_geo_areas).difference({country1, country2, country4})
+        assert len(all_geo_areas) == 3
+        assert not all_geo_areas.difference({country1, country2, country4})

--- a/geo_areas/utils.py
+++ b/geo_areas/utils.py
@@ -4,21 +4,21 @@ from geo_areas.validators import AreaCode
 
 
 def get_all_members_of_geo_groups(validity, geo_areas):
-    all_members = []
+    all_members = set()
     for geo_area in geo_areas:
         if geo_area.area_code == AreaCode.GROUP:
-            valid_memberships = [
-                member
-                for member in GeographicalMembership.objects.filter(
-                    geo_group=geo_area,
-                )
-                if date_ranges_overlap(member.valid_between, validity)
-            ]
-            origins = set(m.member for m in valid_memberships)
-            for membership in valid_memberships:
-                if membership.member.sid in [m.sid for m in origins]:
-                    all_members.append(membership.member)
+            all_members.update(
+                {
+                    membership.member
+                    for membership in GeographicalMembership.objects.filter(
+                        geo_group=geo_area,
+                    )
+                    .current()
+                    .prefetch_related("member")
+                    if date_ranges_overlap(membership.valid_between, validity)
+                },
+            )
         else:
-            all_members.append(geo_area)
+            all_members.add(geo_area)
 
     return all_members

--- a/geo_areas/utils.py
+++ b/geo_areas/utils.py
@@ -7,6 +7,7 @@ def get_all_members_of_geo_groups(validity, geo_areas):
     all_members = set()
     for geo_area in geo_areas:
         if geo_area.area_code == AreaCode.GROUP:
+            # Generate a set of valid members to add to all_members
             all_members.update(
                 {
                     membership.member

--- a/measures/patterns.py
+++ b/measures/patterns.py
@@ -228,15 +228,21 @@ class MeasureCreationPattern:
         if exclusion.area_code == AreaCode.GROUP:
             measure_origins = set(
                 m.member
-                for m in GeographicalMembership.objects.as_at(
+                for m in GeographicalMembership.objects.current()
+                .as_at(
                     measure.valid_between.lower,
-                ).filter(
+                )
+                .filter(
                     geo_group=measure.geographical_area,
                 )
             )
-            for membership in GeographicalMembership.objects.as_at(
-                measure.valid_between.lower,
-            ).filter(geo_group=exclusion):
+            for membership in (
+                GeographicalMembership.objects.current()
+                .as_at(
+                    measure.valid_between.lower,
+                )
+                .filter(geo_group=exclusion)
+            ):
                 member = membership.member
                 assert member.sid in list(
                     m.sid for m in measure_origins


### PR DESCRIPTION
# TP2000-929  Fix quota form geo area member exclusions

## Why
The `get_all_members_of_geo_groups` function  (used when editing a quota order number origin to update any exclusions) doesn't use the latest version of `GeographicalMembership` queryset. This is causing an issue where an end-dated member of the passed in geo group is still ultimately added as an exclusion.

Also, the function doesn't guard against geo groups sharing members, sometimes resulting in a member/geo area being added multiple times as an exclusion.

When testing this PR, another issue had also been identified this time in the create measure journey concerning geo area member exclusions. `create_measure_excluded_geographical_areas` like `get_all_members_of_geo_groups` does not use the latest version of `GeographicalMembership`, causing a server 500 error on attempted measure creation.

## What
- Use current() on querysets to get the latest version of memberships
- Return all members as a set to ensure there are no duplicate geo areas
- Update test

##
Before:
<img width="450" alt="Screenshot 2023-06-28 at 13 04 43" src="https://github.com/uktrade/tamato/assets/118175145/0aff97a6-14ce-4de4-abc4-1ea8f92ee5e6">

##
<img width="450" alt="Screenshot 2023-06-28 at 14 56 41" src="https://github.com/uktrade/tamato/assets/118175145/e921bfa0-df72-4e31-bec7-90c49ad1157c">
