### PR TITLE
TP2000-1030 Fix footnote autocomplete selection

### DIFF
--- a/common/static/common/js/util.js
+++ b/common/static/common/js/util.js
@@ -7,7 +7,7 @@ const nodeListForEach = (nodes, callback) => {
     }
 }
 
-const newLine = /\n/g;
+const newLine = /[\n\r]/g;
 const removeNewLine = (str) => str.replace(newLine, "")
 
 const cleanResults = (results) => {


### PR DESCRIPTION
# TP2000-1030 Fix footnotes autocomplete selection

## Why
Footnote descriptions that contain line break characters (`\r\n`) interfere with the autocomplete field, causing some selections to become unselected. This issue was previously seen with commodities (#932).

## What
- Adds `\r` character to the `newLine` regex used to clean autocomplete field results
