### PR TITLE
TP2000-252  Add ME88 validation to commodities form in create measure journey

### DIFF
--- a/measures/forms.py
+++ b/measures/forms.py
@@ -1199,6 +1199,18 @@ class MeasureCommodityAndDutiesForm(forms.Form):
                 },
             )
 
+        commodity = cleaned_data.get("commodity", "")
+        measure_explosion_level = (
+            self.measure_type.measure_explosion_level if self.measure_type else None
+        )
+        if measure_explosion_level and not commodity.item_id.endswith(
+            "0" * (10 - measure_explosion_level),
+        ):
+            self.add_error(
+                "commodity",
+                f"Commodity must sit at {measure_explosion_level} digit level or higher for measure type {self.measure_type}",
+            )
+
         return cleaned_data
 
 

--- a/measures/tests/test_views.py
+++ b/measures/tests/test_views.py
@@ -35,6 +35,7 @@ from measures.models import Measure
 from measures.models import MeasureCondition
 from measures.models import MeasureConditionComponent
 from measures.models import MeasureExcludedGeographicalArea
+from measures.validators import MeasureExplosionLevel
 from measures.validators import validate_duties
 from measures.views import MeasureCreateWizard
 from measures.views import MeasureFootnotesUpdate
@@ -986,6 +987,7 @@ def test_measure_form_wizard_finish(
     erga_omnes,
 ):
     measure_type = factories.MeasureTypeFactory.create(
+        measure_explosion_level=MeasureExplosionLevel.TARIC,
         measure_component_applicability_code=ApplicabilityCode.PERMITTED,
         valid_between=TaricDateRange(datetime.date(2020, 1, 1), None, "[)"),
     )


### PR DESCRIPTION
# TP2000-252  Add ME88 validation to commodities form in create measure journey

## Why
The commodities form in the create measure journey doesn't take into account the explosion level of the measure type.

## What
- Validates in the form's clean method whether the selected commodity code exceeds the explosion level of the selected measure type
- Adds unit test

##
<img width="450" alt="Screenshot 2023-07-26 at 09 11 12" src="https://github.com/uktrade/tamato/assets/118175145/f9495f4d-0f72-47a5-a0e9-c881605f9e82">

