### PR TITLE
bump: sqlite-s3vfs to 0.0.35 and remove apsw-wheels

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@ aiohttp==3.8.5
 aioresponses==0.7.4
 allure-pytest-bdd==2.8.40
 api-client==1.3.0
-apsw-wheels==3.36.*
 better-exceptions==0.3.3
 beautifulsoup4==4.10.0
 black==23.3.0
@@ -69,7 +68,7 @@ responses==0.12.1
 sentry-sdk==0.20.2
 Sphinx==4.2.0
 sphinx-gherkindoc==3.6.2
-sqlite-s3vfs==0.0.26
+sqlite-s3vfs==0.0.35
 tabulate==0.9.0
 urllib3==1.26.5
 wrapt==1.12.1


### PR DESCRIPTION
# TP2000-198 Your PR title here
<!---
 * Include the JIRA ticket number, eg TP-123, to automatically link.
 * Use 50 characters maximum.
 * Do not end with a full-stop.
--->

## Why
<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Use as many lines as you like.
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions or deliberately ignored edge-cases.
--->
The [GitHub - uktrade/sqlite-s3vfs: Python writable virtual filesystem for SQLite on S3](https://github.com/uktrade/sqlite-s3vfs)  repo now automatically installs the aspw-wheels dependency (see this commit: [Merge pull request #21 from uktrade/build/automatically-install-apsw · uktrade/sqlite-s3vfs@98da943](https://github.com/uktrade/sqlite-s3vfs/commit/98da943566704277fafa9590be076a7a2d2686b8) )

The direct dependency included in Tamato’s requirements.txt should therefore be removed.
## What
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Explain like I'm 5.
 * Use pictures if you can.
--->
Update requirements.txt
<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
## Checklist
- Requires migrations?
- Requires dependency updates?
--->

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
