### PR TITLE
TP2000-953  Downloadable goods report

### DIFF
--- a/importer/goods_report.py
+++ b/importer/goods_report.py
@@ -131,7 +131,7 @@ class GoodsReportLine:
 
     @classmethod
     def csv_column_names(cls, delimiter: str = ",") -> str:
-        """Return a csv (concatenated, string) representaiton of report column
+        """Return a csv (concatenated, string) representation of report column
         names delimited by `delimiter`."""
         return cls._csv_line(cls.COLUMN_NAMES)
 

--- a/importer/urls.py
+++ b/importer/urls.py
@@ -36,6 +36,11 @@ commodity_importer_urlpatterns = [
         views.DownloadAdminTaricView.as_view(),
         name="admin-taric-ui-download",
     ),
+    path(
+        "download-goods-report/<pk>/",
+        views.DownloadGoodsReportView.as_view(),
+        name="goods-report-ui-download",
+    ),
 ]
 
 urlpatterns = general_importer_urlpatterns + commodity_importer_urlpatterns

--- a/workbaskets/jinja2/workbaskets/review-goods.jinja
+++ b/workbaskets/jinja2/workbaskets/review-goods.jinja
@@ -32,11 +32,13 @@
 
     {% if goods_changes %}
 
-      {{ govukButton({
-        "text": "Download as Excel",
-        "href": "TODO",
-        "classes": "govuk-button--secondary",
-      }) }}
+      {% if import_batch_pk %}
+        {{ govukButton({
+          "text": "Download as Excel",
+          "href": url("goods-report-ui-download", kwargs={"pk": import_batch_pk}),
+          "classes": "govuk-button--secondary",
+        }) }}
+      {% endif %}
 
       {% set table_rows = [] %}
       {% for obj in goods_changes %}

--- a/workbaskets/views/ui.py
+++ b/workbaskets/views/ui.py
@@ -39,6 +39,7 @@ from common.views import SortingMixin
 from common.views import TamatoListView
 from common.views import WithPaginationListView
 from exporter.models import Upload
+from importer.models import ImportBatch
 from measures.filters import MeasureFilter
 from measures.models import Measure
 from workbaskets import forms
@@ -381,6 +382,11 @@ class WorkbasketReviewGoodsView(TamatoListView):
             goods_changes.append(obj_data)
 
         context["goods_changes"] = goods_changes
+
+        # Used to provide downloadable Excel report of goods changes from an import
+        import_batch = ImportBatch.objects.filter(workbasket=self.workbasket).last()
+        context["import_batch_pk"] = import_batch.pk if import_batch else None
+
         return context
 
 


### PR DESCRIPTION
# TP2000-953  Downloadable goods report

## Why
Users require the ability to download a report of goods changes resulting from an import in Excel file format.

## What
- Adds view to serve a downloadable goods report in Excel format
- Make 'Download as Excel' button visible only for workbaskets that have an associated import batch

