### PR TITLE
TP2000 1038 adjusts handling of goods nomenclature description updates with no periods

### DIFF
--- a/commodities/import_handlers.py
+++ b/commodities/import_handlers.py
@@ -7,6 +7,7 @@ from django.db import transaction
 from commodities import import_parsers as parsers
 from commodities import models
 from commodities import serializers
+from commodities.models.orm import GoodsNomenclatureDescription
 from common.validators import UpdateType
 from footnotes.models import Footnote
 from importer.handlers import BaseHandler
@@ -154,6 +155,10 @@ class GoodsNomenclatureDescriptionHandler(BaseGoodsNomenclatureDescriptionHandle
         TODO : implement correct period handling to correctly resolve this crude workaround
         """
         data = dict()
+
+        # The code below looks for an existing goods nomenclature description in our db (using the description sid)
+        # and if it finds one it will use the validity start date from that record to use in the new description.
+        # If there is no existing description found then it will use todays date as the validity start date.
         # Setting to today's date is not perfect, and could cause issues in circumstances where the end date of the
         # goods nomenclature is before today, however if that's the case it does not really matter.
         # an additional possibility is that there already exists a description with this date, which will cause a rule
@@ -161,7 +166,14 @@ class GoodsNomenclatureDescriptionHandler(BaseGoodsNomenclatureDescriptionHandle
 
         # Ultimately this is a crude temporary measure that will be superseded by a correct implementation splitting
         # out description periods into a new table
-        data["validity_start"] = date.today()
+
+        goods_nomenclature_description = GoodsNomenclatureDescription.objects.filter(
+            sid=self.data['sid']).latest_approved().first()
+
+        if goods_nomenclature_description and goods_nomenclature_description.described_goods_nomenclature.valid_between.lower:
+            data['validity_start'] = goods_nomenclature_description.described_goods_nomenclature.valid_between.lower
+        else:
+            data['validity_start'] = date.today()
 
         # Update the goods nomenclature description with the start date
         goods_nomenclature_description_handler.data.update(data)

--- a/commodities/import_handlers.py
+++ b/commodities/import_handlers.py
@@ -167,13 +167,23 @@ class GoodsNomenclatureDescriptionHandler(BaseGoodsNomenclatureDescriptionHandle
         # Ultimately this is a crude temporary measure that will be superseded by a correct implementation splitting
         # out description periods into a new table
 
-        goods_nomenclature_description = GoodsNomenclatureDescription.objects.filter(
-            sid=self.data['sid']).latest_approved().first()
+        goods_nomenclature_description = (
+            GoodsNomenclatureDescription.objects.filter(sid=self.data["sid"])
+            .latest_approved()
+            .first()
+        )
 
-        if goods_nomenclature_description and goods_nomenclature_description.described_goods_nomenclature.valid_between.lower:
-            data['validity_start'] = goods_nomenclature_description.described_goods_nomenclature.valid_between.lower
+        if (
+            goods_nomenclature_description
+            and goods_nomenclature_description.described_goods_nomenclature.valid_between.lower
+        ):
+            data[
+                "validity_start"
+            ] = (
+                goods_nomenclature_description.described_goods_nomenclature.valid_between.lower
+            )
         else:
-            data['validity_start'] = date.today()
+            data["validity_start"] = date.today()
 
         # Update the goods nomenclature description with the start date
         goods_nomenclature_description_handler.data.update(data)

--- a/commodities/tests/test_importer.py
+++ b/commodities/tests/test_importer.py
@@ -1,6 +1,7 @@
-import pytest
 from datetime import date
 from unittest.mock import Mock
+
+import pytest
 
 from commodities import models
 from commodities import serializers
@@ -31,47 +32,71 @@ def test_goods_nomenclature_description_importer(
 
 
 def test_goods_nomenclature_description_update_that_comes_without_a_description_period_but_exists_in_our_db(
-        imported_fields_match, date_ranges):
-    goods_nomenclature = factories.GoodsNomenclatureFactory.create(sid=123, valid_between=date_ranges.normal)
-    goods_nomenclature_description = factories.GoodsNomenclatureDescriptionFactory.create(sid=321, validity_start=
-    date_ranges.normal.lower, described_goods_nomenclature=goods_nomenclature)
+    imported_fields_match,
+    date_ranges,
+):
+    goods_nomenclature = factories.GoodsNomenclatureFactory.create(
+        sid=123,
+        valid_between=date_ranges.normal,
+    )
+    goods_nomenclature_description = (
+        factories.GoodsNomenclatureDescriptionFactory.create(
+            sid=321,
+            validity_start=date_ranges.normal.lower,
+            described_goods_nomenclature=goods_nomenclature,
+        )
+    )
 
     goods_nomenclature_description_handler = {
         "transaction_id": 1,
         "data": {
             "sid": 321,
             "described_goods_nomenclature": goods_nomenclature,
-        }
+        },
     }
 
     nursary = Mock()
-    handler = GoodsNomenclatureDescriptionHandler(goods_nomenclature_description_handler, nursary)
+    handler = GoodsNomenclatureDescriptionHandler(
+        goods_nomenclature_description_handler,
+        nursary,
+    )
 
     handler.create_missing_goods_nomenclature_description_period(handler)
 
-    assert goods_nomenclature_description_handler["data"][
-               "validity_start"] == goods_nomenclature_description.validity_start
+    assert (
+        goods_nomenclature_description_handler["data"]["validity_start"]
+        == goods_nomenclature_description.validity_start
+    )
 
 
 def test_goods_nomenclature_description_update_that_comes_without_a_description_period_but_does_not_exist_in_our_db(
-        imported_fields_match, date_ranges):
-    goods_nomenclature = factories.GoodsNomenclatureFactory.create(sid=123, valid_between=date_ranges.normal)
+    imported_fields_match,
+    date_ranges,
+):
+    goods_nomenclature = factories.GoodsNomenclatureFactory.create(
+        sid=123,
+        valid_between=date_ranges.normal,
+    )
 
     goods_nomenclature_description_handler = {
         "transaction_id": 1,
         "data": {
             "sid": 321,
             "described_goods_nomenclature": goods_nomenclature,
-        }
+        },
     }
 
     nursary = Mock()
-    handler = GoodsNomenclatureDescriptionHandler(goods_nomenclature_description_handler, nursary)
+    handler = GoodsNomenclatureDescriptionHandler(
+        goods_nomenclature_description_handler,
+        nursary,
+    )
 
     handler.create_missing_goods_nomenclature_description_period(handler)
 
-    assert goods_nomenclature_description_handler["data"][
-               "validity_start"] == date.today()
+    assert (
+        goods_nomenclature_description_handler["data"]["validity_start"] == date.today()
+    )
 
 
 def test_goods_nomenclature_origin_importer(
@@ -205,6 +230,7 @@ def test_footnote_association_goods_nomenclature_importer(imported_fields_match)
             "associated_footnote": factories.FootnoteFactory,
         },
     )
+
 
 # The fourth of these parameters ("starts_with_normal") currently hangs during run_xml_import
 # Further investigation needed


### PR DESCRIPTION
# TP2000 1038 adjusts handling of goods nomenclature description updates with no periods


## Why
The EU has their Goods Nomenclature Description and Goods Nomenclature Description Period (i.e. the validity dates of the descriptions) split into different tables. However, in TAP they are in the same table, the Goods Nomenclature Description table.

The EU commonly makes updates to Goods Nomenclature Descriptions (e.g. text changes to the description field) without sending a Goods Nomenclature Description Period update in the same TGB file. This is not a problem for the EU as they can make description and period changes independently of each other. In TAP this can cause a variety of problems. One such problem is that our importer used to just drop any Goods Nomenclature Description changes that did not also arrive in a TGB file that contained a Goods Nomenclature Description Period update. An interim fix in this event was to use todays date as the start validity date of a Goods Nomenclature Description as this allowed us to at least perform the Goods Nomenclature Description update in TAP. However, this solution ultimately uses the wrong validity dates and can run into NIG12 errors (e.g. TGB23165).

## What
An upgrade to this interim solution is to search for existing Goods Nomenclature Description’s that match the sid of the Goods Nomenclature Description in the update and use the existing validity start date from that to carry forward in the updated Goods Nomenclature Description. If a Goods Nomenclature Description with the same sid is not found then it can revert to using todays date. 

This is not a longterm fix but rather a slightly more fleshed out interim solution. The longterm fix for this is to split out Goods Nomenclature Description into two tables, replicating the data architecture that the EU uses (Goods Nomenclature Description and Goods Nomenclature Description Period tables). This is a bigger task and preliminary work is being done on this (I have been working on a replica EU database for alignment purposes that could also serve as our seed data for a future Goods Nomenclature Description Period table and Doug is working on an importer 2.0 that will help in the process).

<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
## Checklist
- Requires migrations?
- Requires dependency updates?
--->

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
