### PR TITLE
TP2000 926 Enforce a maximum of one active import per service instance

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -2,3 +2,4 @@ web: gunicorn wsgi --bind 0.0.0.0:$PORT --timeout 1000 --worker-class=gevent --w
 worker: celery -A common.celery worker -O fair -l info -Q standard
 beat: celery -A common.celery beat
 rule-check-worker: celery -A common.celery worker -O fair -l info -Q rule-check
+importer-worker: celery -A common.celery worker -O fair -l info -Q importer

--- a/common/celery.py
+++ b/common/celery.py
@@ -20,3 +20,9 @@ app.autodiscover_tasks()
 # this should be automactically configured via ^^ config_from_object
 # but it isn't so here it's configured here
 app.conf.task_routes = settings.CELERY_ROUTES
+
+# turn on late ack so messages are only consumed from the broker on success
+app.conf.update(
+    task_acks_late=True,
+    broker_transport_options={"confirm_publish": True},
+)

--- a/common/celery.py
+++ b/common/celery.py
@@ -20,9 +20,3 @@ app.autodiscover_tasks()
 # this should be automactically configured via ^^ config_from_object
 # but it isn't so here it's configured here
 app.conf.task_routes = settings.CELERY_ROUTES
-
-# turn on late ack so messages are only consumed from the broker on success
-app.conf.update(
-    task_acks_late=True,
-    broker_transport_options={"confirm_publish": True},
-)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,10 +50,25 @@ services:
     build:
       context: .
       args:
-        - "ENV=${ENV:-prod}"
+        - "ENV=${ENV:-prod}"      
     volumes:
       - ./:/app/
     command: ["celery", "-A" , "common.celery" ,"worker", "-O", "fair", "-l", "info", "-Q", "rule-check"]
+    env_file: 
+      - .env
+      - settings/envs/docker.env
+    restart: "${DOCKER_RESTART_POLICY:-unless-stopped}"
+    depends_on:
+      - celery-redis
+
+  importer-celery:
+    build:
+      context: .
+      args:
+        - "ENV=${ENV:-prod}"
+    volumes:
+      - ./:/app/
+    command: ["celery", "-A" , "common.celery" ,"worker", "-O", "fair", "-l", "info", "-Q", "importer", "--concurrency", "1"]
     env_file: 
       - .env
       - settings/envs/docker.env
@@ -98,7 +113,7 @@ services:
       context: .
       args:
         - "ENV=${ENV:-prod}"
-    image: tamato
+    image: tamato  
     volumes:
       - "${DOCKER_WEB_VOLUME:-./:/app/}"
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,7 +50,7 @@ services:
     build:
       context: .
       args:
-        - "ENV=${ENV:-prod}"      
+        - "ENV=${ENV:-prod}"
     volumes:
       - ./:/app/
     command: ["celery", "-A" , "common.celery" ,"worker", "-O", "fair", "-l", "info", "-Q", "rule-check"]
@@ -113,7 +113,7 @@ services:
       context: .
       args:
         - "ENV=${ENV:-prod}"
-    image: tamato  
+    image: tamato
     volumes:
       - "${DOCKER_WEB_VOLUME:-./:/app/}"
     ports:

--- a/settings/common.py
+++ b/settings/common.py
@@ -545,7 +545,10 @@ CELERY_ROUTES = {
     re.compile(r"(checks)\.tasks\..*"): {
         "queue": "rule-check",
     },
-    re.compile(r"(exporter|importer|notifications|publishing)\.tasks\..*"): {
+    re.compile(r"(importer)\.tasks\..*"): {
+        "queue": "importer",
+    },
+    re.compile(r"(exporter|notifications|publishing)\.tasks\..*"): {
         "queue": "standard",
     },
 }


### PR DESCRIPTION
# TP2000-926 Enforce a maximum of one active import per service instance

## Why
The current parser capability relies on a shared caching resource (referred to as the nursery in the TAP codebase), which is not name-spaced between import processor. This is an issue when imports run in parallel, causing invalid objects to appear in an importer’s cache (nursery).

## What
- A seperate worker for importing has been set up to process importing tasks
- worker set up with a concurrency of 1 so tasks are only processed one at a time in the order they are recieved
- local celery worker set up

