### PR TITLE
fix: add apsw package back in due to latest update causing failure

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 aiohttp==3.8.5
+apsw==3.43.0.0
 aioresponses==0.7.4
 allure-pytest-bdd==2.8.40
 api-client==1.3.0


### PR DESCRIPTION
# TP N/A
<!---
 * Include the JIRA ticket number, eg TP-123, to automatically link.
 * Use 50 characters maximum.
 * Do not end with a full-stop.
--->

## Why
<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Use as many lines as you like.
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions or deliberately ignored edge-cases.
--->
http://sentry.ci.uktrade.digital/organizations/dit/issues/83955/?project=200
Caused by latest apsw release: https://pypi.org/project/apsw/#history

As we removed the direct relation in this PR:
https://github.com/uktrade/tamato/commit/7f4df66963001241be2a590775d637479faf3428

And the dependency from [sqlite-s3vfs](https://github.com/uktrade/sqlite-s3vfs/commit/98da943566704277fafa9590be076a7a2d2686b8) does not specify a version. So we need to pin it and perhaps resolve this in sqlite-s3vfs at a later date (I think we are the only team actively using this package so will ask DI)

## What
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Explain like I'm 5.
 * Use pictures if you can.
--->

<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
## Checklist
- Requires migrations?
- Requires dependency updates?
--->

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
