### PR TITLE
TP2000-680 (Experimental) Prevent zombie rules checks

### DIFF
--- a/workbaskets/tests/test_views.py
+++ b/workbaskets/tests/test_views.py
@@ -513,7 +513,7 @@ def test_workbasket_measures_review_conditions(valid_user_client):
     assert "27" in condition_text
 
 
-@patch("workbaskets.tasks.call_check_workbasket_sync.delay")
+@patch("workbaskets.tasks.call_check_workbasket_sync.apply_async")
 def test_run_business_rules(check_workbasket, valid_user_client, session_workbasket):
     """Test that a GET request to the run-business-rules endpoint returns a 302,
     redirecting to the review workbasket page, runs the `check_workbasket` task,
@@ -551,7 +551,10 @@ def test_run_business_rules(check_workbasket, valid_user_client, session_workbas
 
     session_workbasket.refresh_from_db()
 
-    check_workbasket.assert_called_once_with(session_workbasket.pk)
+    check_workbasket.assert_called_once_with(
+        (session_workbasket.pk,),
+        countdown=1,
+    )
     assert session_workbasket.rule_check_task_id
     assert not session_workbasket.tracked_model_checks.exists()
 

--- a/workbaskets/views/ui.py
+++ b/workbaskets/views/ui.py
@@ -346,7 +346,7 @@ class CurrentWorkBasket(TemplateResponseMixin, FormMixin, View):
         workbasket = self.workbasket
         workbasket.delete_checks()
         task = call_check_workbasket_sync.apply_async(
-            (workbasket.pk),
+            (workbasket.pk,),
             countdown=1,
         )
         logger.info(

--- a/workbaskets/views/ui.py
+++ b/workbaskets/views/ui.py
@@ -345,7 +345,10 @@ class CurrentWorkBasket(TemplateResponseMixin, FormMixin, View):
         newly created task's ID on the workbasket."""
         workbasket = self.workbasket
         workbasket.delete_checks()
-        task = call_check_workbasket_sync.delay(workbasket.pk)
+        task = call_check_workbasket_sync.apply_async(
+            (workbasket.pk),
+            countdown=1,
+        )
         logger.info(
             f"Started rule check against workbasket.id={workbasket.pk} "
             f"on task.id={task.id}",


### PR DESCRIPTION
# TP2000-680 (Experimental) Prevent zombie rules checks
<!---
 * Include the JIRA ticket number, eg TP-123, to automatically link.
 * Use 50 characters maximum.
 * Do not end with a full-stop.
--->

## Why
<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Use as many lines as you like.
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions or deliberately ignored edge-cases.
--->
Running rule checks from the workbasket summary sometimes results in a hanging host Celery task.

## What
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Explain like I'm 5.
 * Use pictures if you can.
--->
In this PR:

- Experiment with replacing Celery's `delay()` with the lower level `apply_async()`, which allows use of a `countdown` parameter, when calling `call_check_workbasket_sync()`. In this case, use a `countdown` value of 1 (second).

Update unit test to reflect change from `delay()` to `apply_async()`.

<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
--->
## Checklist
- Requires migrations? No
- Requires dependency updates? No

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
