### PR TITLE
TP2000-944 : Update ME67 to look at measure based on transaction

### DIFF
--- a/measures/business_rules.py
+++ b/measures/business_rules.py
@@ -1243,7 +1243,12 @@ class ME67(BusinessRule):
     """
 
     def validate(self, exclusion):
-        measure = exclusion.modified_measure
+        from measures.models import Measure
+
+        # Need to get latest version of measure
+        measure = Measure.objects.approved_up_to_transaction(self.transaction).get(
+            sid=exclusion.modified_measure.sid,
+        )
 
         geo_area = measure.geographical_area
         members = geo_area.members.approved_up_to_transaction(

--- a/measures/tests/test_buinsess_rules/test_ME67.py
+++ b/measures/tests/test_buinsess_rules/test_ME67.py
@@ -158,8 +158,8 @@ def test_ME67_multiple_member_periods():
 
     business_rules.ME67(exclusion_1_pass.transaction).validate(exclusion_1_pass)
     business_rules.ME67(exclusion_2_pass.transaction).validate(exclusion_2_pass)
-    business_rules.ME67(exclusion_2_pass.transaction).validate(exclusion_3_pass)
-    business_rules.ME67(exclusion_2_pass.transaction).validate(exclusion_4_pass)
+    business_rules.ME67(exclusion_3_pass.transaction).validate(exclusion_3_pass)
+    business_rules.ME67(exclusion_4_pass.transaction).validate(exclusion_4_pass)
 
     with pytest.raises(BusinessRuleViolation) as e:
         business_rules.ME67(exclusion_1_fail.transaction).validate(exclusion_1_fail)

--- a/measures/tests/test_buinsess_rules/test_ME67.py
+++ b/measures/tests/test_buinsess_rules/test_ME67.py
@@ -224,11 +224,52 @@ def test_ME67_with_end_dates_in_range():
     )
 
 
-#  business_rules.ME67(exclusion_1_pass.transaction).validate(exclusion_1_pass)
-#
-#
-#  with pytest.raises(BusinessRuleViolation) as e:
-#      business_rules.ME67(exclusion_1_fail.transaction).validate(exclusion_1_fail)
-#      assert str(e) == "<ExceptionInfo for raises contextmanager>"
-#
-#
+def test_ME67_gets_latest_version_of_measure():
+    """
+    When checking against exclusions, the rule check historically looked at the
+    old version of the measure.
+
+    This text verifies the fix correctly queries the latest version of the
+    measure, where the measure may also be updated in the same workbasket
+    """
+
+    # setup, create measure with origin as geo group
+    approved_transaction = factories.ApprovedTransactionFactory.create()
+
+    validity = TaricDateRange(date(2021, 1, 1), date(2022, 1, 1))
+    validity2 = TaricDateRange(date(2021, 6, 1), date(2022, 1, 1))
+    geo_group = factories.GeoGroupFactory.create(
+        valid_between=validity,
+        transaction=approved_transaction,
+    )
+    geo_member = factories.GeographicalMembershipFactory.create(
+        geo_group=geo_group,
+        valid_between=validity2,
+        transaction=approved_transaction,
+    )
+
+    # Create measure in history
+    original_measure = factories.MeasureFactory.create(
+        transaction=approved_transaction,
+        geographical_area=geo_group,
+        valid_between=validity,
+    )
+
+    draft_transaction = factories.UnapprovedTransactionFactory.create()
+
+    # Update measure in draft workbasket with new start date
+    original_measure.new_version(
+        workbasket=draft_transaction.workbasket,
+        transaction=draft_transaction,
+        valid_between=validity2,
+    )
+    measure_exclusion = factories.MeasureExcludedGeographicalAreaFactory(
+        transaction=draft_transaction,
+        modified_measure=original_measure,
+        excluded_geographical_area=geo_member.member,
+    )
+
+    # ME67 should not throw an exception in this case, as it will use the measures draft date in the check
+    business_rules.ME67(measure_exclusion.transaction).validate(
+        measure_exclusion,
+    )


### PR DESCRIPTION
When checking against exclusions, the rule check historically looked at the old version of the measure (e.g the one linked to the exclusion, not the potentially most recent version in the same or previous transaction based on the workbasket).

# Additional fix for ME67
 * TP2000-944

## Why
 * ME67 was not behaving correctly 
 * Valid changes may raise business rule violations incorrectly

## What
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Update ME67 to query the latest version of the measure based on the transaction / workbasket

## Checklist
- Requires migrations? No
- Requires dependency updates? No

Links to relevant material
See: [JIRA](https://uktrade.atlassian.net/browse/TP2000-944)
