### PR TITLE
TP2000-400: Workbasket page fixes

### DIFF
--- a/common/static/common/js/checkboxes.js
+++ b/common/static/common/js/checkboxes.js
@@ -14,7 +14,7 @@ class CheckBoxes {
         // get names for checkboxes
         const checkboxes = document.querySelectorAll(this.CHEKCKBOXES);
         checkboxes.forEach(checkbox => {
-            this.state[checkbox.name] = 0;
+            this.state[checkbox.name] = checkbox.checked ? 1 : 0;
         })
 
         if (this.page === "measures") {
@@ -48,17 +48,13 @@ class CheckBoxes {
         const checkedState = event.target.checked;
         for (let checkbox of document.querySelectorAll('[' + checkboxSelector + ']')) {
             checkbox.checked = checkedState;
-            this.state[checkbox.name] = checkedState;
+            this.state[checkbox.name] = checkedState ? 1 : 0;
         }
         this.updateSession();
     }
 
     toggleCheckbox(event) {
-        if (event.target.checked) {
-            this.state[event.target.name] = 1;
-        } else {
-            this.state[event.target.name] = 0;
-        }
+        this.state[event.target.name] = event.target.checked ? 1 : 0;
         this.updateSession();
     }
 

--- a/workbaskets/jinja2/includes/workbaskets/workbasket-selectable-items.jinja
+++ b/workbaskets/jinja2/includes/workbaskets/workbasket-selectable-items.jinja
@@ -33,17 +33,16 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       {% if change_count %}
-        <h2 class="govuk-body">Select a component you would like to edit or remove:</h2>
         <div class="govuk-form-group">
           <fieldset class="govuk-fieldset">
-            <div class="govuk-checkboxes govuk-checkboxes--large">
-              <div class="govuk-checkboxes__item">
-                <input class="govuk-checkboxes__input" id="select-all-pages" name="select-all-pages" type="checkbox">
-                <label class="govuk-label govuk-checkboxes__label govuk-!-padding-right-0" for="selected">Select all {{ change_count }} changes across {{ page_obj.paginator.num_pages }} pages</label>
-              </div>
-            </div>
+            <button
+              value="remove-all"
+              name="form-action"
+              class="govuk-button govuk-button--warning"
+              data-module="govuk-button">Remove all workbasket changes</button>
           </fieldset>
         </div>
+        <h2 class="govuk-body">Select a component you would like to edit or remove:</h2>
 
       {% else %}
         <h2 class="govuk-body">There is nothing in your workbasket yet.</h2>

--- a/workbaskets/tests/test_views.py
+++ b/workbaskets/tests/test_views.py
@@ -299,7 +299,7 @@ def test_review_workbasket_redirects(
         status=WorkflowStatus.EDITING,
     )
     with workbasket.new_transaction() as tx:
-        factories.FootnoteTypeFactory.create_batch(30, transaction=tx)
+        factories.FootnoteTypeFactory.create_batch(150, transaction=tx)
     url = reverse("workbaskets:current-workbasket")
     data = {"form-action": form_action}
     response = valid_user_client.post(f"{url}?page=2", data)

--- a/workbaskets/views/ui.py
+++ b/workbaskets/views/ui.py
@@ -283,6 +283,7 @@ class CurrentWorkBasket(TemplateResponseMixin, FormMixin, View):
         "run-business-rules": "workbaskets:current-workbasket",
         "terminate-rule-check": "workbaskets:current-workbasket",
         "remove-selected": "workbaskets:workbasket-ui-delete-changes",
+        "remove-all": "workbaskets:workbasket-ui-delete-changes",
         "page-prev": "workbaskets:current-workbasket",
         "page-next": "workbaskets:current-workbasket",
     }
@@ -362,6 +363,10 @@ class CurrentWorkBasket(TemplateResponseMixin, FormMixin, View):
             return reverse(
                 self.action_success_url_names[form_action],
             )
+        elif form_action == "remove-all":
+            return reverse(
+                self.action_success_url_names[form_action],
+            )
         elif form_action in ("page-prev", "page-next"):
             return self._append_url_page_param(
                 reverse(
@@ -437,8 +442,8 @@ class CurrentWorkBasket(TemplateResponseMixin, FormMixin, View):
             f"WORKBASKET_SELECTIONS_{self.workbasket.pk}",
         )
         store.clear()
-        select_all = self.request.POST.get("select-all-pages")
-        if select_all:
+        form_action = self.request.POST.get("form-action")
+        if form_action == "remove-all":
             object_list = {obj.id: True for obj in self.workbasket.tracked_models}
             store.add_items(object_list)
         else:

--- a/workbaskets/views/ui.py
+++ b/workbaskets/views/ui.py
@@ -18,11 +18,9 @@ from django.urls import reverse_lazy
 from django.utils.decorators import method_decorator
 from django.views.generic import CreateView
 from django.views.generic import UpdateView
-from django.views.generic.base import TemplateResponseMixin
 from django.views.generic.base import TemplateView
-from django.views.generic.base import View
 from django.views.generic.detail import DetailView
-from django.views.generic.edit import FormMixin
+from django.views.generic.edit import FormView
 from django.views.generic.list import ListView
 
 from checks.models import TrackedModelCheck
@@ -277,7 +275,7 @@ class EditWorkbasketView(PermissionRequiredMixin, TemplateView):
 
 
 @method_decorator(require_current_workbasket, name="dispatch")
-class CurrentWorkBasket(TemplateResponseMixin, FormMixin, View):
+class CurrentWorkBasket(FormView):
     template_name = "workbaskets/summary-workbasket.jinja"
     form_class = forms.SelectableObjectsForm
 
@@ -298,7 +296,7 @@ class CurrentWorkBasket(TemplateResponseMixin, FormMixin, View):
 
     @property
     def paginator(self):
-        return Paginator(self.workbasket.tracked_models, per_page=10)
+        return Paginator(self.workbasket.tracked_models, per_page=50)
 
     @property
     def latest_upload(self):


### PR DESCRIPTION
# TP2000-400: Workbasket page fixes
<!---
 * Include the JIRA ticket number, eg TP-123, to automatically link.
 * Use 50 characters maximum.
 * Do not end with a full-stop.
--->

## Why
<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Use as many lines as you like.
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions or deliberately ignored edge-cases.
--->
* A user can make multiple selections across multiple pages and the remove button removes those objects successfully
* Clearing down a workbasket can be made a single option button, with a confirmation page.


## What
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Explain like I'm 5.
 * Use pictures if you can.
--->
* Pagination number bumped from 10 to 50
* Fixes a bug with persisting object selection across different pages
* Replaces the "select all across X pages" checkbox with a "remove all" button

<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
## Checklist
- Requires migrations?
- Requires dependency updates?
--->

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->

<img width="1208" alt="Screenshot 2023-07-20 at 12 08 29" src="https://github.com/uktrade/tamato/assets/25905279/5e559efb-0f68-4b9c-9281-7f970f3cb485">
