### PR TITLE
implementing requested changes & formatting

### DIFF
--- a/common/static/common/js/application.js
+++ b/common/static/common/js/application.js
@@ -12,6 +12,7 @@ import { initAll } from 'govuk-frontend';
 import initCheckboxes from './checkboxes';
 import initConditionalMeasureConditions from './conditionalMeasureConditions';
 import initFilterDisabledToggleForComCode from './conditionalDisablingFilters'
+import initCloseAccordionSection from './openCloseAccordion';
 showHideCheckboxes();
 // Initialise accessible-autocomplete components without a `name` attr in order
 // to avoid the "dummy" autocomplete field being submitted as part of the form
@@ -25,3 +26,4 @@ initCheckboxes();
 initConditionalMeasureConditions();
 initAutocompleteProgressiveEnhancement();
 initFilterDisabledToggleForComCode();
+initCloseAccordionSection();

--- a/common/static/common/js/application.js
+++ b/common/static/common/js/application.js
@@ -12,7 +12,7 @@ import { initAll } from 'govuk-frontend';
 import initCheckboxes from './checkboxes';
 import initConditionalMeasureConditions from './conditionalMeasureConditions';
 import initFilterDisabledToggleForComCode from './conditionalDisablingFilters'
-import initCloseAccordionSection from './openCloseAccordion';
+import initOpenCloseAccordionSection from './openCloseAccordion';
 showHideCheckboxes();
 // Initialise accessible-autocomplete components without a `name` attr in order
 // to avoid the "dummy" autocomplete field being submitted as part of the form
@@ -26,4 +26,4 @@ initCheckboxes();
 initConditionalMeasureConditions();
 initAutocompleteProgressiveEnhancement();
 initFilterDisabledToggleForComCode();
-initCloseAccordionSection();
+initOpenCloseAccordionSection();

--- a/common/static/common/js/openCloseAccordion.js
+++ b/common/static/common/js/openCloseAccordion.js
@@ -1,0 +1,17 @@
+const initCloseAccordionSection = () => {
+    document.addEventListener('DOMContentLoaded', function() {
+        
+        let expandedSection = document.getElementsByClassName('govuk-accordion__section')
+        let pathname = window.location.pathname
+        if(expandedSection.length > 0){
+            if (pathname.includes('search')){
+                expandedSection[0].classList.add('govuk-accordion__section--expanded');
+            } else {
+                expandedSection[0].classList.remove('govuk-accordion__section--expanded');
+            }
+        }
+    }
+    )
+}
+
+export default initCloseAccordionSection;

--- a/common/static/common/js/openCloseAccordion.js
+++ b/common/static/common/js/openCloseAccordion.js
@@ -1,12 +1,13 @@
-const initCloseAccordionSection = () => {
+// TODO: adjust the pathname filter to account for all objects search/filter pages
+const initOpenCloseAccordionSection = () => {
     document.addEventListener('DOMContentLoaded', function() {
         
         let expandedSection = document.getElementsByClassName('govuk-accordion__section')
         let pathname = window.location.pathname
         if(expandedSection.length > 0){
-            if (pathname.includes('search')){
+            if (pathname.includes('measures/search')){
                 expandedSection[0].classList.add('govuk-accordion__section--expanded');
-            } else {
+            } else if (pathname.includes('measures') && !pathname.includes('search')){
                 expandedSection[0].classList.remove('govuk-accordion__section--expanded');
             }
         }
@@ -14,4 +15,4 @@ const initCloseAccordionSection = () => {
     )
 }
 
-export default initCloseAccordionSection;
+export default initOpenCloseAccordionSection;

--- a/common/static/common/scss/_accordion.scss
+++ b/common/static/common/scss/_accordion.scss
@@ -5,3 +5,9 @@
 .govuk-accordion__section-content > :last-child {
   @extend .govuk-\!-margin-bottom-6;
 }
+.govuk-accordion__section-button {
+  color: black !important;
+}
+.govuk-accordion__icon {
+  display: none !important;
+}

--- a/measures/forms.py
+++ b/measures/forms.py
@@ -769,13 +769,17 @@ class MeasureFilterForm(forms.Form):
         self.helper.layout = Layout(
             Accordion(
                 AccordionSection(
-                    "Select one or more options to search",
+                    "Search and filter",
+                    HTML(
+                        '<h3 class="govuk-body">Select one or more options to search</h3>',
+                    ),
                     Div(
                         Div(
                             Div(
                                 "goods_nomenclature",
                                 Field.text("sid", field_width=Fluid.TWO_THIRDS),
                                 "regulation",
+                                "footnotes",
                                 css_class="govuk-grid-column-one-third",
                             ),
                             Div(
@@ -805,6 +809,9 @@ class MeasureFilterForm(forms.Form):
                             ),
                             Div(
                                 "modc",
+                                HTML(
+                                    "<h3 class='govuk-body'>To use the 'Include inherited measures' filter, enter a valid commodity code in the 'Select commodity code' filter above</h3>",
+                                ),
                                 css_class="govuk-grid-column-full form-group-margin-bottom-2",
                             ),
                             css_class="govuk-grid-row govuk-!-margin-top-6",
@@ -832,7 +839,7 @@ class MeasureFilterForm(forms.Form):
                                 "end_date",
                                 css_class="govuk-grid-column-one-half form-group-margin-bottom-2",
                             ),
-                            css_class="govuk-grid-row govuk-!-padding-top-6 filter-layout__filters",
+                            css_class="govuk-grid-row govuk-!-padding-top-6",
                         ),
                         Div(
                             Div(

--- a/measures/forms.py
+++ b/measures/forms.py
@@ -779,7 +779,7 @@ class MeasureFilterForm(forms.Form):
                                 "goods_nomenclature",
                                 Field.text("sid", field_width=Fluid.TWO_THIRDS),
                                 "regulation",
-                                "footnotes",
+                                "footnote",
                                 css_class="govuk-grid-column-one-third",
                             ),
                             Div(

--- a/measures/jinja2/measures/list.jinja
+++ b/measures/jinja2/measures/list.jinja
@@ -1,4 +1,3 @@
 {% set form_url = "measure-ui-list" %}
 {% set list_include = "includes/measures/list.jinja" %}
-
 {%- include "layouts/list_vertical.jinja" -%}

--- a/measures/jinja2/measures/search.jinja
+++ b/measures/jinja2/measures/search.jinja
@@ -18,7 +18,6 @@
 
   <div class="filter-layout full-width-search">
     <div class="govuk-!-margin-bottom-5 govuk-grid-column-full">
-      <h2 class="govuk-heading-m ">Search and filter</h2>
       <form method="get" action="{{ url(form_url) }}">
           {{ crispy(filter.form) }}
       </form>


### PR DESCRIPTION
# TP2000-1043 - Final implementation changes following full roll out of the design

## Why
Following feedback from the Tariff Managers, there were some further changes requested to the Measures search and filter page.

## What
I have implemented the changes requested on the ticket with the following note:
I have added the `initOpenCloseAccordionSection` which checks for the presence of an AccordionSection then, if on the 'measures/search' page, adds the `govuk-accordion__section--expanded` class. If it is not on the search page, it removes this class. There is an additional check for `measures` in the pathname to prevent all AccordionSections defaulting to closed. 
NOTE: if/when we roll out the changes to the other search and filter pages, this function will need updating to account for other pathnames.
On arrival:
<img width="620" alt="Screenshot 2023-09-15 at 11 58 08" src="https://github.com/uktrade/tamato/assets/46421052/56fa9db0-58ac-47d8-bae3-bf92c38ac353">


After filtering by Current workbasket
<img width="636" alt="Screenshot 2023-09-15 at 12 06 08" src="https://github.com/uktrade/tamato/assets/46421052/8ee49c61-e3a6-45fb-b52c-ffffa76d3e23">
