### PR TITLE
TP2000-949  Improve measure creation performance

### DIFF
--- a/measures/forms.py
+++ b/measures/forms.py
@@ -274,7 +274,7 @@ class MeasureConditionsFormMixin(forms.ModelForm):
                 )
 
         if price and not price_errored:
-            parser = DutySentenceParser.get(measure_start_date)
+            parser = DutySentenceParser.create(measure_start_date)
             components = parser.parse(price)
             if len(components) > 1:
                 self.add_error(
@@ -1226,7 +1226,7 @@ class MeasureCommodityAndDutiesFormSet(MeasureCommodityAndDutiesBaseFormSet):
         # Filter tuples(duty, form) for unique duties to avoid parsing the same duty more than once
         duties = [next(group) for duty, group in groupby(data, key=lambda x: x[0])]
 
-        duty_sentence_parser = DutySentenceParser.get(
+        duty_sentence_parser = DutySentenceParser.create(
             self.measure_start_date,
         )
         for duty, form in duties:

--- a/measures/parsers.py
+++ b/measures/parsers.py
@@ -279,6 +279,7 @@ class DutySentenceParser:
             .exclude(
                 measurement_unit_qualifier__abbreviation__exact="",
             )
+            .select_related("measurement_unit", "measurement_unit_qualifier")
         )
 
         return DutySentenceParser(

--- a/measures/parsers.py
+++ b/measures/parsers.py
@@ -260,7 +260,7 @@ class DutySentenceParser:
         return self.sentence_parser.parse_strict(s)
 
     @classmethod
-    def get(
+    def create(
         cls,
         forward_time: date,
         component_output: Type[TrackedModel] = MeasureComponent,

--- a/measures/patterns.py
+++ b/measures/patterns.py
@@ -69,7 +69,7 @@ class MeasureCreationPattern:
     ) -> None:
         self.workbasket = workbasket
         self.defaults = defaults
-        self.duty_sentence_parser = duty_sentence_parser or DutySentenceParser.get(
+        self.duty_sentence_parser = duty_sentence_parser or DutySentenceParser.create(
             base_date,
         )
         self.condition_sentence_parser = (

--- a/measures/tests/test_forms.py
+++ b/measures/tests/test_forms.py
@@ -587,7 +587,6 @@ def test_measure_forms_commodity_and_duties_form_duties_not_permitted():
     )
 
     assert not form.is_valid()
-    print(form.errors)
     assert (
         f"Duties cannot be added to a commodity for measure type {measure_type}"
         in form.errors["duties"]

--- a/measures/tests/test_forms.py
+++ b/measures/tests/test_forms.py
@@ -563,11 +563,11 @@ def test_measure_forms_commodity_and_duties_form_invalid_selection(
     date_ranges,
 ):
     data = {
-        "commodity": commodity,
+        f"{MEASURE_COMMODITIES_FORMSET_PREFIX}-0-commodity": commodity,
     }
     form = forms.MeasureCommodityAndDutiesForm(
         data,
-        prefix="",
+        prefix=f"{MEASURE_COMMODITIES_FORMSET_PREFIX}-0",
         measure_start_date=date_ranges.normal,
     )
     assert not form.is_valid()
@@ -581,12 +581,13 @@ def test_measure_forms_commodity_and_duties_form_duties_not_permitted():
         measure_component_applicability_code=ApplicabilityCode.NOT_PERMITTED,
     )
     form = forms.MeasureCommodityAndDutiesForm(
-        data={"duties": "123%"},
-        prefix="",
+        data={f"{MEASURE_COMMODITIES_FORMSET_PREFIX}-0-duties": "123%"},
+        prefix=f"{MEASURE_COMMODITIES_FORMSET_PREFIX}-0",
         measure_type=measure_type,
     )
 
     assert not form.is_valid()
+    print(form.errors)
     assert (
         f"Duties cannot be added to a commodity for measure type {measure_type}"
         in form.errors["duties"]

--- a/measures/tests/test_forms.py
+++ b/measures/tests/test_forms.py
@@ -639,7 +639,8 @@ def test_measure_forms_commodity_and_duties_formset_invalid_data(
     duty_sentence_parser,
 ):
     commodity1, commodity2 = factories.GoodsNomenclatureFactory.create_batch(2)
-    invalid_duty_sentence = "abc123"
+    invalid_duty_sentence = "1% + 2GBP / m1"
+    invalid_expression = " / m1"
     data = {
         f"{MEASURE_COMMODITIES_FORMSET_PREFIX}-0-commodity": commodity1.pk,
         f"{MEASURE_COMMODITIES_FORMSET_PREFIX}-0-duties": invalid_duty_sentence,
@@ -655,8 +656,8 @@ def test_measure_forms_commodity_and_duties_formset_invalid_data(
     )
     assert not formset.is_valid()
     assert (
-        f'"{invalid_duty_sentence}" is an invalid duty sentence'
-        in formset.non_form_errors()
+        f'"{invalid_expression}" is an invalid duty expression'
+        in formset.forms[0].errors["duties"]
     )
 
 

--- a/measures/util.py
+++ b/measures/util.py
@@ -49,7 +49,7 @@ def diff_components(
     """
     from measures.parsers import DutySentenceParser
 
-    parser = DutySentenceParser.get(
+    parser = DutySentenceParser.create(
         start_date,
         component_output=component_output,
     )

--- a/measures/validators.py
+++ b/measures/validators.py
@@ -110,7 +110,7 @@ def validate_duties(duties, measure_start_date):
     """Validate duty sentence by parsing it."""
     from measures.parsers import DutySentenceParser
 
-    duty_sentence_parser = DutySentenceParser.get(
+    duty_sentence_parser = DutySentenceParser.create(
         measure_start_date,
     )
 

--- a/measures/views.py
+++ b/measures/views.py
@@ -619,25 +619,40 @@ class MeasureCreateWizard(
     def get_form_kwargs(self, step):
         kwargs = {}
         if step == self.COMMODITIES:
-            min_commodity_count = self.get_cleaned_data_for_step(
-                self.MEASURE_DETAILS,
-            ).get("min_commodity_count")
-            kwargs.update({"min_commodity_count": min_commodity_count})
-
-        if step == self.COMMODITIES or step == self.CONDITIONS:
+            measure_start_date = None
+            measure_type = None
+            min_commodity_count = 0
             measure_details = self.get_cleaned_data_for_step(self.MEASURE_DETAILS)
-            # duty sentence validation requires the measure start date so pass it to form kwargs here
-            valid_between = measure_details.get("valid_between")
-            measure_type = measure_details.get("measure_type")
-            # commodities/duties step is a formset which expects form_kwargs to pass kwargs to its child forms
+            if measure_details:
+                measure_start_date = measure_details.get("valid_between").lower
+                measure_type = measure_type = measure_details.get("measure_type")
+                min_commodity_count = measure_details.get("min_commodity_count")
+            kwargs.update(
+                {
+                    "min_commodity_count": min_commodity_count,
+                    "measure_start_date": measure_start_date,
+                },
+            )
             kwargs["form_kwargs"] = {
-                "measure_start_date": valid_between.lower,
+                "measure_type": measure_type,
+            }
+
+        if step == self.CONDITIONS:
+            measure_start_date = None
+            measure_type = None
+            measure_details = self.get_cleaned_data_for_step(self.MEASURE_DETAILS)
+            if measure_details:
+                measure_start_date = measure_details.get("valid_between").lower
+                measure_type = measure_details.get("measure_type")
+            kwargs["form_kwargs"] = {
+                "measure_start_date": measure_start_date,
                 "measure_type": measure_type,
             }
 
         if step == self.SUMMARY:
-            measure_type = self.get_cleaned_data_for_step(self.MEASURE_DETAILS).get(
-                "measure_type",
+            measure_details = self.get_cleaned_data_for_step(self.MEASURE_DETAILS)
+            measure_type = (
+                measure_details.get("measure_type") if measure_details else None
             )
             kwargs.update(
                 {

--- a/measures/views.py
+++ b/measures/views.py
@@ -609,6 +609,15 @@ class MeasureCreateWizard(
         return render(self.request, "measures/confirm-create-multiple.jinja", context)
 
     def get_all_cleaned_data(self):
+        """
+        Returns a merged dictionary of all step cleaned_data. If a step contains
+        a `FormSet`, the key will be prefixed with 'formset-' and contain a list
+        of the formset cleaned_data dictionaries, as expected in
+        `create_measures()`.
+
+        Note: This patched version of `super().get_all_cleaned_data()` takes advantage of retrieving previously-saved
+        cleaned_data by summary page to avoid revalidating forms unnecessarily.
+        """
         all_cleaned_data = {}
         for form_key in self.get_form_list():
             cleaned_data = self.get_cleaned_data_for_step(form_key)
@@ -623,6 +632,13 @@ class MeasureCreateWizard(
         return all_cleaned_data
 
     def get_cleaned_data_for_step(self, step):
+        """
+        Returns cleaned data for a given `step`.
+
+        Note: This patched version of `super().get_cleaned_data_for_step` temporarily saves the cleaned_data
+        to provide quick retrieval should another call for it be made in the same request (as happens in
+        `get_form_kwargs()` and qtemplate for summary page) to avoid revalidating forms unnecessarily.
+        """
         self.cleaned_data = getattr(self, "cleaned_data", {})
         if step in self.cleaned_data:
             return self.cleaned_data[step]

--- a/measures/views.py
+++ b/measures/views.py
@@ -573,15 +573,16 @@ class MeasureCreateWizard(
 
                     measures_data.append(measure_data)
 
+        parser = DutySentenceParser.get(
+            measure_start_date,
+            component_output=MeasureConditionComponent,
+        )
+
         created_measures = []
 
         for measure_data in measures_data:
             # creates measure in DB
             measure = measure_creation_pattern.create(**measure_data)
-            parser = DutySentenceParser.get(
-                measure.valid_between.lower,
-                component_output=MeasureConditionComponent,
-            )
             self.create_measure_conditions(
                 data,
                 measure,

--- a/measures/views.py
+++ b/measures/views.py
@@ -666,12 +666,14 @@ class MeasureCreateWizard(
                 measure_start_date = measure_details.get("valid_between").lower
                 measure_type = measure_type = measure_details.get("measure_type")
                 min_commodity_count = measure_details.get("min_commodity_count")
+            # Kwargs expected by formset
             kwargs.update(
                 {
                     "min_commodity_count": min_commodity_count,
                     "measure_start_date": measure_start_date,
                 },
             )
+            # Kwargs expected by forms in formset
             kwargs["form_kwargs"] = {
                 "measure_type": measure_type,
             }

--- a/measures/views.py
+++ b/measures/views.py
@@ -608,6 +608,28 @@ class MeasureCreateWizard(
 
         return render(self.request, "measures/confirm-create-multiple.jinja", context)
 
+    def get_all_cleaned_data(self):
+        all_cleaned_data = {}
+        for form_key in self.get_form_list():
+            cleaned_data = self.get_cleaned_data_for_step(form_key)
+            if isinstance(cleaned_data, (tuple, list)):
+                all_cleaned_data.update(
+                    {
+                        f"formset-{form_key}": cleaned_data,
+                    },
+                )
+            else:
+                all_cleaned_data.update(cleaned_data)
+        return all_cleaned_data
+
+    def get_cleaned_data_for_step(self, step):
+        self.cleaned_data = getattr(self, "cleaned_data", {})
+        if step in self.cleaned_data:
+            return self.cleaned_data[step]
+
+        self.cleaned_data[step] = super().get_cleaned_data_for_step(step)
+        return self.cleaned_data[step]
+
     def get_context_data(self, form, **kwargs):
         context = super().get_context_data(form=form, **kwargs)
         context["step_metadata"] = self.step_metadata

--- a/measures/views.py
+++ b/measures/views.py
@@ -573,7 +573,7 @@ class MeasureCreateWizard(
 
                     measures_data.append(measure_data)
 
-        parser = DutySentenceParser.get(
+        parser = DutySentenceParser.create(
             measure_start_date,
             component_output=MeasureConditionComponent,
         )
@@ -880,7 +880,7 @@ class MeasureUpdate(
                 workbasket=workbasket,
                 base_date=obj.valid_between.lower,
             )
-            parser = DutySentenceParser.get(
+            parser = DutySentenceParser.create(
                 obj.valid_between.lower,
                 component_output=MeasureConditionComponent,
             )


### PR DESCRIPTION
# TP2000-949  Improve measure creation performance


## Why
Users are experiencing performance-related issues when creating measures with 50+ commodities and duties.
The issue appears to be caused by a combination of how the duty sentencer parser is being used and how the form wizard fetches cleaned data for a step:

1) A new duty sentence parser is loaded each time to validate a duties field in the formset

2) The same duty sentence may be parsed multiple times

3) A new duty sentence parser is loaded for each measure created

4) `get_cleaned_data_for_step()` revalidates a form before returning the cleaned data (exacerbating 1). This is used both in `get_form_kwargs()` and on the summary page to populate the template. It can become a recursive call if a form's kwargs depends on the cleaned data of another form, as happens with commodities step fetching measure details cleaned data

5) `get_all_cleaned_data()` revalidates all forms before returning the cleaned data (exacerbating 1)


## What
- Validates a set of duties at formset level so as to initialise duty parser once and avoid parsing the same duty sentence multiple times

- Uses `selected_related()` on measurements query in the duty parser to reduce database hits

- Initialises duty parser outside of `measures_data` for loop in `create_measures` since the start date is the same for all measures being created

- Overrides `get_cleaned_data_for_step()` to store a step's cleaned data to avoid revalidating a form during multiple calls in the same request

- Overrides `get_all_cleaned_data()` to use already stored cleaned data from summary page (commodities, condition, measure details) to avoid revalidating those forms

- Adds and updates unit tests

##
Before: 70 commodities with duties, ~33k queries, ~2.5 minutes
<img width="1912" alt="Screenshot 2023-07-19 at 09 18 24" src="https://github.com/uktrade/tamato/assets/118175145/d97b7a16-df59-4dfb-8e63-49f4d36ce5e6">
#
After: same 70 commodities with duties, ~1k queries, ~20 seconds
<img width="1912" alt="Screenshot 2023-07-19 at 09 26 36" src="https://github.com/uktrade/tamato/assets/118175145/748f7979-5af8-4a2b-b8d0-abfefce6c6a5">




