### PR TITLE
TP2000-993 - Master importer status updates stall

### DIFF
--- a/importer/tests/test_forms.py
+++ b/importer/tests/test_forms.py
@@ -96,6 +96,7 @@ def test_upload_taric_form_save(run_batch, chunk_taric, superuser):
 
         assert batch.name == "test_upload"
         assert batch.split_job == False
+        assert batch.workbasket
 
         run_batch.assert_called_once()
         chunk_taric.assert_called_once()


### PR DESCRIPTION
# TP2000-993 - Master importer status updates stall
<!---
 * Include the JIRA ticket number, eg TP-123, to automatically link.
 * Use 50 characters maximum.
 * Do not end with a full-stop.
--->

## Why
<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Use as many lines as you like.
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions or deliberately ignored edge-cases.
--->

No workbasket is associated with an ImportBatch that has been created via the master importer. The workbasket is needed in order to correctly transition the import state during the parse phase of the import (asynchronously executed on a background task via Celery). The result is an import hung in IMPORTING state.

## What
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Explain like I'm 5.
 * Use pictures if you can.
--->

This PR associates ImportBatch instances with a workbasket within the master importer form save processing. The associated unit test has also been updated to account for this change.

<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
--->
## Checklist
- Requires migrations? No
- Requires dependency updates? No

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
