### PR TITLE
TP2000-968  Add comments column to goods report

### DIFF
--- a/importer/management/commands/generate_goods_report.py
+++ b/importer/management/commands/generate_goods_report.py
@@ -128,7 +128,7 @@ class Command(BaseCommand):
         if output_format == "csv":
             self.stdout.write(goods_report.csv(delimiter=","))
         elif output_format == "md":
-            self.stdout.write(goods_report.markdown_table())
+            self.stdout.write(goods_report.markdown())
         else:
             directory = self.get_output_directory()
             filename = self.get_output_base_filename()

--- a/workbaskets/views/ui.py
+++ b/workbaskets/views/ui.py
@@ -334,6 +334,7 @@ class WorkbasketReviewGoodsView(WithCurrentWorkBasket, TemplateView):
                     line.suffix,
                     line.validity_start_date,
                     line.validity_end_date,
+                    line.comments,
                 ]
                 for line in goods_report.report_lines
             ]


### PR DESCRIPTION
# TP2000-968  Add comments column to goods report

## Why
Comments help to provide Tariff Managers with supplementary information (such as details of new descriptions and indent numbers) from the TGB file not displayable in other columns of the goods report.

## What
- Adds comments column to goods report generation
- Uses tabulate library to generate Markdown table representation of report
- Updates workbasket review goods tab to include new column

##
| update_type   | whats_being_updated                   |   goods_nomenclature_code |   suffix | validity_start_date   | validity_end_date   | comments                                     |   containing_transaction_id |   containing_message_id |
|:--------------|:--------------------------------------|--------------------------:|---------:|:----------------------|:--------------------|:---------------------------------------------|----------------------------:|------------------------:|
| CREATE        | Goods nomenclature description        |                1234567890 |       80 |                       |                     | New description: A new description           |                    12345678 |                       1 |
| CREATE        | Goods nomenclature description period |                1234567890 |       80 | 2023-01-01            |                     |                                              |                    12345678 |                       2 |
| CREATE        | Goods nomenclature                    |                1234567890 |       80 | 2023-01-01            |                     |                                              |                    12345678 |                       3 |
| CREATE        | Indent                                |                1234567890 |       10 | 2023-01-01            |                     | Number of indents: 04                        |                    12345678 |                       4 |
| CREATE        | Goods nomenclature origin             |                2123456789 |       80 |                       |                     | 1234567889 as origin to 2123456789           |                    12345678 |                       5 |
| CREATE        | Goods nomenclature successor          |                2234567890 |       80 |                       |                     | 2234567890 is being absorbed into 3123456789 |                    12345678 |                       6 |
