### PR TITLE
adding debounce to submit new measure

### DIFF
--- a/common/static/common/js/application.js
+++ b/common/static/common/js/application.js
@@ -13,7 +13,7 @@ import initCheckboxes from './checkboxes';
 import initConditionalMeasureConditions from './conditionalMeasureConditions';
 import initFilterDisabledToggleForComCode from './conditionalDisablingFilters'
 import initOpenCloseAccordionSection from './openCloseAccordion';
-import debounceButton from './buttonDebounce'
+import tapDebounce from './buttonDebounce';
 showHideCheckboxes();
 // Initialise accessible-autocomplete components without a `name` attr in order
 // to avoid the "dummy" autocomplete field being submitted as part of the form
@@ -28,4 +28,4 @@ initConditionalMeasureConditions();
 initAutocompleteProgressiveEnhancement();
 initFilterDisabledToggleForComCode();
 initOpenCloseAccordionSection();
-debounceButton();
+tapDebounce();

--- a/common/static/common/js/application.js
+++ b/common/static/common/js/application.js
@@ -13,7 +13,7 @@ import initCheckboxes from './checkboxes';
 import initConditionalMeasureConditions from './conditionalMeasureConditions';
 import initFilterDisabledToggleForComCode from './conditionalDisablingFilters'
 import initOpenCloseAccordionSection from './openCloseAccordion';
-import tapDebounce from './buttonDebounce';
+import initTapDebounce from './buttonDebounce';
 showHideCheckboxes();
 // Initialise accessible-autocomplete components without a `name` attr in order
 // to avoid the "dummy" autocomplete field being submitted as part of the form
@@ -28,4 +28,4 @@ initConditionalMeasureConditions();
 initAutocompleteProgressiveEnhancement();
 initFilterDisabledToggleForComCode();
 initOpenCloseAccordionSection();
-tapDebounce();
+initTapDebounce();

--- a/common/static/common/js/application.js
+++ b/common/static/common/js/application.js
@@ -13,6 +13,7 @@ import initCheckboxes from './checkboxes';
 import initConditionalMeasureConditions from './conditionalMeasureConditions';
 import initFilterDisabledToggleForComCode from './conditionalDisablingFilters'
 import initOpenCloseAccordionSection from './openCloseAccordion';
+import debounceButton from './buttonDebounce'
 showHideCheckboxes();
 // Initialise accessible-autocomplete components without a `name` attr in order
 // to avoid the "dummy" autocomplete field being submitted as part of the form
@@ -27,3 +28,4 @@ initConditionalMeasureConditions();
 initAutocompleteProgressiveEnhancement();
 initFilterDisabledToggleForComCode();
 initOpenCloseAccordionSection();
+debounceButton();

--- a/common/static/common/js/buttonDebounce.js
+++ b/common/static/common/js/buttonDebounce.js
@@ -1,12 +1,12 @@
 let button = document.getElementById('add-debounce')
+let infoText = document.getElementById('add-debounce-inset-text')
 
 const debounceButton = () => {
     if (button) {
-        console.log('button', button)
         addEventListener('submit', function() {
             button.disabled = true,
-            alert("Your action is being processed and the submit button is now disabled. You will be taken to a confirmation screen once the action has been processed.")}
-        )
+            infoText.classList.remove('js-hidden')
+        })
     }
 }
 

--- a/common/static/common/js/buttonDebounce.js
+++ b/common/static/common/js/buttonDebounce.js
@@ -1,13 +1,24 @@
-let button = document.getElementById('add-debounce')
-let infoText = document.getElementById('add-debounce-inset-text')
+const tapDebounce = function(event) {
+    console.log('b fires')
+    let DEBOUNCE_TIMEOUT_IN_SECONDS = 5;
 
-const debounceButton = () => {
-    if (button) {
-        addEventListener('submit', function() {
-            button.disabled = true,
-            infoText.classList.remove('js-hidden')
-        })
+    if (this.tapDebounceFormSubmitTimer) {
+        console.log('c fires')
+        event.preventDefault();
+        button.disabled = true
+        return false
     }
-}
 
-export default debounceButton;
+
+    this.tapDebounceFormSubmitTimer = setTimeout(function () {
+        this.tapDebounceFormSubmitTimer = null;
+    }.bind(this), DEBOUNCE_TIMEOUT_IN_SECONDS * 1000);
+};
+
+document.querySelectorAll("[data-prevent-double-click").forEach(
+    (element) => {
+        element.addEventListener('click', tapDebounce);
+    }
+)
+
+export default tapDebounce;

--- a/common/static/common/js/buttonDebounce.js
+++ b/common/static/common/js/buttonDebounce.js
@@ -26,7 +26,7 @@ const tapDebounce = (event) => {
 
 
 const initTapDebounce = () => {
-  document.querySelectorAll("[data-prevent-double-click").forEach(
+  document.querySelectorAll("[data-prevent-double-click]").forEach(
     (element) => {
         
       element.addEventListener('click', tapDebounce);

--- a/common/static/common/js/buttonDebounce.js
+++ b/common/static/common/js/buttonDebounce.js
@@ -1,22 +1,31 @@
-const tapDebounce = function(event) {
+const tapDebounce = (event) => {
     let DEBOUNCE_TIMEOUT_IN_SECONDS = 5;
-
-    if (this.tapDebounceFormSubmitTimer) {
-        event.preventDefault();
-        button.disabled = true
-        return false
+    let target = event.target;
+    if (target.tapDebounceFormSubmitTimer) {
+      event.preventDefault();
+      return false;
     }
 
+    let targetDefaultCursor = target.style.cursor;
 
-    this.tapDebounceFormSubmitTimer = setTimeout(function () {
-        this.tapDebounceFormSubmitTimer = null;
-    }.bind(this), DEBOUNCE_TIMEOUT_IN_SECONDS * 1000);
+    target.tapDebounceFormSubmitTimer = setTimeout(
+      function () {
+        target.tapDebounceFormSubmitTimer = null;
+        target.style.cursor = targetDefaultCursor;
+      }.bind(target),
+      DEBOUNCE_TIMEOUT_IN_SECONDS * 1000
+    );
+    target.style.cursor = "wait";
 };
 
-document.querySelectorAll("[data-prevent-double-click").forEach(
-    (element) => {
-        element.addEventListener('click', tapDebounce);
-    }
-)
 
-export default tapDebounce;
+const initTapDebounce = () => {
+  document.querySelectorAll("[data-prevent-double-click").forEach(
+    (element) => {
+        
+      element.addEventListener('click', tapDebounce);
+    }
+  )
+}
+
+export default initTapDebounce;

--- a/common/static/common/js/buttonDebounce.js
+++ b/common/static/common/js/buttonDebounce.js
@@ -1,3 +1,9 @@
+/**
+ * govuk data-prevent-double-click function has a timeout of 1 second. 
+ * If the request takes > 1 second, the button can be clicked again.
+ * This duplicates the functionality but increases the timeout to 5 seconds.
+ */
+
 const tapDebounce = (event) => {
     let DEBOUNCE_TIMEOUT_IN_SECONDS = 5;
     let target = event.target;

--- a/common/static/common/js/buttonDebounce.js
+++ b/common/static/common/js/buttonDebounce.js
@@ -1,0 +1,14 @@
+let button = document.querySelectorAll('span.add-debounce > button')[0]
+
+const debounceButton = () => {
+    if (!button) {
+        return
+    } else if (button) {
+        addEventListener('submit', function() {
+            button.disabled = true,
+            alert("Your action is being processed and the submit button is now disabled. You will be taken to a confirmation screen once the action has been processed.")}
+        )
+    }
+}
+
+export default debounceButton;

--- a/common/static/common/js/buttonDebounce.js
+++ b/common/static/common/js/buttonDebounce.js
@@ -1,9 +1,8 @@
-let button = document.querySelectorAll('span.add-debounce > button')[0]
+let button = document.getElementById('add-debounce')
 
 const debounceButton = () => {
-    if (!button) {
-        return
-    } else if (button) {
+    if (button) {
+        console.log('button', button)
         addEventListener('submit', function() {
             button.disabled = true,
             alert("Your action is being processed and the submit button is now disabled. You will be taken to a confirmation screen once the action has been processed.")}

--- a/common/static/common/js/buttonDebounce.js
+++ b/common/static/common/js/buttonDebounce.js
@@ -1,9 +1,7 @@
 const tapDebounce = function(event) {
-    console.log('b fires')
     let DEBOUNCE_TIMEOUT_IN_SECONDS = 5;
 
     if (this.tapDebounceFormSubmitTimer) {
-        console.log('c fires')
         event.preventDefault();
         button.disabled = true
         return false

--- a/measures/jinja2/measures/create-review.jinja
+++ b/measures/jinja2/measures/create-review.jinja
@@ -130,5 +130,5 @@
     {% endif %}
   {% endcall %}
 
-  <span class="add-debounce">{{ govukButton({"text": "Create", "preventDoubleClick": true, css_class:"test"}) }}</span>
+  {{ govukButton({"text": "Create", "preventDoubleClick": true, "attributes": {"id": "add-debounce"},}) }}
 {% endblock %}

--- a/measures/jinja2/measures/create-review.jinja
+++ b/measures/jinja2/measures/create-review.jinja
@@ -129,6 +129,5 @@
       {% endfor %}
     {% endif %}
   {% endcall %}
-  {{ govukInsetText({"text": "Your measures are being processed and the submit button is now disabled. You will be taken to a confirmation screen once the measures have been created.", "classes": "js-hidden", "attributes": {"id": "add-debounce-inset-text"},})}}
-  {{ govukButton({"text": "Create", "preventDoubleClick": true, "attributes": {"id": "add-debounce"},}) }}
+  {{ govukButton({"text": "Create", "preventDoubleClick": true}) }}
 {% endblock %}

--- a/measures/jinja2/measures/create-review.jinja
+++ b/measures/jinja2/measures/create-review.jinja
@@ -1,5 +1,5 @@
 {% extends "measures/create-wizard-step.jinja" %}
-
+{% from "components/inset-text/macro.njk" import govukInsetText %}
 {% from "components/summary-list/macro.njk" import govukSummaryList %}
 {% from 'includes/measures/macros/conditions.jinja' import requirement %}
 
@@ -129,6 +129,6 @@
       {% endfor %}
     {% endif %}
   {% endcall %}
-
+  {{ govukInsetText({"text": "Your measures are being processed and the submit button is now disabled. You will be taken to a confirmation screen once the measures have been created.", "classes": "js-hidden", "attributes": {"id": "add-debounce-inset-text"},})}}
   {{ govukButton({"text": "Create", "preventDoubleClick": true, "attributes": {"id": "add-debounce"},}) }}
 {% endblock %}

--- a/measures/jinja2/measures/create-review.jinja
+++ b/measures/jinja2/measures/create-review.jinja
@@ -130,5 +130,5 @@
     {% endif %}
   {% endcall %}
 
-  {{ govukButton({"text": "Create", "preventDoubleClick": true,}) }}
+  <span class="add-debounce">{{ govukButton({"text": "Create", "preventDoubleClick": true, css_class:"test"}) }}</span>
 {% endblock %}


### PR DESCRIPTION
# TP-2000-468 Double click error on measure create complete

## Why
The preventDoubleClick functionality has a time out on it. Occasionally, we exceed this timeout and the user is then able to double click the button, creating 2x the number of intended measures.

## What
We have duplicated the data-prevent-double-click functionality, extending the timer to 5 seconds. Should we discover that some events are taking longer than 5 seconds, we can extend this timer again.
