### PR TITLE
TP2000-933 Fix failing importer tests

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -987,6 +987,20 @@ def loading_report_storage(s3):
     )
 
 
+@pytest.fixture
+def importer_storage(s3):
+    """Patch CommodityImporterStorage with moto so that nothing is really
+    uploaded to s3."""
+    from importer.storages import CommodityImporterStorage
+
+    storage = make_storage_mock(
+        s3,
+        CommodityImporterStorage,
+        bucket_name=settings.IMPORTER_STORAGE_BUCKET_NAME,
+    )
+    return storage
+
+
 @pytest.fixture(
     params=(
         (make_duplicate_record, True),

--- a/importer/chunker.py
+++ b/importer/chunker.py
@@ -14,7 +14,7 @@ from importer import models
 from importer.namespaces import make_schema_dataclass
 from importer.namespaces import nsmap
 from importer.namespaces import xsd_schema_paths
-from importer.utils import dependency_tree
+from importer.utils import build_dependency_tree
 
 MAX_FILE_SIZE = 1024 * 1024 * 50  # Will keep chunks roughly close to 50MB
 Tags = make_schema_dataclass(xsd_schema_paths)
@@ -233,6 +233,7 @@ def write_transaction_to_chunk(
     if batch.split_job:
         record_code = get_record_code(transaction)
 
+        dependency_tree = build_dependency_tree()
         if record_code not in dependency_tree:
             return
 

--- a/importer/tests/management/commands/test_chunk_taric.py
+++ b/importer/tests/management/commands/test_chunk_taric.py
@@ -31,7 +31,7 @@ def test_setup_batch_no_split_with_dependencies_creates_dependencies_records(
         "test_batch_with_deps",
         valid_user,
         False,
-        [1],
+        [batch.pk],
     )
     assert isinstance(batch_with_deps, ImportBatch)
     assert batch.split_job is False


### PR DESCRIPTION
# TP2000-933 Fix failing importer tests

## Why
Follow-up PR to https://github.com/uktrade/tamato/pull/961 to fix some unit tests that fell through the net. 

## What
- Mocks `CommodityImportStorage.save()` to fix `CommodityImportForm` test
- Calls `build_dependency_tree()` directly to populate `dependency_tree` (previously showing as empty) to fix `test_write_transaction_to_chunk_exceed_max_file_size`
- Fixes test_chunk_taric.py test by passing in pk of preceeding batch

