### PR TITLE
TP2000-967  Prefill workbasket description for an import

### DIFF
--- a/importer/forms.py
+++ b/importer/forms.py
@@ -218,8 +218,11 @@ class CommodityImportForm(ImportFormMixin, forms.Form):
         make sense to use commit=False. process_file() should be moved into the
         view if this (common) behaviour becomes required.
         """
+        file_name = os.path.splitext(self.cleaned_data["name"])[0]
+        description = f"TARIC {file_name} commodity code changes"
         workbasket = WorkBasket.objects.create(
             title=self.cleaned_data["workbasket_title"],
+            reason=description,
             author=self.request.user,
         )
         workbasket.save()

--- a/importer/tests/test_forms.py
+++ b/importer/tests/test_forms.py
@@ -139,6 +139,11 @@ def test_commodity_import_form_valid_envelope(
         assert batch.name.find(file_data["taric_file"].name) != -1
         assert batch.split_job == False
         assert batch.author.id == superuser.id
+        assert batch.workbasket.title == data["workbasket_title"]
+        assert (
+            batch.workbasket.reason
+            == f'TARIC {file_data["taric_file"].name[:-4]} commodity code changes'
+        )
 
         run_batch.assert_called_once()
         chunk_taric.assert_called_once()


### PR DESCRIPTION
# TP2000-967  Prefill workbasket description for an import

## Why
Tariff managers typically use the TGB file name in the description of an import's workbasket. This description could be prefilled so that it doesn't have to be manually updated later. 

## What
- Prefills the import batch's workbasket description in the format "TARIC [file_name] commodity code changes" as seen with other imports' workbaskets
