### PR TITLE
TP2000-912: Commodity VAT & excise measures

### DIFF
--- a/commodities/jinja2/includes/commodities/tabs/measures-declarable.jinja
+++ b/commodities/jinja2/includes/commodities/tabs/measures-declarable.jinja
@@ -12,6 +12,11 @@
       "href": url('commodity-ui-detail-measures-declarable', args=[commodity.sid]),
       "selected": True,
     },
+    {
+      "text": "VAT & excise measures",
+      "href": url('commodity-ui-detail-measures-vat-excise', args=[commodity.sid]),
+      "selected": False,
+    },
   ]
 %}
 

--- a/commodities/jinja2/includes/commodities/tabs/measures-defined.jinja
+++ b/commodities/jinja2/includes/commodities/tabs/measures-defined.jinja
@@ -12,6 +12,11 @@
       "href": url('commodity-ui-detail-measures-declarable', args=[commodity.sid]),
       "selected": False,
     },
+    {
+      "text": "VAT & excise measures",
+      "href": url('commodity-ui-detail-measures-vat-excise', args=[commodity.sid]),
+      "selected": False,
+    },
   ]
 %}
 

--- a/commodities/jinja2/includes/commodities/tabs/measures-vat-excise.jinja
+++ b/commodities/jinja2/includes/commodities/tabs/measures-vat-excise.jinja
@@ -33,7 +33,7 @@
     <div class="app-related-items" role="complementary">
         <h2 class="govuk-heading-s" id="subsection-title">Actions</h2>
         <ul class="govuk-list govuk-!-font-size-16">
-            <li><a class="govuk-link" href="https://www.trade-tariff.service.gov.uk/commodities/{{ object.item_id }}#vat_excise" target="_blank" noopener noreferrer>View this data on the UK Integrated Online Tariff </a></li>
+            <li><a class="govuk-link" href="{{ uk_tariff_url }}" target="_blank" noopener noreferrer>View this data on the UK Integrated Online Tariff </a></li>
         </ul>
     </div>
   </div>

--- a/commodities/jinja2/includes/commodities/tabs/measures-vat-excise.jinja
+++ b/commodities/jinja2/includes/commodities/tabs/measures-vat-excise.jinja
@@ -1,0 +1,84 @@
+{% extends "commodities/detail.jinja" %}
+{% from "components/sort_by.jinja" import sort_by %}
+
+{% set extra_tabs_links = [
+    {
+      "text": "Measures as defined",
+      "href": url('commodity-ui-detail-measures-as-defined', args=[object.sid]),
+      "selected": False,
+    },
+    {
+      "text": "Measures on declarable commodities",
+      "href": url('commodity-ui-detail-measures-declarable', args=[object.sid]),
+      "selected": False,
+    },
+    {
+      "text": "VAT & excise measures",
+      "href": url('commodity-ui-detail-measures-vat-excise', args=[object.sid]),
+      "selected": True,
+    },
+  ]
+%}
+
+{% block extra_tabs %}
+{{ fake_tabs(extra_tabs_links) }}
+{% endblock %}
+
+{% block tab_content %}
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-three-quarters">
+    <h2 class="govuk-heading-l">VAT & excise measures</h2>
+  </div>
+  <div class="govuk-grid-column-one-quarter">
+    <div class="app-related-items" role="complementary">
+        <h2 class="govuk-heading-s" id="subsection-title">Actions</h2>
+        <ul class="govuk-list govuk-!-font-size-16">
+            <li><a class="govuk-link" href="https://www.trade-tariff.service.gov.uk/commodities/{{ object.item_id }}#vat_excise" target="_blank" noopener noreferrer>View this data on the UK Integrated Online Tariff </a></li>
+        </ul>
+    </div>
+  </div>
+</div>
+
+{% set table_rows = [] %}
+
+{% for object in vat_excise_measures %}
+
+  {% set excluded_countries %}
+  {% if object.measure.relationships.excluded_countries %}
+    {% for country in object.measure.relationships.excluded_countries.data %}
+      {{ country.id }}{% if not loop.last %}, {% endif %}
+    {% endfor %}
+  {% else %}
+  —
+  {% endif %}
+  {% endset %}
+
+  {{ table_rows.append([
+    {"text": object.measure.id },
+    {"text": object.measure_type.attributes.description },
+    {"text": object.geographical_area.attributes.description if object.geographical_area else "—" },
+    {"text": excluded_countries },
+    {"text": object.duty_expression.attributes.verbose_duty if object.duty_expression else "—" },
+    {"text": format_date_string(object.measure.attributes.effective_start_date) if object.measure.attributes.effective_start_date else "—" },
+    {"text": format_date_string(object.measure.attributes.effective_end_date) if object.measure.attributes.effective_end_date else "—"},
+  ]) or "" }}
+{% endfor %}
+
+{% if vat_excise_measures %}
+  {{ govukTable({
+    "head": [
+      {"text": "ID"},
+      {"text": "Measure type"},
+      {"text": "Geographical area"},
+      {"text": "Excluded countries"},
+      {"text": "Duties"},
+      {"text": "Start date"},
+      {"text": "End date"},
+    ],
+    "rows": table_rows
+  }) }}
+{% else %}
+  <p class="govuk-body">There are no VAT or excise measures for this commodity code.</p>
+{% endif %}
+
+{% endblock %}

--- a/commodities/tests/conftest.py
+++ b/commodities/tests/conftest.py
@@ -586,3 +586,233 @@ def scenario_8(scenario_7, transaction_pool) -> TScenario:
     ]
 
     return (collection, changes)
+
+
+@pytest.fixture
+def mock_commodity_data_geo_area():
+    return {
+        "id": "1011",
+        "type": "geographical_area",
+        "attributes": {
+            "id": "1011",
+            "description": "ERGA OMNES",
+            "geographical_area_id": "1011",
+        },
+        "relationships": {
+            "children_geographical_areas": {
+                "data": [
+                    # omitted
+                ],
+            },
+        },
+    }
+
+
+@pytest.fixture
+def mock_commodity_data_no_vat_excise(mock_commodity_data_geo_area):
+    """Partial data from the tariffs API commodities endpoint for commodity code
+    0101210000 See common/tariffs_api.py."""
+    return {
+        "included": [
+            {
+                "id": "103",
+                "type": "measure_type",
+                "attributes": {
+                    "description": "Third country duty",
+                    "measure_type_series_id": "C",
+                    "measure_component_applicable_code": 1,
+                    "order_number_capture_code": 2,
+                    "trade_movement_code": 0,
+                    "validity_end_date": None,
+                    "validity_start_date": "1972-01-01T00:00:00.000Z",
+                    "id": "103",
+                    "measure_type_series_description": "Applicable duty",
+                },
+            },
+            mock_commodity_data_geo_area,
+            {
+                "id": "20000000",
+                "type": "measure",
+                "attributes": {
+                    "origin": "eu",
+                    "import": True,
+                    "export": False,
+                    "id": 20000000,
+                    "effective_start_date": "2021-01-01T00:00:00.000Z",
+                    "effective_end_date": None,
+                    "excise": False,
+                    "vat": False,
+                    "reduction_indicator": None,
+                    "meursing": False,
+                    "resolved_duty_expression": "",
+                    "universal_waiver_applies": False,
+                },
+                "relationships": {
+                    "duty_expression": {
+                        "data": {
+                            "id": "20000000-duty_expression",
+                            "type": "duty_expression",
+                        },
+                    },
+                    "measure_type": {"data": {"id": "103", "type": "measure_type"}},
+                    "geographical_area": {
+                        "data": {"id": "1011", "type": "geographical_area"},
+                    },
+                    "excluded_countries": {"data": []},
+                },
+            },
+            {
+                "id": "2982599-duty_expression",
+                "type": "duty_expression",
+                "attributes": {
+                    "base": "p/st",
+                    "formatted_base": "<abbr title='Number of items'>p/st</abbr>",
+                    "verbose_duty": "items (p/st)",
+                },
+            },
+            {
+                "id": "109",
+                "type": "measure_type",
+                "attributes": {
+                    "description": "Supplementary unit",
+                    "measure_type_series_id": "O",
+                    "measure_component_applicable_code": 1,
+                    "order_number_capture_code": 2,
+                    "trade_movement_code": 2,
+                    "validity_end_date": None,
+                    "validity_start_date": "2008-01-01T00:00:00.000Z",
+                    "id": "109",
+                    "measure_type_series_description": "Supplementary unit",
+                },
+            },
+            {
+                "id": "2982599",
+                "type": "measure",
+                "attributes": {
+                    "origin": "eu",
+                    "import": True,
+                    "export": True,
+                    "id": 2982599,
+                    "effective_start_date": "2008-01-01T00:00:00.000Z",
+                    "effective_end_date": None,
+                    "excise": False,
+                    "vat": False,
+                    "reduction_indicator": None,
+                    "meursing": False,
+                    "resolved_duty_expression": "",
+                    "universal_waiver_applies": False,
+                },
+                "relationships": {
+                    "duty_expression": {
+                        "data": {
+                            "id": "2982599-duty_expression",
+                            "type": "duty_expression",
+                        },
+                    },
+                    "measure_type": {"data": {"id": "109", "type": "measure_type"}},
+                    "geographical_area": {
+                        "data": {"id": "1011", "type": "geographical_area"},
+                    },
+                    "excluded_countries": {"data": []},
+                },
+            },
+            {
+                "id": "-1010362444-duty_expression",
+                "type": "duty_expression",
+                "attributes": {
+                    "base": "20.00 %",
+                    "formatted_base": "<span>20.00</span> %",
+                    "verbose_duty": "20.00%",
+                },
+            },
+            {
+                "id": "20204539-duty_expression",
+                "type": "duty_expression",
+                "attributes": {"base": "", "formatted_base": "", "verbose_duty": ""},
+            },
+        ],
+    }
+
+
+@pytest.fixture
+def mock_commodity_data_vat_measure():
+    return {
+        "id": "-1010362444",
+        "type": "measure",
+        "attributes": {
+            "origin": "uk",
+            "import": True,
+            "export": False,
+            "id": -1010362444,
+            "effective_start_date": "2020-06-01T00:00:00.000Z",
+            "effective_end_date": None,
+            "excise": False,
+            "vat": True,
+            "reduction_indicator": None,
+            "meursing": False,
+            "resolved_duty_expression": "",
+            "universal_waiver_applies": False,
+        },
+        "relationships": {
+            "duty_expression": {
+                "data": {
+                    "id": "-1010362444-duty_expression",
+                    "type": "duty_expression",
+                },
+            },
+            "measure_type": {"data": {"id": "305", "type": "measure_type"}},
+            "geographical_area": {"data": {"id": "1011", "type": "geographical_area"}},
+            "excluded_countries": {"data": []},
+        },
+    }
+
+
+@pytest.fixture
+def mock_commodity_data_vat_measure_type():
+    return {
+        "id": "305",
+        "type": "measure_type",
+        "attributes": {
+            "description": "Value added tax",
+            "measure_type_series_id": "P",
+            "measure_component_applicable_code": 0,
+            "order_number_capture_code": 2,
+            "trade_movement_code": 0,
+            "validity_end_date": None,
+            "validity_start_date": "1972-01-01T00:00:00.000Z",
+            "id": "305",
+            "measure_type_series_description": "VAT",
+        },
+    }
+
+
+@pytest.fixture
+def mock_commodity_data_vat_duty_expression():
+    return {
+        "id": "-1010362444-duty_expression",
+        "type": "duty_expression",
+        "attributes": {
+            "base": "20.00 %",
+            "formatted_base": "<span>20.00</span> %",
+            "verbose_duty": "20.00%",
+        },
+    }
+
+
+@pytest.fixture
+def mock_commodity_data_vat_excise(
+    mock_commodity_data_no_vat_excise,
+    mock_commodity_data_vat_measure,
+    mock_commodity_data_vat_measure_type,
+    mock_commodity_data_vat_duty_expression,
+):
+    """Partial data from the tariffs API commodities endpoint for commodity code
+    0101210000 See common/tariffs_api.py."""
+    extra = [
+        mock_commodity_data_vat_duty_expression,
+        mock_commodity_data_vat_measure_type,
+        mock_commodity_data_vat_measure,
+    ]
+    data = mock_commodity_data_no_vat_excise.copy()
+    data["included"].extend(extra)
+    return data

--- a/commodities/tests/test_views.py
+++ b/commodities/tests/test_views.py
@@ -10,8 +10,6 @@ from commodities.models.orm import GoodsNomenclature
 from commodities.views import CommodityList
 from common.models.transactions import Transaction
 from common.models.utils import override_current_transaction
-from common.tariffs_api import COMMODITIES
-from common.tariffs_api import ENDPOINTS
 from common.tests import factories
 from common.tests.factories import GoodsNomenclatureDescriptionFactory
 from common.tests.factories import GoodsNomenclatureFactory
@@ -115,13 +113,13 @@ def test_commodities_detail_views(
 ):
     """Verify that commodity detail views are under the url commodities/ and
     don't return an error."""
-    requests_mock.get(url=f"{ENDPOINTS[COMMODITIES]}0000000000", status_code=400)
     override_models = {"commodities.views.CommodityAddFootnote": GoodsNomenclature}
     assert_model_view_renders(
         view,
         url_pattern,
         valid_user_client,
         override_models=override_models,
+        requests_mock=requests_mock,
     )
 
 

--- a/commodities/tests/test_views.py
+++ b/commodities/tests/test_views.py
@@ -10,6 +10,8 @@ from commodities.models.orm import GoodsNomenclature
 from commodities.views import CommodityList
 from common.models.transactions import Transaction
 from common.models.utils import override_current_transaction
+from common.tariffs_api import COMMODITIES
+from common.tariffs_api import ENDPOINTS
 from common.tests import factories
 from common.tests.factories import GoodsNomenclatureDescriptionFactory
 from common.tests.factories import GoodsNomenclatureFactory
@@ -108,10 +110,12 @@ def test_commodities_detail_views(
     view,
     url_pattern,
     valid_user_client,
+    requests_mock,
     session_with_workbasket,
 ):
     """Verify that commodity detail views are under the url commodities/ and
     don't return an error."""
+    requests_mock.get(url=f"{ENDPOINTS[COMMODITIES]}0000000000", status_code=400)
     override_models = {"commodities.views.CommodityAddFootnote": GoodsNomenclature}
     assert_model_view_renders(
         view,

--- a/commodities/urls.py
+++ b/commodities/urls.py
@@ -60,6 +60,11 @@ urlpatterns = [
         name="commodity-ui-detail-measures-as-defined",
     ),
     path(
+        f"commodities/<sid>/measures-vat-excise/",
+        views.CommodityMeasuresVATExcise.as_view(),
+        name="commodity-ui-detail-measures-vat-excise",
+    ),
+    path(
         f"commodities/<sid>/version/",
         views.CommodityVersion.as_view(),
         name="commodity-ui-detail-version",

--- a/commodities/views.py
+++ b/commodities/views.py
@@ -239,14 +239,51 @@ class CommodityMeasuresVATExcise(CommodityMixin, TrackedModelDetailView):
             return None
         return data
 
-    def get_related(self, measure, key):
+    def get_related(self, measure, relationship_name):
+        """
+        The data we get from the tariffs API is structured like this:
+        {
+            "data": {
+                "id": <id>,
+                "type": <object type>,
+                "attributes": {<commodity attributes>}
+            },
+            "relationships": {
+                <relationship name>: {
+                    "data": [
+                        {"id": <id>,"type": <object type>},
+                        etc
+                    ]
+            },
+            "included": [
+                {
+                    "id": <id>,
+                    "type": <object type>,
+                    "attributes": {<object attributes>},
+                    "relationships": {
+                        <relationship name>: {
+                            "data": [
+                                {"id": <id>,"type": <object type>},
+                                etc
+                            ]
+                    },
+                }
+            ]
+        }
+        We use the relationships dictionaries to return the full data for a related object.
+
+        :param measure: Measure data as returned in "included" list
+        :param relationship_name: <relationship name> used as a key to lookup the data in the "relationships" dictionary
+        """
         all_related = [
             related
             for related in self.commodity_data["included"]
-            if measure["relationships"].get(key)
-            and related["id"] == measure["relationships"][key]["data"]["id"]
+            if measure["relationships"].get(relationship_name)
+            and related["id"]
+            == measure["relationships"][relationship_name]["data"]["id"]
         ]
         if all_related:
+            # don't expect there to be duplicate ids
             return all_related[0]
         return None
 

--- a/commodities/views.py
+++ b/commodities/views.py
@@ -20,6 +20,7 @@ from commodities.models.dc import SnapshotMoment
 from commodities.models.dc import get_chapter_collection
 from commodities.models.orm import FootnoteAssociationGoodsNomenclature
 from common.serializers import AutoCompleteSerializer
+from common.tariffs_api import URLs
 from common.tariffs_api import get_commodity_data
 from common.views import SortingMixin
 from common.views import TrackedModelDetailMixin
@@ -254,6 +255,9 @@ class CommodityMeasuresVATExcise(CommodityMixin, TrackedModelDetailView):
         context["selected_tab"] = "measures"
         context["commodity"] = self.object
         context["commodity_data"] = self.commodity_data
+        context[
+            "uk_tariff_url"
+        ] = f"{URLs.BASE_URL.value}commodities/{self.object.item_id}#vat_excise"
         if self.commodity_data:
             measures = [
                 item

--- a/commodities/views.py
+++ b/commodities/views.py
@@ -20,6 +20,7 @@ from commodities.models.dc import SnapshotMoment
 from commodities.models.dc import get_chapter_collection
 from commodities.models.orm import FootnoteAssociationGoodsNomenclature
 from common.serializers import AutoCompleteSerializer
+from common.tariffs_api import get_commodity_data
 from common.views import SortingMixin
 from common.views import TrackedModelDetailMixin
 from common.views import TrackedModelDetailView
@@ -223,6 +224,54 @@ class MeasuresOnDeclarableCommoditiesList(CommodityMeasuresAsDefinedList):
         url_params = urlencode({"goods_nomenclature": self.commodity.id, "modc": True})
         measures_url = f"{reverse('measure-ui-list')}?{url_params}"
         context["measures_url"] = measures_url
+
+        return context
+
+
+class CommodityMeasuresVATExcise(CommodityMixin, TrackedModelDetailView):
+    template_name = "includes/commodities/tabs/measures-vat-excise.jinja"
+
+    @cached_property
+    def commodity_data(self):
+        data = get_commodity_data(self.object.item_id)
+        if not data:
+            return None
+        return data
+
+    def get_related(self, measure, key):
+        all_related = [
+            related
+            for related in self.commodity_data["included"]
+            if measure["relationships"].get(key)
+            and related["id"] == measure["relationships"][key]["data"]["id"]
+        ]
+        if all_related:
+            return all_related[0]
+        return None
+
+    def get_context_data(self, *args, **kwargs):
+        context = super().get_context_data(*args, **kwargs)
+        context["selected_tab"] = "measures"
+        context["commodity"] = self.object
+        context["commodity_data"] = self.commodity_data
+        if self.commodity_data:
+            measures = [
+                item
+                for item in self.commodity_data["included"]
+                if item["type"] == "measure"
+            ]
+            vat_excise_measures = [
+                {
+                    "measure": item,
+                    "measure_type": self.get_related(item, "measure_type"),
+                    "geographical_area": self.get_related(item, "geographical_area"),
+                    "duty_expression": self.get_related(item, "duty_expression"),
+                }
+                for item in measures
+                if item["attributes"].get("vat") or item["attributes"].get("excise")
+            ]
+            context["measures"] = measures
+            context["vat_excise_measures"] = vat_excise_measures
 
         return context
 

--- a/common/jinja2.py
+++ b/common/jinja2.py
@@ -1,5 +1,6 @@
 import os
 import re
+from datetime import datetime
 
 from crispy_forms.utils import render_crispy_form
 from django.conf import settings
@@ -104,6 +105,15 @@ def debug_output(text):
     return ""
 
 
+def format_date_string(date_str):
+    """Parses and converts a date string from the format returned by the tariffs
+    API to the one used in the TAP UI."""
+    if date_str:
+        date_object = datetime.strptime(date_str, "%Y-%m-%dT%H:%M:%S.%fZ").date()
+        return date_object.strftime("%d %b %Y")
+    return ""
+
+
 def environment(**kwargs):
     """
     Set up the Jinja template environment.
@@ -132,6 +142,7 @@ def environment(**kwargs):
             "render_bundle": render_bundle,
             "settings": settings,
             "static": static,
+            "format_date_string": format_date_string,
             "intcomma": intcomma,
             "url": reverse,
             "webpack_static": webpack_static,

--- a/common/tariffs_api.py
+++ b/common/tariffs_api.py
@@ -5,16 +5,43 @@ import aiohttp
 import requests
 
 BASE_URL = "https://www.trade-tariff.service.gov.uk/api/v2/"
-QUOTAS = f"{BASE_URL}quotas/search"
+
+QUOTAS = "quotas"
+# GET /quotas/search
+# Retrieves a list of quota definitions
+# Retrieves a paginated list of quota definitions, optionally filtered by a variety of parameters.
+# https://api.trade-tariff.service.gov.uk/reference.html#get-quotas-search
+
+COMMODITIES = "commodities"
+# GET /commodities/{id}
+# Retrieves a commodity
+# This resource represents a single commodity. For this resource, id is a goods_nomenclature_item_id and it is used to uniquely identify a commodity and request it from the API.
+# id should be a string of ten (10) digits.
+# https://api.trade-tariff.service.gov.uk/reference.html#get-commodities-id
+
+ENDPOINTS = {
+    QUOTAS: f"{BASE_URL}quotas/search",
+    COMMODITIES: f"{BASE_URL}commodities/",
+}
 
 
-def get_quota_data(order_number):
-    params = urlencode({"order_number": order_number})
-    response = requests.get(f"{QUOTAS}?{params}")
+def parse_response(response):
     if response.status_code == 200:
         return response.json()
     else:
         return None
+
+
+def get_commodity_data(id):
+    url = f"{ENDPOINTS[COMMODITIES]}{id}"
+    print(url)
+    return parse_response(requests.get(url))
+
+
+def get_quota_data(params):
+    params = urlencode({**params})
+    url = f"{ENDPOINTS[QUOTAS]}?{params}"
+    return parse_response(requests.get(url))
 
 
 async def async_get(url, session):
@@ -31,7 +58,7 @@ async def async_get_all(urls):
         return await asyncio.gather(*[async_get(url, session) for url in urls])
 
 
-def build_urls(order_number, object_list):
+def build_quota_definition_urls(order_number, object_list):
     params = [
         {
             "order_number": order_number,
@@ -41,7 +68,7 @@ def build_urls(order_number, object_list):
         }
         for d in object_list
     ]
-    return [f"{QUOTAS}?{urlencode(p)}" for p in params]
+    return [f"{ENDPOINTS[QUOTAS]}?{urlencode(p)}" for p in params]
 
 
 def serialize_quota_data(data):
@@ -69,7 +96,7 @@ def get_quota_definitions_data(order_number, object_list):
     periods to build urls to get the data for all of them.
     """
 
-    urls = build_urls(order_number, object_list)
+    urls = build_quota_definition_urls(order_number, object_list)
 
     data = asyncio.run(async_get_all(urls))
 

--- a/common/tariffs_api.py
+++ b/common/tariffs_api.py
@@ -1,4 +1,5 @@
 import asyncio
+from enum import Enum
 from urllib.parse import urlencode
 
 import aiohttp
@@ -6,23 +7,26 @@ import requests
 
 BASE_URL = "https://www.trade-tariff.service.gov.uk/api/v2/"
 
-QUOTAS = "quotas"
-# GET /quotas/search
-# Retrieves a list of quota definitions
-# Retrieves a paginated list of quota definitions, optionally filtered by a variety of parameters.
-# https://api.trade-tariff.service.gov.uk/reference.html#get-quotas-search
 
-COMMODITIES = "commodities"
-# GET /commodities/{id}
-# Retrieves a commodity
-# This resource represents a single commodity. For this resource, id is a goods_nomenclature_item_id and it is used to uniquely identify a commodity and request it from the API.
-# id should be a string of ten (10) digits.
-# https://api.trade-tariff.service.gov.uk/reference.html#get-commodities-id
+class Endpoints(Enum):
+    QUOTAS = f"{BASE_URL}quotas/search"
+    """
+    GET /quotas/search Retrieves a list of quota definitions Retrieves a
+    paginated list of quota definitions, optionally filtered by a variety of
+    parameters.
 
-ENDPOINTS = {
-    QUOTAS: f"{BASE_URL}quotas/search",
-    COMMODITIES: f"{BASE_URL}commodities/",
-}
+    https://api.trade-tariff.service.gov.uk/reference.html#get-quotas-search
+    """
+    COMMODITIES = f"{BASE_URL}commodities/"
+    """
+    GET /commodities/{id} Retrieves a commodity This resource represents a
+    single commodity.
+
+    For this resource, id is a goods_nomenclature_item_id and it is used to
+    uniquely identify a commodity and request it from the API. id should be a
+    string of ten (10) digits.
+    https://api.trade-tariff.service.gov.uk/reference.html#get-commodities-id
+    """
 
 
 def parse_response(response):
@@ -33,14 +37,14 @@ def parse_response(response):
 
 
 def get_commodity_data(id):
-    url = f"{ENDPOINTS[COMMODITIES]}{id}"
+    url = f"{Endpoints.COMMODITIES.value}{id}"
     print(url)
     return parse_response(requests.get(url))
 
 
 def get_quota_data(params):
     params = urlencode({**params})
-    url = f"{ENDPOINTS[QUOTAS]}?{params}"
+    url = f"{Endpoints.QUOTAS.value}?{params}"
     return parse_response(requests.get(url))
 
 
@@ -68,7 +72,7 @@ def build_quota_definition_urls(order_number, object_list):
         }
         for d in object_list
     ]
-    return [f"{ENDPOINTS[QUOTAS]}?{urlencode(p)}" for p in params]
+    return [f"{Endpoints.QUOTAS.value}?{urlencode(p)}" for p in params]
 
 
 def serialize_quota_data(data):

--- a/common/tariffs_api.py
+++ b/common/tariffs_api.py
@@ -5,11 +5,14 @@ from urllib.parse import urlencode
 import aiohttp
 import requests
 
-BASE_URL = "https://www.trade-tariff.service.gov.uk/api/v2/"
+
+class URLs(Enum):
+    BASE_URL = "https://www.trade-tariff.service.gov.uk/"
+    API_URL = f"{BASE_URL}api/v2/"
 
 
 class Endpoints(Enum):
-    QUOTAS = f"{BASE_URL}quotas/search"
+    QUOTAS = f"{URLs.API_URL.value}quotas/search"
     """
     GET /quotas/search Retrieves a list of quota definitions Retrieves a
     paginated list of quota definitions, optionally filtered by a variety of
@@ -17,7 +20,7 @@ class Endpoints(Enum):
 
     https://api.trade-tariff.service.gov.uk/reference.html#get-quotas-search
     """
-    COMMODITIES = f"{BASE_URL}commodities/"
+    COMMODITIES = f"{URLs.API_URL.value}commodities/"
     """
     GET /commodities/{id} Retrieves a commodity This resource represents a
     single commodity.

--- a/common/tests/test_tariffs_api.py
+++ b/common/tests/test_tariffs_api.py
@@ -1,7 +1,6 @@
 import pytest
 
-from common.tariffs_api import ENDPOINTS
-from common.tariffs_api import QUOTAS
+from common.tariffs_api import Endpoints
 from common.tariffs_api import async_get_all
 from common.tariffs_api import build_quota_definition_urls
 from common.tariffs_api import get_quota_data
@@ -20,13 +19,13 @@ def quota_definitions(quota_order_number):
 
 
 def test_get_quota_data_error(quota_order_number, requests_mock):
-    requests_mock.get(url=ENDPOINTS[QUOTAS], status_code=400)
+    requests_mock.get(url=Endpoints.QUOTAS.value, status_code=400)
     data = get_quota_data({"order_number": quota_order_number.id})
     assert data is None
 
 
 async def test_get_quota_data_ok(quota_order_number, requests_mock, quotas_json):
-    requests_mock.get(url=ENDPOINTS[QUOTAS], json=quotas_json, status_code=200)
+    requests_mock.get(url=Endpoints.QUOTAS.value, json=quotas_json, status_code=200)
     data = get_quota_data({"order_number": quota_order_number.id})
     assert data == quotas_json
 
@@ -76,7 +75,7 @@ def test_build_quota_definition_urls(quota_order_number, quota_definitions):
     )
     assert len(urls) == 5
     for i, url in enumerate(urls):
-        assert QUOTAS in url
+        assert "quotas" in url
         assert str(quota_definitions[i].valid_between.lower.year) in url
         assert str(quota_definitions[i].valid_between.lower.month) in url
         assert str(quota_definitions[i].valid_between.lower.day) in url

--- a/common/tests/util.py
+++ b/common/tests/util.py
@@ -36,8 +36,7 @@ from common.models.trackedmodel import TrackedModel
 from common.models.transactions import Transaction
 from common.renderers import counter_generator
 from common.serializers import validate_taric_xml_record_order
-from common.tariffs_api import COMMODITIES
-from common.tariffs_api import ENDPOINTS
+from common.tariffs_api import Endpoints
 from common.tests import factories
 from common.util import TaricDateRange
 from common.util import get_accessor
@@ -423,7 +422,10 @@ def assert_model_view_renders(
 
     instance = factory.create()
     if isinstance(instance, GoodsNomenclature):
-        requests_mock.get(url=f"{ENDPOINTS[COMMODITIES]}{instance.item_id}", json={})
+        requests_mock.get(
+            url=f"{Endpoints.COMMODITIES.value}{instance.item_id}",
+            json={},
+        )
 
     # Build URL using fields from the model.
     # An error retrieving model fields may indicate the class-based-view's

--- a/common/tests/util.py
+++ b/common/tests/util.py
@@ -30,11 +30,14 @@ from freezegun import freeze_time
 from lxml import etree
 from pytz import timezone
 
+from commodities.models.orm import GoodsNomenclature
 from common.business_rules import BusinessRule
 from common.models.trackedmodel import TrackedModel
 from common.models.transactions import Transaction
 from common.renderers import counter_generator
 from common.serializers import validate_taric_xml_record_order
+from common.tariffs_api import COMMODITIES
+from common.tariffs_api import ENDPOINTS
 from common.tests import factories
 from common.util import TaricDateRange
 from common.util import get_accessor
@@ -300,10 +303,8 @@ def get_class_based_view_urls_matching_url(
 
 
 def get_view_model(view_class, override_models):
-    """
-    :return view_model from a view class, if the fully qualified classname is present inf override_models
-    this is returned instead.
-    """
+    """:return view_model from a view class, if the fully qualified classname is
+    present inf override_models this is returned instead."""
     # User may supply their own model in the override_models dict, keyed by the view_class
     fq_class_name = fully_qualified_classname(view_class)
     if fq_class_name in override_models:
@@ -394,6 +395,7 @@ def assert_model_view_renders(
     url_pattern,
     valid_user_client,
     override_models: Optional[Dict[str, ModelBase]] = None,
+    requests_mock=None,
 ):
     """
     Integration test to verify class based views.
@@ -420,6 +422,8 @@ def assert_model_view_renders(
     assert factory is not None, f"Factory not found: factories.{factory_class_name}"
 
     instance = factory.create()
+    if isinstance(instance, GoodsNomenclature):
+        requests_mock.get(url=f"{ENDPOINTS[COMMODITIES]}{instance.item_id}", json={})
 
     # Build URL using fields from the model.
     # An error retrieving model fields may indicate the class-based-view's
@@ -781,7 +785,8 @@ def only_applicable_after(cutoff):
     """
     Decorator which asserts that a test fails after a specified cutoff date.
 
-    :param cutoff: A date string, or datetime object before which the test should fail.
+    :param cutoff: A date string, or datetime object before which the test
+        should fail.
     """
     cutoff = parse_date(cutoff)
 

--- a/conftest.py
+++ b/conftest.py
@@ -42,8 +42,7 @@ from common.models.transactions import Transaction
 from common.models.transactions import TransactionPartition
 from common.models.utils import override_current_transaction
 from common.serializers import TrackedModelSerializer
-from common.tariffs_api import ENDPOINTS
-from common.tariffs_api import QUOTAS
+from common.tariffs_api import Endpoints
 from common.tests import factories
 from common.tests.models import model_with_history
 from common.tests.util import Dates
@@ -1450,7 +1449,7 @@ def quota_order_number():
 
 @pytest.fixture
 def mock_quota_api_no_data(requests_mock):
-    yield requests_mock.get(url=ENDPOINTS[QUOTAS], json={})
+    yield requests_mock.get(url=Endpoints.QUOTAS.value, json={})
 
 
 @pytest.fixture

--- a/conftest.py
+++ b/conftest.py
@@ -42,6 +42,7 @@ from common.models.transactions import Transaction
 from common.models.transactions import TransactionPartition
 from common.models.utils import override_current_transaction
 from common.serializers import TrackedModelSerializer
+from common.tariffs_api import ENDPOINTS
 from common.tariffs_api import QUOTAS
 from common.tests import factories
 from common.tests.models import model_with_history
@@ -1449,7 +1450,7 @@ def quota_order_number():
 
 @pytest.fixture
 def mock_quota_api_no_data(requests_mock):
-    yield requests_mock.get(url=QUOTAS, json={})
+    yield requests_mock.get(url=ENDPOINTS[QUOTAS], json={})
 
 
 @pytest.fixture

--- a/quotas/jinja2/includes/quotas/actions.jinja
+++ b/quotas/jinja2/includes/quotas/actions.jinja
@@ -13,7 +13,7 @@
             <li><a class="govuk-link" href="{{ delete_url }}">Delete this {{object._meta.verbose_name}}</a></li>
           {% endif %}
           <br><br>
-          <li><a class="govuk-link" href="https://www.trade-tariff.service.gov.uk/quota_search?order_number={{ object.order_number }}" target="_blank" noopener noreferrer>View this quota on the UK Integrated Online Tariff </a></li>
+          <li><a class="govuk-link" href="{{ uk_tariff_url }}" target="_blank" noopener noreferrer>View this quota on the UK Integrated Online Tariff </a></li>
       </ul>
   </div>
 </div>

--- a/quotas/tests/test_views.py
+++ b/quotas/tests/test_views.py
@@ -5,9 +5,10 @@ from bs4 import BeautifulSoup
 from django.contrib.humanize.templatetags.humanize import intcomma
 from django.urls import reverse
 
-from common import tariffs_api
 from common.models.transactions import Transaction
 from common.models.utils import override_current_transaction
+from common.tariffs_api import ENDPOINTS
+from common.tariffs_api import QUOTAS
 from common.tests import factories
 from common.tests.util import assert_model_view_renders
 from common.tests.util import assert_read_only_model_view_returns_list
@@ -140,7 +141,7 @@ def test_quota_detail_api_response_no_results(
 
     response_json = {"meta": {"pagination": {"total_count": 0}}}
 
-    response = requests_mock.get(url=tariffs_api.QUOTAS, json=response_json)
+    response = requests_mock.get(url=ENDPOINTS[QUOTAS], json=response_json)
 
     response = valid_user_client.get(
         reverse("quota-ui-detail", kwargs={"sid": quota.sid}),
@@ -162,7 +163,7 @@ def test_quota_detail_api_response_has_results(
         valid_between=date_ranges.future,
     )
 
-    response = requests_mock.get(url=tariffs_api.QUOTAS, json=quotas_json)
+    response = requests_mock.get(url=ENDPOINTS[QUOTAS], json=quotas_json)
 
     response = valid_user_client.get(
         reverse("quota-ui-detail", kwargs={"sid": quota_order_number.sid}),

--- a/quotas/tests/test_views.py
+++ b/quotas/tests/test_views.py
@@ -7,8 +7,7 @@ from django.urls import reverse
 
 from common.models.transactions import Transaction
 from common.models.utils import override_current_transaction
-from common.tariffs_api import ENDPOINTS
-from common.tariffs_api import QUOTAS
+from common.tariffs_api import Endpoints
 from common.tests import factories
 from common.tests.util import assert_model_view_renders
 from common.tests.util import assert_read_only_model_view_returns_list
@@ -141,7 +140,7 @@ def test_quota_detail_api_response_no_results(
 
     response_json = {"meta": {"pagination": {"total_count": 0}}}
 
-    response = requests_mock.get(url=ENDPOINTS[QUOTAS], json=response_json)
+    response = requests_mock.get(url=Endpoints.QUOTAS.value, json=response_json)
 
     response = valid_user_client.get(
         reverse("quota-ui-detail", kwargs={"sid": quota.sid}),
@@ -163,7 +162,7 @@ def test_quota_detail_api_response_has_results(
         valid_between=date_ranges.future,
     )
 
-    response = requests_mock.get(url=ENDPOINTS[QUOTAS], json=quotas_json)
+    response = requests_mock.get(url=Endpoints.QUOTAS.value, json=quotas_json)
 
     response = valid_user_client.get(
         reverse("quota-ui-detail", kwargs={"sid": quota_order_number.sid}),

--- a/quotas/views.py
+++ b/quotas/views.py
@@ -15,6 +15,7 @@ from common.business_rules import UniqueIdentifyingFields
 from common.business_rules import UpdateValidity
 from common.forms import delete_form_for
 from common.serializers import AutoCompleteSerializer
+from common.tariffs_api import URLs
 from common.tariffs_api import get_quota_data
 from common.tariffs_api import get_quota_definitions_data
 from common.validators import UpdateType
@@ -129,6 +130,9 @@ class QuotaDetail(QuotaOrderNumberMixin, TrackedModelDetailView, SortingMixin):
 
         current_definition = definitions.as_at_and_beyond(date.today()).first()
         context["current_definition"] = current_definition
+        context[
+            "uk_tariff_url"
+        ] = f"{URLs.BASE_URL.value}quota_search?order_number={self.object.order_number}"
 
         context[
             "quota_associations"

--- a/quotas/views.py
+++ b/quotas/views.py
@@ -117,7 +117,7 @@ class QuotaDetail(QuotaOrderNumberMixin, TrackedModelDetailView, SortingMixin):
 
     @property
     def quota_data(self):
-        data = get_quota_data(self.object.order_number)
+        data = get_quota_data({"order_number": self.object.order_number})
         if not data or data["meta"]["pagination"]["total_count"] == 0:
             return None
         return data.get("data")[0]


### PR DESCRIPTION
# TP2000-912: VAT & excise measures
<!---
 * Include the JIRA ticket number, eg TP-123, to automatically link.
 * Use 50 characters maximum.
 * Do not end with a full-stop.
--->

## Why
<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Use as many lines as you like.
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions or deliberately ignored edge-cases.
--->
* Users want to be able to see VAT & excise measures related to a commodity code that aren't held in TAP

## What
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Explain like I'm 5.
 * Use pictures if you can.
--->
* Adds a VAT & excise measures tab to the commodity detail page
* Adds the commodity endpoint to the tariffs api module

<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
## Checklist
- Requires migrations?
- Requires dependency updates?
--->

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->

<img width="1206" alt="Screenshot 2023-08-23 at 16 36 56" src="https://github.com/uktrade/tamato/assets/25905279/4de1709a-b717-4ae9-b0de-77006e5718ae">

