### PR TITLE
TP2000-920 Add additional filters to the import list page

### DIFF
--- a/common/jinja2/macros/inline_filter_links.jinja
+++ b/common/jinja2/macros/inline_filter_links.jinja
@@ -1,0 +1,14 @@
+{% macro inline_filter_links(filter_links_list) -%}
+  <ul class="govuk-list">
+    {% for filter_link in filter_links_list %}
+      <li>
+        <a
+            href="{{filter_link.href}}"
+            class="govuk-link govuk-link--no-underline govuk-link--no-visited-state {% if filter_link.selected %}selected-link{% endif %}"
+        >{{filter_link.text}}
+        </a>
+      </li>
+    {% endfor %}
+  </ul>
+{%- endmacro %}
+

--- a/conftest.py
+++ b/conftest.py
@@ -54,6 +54,7 @@ from common.tests.util import make_duplicate_record
 from common.tests.util import make_non_duplicate_record
 from common.tests.util import raises_if
 from common.validators import UpdateType
+from importer.models import ImportBatchStatus
 from importer.nursery import get_nursery
 from importer.taric import process_taric_xml_stream
 from workbaskets.models import WorkBasket
@@ -171,9 +172,9 @@ def assert_spanning_enforced(spanning_dates, update_type):
 
     This is useful in implementing tests for business rules of the form:
 
-        When a "contained object" is used in a "container object" the validity
-        period of the "container object" must span the validity period of the
-        "contained object".
+    When a "contained object" is used in a "container object" the validity
+    period of the "container object" must span the validity period of the
+    "contained object".
     """
 
     def check(
@@ -1315,11 +1316,12 @@ def unordered_transactions():
     Fixture that creates some transactions, where one is a draft.
 
     The draft transaction has approved transactions on either side, this allows
-    testing of save_draft and it's callers to verify the transactions are getting
-    sorted.
+    testing of save_draft and it's callers to verify the transactions are
+    getting sorted.
 
-    UnorderedTransactionData is returned, so the user can set the new_transaction partition to DRAFT
-    and while also using an existing_transaction.
+    UnorderedTransactionData is returned, so the user can set the
+    new_transaction partition to DRAFT and while also using an
+    existing_transaction.
     """
     from common.tests.factories import ApprovedTransactionFactory
     from common.tests.factories import FootnoteFactory
@@ -1459,3 +1461,48 @@ def quotas_json():
 def mock_aioresponse():
     with aioresponses() as m:
         yield m
+
+
+@pytest.fixture
+def importing_import_batch():
+    editing_workbasket = factories.WorkBasketFactory.create()
+    return factories.ImportBatchFactory.create(
+        status=ImportBatchStatus.IMPORTING,
+        workbasket_id=editing_workbasket.id,
+    )
+
+
+@pytest.fixture
+def failed_import_batch():
+    editing_workbasket = factories.WorkBasketFactory.create()
+    return factories.ImportBatchFactory.create(
+        status=ImportBatchStatus.FAILED,
+        workbasket_id=editing_workbasket.id,
+    )
+
+
+@pytest.fixture
+def completed_import_batch():
+    editing_workbasket = factories.WorkBasketFactory.create()
+    return factories.ImportBatchFactory.create(
+        status=ImportBatchStatus.SUCCEEDED,
+        workbasket_id=editing_workbasket.id,
+    )
+
+
+@pytest.fixture
+def published_import_batch():
+    published_workbasket = factories.PublishedWorkBasketFactory.create()
+    return factories.ImportBatchFactory.create(
+        status=ImportBatchStatus.SUCCEEDED,
+        workbasket_id=published_workbasket.id,
+    )
+
+
+@pytest.fixture
+def empty_import_batch():
+    archived_workbasket = factories.ArchivedWorkBasketFactory.create()
+    return factories.ImportBatchFactory.create(
+        status=ImportBatchStatus.SUCCEEDED,
+        workbasket_id=archived_workbasket.id,
+    )

--- a/importer/filters.py
+++ b/importer/filters.py
@@ -45,4 +45,4 @@ class TaricImportFilter(TamatoFilter):
 
     class Meta:
         model = models.ImportBatch
-        fields = ["search", "status"]
+        fields = ["search", "status", "workbasket__status"]

--- a/importer/jinja2/eu-importer/select-imports.jinja
+++ b/importer/jinja2/eu-importer/select-imports.jinja
@@ -30,7 +30,7 @@
     },
     {
       "text": "Empty",
-      "href": "?status=SUCCEEDED&workbasket__status=Archived",
+      "href": "?status=SUCCEEDED&workbasket__status=ARCHIVED",
       "selected": selected_link == "empty"
     },
     {

--- a/importer/jinja2/eu-importer/select-imports.jinja
+++ b/importer/jinja2/eu-importer/select-imports.jinja
@@ -2,9 +2,44 @@
 
 {% from "components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
 {% from "components/table/macro.njk" import govukTable %}
+{% from "macros/inline_filter_links.jinja" import inline_filter_links %}
 
 {% set page_title = "EU Taric import list" %}
 {% set list_include = "includes/taric_importer_list.jinja" %}
+
+{% set filter_links_list = [
+    {
+      "text": "All",
+      "href": "?status=",
+      "selected": selected_link == "all",
+    },
+    {
+      "text": "Importing",
+      "href": "?status=IMPORTING",
+      "selected": selected_link == "importing"
+    },
+    {
+      "text": "Completed",
+      "href": "?status=SUCCEEDED&workbasket__status=EDITING",
+      "selected": selected_link == "completed"
+    },
+    {
+      "text": "Published",
+      "href": "?status=SUCCEEDED&workbasket__status=PUBLISHED",
+      "selected": selected_link == "published"
+    },
+    {
+      "text": "Empty",
+      "href": "?status=SUCCEEDED&workbasket__status=Archived",
+      "selected": selected_link == "empty"
+    },
+    {
+      "text": "Errored",
+      "href": "?status=FAILED",
+      "selected": selected_link == "errored"
+    },
+  ]
+%}
 
 
 {% block breadcrumb %}
@@ -35,44 +70,7 @@
 
   <nav class="workbasket-filters">
     <p class="govuk-body govuk-!-font-weight-bold">Filter results:</p>
-    <ul class="govuk-list">
-      <li>
-        <a
-          href="{{ request.path }}?status="
-          class="govuk-link govuk-link--no-underline govuk-link--no-visited-state {% if selected_link == 'all' %}selected-link{% endif %}"
-        >All</a>
-      </li>
-      <li>
-        <a
-          href="{{ request.path }}?status=IMPORTING"
-          class="govuk-link govuk-link--no-underline govuk-link--no-visited-state {% if selected_link == 'importing' %}selected-link{% endif %}"
-        >Importing</a>
-      </li>
-      <li>
-        <a
-          href="{{ request.path }}?status=SUCCEEDED&workbasket__status=EDITING"
-          class="govuk-link govuk-link--no-underline govuk-link--no-visited-state {% if selected_link == 'completed' %}selected-link{% endif %}"
-        >Completed</a>
-      </li>
-      <li>
-        <a
-          href="{{ request.path }}?status=SUCCEEDED&workbasket__status=PUBLISHED"
-          class="govuk-link govuk-link--no-underline govuk-link--no-visited-state {% if selected_link == 'published' %}selected-link{% endif %}"
-        >Published</a>
-      </li>
-      <li>
-        <a
-          href="{{ request.path }}?status=SUCCEEDED&workbasket__status=ARCHIVED"
-          class="govuk-link govuk-link--no-underline govuk-link--no-visited-state {% if selected_link == 'empty' %}selected-link{% endif %}"
-        >Empty</a>
-      </li>
-      <li>
-        <a
-          href="{{ request.path }}?status=FAILED"
-          class="govuk-link govuk-link--no-underline govuk-link--no-visited-state {% if selected_link == 'errored' %}selected-link{% endif %}"
-        >Errored</a>
-      </li>
-    </ul>
+      {{ inline_filter_links(filter_links_list) }}
   </nav>
     
   <hr class="govuk-section-break govuk-section-break--visible">

--- a/importer/jinja2/eu-importer/select-imports.jinja
+++ b/importer/jinja2/eu-importer/select-imports.jinja
@@ -39,37 +39,37 @@
       <li>
         <a
           href="{{ request.path }}?status="
-          class="govuk-link govuk-link--no-underline govuk-link--no-visited-state {% if not request.GET.status %}selected-link{% endif %}"
+          class="govuk-link govuk-link--no-underline govuk-link--no-visited-state {% if selected_link == 'all' %}selected-link{% endif %}"
         >All</a>
       </li>
       <li>
         <a
           href="{{ request.path }}?status=IMPORTING"
-          class="govuk-link govuk-link--no-underline govuk-link--no-visited-state {% if request.GET.status == 'IMPORTING' %}selected-link{% endif %}"
+          class="govuk-link govuk-link--no-underline govuk-link--no-visited-state {% if selected_link == 'importing' %}selected-link{% endif %}"
         >Importing</a>
       </li>
       <li>
         <a
           href="{{ request.path }}?status=SUCCEEDED&workbasket__status=EDITING"
-          class="govuk-link govuk-link--no-underline govuk-link--no-visited-state {% if request.GET.status == 'SUCCEEDED' and request.GET.workbasket__status == 'EDITING' %}selected-link{% endif %}"
+          class="govuk-link govuk-link--no-underline govuk-link--no-visited-state {% if selected_link == 'completed' %}selected-link{% endif %}"
         >Completed</a>
       </li>
       <li>
         <a
           href="{{ request.path }}?status=SUCCEEDED&workbasket__status=PUBLISHED"
-          class="govuk-link govuk-link--no-underline govuk-link--no-visited-state {% if request.GET.status == 'SUCCEEDED' and request.GET.workbasket__status == 'PUBLISHED' %}selected-link{% endif %}"
+          class="govuk-link govuk-link--no-underline govuk-link--no-visited-state {% if selected_link == 'published' %}selected-link{% endif %}"
         >Published</a>
       </li>
       <li>
         <a
           href="{{ request.path }}?status=SUCCEEDED&workbasket__status=ARCHIVED"
-          class="govuk-link govuk-link--no-underline govuk-link--no-visited-state {% if request.GET.status == 'SUCCEEDED' and request.GET.workbasket__status == 'ARCHIVED' %}selected-link{% endif %}"
+          class="govuk-link govuk-link--no-underline govuk-link--no-visited-state {% if selected_link == 'empty' %}selected-link{% endif %}"
         >Empty</a>
       </li>
       <li>
         <a
           href="{{ request.path }}?status=FAILED"
-          class="govuk-link govuk-link--no-underline govuk-link--no-visited-state {% if request.GET.status == 'FAILED' %}selected-link{% endif %}"
+          class="govuk-link govuk-link--no-underline govuk-link--no-visited-state {% if selected_link == 'errored' %}selected-link{% endif %}"
         >Errored</a>
       </li>
     </ul>

--- a/importer/jinja2/eu-importer/select-imports.jinja
+++ b/importer/jinja2/eu-importer/select-imports.jinja
@@ -36,8 +36,6 @@
   <nav class="workbasket-filters">
     <p class="govuk-body govuk-!-font-weight-bold">Filter results:</p>
     <ul class="govuk-list">
-      <li>TODO: TP2000-920</li>
-      <!--
       <li>
         <a
           href="{{ request.path }}?status="
@@ -46,23 +44,34 @@
       </li>
       <li>
         <a
-          href="{{ request.path }}?status="
-          class="govuk-link govuk-link--no-underline govuk-link--no-visited-state {% if request.GET.status == 'IMPORTED' %}selected-link{% endif %}"
-        >Imported</a>
+          href="{{ request.path }}?status=IMPORTING"
+          class="govuk-link govuk-link--no-underline govuk-link--no-visited-state {% if request.GET.status == 'IMPORTING' %}selected-link{% endif %}"
+        >Importing</a>
       </li>
       <li>
         <a
-          href="{{ request.path }}?status=REVIEW"
-          class="govuk-link govuk-link--no-underline govuk-link--no-visited-state {% if request.GET.status == 'REVIEW' %}selected-link{% endif %}"
-        >In review</a>
-      </li>
-      <li>
-        <a
-          href="{{ request.path }}?status=COMPLETED"
-          class="govuk-link govuk-link--no-underline govuk-link--no-visited-state {% if request.GET.status == 'COMPLETED' %}selected-link{% endif %}"
+          href="{{ request.path }}?status=SUCCEEDED&workbasket__status=EDITING"
+          class="govuk-link govuk-link--no-underline govuk-link--no-visited-state {% if request.GET.status == 'SUCCEEDED' and request.GET.workbasket__status == 'EDITING' %}selected-link{% endif %}"
         >Completed</a>
       </li>
-      -->
+      <li>
+        <a
+          href="{{ request.path }}?status=SUCCEEDED&workbasket__status=PUBLISHED"
+          class="govuk-link govuk-link--no-underline govuk-link--no-visited-state {% if request.GET.status == 'SUCCEEDED' and request.GET.workbasket__status == 'PUBLISHED' %}selected-link{% endif %}"
+        >Published</a>
+      </li>
+      <li>
+        <a
+          href="{{ request.path }}?status=SUCCEEDED&workbasket__status=ARCHIVED"
+          class="govuk-link govuk-link--no-underline govuk-link--no-visited-state {% if request.GET.status == 'SUCCEEDED' and request.GET.workbasket__status == 'ARCHIVED' %}selected-link{% endif %}"
+        >Empty</a>
+      </li>
+      <li>
+        <a
+          href="{{ request.path }}?status=FAILED"
+          class="govuk-link govuk-link--no-underline govuk-link--no-visited-state {% if request.GET.status == 'FAILED' %}selected-link{% endif %}"
+        >Errored</a>
+      </li>
     </ul>
   </nav>
     

--- a/importer/views.py
+++ b/importer/views.py
@@ -13,6 +13,8 @@ from importer import forms
 from importer import models
 from importer.filters import ImportBatchFilter
 from importer.filters import TaricImportFilter
+from importer.models import ImportBatchStatus
+from workbaskets.validators import WorkflowStatus
 
 
 class ImportBatchList(RequiresSuperuserMixin, WithPaginationListView):
@@ -68,6 +70,36 @@ class CommodityImportListView(
     queryset = models.ImportBatch.objects.order_by("-created_at")
     template_name = "eu-importer/select-imports.jinja"
     filterset_class = TaricImportFilter
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+
+        import_status = self.request.GET.get("status")
+        workbasket_status = self.request.GET.get("workbasket__status")
+
+        context["selected_link"] = "all"
+
+        if (
+            import_status == ImportBatchStatus.SUCCEEDED
+            and workbasket_status == WorkflowStatus.EDITING
+        ):
+            context["selected_link"] = "completed"
+        elif (
+            import_status == ImportBatchStatus.SUCCEEDED
+            and workbasket_status == WorkflowStatus.PUBLISHED
+        ):
+            context["selected_link"] = "published"
+        elif (
+            import_status == ImportBatchStatus.SUCCEEDED
+            and workbasket_status == WorkflowStatus.ARCHIVED
+        ):
+            context["selected_link"] = "empty"
+        elif import_status == ImportBatchStatus.IMPORTING and workbasket_status == None:
+            context["selected_link"] = "importing"
+        elif import_status == ImportBatchStatus.FAILED and workbasket_status == None:
+            context["selected_link"] = "errored"
+
+        return context
 
 
 class CommodityImportCreateView(


### PR DESCRIPTION
# TP-2000-920-Filter import by combined import status and workbasket status

## Why
There's a need to filter imports on the list page by not only their status but  in combination with their linked workbasket's status too.

## What
5 filters have been added to the import list page (beyond the all status): 

Importing - This filters for imports with a status of IMPORTING. 

Completed - This filters for imports with a status of SUCCEEDED and a linked workbasket status of EDITING

Published - This filters for imports with a status of SUCCEEDED and a linked workbasket status of PUBLISHED

Empty - This filters for imports with a status of SUCCEEDED and a linked workbasket status of ARCHIVED

Errored - This filters for imports with a status of FAILED


I've also added tests to check that the right filters are rendered, and that their links do what they say on the tin 🌻 



## Checklist
- Requires migrations? - no
- Requires dependency updates? - no

