### PR TITLE
TP2000-1011 - Updating measure footnote details to show the latest description

### DIFF
--- a/measures/jinja2/includes/measures/tabs/footnotes.jinja
+++ b/measures/jinja2/includes/measures/tabs/footnotes.jinja
@@ -7,7 +7,7 @@
   {% for association in object.footnoteassociationmeasure_set.current() %}
     {{ table_rows.append([
         {"text": create_link(association.associated_footnote.get_url(), association.associated_footnote|string) },
-        {"text": association.associated_footnote.descriptions.first().description },
+        {"text": association.associated_footnote.descriptions.last().description },
       ]) or "" }}
   {% endfor %}
     {{ govukTable({


### PR DESCRIPTION
# TP2000-1011 Updating measure footnote details to show the latest description
<!---
 * Include the JIRA ticket number, eg TP-123, to automatically link.
 * Use 50 characters maximum.
 * Do not end with a full-stop.
--->

## Why
It was previously displaying the first footnote description in the queryset of associated footnotes when this was the oldest and not current one.

![image](https://github.com/uktrade/tamato/assets/97194636/45e20b31-3755-49d1-8b53-7cc1eb302d79)

CD624 current footnote description:
![image](https://github.com/uktrade/tamato/assets/97194636/4fb67f51-efc3-4b5e-8982-c4af20512db4)


## What
Updated to display the last footnote description rather than the first.

<img width="1264" alt="image" src="https://github.com/uktrade/tamato/assets/97194636/cbfb8ab1-101b-41e2-9693-332f10baf45f">


<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
## Checklist
- Requires migrations?
- Requires dependency updates?
--->

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
