### PR TITLE
TP2000-987 - Add '0 goods items' support on importer list view

### DIFF
--- a/importer/jinja2/includes/taric_importer_list.jinja
+++ b/importer/jinja2/includes/taric_importer_list.jinja
@@ -1,18 +1,20 @@
 {% set table_rows = [] %}
 
 {% for object in object_list %}
-  {%- set object_status -%}
+  {%- set import_status_cell -%}
     <span class="status-badge">{{object.status}}</a>
   {%- endset -%}
 
-  {%- set object_link -%}
-    {% if object.status == "SUCCEEDED" and object.workbasket and object.workbasket.status == "EDITING" %}
+  {%- set goods_status_cell -%}
+    {% if goods_status(object) == "editable_goods" %}
       <form action="{{ url("workbaskets:workbasket-ui-list") }}" method="post">
         <input type="hidden" name="csrfmiddlewaretoken" value="{{ csrf_token }}">
         <input type="hidden" name="workbasket" value="{{ object.workbasket.pk }}">
         <input type="hidden" name="workbasket-tab" value="review-goods">
         <input type="submit" class="button-link" name="submit" value="Edit/View workbasket">
       </form>
+    {% elif goods_status(object) == "no_goods" %}
+      <span>0 goods items</span>
     {%- else -%}
       <span></span>
     {%- endif -%}
@@ -36,8 +38,8 @@
     {"text": object.name},
     {"text": "{:%d %b %Y}".format(object.created_at)},
     {"text": author},
-    {"text": object_status},
-    {"html": object_link},
+    {"text": import_status_cell},
+    {"html": goods_status_cell, "classes": "goods-status " ~ goods_status(object)},
   ]) or "" }}
 {% endfor %}
 

--- a/importer/views.py
+++ b/importer/views.py
@@ -104,7 +104,37 @@ class CommodityImportListView(
         elif import_status == ImportBatchStatus.FAILED and workbasket_status == None:
             context["selected_link"] = "errored"
 
+        context["goods_status"] = self.goods_status
+
         return context
+
+    @classmethod
+    def goods_status(cls, import_batch: ImportBatchFilter) -> str:
+        """Returns the goods status of an ImportBatch instance, used to
+        determine rendered output of the goods status column in this list view's
+        template."""
+        workbasket = import_batch.workbasket
+
+        if (
+            import_batch.status == ImportBatchStatus.SUCCEEDED
+            and workbasket
+            and workbasket.status == WorkflowStatus.EDITING
+        ):
+            return "editable_goods"
+        elif (
+            import_batch.status == ImportBatchStatus.SUCCEEDED
+            and import_batch.taric_file
+            and (
+                not workbasket
+                or (workbasket and workbasket.status == WorkflowStatus.ARCHIVED)
+            )
+        ):
+            # ImportBatch instances without a `taric_file` object are legacy
+            # instances and are not considered to have "no_goods" status.
+            return "no_goods"
+        else:
+            # All other statuses are considered empty.
+            return "empty"
 
 
 class CommodityImportCreateView(

--- a/importer/views.py
+++ b/importer/views.py
@@ -124,10 +124,7 @@ class CommodityImportListView(
         elif (
             import_batch.status == ImportBatchStatus.SUCCEEDED
             and import_batch.taric_file
-            and (
-                not workbasket
-                or (workbasket and workbasket.status == WorkflowStatus.ARCHIVED)
-            )
+            and (not workbasket or workbasket.status == WorkflowStatus.ARCHIVED)
         ):
             # ImportBatch instances without a `taric_file` object are legacy
             # instances and are not considered to have "no_goods" status.


### PR DESCRIPTION
# TP2000-987 - Add '0 goods items' support on importer list view
<!---
 * Include the JIRA ticket number, eg TP-123, to automatically link.
 * Use 50 characters maximum.
 * Do not end with a full-stop.
--->

## Why
<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Use as many lines as you like.
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions or deliberately ignored edge-cases.
--->
When successfully importing a TARIC3 file containing goods-related elements, the import status shows SUCCEEDED, and the goods status column provides a navigation link to the related workbasket into which the goods objects have been saved.

However, when successfully importing TARIC file containing no goods-related elements, the import status correctly shows SUCCEEDED, but the goods status column is empty. This can leave some uncertainty about the status of the import.

## What
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Explain like I'm 5.
 * Use pictures if you can.
--->
This PR:

* Factors out display decision logic into a view function.
* Populates the goods status column with "0 goods items" if an TARIC file is successfully imported but contains no goods-related elements.
* Adds unit tests to validate that correct goods status column contents are rendered on the goods importer list view.

![image](https://github.com/uktrade/tamato/assets/85895113/dee6c921-91c9-4d96-b89b-60d0a82eaaa9)

<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
--->
## Checklist
- Requires migrations? No
- Requires dependency updates? No

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
