### PR TITLE
footnote description fix for MultipleObjectsReturned error

### DIFF
--- a/footnotes/views.py
+++ b/footnotes/views.py
@@ -81,7 +81,7 @@ class FootnoteCreateDescriptionMixin:
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        context["described_object"] = models.Footnote.objects.get(
+        context["described_object"] = models.Footnote.objects.current().get(
             footnote_type__footnote_type_id=(
                 self.kwargs.get("footnote_type__footnote_type_id")
             ),
@@ -218,7 +218,7 @@ class FootnoteDescriptionCreate(
 
     def get_initial(self):
         initial = super().get_initial()
-        initial["described_footnote"] = models.Footnote.objects.get(
+        initial["described_footnote"] = models.Footnote.objects.current().get(
             footnote_type__footnote_type_id=(
                 self.kwargs.get("footnote_type__footnote_type_id")
             ),


### PR DESCRIPTION
# TP2000-1054 footnote description fix for MultipleObjectsReturned error
<!---
 * Include the JIRA ticket number, eg TP-123, to automatically link.
 * Use 50 characters maximum.
 * Do not end with a full-stop.
--->

## Why
When trying to create a footnote description for a footnot with multiple versions the .get() returns more than one result

## What
added `.current()` to only return the latest version of the footnote. So the footnotes/xxxxx/description-create/ page does not error when trying to access it.

<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
## Checklist
- Requires migrations?
- Requires dependency updates?
--->

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
