### PR TITLE
TP2000-946  Fix geo area description create error

### DIFF
--- a/geo_areas/views.py
+++ b/geo_areas/views.py
@@ -67,7 +67,7 @@ class GeoAreaCreateDescriptionMixin:
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        context["described_object"] = GeographicalArea.objects.get(
+        context["described_object"] = GeographicalArea.objects.current().get(
             sid=(self.kwargs.get("sid")),
         )
         return context
@@ -113,7 +113,7 @@ class GeoAreaDescriptionCreate(
 ):
     def get_initial(self):
         initial = super().get_initial()
-        initial["described_geographicalarea"] = GeographicalArea.objects.get(
+        initial["described_geographicalarea"] = GeographicalArea.objects.current().get(
             sid=(self.kwargs.get("sid")),
         )
         return initial


### PR DESCRIPTION
# TP2000-946  Fix geo area description create error

## Why
Attempting to create a description for the Geographical Region Saint Helena raises `MultipleObjectsReturned` error.

## What
- Updates `GeoAreaDescriptionCreate` view and `GeoAreaCreateDescriptionMixin` to use `current()` in queryset to get the latest version of a geo area
- Adds test for creating a geo area description

