### PR TITLE
TP2000-807 Goods file reporting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,3 +162,6 @@ ner_output_file.txt
 
 tmp/**
 _dumped_cache.pkl
+
+# Vim
+.swp

--- a/importer/goods_report.py
+++ b/importer/goods_report.py
@@ -181,6 +181,7 @@ class GoodsReport:
 
     def save_xlsx(self, filepath: str) -> None:
         """Save report to an Excel file in xlsx file format."""
+        # TODO: is filepath better replaced with a writable file object?
         # TODO: generate and save to Excel file format.
         print("TODO: implement Excel file creation.")
 
@@ -190,6 +191,7 @@ class GoodsReport:
 
     def save_markdown(self, filepath: str) -> None:
         """Save report in markdown format to a file located at filepath."""
+        # TODO: is filepath better replaced with a writable file object?
         self.markdown()
         # TODO: save to file.
         print("TODO: implement markdown file creation.")

--- a/importer/goods_report.py
+++ b/importer/goods_report.py
@@ -3,6 +3,7 @@ import os
 from dataclasses import dataclass
 from typing import Generator
 from typing import List
+from typing import TextIO
 from xml.etree import ElementTree as ET
 
 from common.validators import UpdateType
@@ -101,8 +102,9 @@ class GoodsReportLine:
         # "original_message_id",
         # "original_transaction_id",
     )
+    """Column names used within generated reports."""
 
-    def __init__(self, record_element: ET.Element):
+    def __init__(self, record_element: ET.Element) -> None:
         self.record_element = record_element
 
         # Report columns.
@@ -111,13 +113,16 @@ class GoodsReportLine:
         self.goods_nomenclature_item_id = self._get_goods_nomenclature_item_id()
 
     def as_list(self) -> List[str]:
+        """Return a report line as a list of report columns."""
         return [
             self.update_type,
             self.record_name,
             self.goods_nomenclature_item_id,
         ]
 
-    def as_str(self, separator=", "):
+    def as_str(self, separator: str = ", ") -> str:
+        """Return a report line as a string concatenation of report columns,
+        each separated by `separator`."""
         return f"{separator}".join(self.as_list())
 
     def _get_update_type(self) -> str:
@@ -129,8 +134,10 @@ class GoodsReportLine:
         try:
             return UpdateType(int(update_type_id)).name
         except:
-            pass
-        return "Unknown"
+            logger.info(
+                f"Malformed update type information encountered, " f"{update_type_id}",
+            )
+            return "Unknown"
 
     def _get_record_name(self) -> str:
         """Get the human-readable name of record being updated."""
@@ -162,28 +169,36 @@ class GoodsReportLine:
 
 class GoodsReport:
     """
-    NOTE:
-    - If caching results on S3, then should function names indicate the results
-      may not be freshly generated?
+    Represents a report providing information about goods-related entities.
+
+    A report can be externalised to a variety of formats via this class's
+    methods.
     """
 
     report_lines: List[GoodsReportLine] = []
     """List of ReportLines representing reported records in the order that they
     appear within the TARIC3 XML file."""
 
-    def save_xlsx(self, filepath):
+    def save_xlsx(self, filepath: str) -> None:
         """Save report to an Excel file in xlsx file format."""
-        # TODO
+        # TODO: generate and save to Excel file format.
+        print("TODO: implement Excel file creation.")
 
     def markdown(self) -> str:
         """Return report in markdown format."""
-        # TODO
+        # TODO: generate and return markdown text content.
 
-    def save_markdown(self, filepath):
+    def save_markdown(self, filepath: str) -> None:
         """Save report in markdown format to a file located at filepath."""
-        # TODO
+        self.markdown()
+        # TODO: save to file.
+        print("TODO: implement markdown file creation.")
 
-    def plaintext(self, separator=", ", include_column_names=False) -> str:
+    def plaintext(
+        self,
+        separator: str = ", ",
+        include_column_names: bool = False,
+    ) -> str:
         """Return a plain-text representation of the report."""
         str_repr = ""
         if include_column_names:
@@ -196,7 +211,7 @@ class GoodsReport:
 class GoodsReporter:
     """Parses and builds a goods report for a TARIC3 XML file."""
 
-    def __init__(self, goods_file):
+    def __init__(self, goods_file: TextIO) -> None:
         self.goods_file = goods_file
 
     def create_report(self) -> GoodsReport:

--- a/importer/goods_report.py
+++ b/importer/goods_report.py
@@ -1,0 +1,261 @@
+import logging
+import os
+from dataclasses import dataclass
+from typing import Generator
+from typing import List
+from xml.etree import ElementTree as ET
+
+from common.validators import UpdateType
+
+logger = logging.getLogger(__name__)
+
+
+TARIC3_NAMESPACES = {
+    "env": "urn:publicid:-:DGTAXUD:GENERAL:ENVELOPE:1.0",
+    "oub": "urn:publicid:-:DGTAXUD:TARIC:MESSAGE:1.0",
+}
+"""XML namespaces used in valid XML envelopes."""
+
+
+# Goods Nomenclature XML tag names.
+GOODS_NOMENCLATURE_TAG = "oub:goods.nomenclature"
+GOODS_NOMENCLATURE_INDENT_TAG = "oub:goods.nomenclature.indent"
+GOODS_NOMENCLATURE_DESCRIPTION_PERIOD_TAG = "oub:goods.nomenclature.description.period"
+GOODS_NOMENCLATURE_DESCRIPTION_TAG = "oub:goods.nomenclature.description"
+GOODS_NOMENCLATURE_ORIGIN_TAG = "oub:goods.nomenclature.origin"
+GOODS_NOMENCLATURE_SUCCESSOR_TAG = "oub:goods.nomenclature.successor"
+
+
+@dataclass
+class RecordInfo:
+    """Informational class for Goods Nomenclature related record types."""
+
+    xml_tag: str
+    name: str
+    record_code: str
+    subrecord_code: str
+
+
+RECORD_TAG_TO_RECORD_INFO_MAP = {
+    GOODS_NOMENCLATURE_TAG: RecordInfo(
+        GOODS_NOMENCLATURE_TAG,
+        "Goods nomenclature",
+        "400",
+        "00",
+    ),
+    GOODS_NOMENCLATURE_INDENT_TAG: RecordInfo(
+        GOODS_NOMENCLATURE_INDENT_TAG,
+        "Indent",
+        "400",
+        "05",
+    ),
+    GOODS_NOMENCLATURE_DESCRIPTION_PERIOD_TAG: RecordInfo(
+        GOODS_NOMENCLATURE_DESCRIPTION_PERIOD_TAG,
+        "Goods nomenclature description period",
+        "400",
+        "10",
+    ),
+    GOODS_NOMENCLATURE_DESCRIPTION_TAG: RecordInfo(
+        GOODS_NOMENCLATURE_DESCRIPTION_TAG,
+        "Goods nomenclature description",
+        "400",
+        "15",
+    ),
+    GOODS_NOMENCLATURE_ORIGIN_TAG: RecordInfo(
+        GOODS_NOMENCLATURE_ORIGIN_TAG,
+        "Goods nomenclature origin",
+        "400",
+        "35",
+    ),
+    GOODS_NOMENCLATURE_SUCCESSOR_TAG: RecordInfo(
+        GOODS_NOMENCLATURE_SUCCESSOR_TAG,
+        "Goods nomenclature successor",
+        "400",
+        "40",
+    ),
+}
+"""Dictionary mapping of Goods record tags to RecordInfo instances, each
+representing a TARIC3 record that can appear in a goods report."""
+
+
+RECORD_CODE_TO_RECORD_INFO_MAP = {
+    f"{r.record_code}{r.subrecord_code}": r
+    for r in RECORD_TAG_TO_RECORD_INFO_MAP.values()
+}
+"""Dictionary mapping of record code + subrecord code to RecordInfo
+instances."""
+
+
+class GoodsReportLine:
+    """Report lines for specific types of record."""
+
+    COLUMN_NAMES = (
+        "update_type",
+        "whats_being_updated",
+        "goods_nomenclature_code",
+        # TODO:
+        # "suffix",
+        # "validity_start_date",
+        # "validity_end_date",
+        # "comments",
+        # "original_message_id",
+        # "original_transaction_id",
+    )
+
+    def __init__(self, record_element: ET.Element):
+        self.record_element = record_element
+
+        # Report columns.
+        self.update_type = self._get_update_type()
+        self.record_name = self._get_record_name()
+        self.goods_nomenclature_item_id = self._get_goods_nomenclature_item_id()
+
+    def as_list(self) -> List[str]:
+        return [
+            self.update_type,
+            self.record_name,
+            self.goods_nomenclature_item_id,
+        ]
+
+    def as_str(self, separator=", "):
+        return f"{separator}".join(self.as_list())
+
+    def _get_update_type(self) -> str:
+        """Get the TARIC update type - one of UPDATE, DELETE and CREATE."""
+        update_type_id = self.record_element.findtext(
+            "oub:update.type",
+            namespaces=TARIC3_NAMESPACES,
+        )
+        try:
+            return UpdateType(int(update_type_id)).name
+        except:
+            pass
+        return "Unknown"
+
+    def _get_record_name(self) -> str:
+        """Get the human-readable name of record being updated."""
+        record_code_match = self.record_element.findtext(
+            "./oub:record.code",
+            default="",
+            namespaces=TARIC3_NAMESPACES,
+        ).strip()
+        subrecord_code_match = self.record_element.findtext(
+            "./oub:subrecord.code",
+            default="",
+            namespaces=TARIC3_NAMESPACES,
+        ).strip()
+        return RECORD_CODE_TO_RECORD_INFO_MAP.get(
+            f"{record_code_match}{subrecord_code_match}",
+        ).name
+
+    def _get_goods_nomenclature_item_id(self) -> str:
+        """Get the item id of the associated goods nomenclature instance."""
+        return self.record_element.findtext(
+            ".//oub:goods.nomenclature.item.id",
+            default="",
+            namespaces=TARIC3_NAMESPACES,
+        ).strip()
+
+    def __str__(self) -> str:
+        return self.as_str()
+
+
+class GoodsReport:
+    """
+    NOTE:
+    - If caching results on S3, then should function names indicate the results
+      may not be freshly generated?
+    """
+
+    report_lines: List[GoodsReportLine] = []
+    """List of ReportLines representing reported records in the order that they
+    appear within the TARIC3 XML file."""
+
+    def save_xlsx(self, filepath):
+        """Save report to an Excel file in xlsx file format."""
+        # TODO
+
+    def markdown(self) -> str:
+        """Return report in markdown format."""
+        # TODO
+
+    def save_markdown(self, filepath):
+        """Save report in markdown format to a file located at filepath."""
+        # TODO
+
+    def plaintext(self, separator=", ", include_column_names=False) -> str:
+        """Return a plain-text representation of the report."""
+        str_repr = ""
+        if include_column_names:
+            str_repr += f"{separator}".join(GoodsReportLine.COLUMN_NAMES) + "\n"
+        for line in self.report_lines:
+            str_repr += f"{line.as_str(separator)}\n"
+        return str_repr
+
+
+class GoodsReporter:
+    """Parses and builds a goods report for a TARIC3 XML file."""
+
+    def __init__(self, goods_file):
+        self.goods_file = goods_file
+
+    def create_report(self) -> GoodsReport:
+        """Create an instance of GoodsReport by parsing a TARIC3 XML file,
+        extracting information relevant to a goods report."""
+
+        base_filename = os.path.basename(self.goods_file.name)
+
+        logger.debug(f"Begin generating report object for {base_filename}.")
+
+        goods_report = GoodsReport()
+        record_count = 0
+
+        for record_element in self._iter_records():
+            record_count += 1
+            if self._is_reportable(record_element):
+                report_line = GoodsReportLine(record_element)
+                goods_report.report_lines.append(report_line)
+
+        logger.debug(
+            f"Found {len(goods_report.report_lines)} goods-related "
+            f"records from a total of {record_count} records.",
+        )
+        logger.debug(f"Finished generating report object for {base_filename}.")
+
+        return goods_report
+
+    def _is_reportable(self, record_element: ET.Element) -> bool:
+        """Returns True if record is a match by record code and subrecord code
+        for those records that are to be included in the generated report, False
+        otherwise."""
+
+        record_code_match = record_element.findtext(
+            "./oub:record.code",
+            default="",
+            namespaces=TARIC3_NAMESPACES,
+        ).strip()
+        subrecord_code_match = record_element.findtext(
+            "./oub:subrecord.code",
+            default="",
+            namespaces=TARIC3_NAMESPACES,
+        ).strip()
+        return (
+            f"{record_code_match}{subrecord_code_match}"
+            in RECORD_CODE_TO_RECORD_INFO_MAP.keys()
+        )
+
+    def _iter_records(self) -> Generator[ET.Element, None, None]:
+        """Generator returning an iterator over the records of the goods
+        file."""
+        tree = ET.parse(self.goods_file)
+        root = tree.getroot()
+
+        for transaction in root.iterfind(
+            "./env:transaction",
+            namespaces=TARIC3_NAMESPACES,
+        ):
+            for record in transaction.iterfind(
+                "./env:app.message/oub:transmission/oub:record",
+                namespaces=TARIC3_NAMESPACES,
+            ):
+                yield record

--- a/importer/goods_report.py
+++ b/importer/goods_report.py
@@ -313,8 +313,30 @@ class GoodsReporter:
         )
 
     def _iter_records(self) -> Generator[Tuple[str, str, ET.Element], None, None]:
-        """Generator returning an iterator over the records of the goods
-        file."""
+        """
+        Generator yielding each record in the parsed goods file, along with the
+        ID of its containing transaction and ID of its containing message, as a
+        tuple.
+
+        For instance, a tuple of ("123456", "1", <ET.Element>) would be yielded
+        on the first iteration of the following XML content:
+
+        .. code-block:: python
+
+            <?xml version="1.0" encoding="UTF-8"?>
+            <env:envelope xmlns="urn:..." xmlns:env="urn:publicid:-:DGTAXUD:GENERAL:ENVELOPE:1.0" id="23800">
+                <env:transaction id="12345678">
+                    <env:app.message id="1">
+                        <oub:transmission xmlns:oub="urn:publicid:-:DGTAXUD:TARIC:MESSAGE:1.0" xmlns:env="urn:publicid:-:DGTAXUD:GENERAL:ENVELOPE:1.0">
+                            <oub:record>
+                                ...
+                            </oub:record>
+                        </oub:transmission>
+                    </env:app.message>
+                </env:transaction>
+                ...
+            </env:envelope>
+        """
         tree = ET.parse(self.goods_file)
         root = tree.getroot()
 

--- a/importer/goods_report.py
+++ b/importer/goods_report.py
@@ -1,6 +1,8 @@
+import csv
 import logging
 import os
 from dataclasses import dataclass
+from io import StringIO
 from typing import Generator
 from typing import List
 from typing import TextIO
@@ -124,10 +126,10 @@ class GoodsReportLine:
         self.containing_message_id = containing_message_id
 
     @classmethod
-    def stringified_column_names(cls, separator: str = ", ") -> str:
-        """Return a concatenated, string representaiton of report column names
-        separated by `separator."""
-        return f"{separator}".join(cls.COLUMN_NAMES)
+    def csv_column_names(cls, delimiter: str = ",") -> str:
+        """Return a csv (concatenated, string) representaiton of report column
+        names delimited by `delimiter`."""
+        return cls._csv_line(cls.COLUMN_NAMES)
 
     def as_list(self) -> List[str]:
         """Return a report line as a list of report columns."""
@@ -142,10 +144,17 @@ class GoodsReportLine:
             self.containing_message_id,
         ]
 
-    def as_str(self, separator: str = ", ") -> str:
+    def as_csv(self, delimiter: str = ",") -> str:
         """Return a report line as a string concatenation of report columns,
-        each separated by `separator`."""
-        return f"{separator}".join(self.as_list())
+        each delimited by `delimiter`."""
+        return self._csv_line(self.as_list())
+
+    @classmethod
+    def _csv_line(cls, line: List, delimiter=",") -> str:
+        string_io = StringIO()
+        writer = csv.writer(string_io, delimiter=delimiter)
+        writer.writerow(line)
+        return string_io.getvalue()
 
     def _get_update_type(self) -> str:
         """Get the TARIC update type - one of UPDATE, DELETE and CREATE."""
@@ -210,7 +219,7 @@ class GoodsReportLine:
         ).strip()
 
     def __str__(self) -> str:
-        return self.as_str()
+        return self.as_csv()
 
 
 class GoodsReport:
@@ -225,35 +234,29 @@ class GoodsReport:
     """List of ReportLines representing reported records in the order that they
     appear within the TARIC3 XML file."""
 
-    def save_xlsx(self, filepath: str) -> None:
-        """Save report to an Excel file in xlsx file format."""
-        # TODO: is filepath better replaced with a writable file object?
-        # TODO: generate and save to Excel file format.
-        print("TODO: implement Excel file creation.")
+    def csv(
+        self,
+        delimiter: str = ",",
+        include_column_names: bool = False,
+    ) -> str:
+        """Return a csv string representation of the report."""
+        str_repr = ""
+        if include_column_names:
+            str_repr += GoodsReportLine.csv_column_names()
+        for line in self.report_lines:
+            str_repr += f"{line.as_csv(delimiter)}"
+        return str_repr
 
     def markdown(self) -> str:
         """Return report in markdown format."""
         # TODO: generate and return markdown text content.
+        return "TODO: implement markdown output."
 
-    def save_markdown(self, filepath: str) -> None:
-        """Save report in markdown format to a file located at filepath."""
+    def xlsx_file(self, filepath: str) -> None:
+        """Save report to an Excel file in xlsx file format."""
         # TODO: is filepath better replaced with a writable file object?
-        self.markdown()
-        # TODO: save to file.
-        print("TODO: implement markdown file creation.")
-
-    def plaintext(
-        self,
-        separator: str = ", ",
-        include_column_names: bool = False,
-    ) -> str:
-        """Return a plain-text representation of the report."""
-        str_repr = ""
-        if include_column_names:
-            str_repr += GoodsReportLine.stringified_column_names() + "\n"
-        for line in self.report_lines:
-            str_repr += f"{line.as_str(separator)}\n"
-        return str_repr
+        # TODO: generate and save to Excel file format.
+        print("TODO: implement Excel file creation.")
 
 
 class GoodsReporter:

--- a/importer/goods_report.py
+++ b/importer/goods_report.py
@@ -2,12 +2,16 @@ import csv
 import logging
 import os
 from dataclasses import dataclass
+from io import BytesIO
 from io import StringIO
 from typing import Generator
 from typing import List
 from typing import TextIO
 from typing import Tuple
 from xml.etree import ElementTree as ET
+
+from openpyxl import Workbook
+from openpyxl.styles import Font
 
 from common.validators import UpdateType
 
@@ -237,7 +241,7 @@ class GoodsReport:
     def csv(
         self,
         delimiter: str = ",",
-        include_column_names: bool = False,
+        include_column_names: bool = True,
     ) -> str:
         """Return a csv string representation of the report."""
         str_repr = ""
@@ -247,16 +251,35 @@ class GoodsReport:
             str_repr += f"{line.as_csv(delimiter)}"
         return str_repr
 
-    def markdown(self) -> str:
-        """Return report in markdown format."""
+    def markdown(
+        self,
+        include_column_names: bool = True,
+    ) -> str:
+        """Return a markdown string representation of the format."""
         # TODO: generate and return markdown text content.
         return "TODO: implement markdown output."
 
-    def xlsx_file(self, filepath: str) -> None:
-        """Save report to an Excel file in xlsx file format."""
-        # TODO: is filepath better replaced with a writable file object?
-        # TODO: generate and save to Excel file format.
-        print("TODO: implement Excel file creation.")
+    def xlsx_file(
+        self,
+        xlsx_io: BytesIO,
+        include_column_names: bool = True,
+    ) -> None:
+        """Write report contents to a BytesIO object, xlsx_io, in Excel (xlsx)
+        file format."""
+
+        workbook = Workbook()
+        sheet = workbook.active
+
+        if include_column_names:
+            column_names = GoodsReportLine.COLUMN_NAMES
+            sheet.append(column_names)
+            for cell in sheet[1]:
+                cell.font = Font(bold=True)
+
+        for line in self.report_lines:
+            sheet.append(line.as_list())
+
+        workbook.save(xlsx_io.name)
 
 
 class GoodsReporter:

--- a/importer/goods_report.py
+++ b/importer/goods_report.py
@@ -112,6 +112,12 @@ class GoodsReportLine:
         self.record_name = self._get_record_name()
         self.goods_nomenclature_item_id = self._get_goods_nomenclature_item_id()
 
+    @classmethod
+    def stringified_column_names(cls, separator: str = ", "):
+        """Return a concatenated, string representaiton of report column names
+        separated by `separator."""
+        return f"{separator}".join(cls.COLUMN_NAMES)
+
     def as_list(self) -> List[str]:
         """Return a report line as a list of report columns."""
         return [
@@ -204,7 +210,7 @@ class GoodsReport:
         """Return a plain-text representation of the report."""
         str_repr = ""
         if include_column_names:
-            str_repr += f"{separator}".join(GoodsReportLine.COLUMN_NAMES) + "\n"
+            str_repr += GoodsReportLine.stringified_column_names() + "\n"
         for line in self.report_lines:
             str_repr += f"{line.as_str(separator)}\n"
         return str_repr

--- a/importer/management/commands/generate_goods_report.py
+++ b/importer/management/commands/generate_goods_report.py
@@ -39,12 +39,18 @@ class Command(BaseCommand):
         parser.add_argument(
             "--output-format",
             help=(
-                "Specify the format of the generated report. Default behaviour "
-                "is to output a plain text version of the report to stdout."
+                "Specify the format of the generated report. "
+                "Default behaviour is to output a csv (Excel dialect) version "
+                "of the report to stdout. "
+                "Specifying md outputs a markdown formatted version of the "
+                "report to stdout. "
+                "Specifying xlsx-file saves an Excel formatted version of the "
+                "report to file, using a filename derived from the TARIC3 input "
+                "filename."
             ),
             nargs="?",
-            choices=("xlsx", "md", "text"),
-            default="text",
+            choices=("csv", "md", "xlsx-file"),
+            default="csv",
         )
 
         parser.add_argument(
@@ -113,19 +119,17 @@ class Command(BaseCommand):
         goods_report = reporter.create_report()
 
         output_format = self.options.get("output_format")
-        if output_format == "text":
+        if output_format == "csv":
             self.stdout.write(
-                goods_report.plaintext(separator=", ", include_column_names=True),
+                goods_report.csv(delimiter=",", include_column_names=True),
             )
+        elif output_format == "md":
+            self.stdout.write(goods_report.markdown())
         else:
             directory = self.get_output_directory()
             filename = self.get_output_base_filename()
-            if output_format == "xlsx":
-                filepath = f"{directory}{filename}.xlsx"
-                goods_report.save_xlsx(filepath)
-            else:
-                filepath = f"{directory}{filename}.md"
-                goods_report.save_markdown(filepath)
+            filepath = f"{directory}{filename}.xlsx"
+            goods_report.xlsx_file(filepath)
             self.stdout.write(
                 self.style.SUCCESS(f"Generated report file {filepath}"),
             )

--- a/importer/management/commands/generate_goods_report.py
+++ b/importer/management/commands/generate_goods_report.py
@@ -1,0 +1,80 @@
+from typing import Any
+from typing import Optional
+
+from django.core.management import BaseCommand
+from django.core.management.base import CommandParser
+
+from importer.goods_report import GoodsReporter
+from importer.models import ImportBatch
+
+
+class Command(BaseCommand):
+    help = (
+        "Generate a report detailing the goods-related elements in a TARIC3 "
+        "standards-compliant XML file. The filename of the generated report "
+        "will be taken from the name of the specified ImportBatch instance, "
+        "with a file extension to match the output format."
+    )
+
+    def add_arguments(self, parser: CommandParser) -> None:
+        group = parser.add_mutually_exclusive_group(required=True)
+        group.add_argument(
+            "--import-batch-id",
+            help=(
+                "The primary key ID of ImportBatch instance for which a report "
+                "should be generated."
+            ),
+            type=int,
+        )
+        group.add_argument(
+            "--taric-filepath",
+            help=(
+                "The file path to a TARIC3 standards-compliant file for which "
+                "a report should be generated."
+            ),
+            type=str,
+        )
+        parser.add_argument(
+            "--output-format",
+            help=(
+                "Specify the format of the generated report. Default behaviour "
+                "is to output a plain text version of the report to stdout."
+            ),
+            nargs="?",
+            choices=("xlsx", "md", "text"),
+            default="text",
+        )
+
+    def handle(self, *args: Any, **options: Any) -> Optional[str]:
+        if options.get("import_batch_id"):
+            import_batch = ImportBatch.objects.get(
+                pk=int(options["import_batch_id"]),
+            ).taric_file
+            taric_file = import_batch.taric_file
+            self.stdout.write(
+                f"Generating report for {repr(import_batch)}...",
+            )
+        else:
+            taric_file = open(options["taric_filepath"], "r")
+            self.stdout.write(
+                f"Generating report for {taric_file.name}...",
+            )
+
+        reporter = GoodsReporter(taric_file)
+        goods_report = reporter.create_report()
+
+        # print("*** goods_report.report_lines")
+        output_format = options.get("output_format")
+        if output_format == "text":
+            self.stdout.write(
+                goods_report.plaintext(separator=", ", include_column_names=True),
+            )
+        elif output_format == "md":
+            self.stdout.write("TODO")
+        elif output_format == "xlsx":
+            self.stdout.write("TODO")
+            self.stdout.write(
+                self.style.SUCCESS(
+                    f"Generated report file {taric_file.name}.xlsx.",
+                ),
+            )

--- a/importer/models.py
+++ b/importer/models.py
@@ -164,6 +164,12 @@ class ImportBatch(TimestampedMixin):
     def __str__(self):
         return f"Batch pk:{self.pk}, name:{self.name}"
 
+    def __repr__(self) -> str:
+        return (
+            f"ImportBatch(pk={self.pk}, name={self.name}, "
+            f"author={self.author}, status={self.status})"
+        )
+
 
 class ImporterXMLChunk(TimestampedMixin):
     """A chunk of TARIC XML."""


### PR DESCRIPTION
# TP2000-807 Goods file reporting
<!---
 * Include the JIRA ticket number, eg TP-123, to automatically link.
 * Use 50 characters maximum.
 * Do not end with a full-stop.
--->

## Why
<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Use as many lines as you like.
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions or deliberately ignored edge-cases.
--->
`ImportBatch` instances must have an Excel format goods reporting capability. Reports in this format may then be downloadable by TAP users via a UI intergration. Ideally, other formats, such as csv and markdown, should also be supported.

## What
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Explain like I'm 5.
 * Use pictures if you can.
--->
This PR:

- Provides a library capability for parsing and generating reports of goods-related items in TARIC3 files.
- Offers report output formats of CSV (in Excel dialect) and Excel file (xslx).
- Provides a Django management command, `generate_goods_report`, to access report file generation capabilities, with a variety of options (generate from TARIC3 file on the file system, generate from ImportBatch instance, etc).

<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
--->
## Checklist
- Requires migrations? No
- Requires dependency updates? No

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
