### PR TITLE
TP2000-997 - Prevent dangling goods.xlsx after test runs

### DIFF
--- a/importer/tests/management/commands/test_generate_goods_report.py
+++ b/importer/tests/management/commands/test_generate_goods_report.py
@@ -1,4 +1,6 @@
+import os
 from os import path
+from unittest.mock import mock_open
 from unittest.mock import patch
 
 import pytest
@@ -51,10 +53,6 @@ def test_generate_goods_report_required_arguments(args, exception_type, error_ms
             "md",
             "importer.goods_report.GoodsReport.markdown",
         ),
-        (
-            "xlsx-file",
-            "importer.goods_report.GoodsReport.xlsx_file",
-        ),
     ],
 )
 def test_generate_goods_report_output_format(output_format, mock_output):
@@ -69,3 +67,30 @@ def test_generate_goods_report_output_format(output_format, mock_output):
             output_format,
         )
         mock.assert_called_once()
+
+
+def test_generate_goods_report_output_xlsx_file():
+    """Test that `generate_goods_report` command generates a report in the xlsx-
+    file output format."""
+
+    def mock_xlsx_open(filename, mode):
+        if os.path.basename(filename) == "goods.xlsx":
+            return mock_open().return_value
+        return open(filename, mode)
+
+    with patch(
+        "importer.goods_report.GoodsReport.xlsx_file",
+        return_value="",
+    ) as mocked_xlsx_file:
+        with patch(
+            "importer.management.commands.generate_goods_report.open",
+            mock_xlsx_open,
+        ):
+            call_command(
+                "generate_goods_report",
+                "--taric-filepath",
+                f"{TEST_FILES_PATH}/goods.xml",
+                "--output-format",
+                "xlsx-file",
+            )
+            mocked_xlsx_file.assert_called_once()


### PR DESCRIPTION
# TP2000-997 - Prevent dangling goods.xlsx after test runs
<!---
 * Include the JIRA ticket number, eg TP-123, to automatically link.
 * Use 50 characters maximum.
 * Do not end with a full-stop.
--->

## Why
<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Use as many lines as you like.
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions or deliberately ignored edge-cases.
--->

A `goods.xlsx` file is left hanging around after importer test runs. Specifically, the test for the xlsx report format generates a file - one of the formats tested by `test_generate_goods_report_output_format`.

## What
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Explain like I'm 5.
 * Use pictures if you can.
--->

Factor out the test for the xlsx report format and conditionally mock the `file()` built-in when applied to opening the `goods.xlsx` file.

<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
## Checklist
- Requires migrations?
- Requires dependency updates?
--->

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
