### PR TITLE
fix: TP2000-980 filter 09 quotas from quotas cant be used report

### DIFF
--- a/reports/reports/quotas_cannot_be_used.py
+++ b/reports/reports/quotas_cannot_be_used.py
@@ -73,7 +73,11 @@ class Report(ReportBaseTable):
             .exclude(definitions__in=quotas_with_definition_periods)
         )
 
-        matching_data.update(quota_order_numbers_without_definitions.exclude(order_number__startswith="09"))
+        matching_data.update(
+            quota_order_numbers_without_definitions.exclude(
+                order_number__startswith="09"
+            )
+        )
 
         for quota in quotas_with_definition_periods:
             if not str(quota.order_number).startswith("09"):


### PR DESCRIPTION
# TP2000-980 - filter 09 quotas from quotas cant be used report
<!---
 * Include the JIRA ticket number, eg TP-123, to automatically link.
 * Use 50 characters maximum.
 * Do not end with a full-stop.
--->

## Why
<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Use as many lines as you like.
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions or deliberately ignored edge-cases.
--->
We are filtering out “09xxxx”, these are effectively EU quotas and they’re slowly being closed down.
## What
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Explain like I'm 5.
 * Use pictures if you can.
--->
During the query against the db, we are excluding quota order numbers that begin with 09.
<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
## Checklist
- Requires migrations?
- Requires dependency updates?
--->

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
