### PR TITLE
TP2000-1009

### DIFF
--- a/measures/business_rules.py
+++ b/measures/business_rules.py
@@ -1338,12 +1338,9 @@ class ME70(BusinessRule):
 
 
 class ME71(FootnoteApplicability):
-    """
-    Footnotes with a footnote type for which the application type = "CN
-    footnotes" cannot be associated with TARIC codes (codes with pos.
-
-    9-10 different from 00).
-    """
+    """Footnotes with a footnote type for which the application type = "CN
+    footnotes" cannot be associated with TARIC codes (codes with pos 9-10
+    different from 00)."""
 
     applicable_field = "footnoted_measure"
 

--- a/measures/business_rules.py
+++ b/measures/business_rules.py
@@ -1229,7 +1229,6 @@ class ME66(ExclusionMembership):
     excluded_from = "modified_measure"
 
 
-@skip_when_deleted
 class ME67(BusinessRule):
     """
     The membership period of the excluded geographical area must span the valid

--- a/measures/jinja2/includes/measures/tabs/core_data.jinja
+++ b/measures/jinja2/includes/measures/tabs/core_data.jinja
@@ -42,7 +42,7 @@
         },
         {
             "key": {"text": "Additional code"},
-            "value": {"text": create_link(url("additional_code-ui-detail", kwargs={"sid": object.additional_code.sid}), object.additional_code.sid) if object.additional_code else "-"},
+            "value": {"text": create_link(url("additional_code-ui-detail", kwargs={"sid": object.additional_code.sid}), object.additional_code.type.sid~object.additional_code.code) if object.additional_code else "-"},
             "actions": {"items": []}
         },
         {


### PR DESCRIPTION
# TP2000-1009
Update ME67 and add a test to verify it handles deleted measures correctly

## Why
 * In production deleting a measure still triggers ME67 which fails because it cant find the measure .... becuase its deleted

## What
* Altered the query in ME67 to find the measure, if it cant find it - its fine, dont check. 
* Added test to verify (which also failerd before update)
* All rules passing ion workbasket that originally seeded the ticket 

## Checklist
- Requires migrations? No 
- Requires dependency updates? No 

Links to relevant material
See: [Description](https://uktrade.atlassian.net/browse/TP2000-1009)
