### PR TITLE
TP2000-1008 Fix geo membership creation

### DIFF
--- a/geo_areas/views.py
+++ b/geo_areas/views.py
@@ -322,10 +322,9 @@ class GeographicalMembershipsCreate(
         members = [d["member"] for d in form.cleaned_data if "member" in d]
         geo_groups = [d["geo_group"] for d in form.cleaned_data if "geo_group" in d]
 
-        tx = self.get_transaction()
-
         if members:
             for member, valid_between in zip(members, validity_periods):
+                tx = self.get_transaction()
                 membership = GeographicalMembership(
                     geo_group=geo_area,
                     member=member,
@@ -337,6 +336,7 @@ class GeographicalMembershipsCreate(
 
         if geo_groups:
             for geo_group, valid_between in zip(geo_groups, validity_periods):
+                tx = self.get_transaction()
                 membership = GeographicalMembership(
                     geo_group=geo_group,
                     member=geo_area,

--- a/geo_areas/views.py
+++ b/geo_areas/views.py
@@ -166,7 +166,7 @@ class GeoAreaUpdateMixin(GeoAreaMixin, TrackedModelDetailMixin):
         else:
             return
 
-        tx = WorkBasket.get_current_transaction(self.request)
+        tx = self.workbasket.new_transaction()
         valid_between = form.cleaned_data["new_membership_valid_between"]
         membership = GeographicalMembership(
             geo_group=geo_group,
@@ -322,7 +322,7 @@ class GeographicalMembershipsCreate(
         members = [d["member"] for d in form.cleaned_data if "member" in d]
         geo_groups = [d["geo_group"] for d in form.cleaned_data if "geo_group" in d]
 
-        tx = WorkBasket.get_current_transaction(self.request)
+        tx = self.get_transaction()
 
         if members:
             for member, valid_between in zip(members, validity_periods):

--- a/geo_areas/views.py
+++ b/geo_areas/views.py
@@ -166,13 +166,12 @@ class GeoAreaUpdateMixin(GeoAreaMixin, TrackedModelDetailMixin):
         else:
             return
 
-        tx = self.workbasket.new_transaction()
         valid_between = form.cleaned_data["new_membership_valid_between"]
         membership = GeographicalMembership(
             geo_group=geo_group,
             member=member,
             valid_between=valid_between,
-            transaction=tx,
+            transaction=self.workbasket.new_transaction(),
             update_type=UpdateType.CREATE,
         )
         membership.save()
@@ -324,24 +323,22 @@ class GeographicalMembershipsCreate(
 
         if members:
             for member, valid_between in zip(members, validity_periods):
-                tx = self.get_transaction()
                 membership = GeographicalMembership(
                     geo_group=geo_area,
                     member=member,
                     valid_between=valid_between,
-                    transaction=tx,
+                    transaction=self.get_transaction(),
                     update_type=UpdateType.CREATE,
                 )
                 membership.save()
 
         if geo_groups:
             for geo_group, valid_between in zip(geo_groups, validity_periods):
-                tx = self.get_transaction()
                 membership = GeographicalMembership(
                     geo_group=geo_group,
                     member=geo_area,
                     valid_between=valid_between,
-                    transaction=tx,
+                    transaction=self.get_transaction(),
                     update_type=UpdateType.CREATE,
                 )
                 membership.save()


### PR DESCRIPTION
# TP2000-1008 Fix geo membership creation

## Why
Creating a new geographical membership via the ‘Create a new membership' link on the 'Memberships’ tab of a geographical area detail view does not show the membership association creation in the workbasket summary if the current workbasket has no previous transactions. It erroneously uses the workbasket's last transaction or the most recent global transaction.

## What
- Uses a new transaction in the current workbasket for each membership being created

