### PR TITLE
TP2000-936 Add validity period to quota order number autocomplete label

### DIFF
--- a/quotas/models.py
+++ b/quotas/models.py
@@ -87,7 +87,7 @@ class QuotaOrderNumber(TrackedModel, ValidityMixin):
 
     @property
     def autocomplete_label(self):
-        return str(self)
+        return f"{self} ({self.valid_between.lower} - {self.valid_between.upper})"
 
     @property
     def is_origin_quota(self):

--- a/quotas/tests/test_models.py
+++ b/quotas/tests/test_models.py
@@ -104,3 +104,21 @@ def test_quota_definition_get_url():
         definition.get_url()
         == f"{reverse('quota-ui-detail', kwargs={'sid': order_number.sid})}#definition-details"
     )
+
+
+def test_quota_order_number_autocomplete_label(date_ranges):
+    """Tests that quota order number autocomplete label displays order number
+    with validity period."""
+    order_number = factories.QuotaOrderNumberFactory.create(
+        order_number="123456",
+        valid_between=date_ranges.earlier,
+    )
+    order_number2 = factories.QuotaOrderNumberFactory.create(
+        order_number="123456",
+        valid_between=date_ranges.no_end,
+    )
+    assert (
+        order_number.autocomplete_label
+        == f"{order_number} ({order_number.valid_between.lower} - {order_number.valid_between.upper})"
+    )
+    assert order_number.autocomplete_label != order_number2.autocomplete_label

--- a/quotas/tests/test_models.py
+++ b/quotas/tests/test_models.py
@@ -2,6 +2,7 @@ import pytest
 from django.db import IntegrityError
 from django.urls import reverse
 
+from common.serializers import AutoCompleteSerializer
 from common.tests import factories
 from common.tests.util import raises_if
 
@@ -122,3 +123,7 @@ def test_quota_order_number_autocomplete_label(date_ranges):
         == f"{order_number} ({order_number.valid_between.lower} - {order_number.valid_between.upper})"
     )
     assert order_number.autocomplete_label != order_number2.autocomplete_label
+
+    autocomplete = AutoCompleteSerializer()
+    autocomplete_label = autocomplete.to_representation(order_number).get("label")
+    assert order_number.autocomplete_label == autocomplete_label


### PR DESCRIPTION
# TP2000-936 Add validity period to quota order number autocomplete label

## Why
Autocomplete results for quota order numbers don't distinguish multiple versions of the same quota order numbers with different validity periods. 

## What
- Adds validity period to quota order number autocomplete label to help users identity the correct quota order number for their use

##
Before:
<img width="500" alt="Screenshot 2023-06-29 at 11 03 51" src="https://github.com/uktrade/tamato/assets/118175145/6faf7dda-6921-4c3b-9573-744eaf9d0477">

##
After:
<img width="500" alt="Screenshot 2023-06-29 at 10 48 05" src="https://github.com/uktrade/tamato/assets/118175145/de3f5122-390c-47a5-a34e-cf18f8d3fa1f">
