### PR TITLE
TP2000-961: Fix missing edit-update measure view

### DIFF
--- a/measures/views.py
+++ b/measures/views.py
@@ -852,6 +852,10 @@ class MeasureUpdate(
         return obj
 
 
+class MeasureEditUpdate(MeasureUpdate):
+    pass
+
+
 class MeasureConfirmUpdate(MeasureMixin, TrackedModelDetailView):
     template_name = "common/confirm_update.jinja"
 


### PR DESCRIPTION
# TP2000-961: Fix missing edit-update measure view
<!---
 * Include the JIRA ticket number, eg TP-123, to automatically link.
 * Use 50 characters maximum.
 * Do not end with a full-stop.
--->

## Why
<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Use as many lines as you like.
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions or deliberately ignored edge-cases.
--->
* If a measure already has edits in the current workbasket, the edit link on the measure detail page is hidden. This was because the measure-edit-update url did not exist

## What
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Explain like I'm 5.
 * Use pictures if you can.
--->
* Add MeasureEditUpdate view that inherits from MeasureUpdate as an initial fix. This view should be updated to support "real updates" in future

<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
## Checklist
- Requires migrations?
- Requires dependency updates?
--->

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
