### PR TITLE
TP-2000-1025 - Bugfix - Certificate is not a valid field in MeasureList view

### DIFF
--- a/measures/filters.py
+++ b/measures/filters.py
@@ -259,12 +259,15 @@ class MeasureFilter(TamatoFilter):
     def certificates_filter(self, queryset, name, value):
         if value:
             wanted_measures_ids = set()
-            measure_conditions = MeasureCondition.objects.filter(
-                required_certificate=value.trackedmodel_ptr_id,
-            )
+            certificates = Certificate.objects.filter(sid=value.sid)
+            for certificate in certificates:
+                measure_conditions = MeasureCondition.objects.filter(
+                    required_certificate=certificate,
+                )
 
-            for condition in measure_conditions:
-                wanted_measures_ids.add(condition.dependent_measure_id)
+                for condition in measure_conditions:
+                    wanted_measures_ids.add(condition.dependent_measure_id)
+
             queryset = queryset.filter(id__in=wanted_measures_ids)
 
         return queryset

--- a/measures/filters.py
+++ b/measures/filters.py
@@ -192,7 +192,7 @@ class MeasureFilter(TamatoFilter):
     certificates = AutoCompleteFilter(
         label="Certificates",
         field_name="conditions__required_certificate",
-        queryset=Certificate.objects.all(),
+        queryset=Certificate.objects.current(),
         method="certificates_filter",
         attrs={
             "display_class": GOV_UK_TWO_THIRDS,
@@ -257,8 +257,16 @@ class MeasureFilter(TamatoFilter):
         return queryset
 
     def certificates_filter(self, queryset, name, value):
+        """
+        Returns a MeasuresQuerySet for Measures associated with a specific
+        Certificate via MeasureCondition.
+
+        1. check for Ceritificates with a matching SID
+        2. match associated MeasureConditions
+        3. filter by dependent_measure_ids
+        """
         if value:
-            wanted_measures_ids = set()
+            measure_ids = set()
             certificates = Certificate.objects.filter(sid=value.sid)
             for certificate in certificates:
                 measure_conditions = MeasureCondition.objects.filter(
@@ -266,9 +274,9 @@ class MeasureFilter(TamatoFilter):
                 )
 
                 for condition in measure_conditions:
-                    wanted_measures_ids.add(condition.dependent_measure_id)
+                    measure_ids.add(condition.dependent_measure_id)
 
-            queryset = queryset.filter(id__in=wanted_measures_ids)
+            queryset = queryset.filter(id__in=measure_ids)
 
         return queryset
 

--- a/measures/tests/test_filters.py
+++ b/measures/tests/test_filters.py
@@ -51,11 +51,17 @@ def test_filter_by_certificates(
     session.save()
 
     measure_with_certificate = factories.MeasureFactory.create()
+    measure_with_different_certificate = factories.MeasureFactory.create()
     measure_no_certificate = factories.MeasureFactory.create()
     certificate = factories.CertificateFactory.create()
+    other_certificate = factories.CertificateFactory.create()
     factories.MeasureConditionFactory.create(
         dependent_measure=measure_with_certificate,
         required_certificate=certificate,
+    )
+    factories.MeasureConditionFactory.create(
+        dependent_measure=measure_with_different_certificate,
+        required_certificate=other_certificate,
     )
 
     qs = Measure.objects.all()
@@ -70,3 +76,4 @@ def test_filter_by_certificates(
 
     assert measure_with_certificate in res
     assert measure_no_certificate not in res
+    assert measure_with_different_certificate not in res

--- a/measures/tests/test_filters.py
+++ b/measures/tests/test_filters.py
@@ -39,3 +39,34 @@ def test_filter_by_current_workbasket(
     )
     assert len(result) == len(session_workbasket.measures)
     assert set(session_workbasket.measures) == set(result)
+
+
+def test_filter_by_certificates(
+    valid_user_client,
+    session_workbasket: WorkBasket,
+    session_request,
+):
+    session = valid_user_client.session
+    session["workbasket"] = {"id": session_workbasket.pk}
+    session.save()
+
+    measure_with_certificate = factories.MeasureFactory.create()
+    measure_no_certificate = factories.MeasureFactory.create()
+    certificate = factories.CertificateFactory.create()
+    factories.MeasureConditionFactory.create(
+        dependent_measure=measure_with_certificate,
+        required_certificate=certificate,
+    )
+
+    qs = Measure.objects.all()
+
+    self = MeasureFilter(data={"certificates": certificate.trackedmodel_ptr_id})
+    res = MeasureFilter.certificates_filter(
+        self,
+        queryset=qs,
+        name="certificates",
+        value=certificate,
+    )
+
+    assert measure_with_certificate in res
+    assert measure_no_certificate not in res


### PR DESCRIPTION
# TP-2000-1025 - Bugfix - Certificate is not a valid field in MeasureList view

## Why
This is a bugfix for the Certificates filter on the find and edit measures page introduced in [PR 1014](https://github.com/uktrade/tamato/pull/1014)

## What
The previous filter assumed that there was a direct link between Measures and Certificates. There is not.
This filter uses the link via MeasureCondition and adds tests.

## Checklist
No migrations or dependencies.

[TAP Bug comment thread](https://teams.microsoft.com/l/message/19:fdd22c5d3132421cbffc1ba7454f7d10@thread.tacv2/1693817104622?tenantId=8fa217ec-33aa-46fb-ad96-dfe68006bb86&groupId=16ae1baa-31cc-4fda-8ea7-cfcd00d254ed&parentMessageId=1693817104622&teamName=Tariff%20Team&channelName=TAP%20Bugs&createdTime=1693817104622&allowXTenantAccess=false)

<img width="825" alt="Screenshot 2023-09-04 at 17 48 07" src="https://github.com/uktrade/tamato/assets/46421052/f7cd1210-5b6f-43d8-84cd-f29ea6839963">