### PR TITLE
Fix for envelope export, when a measurement unit is created.

### DIFF
--- a/publishing/tests/test_util.py
+++ b/publishing/tests/test_util.py
@@ -146,6 +146,10 @@ def test_all_tracked_models_validate_envelope(queued_workbasket):
     factories.MeasurementUnitQualifierFactory(transaction=approved_transaction)
     factories.MeasurementUnitFactory(transaction=approved_transaction)
     factories.MeasurementFactory(transaction=approved_transaction)
+    factories.MeasurementFactory(
+        transaction=approved_transaction,
+        measurement_unit_qualifier=None,
+    )
 
     factories.QuotaAssociationFactory(transaction=approved_transaction)
     factories.QuotaBlockingFactory(transaction=approved_transaction)

--- a/publishing/util.py
+++ b/publishing/util.py
@@ -42,7 +42,7 @@ model_taric_record_count = dict(
         "MeasureType": 2,
         "Measure": 1,
         "MeasurementUnitQualifier": 2,
-        "MeasurementUnit": 2,
+        "MeasurementUnit": 2,  # correct, has dependent
         "Measurement": 1,
         "MonetaryUnit": 2,
         "QuotaAssociation": 1,
@@ -117,6 +117,17 @@ def validate_envelope(envelope_file, workbaskets, skip_declaration=False):
             raise
 
 
+def get_expected_model_taric_record_count(tracked_model):
+    expected_count = model_taric_record_count[tracked_model.__class__.__name__]
+
+    # add clause for possible exclusion of Measurement, based on no measurement qualifier
+    if tracked_model.__class__.__name__ == "Measurement":
+        if not tracked_model.measurement_unit_qualifier:
+            expected_count = 0
+
+    return expected_count
+
+
 def validate_taric_xml_record_order(xml, workbaskets):
     """
     Raise AssertionError if:
@@ -136,9 +147,9 @@ def validate_taric_xml_record_order(xml, workbaskets):
             workbasket_transaction_count += 1
             for tracked_model in tracked_models:
                 # dictionary that maps the tracked model class to taric record count
-                expected_record_count += model_taric_record_count[
-                    tracked_model.__class__.__name__
-                ]
+                expected_record_count += get_expected_model_taric_record_count(
+                    tracked_model,
+                )
 
     envelope_record_count = 0
     envelope_transaction_count = 0


### PR DESCRIPTION
There is a condition where a measurement may not be present in the XML if there is no associated measurement unit qualifier. 

This issue currently prevents an existing workbasket from correctly producing an envelope as it fails at the count of expected elements. 

This fix updates the logic used to count the expected elements and corrects the issue. Tests also added

## What
 * Added a method to conditionally count measurements if the measurement is in the workbasket, and there is an associated unit qualifier 
 * Updates tests to check correctly for this