### PR TITLE
TP2000-1054  Fix DescriptionCreate MultipleObjectsReturned error

### DIFF
--- a/additional_codes/tests/test_views.py
+++ b/additional_codes/tests/test_views.py
@@ -4,9 +4,13 @@ import factory
 import pytest
 from dateutil.relativedelta import relativedelta
 from django.core.exceptions import ValidationError
+from django.urls import reverse
 
 from additional_codes.models import AdditionalCode
+from additional_codes.models import AdditionalCodeDescription
 from additional_codes.views import AdditionalCodeList
+from common.models import Transaction
+from common.models.utils import override_current_transaction
 from common.tests import factories
 from common.tests.util import assert_model_view_renders
 from common.tests.util import assert_read_only_model_view_returns_list
@@ -186,3 +190,36 @@ def test_additional_code_type_api_list_view(valid_user_client):
         expected_results,
         valid_user_client,
     )
+
+
+def test_additional_code_description_create(valid_user_client):
+    """Tests that `AdditionalCodeDescriptionCreate` view returns 200 and creates
+    a description for the current version of an additional code."""
+    additional_code = factories.AdditionalCodeFactory.create()
+    new_version = additional_code.new_version(
+        workbasket=additional_code.transaction.workbasket,
+    )
+    assert not AdditionalCodeDescription.objects.exists()
+
+    url = reverse(
+        "additional_code-ui-description-create",
+        kwargs={"sid": new_version.sid},
+    )
+    data = {
+        "description": "new test description",
+        "described_additionalcode": new_version.pk,
+        "validity_start_0": 1,
+        "validity_start_1": 1,
+        "validity_start_2": 2023,
+    }
+
+    with override_current_transaction(Transaction.objects.last()):
+        get_response = valid_user_client.get(url)
+        assert get_response.status_code == 200
+
+        post_response = valid_user_client.post(url, data)
+        assert post_response.status_code == 302
+
+    assert AdditionalCodeDescription.objects.filter(
+        described_additionalcode__sid=new_version.sid,
+    ).exists()

--- a/additional_codes/views.py
+++ b/additional_codes/views.py
@@ -170,7 +170,7 @@ class AdditionalCodeCreateDescriptionMixin:
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        context["described_object"] = AdditionalCode.objects.get(
+        context["described_object"] = AdditionalCode.objects.current().get(
             sid=(self.kwargs.get("sid")),
         )
         return context
@@ -193,7 +193,7 @@ class AdditionalCodeDescriptionCreate(
 
     def get_initial(self):
         initial = super().get_initial()
-        initial["described_additionalcode"] = AdditionalCode.objects.get(
+        initial["described_additionalcode"] = AdditionalCode.objects.current().get(
             sid=(self.kwargs.get("sid")),
         )
         return initial

--- a/footnotes/views.py
+++ b/footnotes/views.py
@@ -81,7 +81,7 @@ class FootnoteCreateDescriptionMixin:
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        context["described_object"] = models.Footnote.objects.get(
+        context["described_object"] = models.Footnote.objects.current().get(
             footnote_type__footnote_type_id=(
                 self.kwargs.get("footnote_type__footnote_type_id")
             ),
@@ -218,7 +218,7 @@ class FootnoteDescriptionCreate(
 
     def get_initial(self):
         initial = super().get_initial()
-        initial["described_footnote"] = models.Footnote.objects.get(
+        initial["described_footnote"] = models.Footnote.objects.current().get(
             footnote_type__footnote_type_id=(
                 self.kwargs.get("footnote_type__footnote_type_id")
             ),


### PR DESCRIPTION
# TP2000-1054 Fix DescriptionCreate MultipleObjectsReturned error

## Why
`FootnoteDescriptionCreate` view raises a `MultipleObjectsReturned` error when it encounters a footnote with more than one version.

## What
- Uses current() to return the current version of the object only
- Prevents the same issue from occurring in `AdditionalCodeDescriptionCreate`
- Adds view unit tests
