### PR TITLE
Tp2000 1070  address negative action edge case

### DIFF
--- a/measures/forms.py
+++ b/measures/forms.py
@@ -240,7 +240,7 @@ class MeasureConditionsFormMixin(forms.ModelForm):
         """
         price = cleaned_data.get("reference_price")
         certificate = cleaned_data.get("required_certificate")
-        applicable_duty = cleaned_data.get("applicable_duty")
+        cleaned_data.get("applicable_duty")
         action = cleaned_data.get("action")
 
         # Note this is a quick fix & hard coded for now
@@ -260,14 +260,6 @@ class MeasureConditionsFormMixin(forms.ModelForm):
                 None,
                 ValidationError(
                     "For each condition you must complete either ‘reference price or quantity’ or ‘certificate, licence or document’.",
-                ),
-            )
-
-        if is_negative_action_code and (price or certificate or applicable_duty):
-            self.add_error(
-                None,
-                ValidationError(
-                    "If the action code is negative you do not need to enter ‘reference price or quantity’, ‘certificate, licence or document’ or ‘duty’.",
                 ),
             )
 
@@ -379,7 +371,6 @@ class MeasureConditionsBaseFormSet(FormSet):
         Validates formset using validate_conditions_formset which will raise a
         ValidationError if the formset contains errors.
         """
-
         # cleaned_data is only set if forms are all valid
         if any(self.errors):
             # Don't bother validating the formset unless each form is valid on its own
@@ -391,7 +382,11 @@ class MeasureConditionsBaseFormSet(FormSet):
                 continue
             cleaned_data += [form.cleaned_data]
 
-        validate_conditions_formset(cleaned_data)
+        actions = [form["action"] for form in cleaned_data]
+        negative_actions = models.MeasureActionPair.objects.filter(
+            negative_action__in=actions,
+        ).values_list("negative_action", flat=True)
+        validate_conditions_formset(cleaned_data, negative_actions)
 
         return cleaned_data
 

--- a/measures/forms.py
+++ b/measures/forms.py
@@ -240,7 +240,6 @@ class MeasureConditionsFormMixin(forms.ModelForm):
         """
         price = cleaned_data.get("reference_price")
         certificate = cleaned_data.get("required_certificate")
-        cleaned_data.get("applicable_duty")
         action = cleaned_data.get("action")
 
         # Note this is a quick fix & hard coded for now

--- a/measures/forms.py
+++ b/measures/forms.py
@@ -252,8 +252,7 @@ class MeasureConditionsFormMixin(forms.ModelForm):
         if (
             not skip_price_and_reference_check
             and not is_negative_action_code
-            and (not price and not certificate)
-            or (price and certificate)
+            and (price and certificate)
         ):
             self.add_error(
                 None,

--- a/measures/jinja2/includes/measures/conditions.jinja
+++ b/measures/jinja2/includes/measures/conditions.jinja
@@ -15,14 +15,14 @@
 
         {% if condition.reference_price_string -%}
           <span class="condition_reference">
-            (> {{ condition.reference_price_string }})
+            (&gt; {{ condition.reference_price_string }})
           </span>
         {%- endif %}
 
         <span class="condition_action">{{ condition.action.code }}</span>
 
-        {% if condition.condition_string %}
-          - {{ condition.condition_string }}
+        {% if condition.duty_sentence %}
+          - {{ condition.duty_sentence }}
         {% endif %}
       </li>
     {%- endfor %}

--- a/measures/jinja2/includes/measures/list.jinja
+++ b/measures/jinja2/includes/measures/list.jinja
@@ -61,7 +61,7 @@
                 {"html": create_link(url("geo_area-ui-detail", kwargs={"sid": measure.geographical_area.sid}), measure.geographical_area.area_id ~ " - " ~ measure.geographical_area.get_description().description) if measure.geographical_area else '-'},
                 {"text": create_link(measure.order_number.get_url(), measure.order_number.order_number) if measure.order_number else '-'},
                 {"text": footnotes_display(measure.footnoteassociationmeasure_set.current())},
-                {"text": conditions_list(measure) if measure.conditions.latest_approved() else "-", "classes": "govuk-!-width-one-quarter"},
+                {"text": conditions_list(measure) if measure.conditions.current() else "-", "classes": "govuk-!-width-one-quarter"},
               ]) or "" }} 
           {% endfor %}
         {{ govukTable({

--- a/measures/models.py
+++ b/measures/models.py
@@ -840,36 +840,10 @@ class MeasureCondition(GetTabURLMixin, TrackedModel):
 
         out.append(f"perform action {self.action.code} - {self.action.description}")
 
-        if self.condition_string:
-            out.append(f"\n\nApplicable duty is {self.condition_string}")
+        if self.duty_sentence:
+            out.append(f"\n\nApplicable duty is {self.duty_sentence}")
 
         return " ".join(out)
-
-    @property
-    def condition_string(self) -> str:
-        out: list[str] = []
-
-        components = self.components.latest_approved()
-        measures: set[str] = set()
-        measure_types: set[str] = set()
-        additional_codes: set[str] = set()
-
-        for mcc in components:
-            measures.add(mcc.condition.dependent_measure.sid)
-            measure_types.add(mcc.condition.dependent_measure.measure_type.sid)
-            if mcc.condition.dependent_measure.additional_code:
-                additional_codes.add(
-                    mcc.condition.dependent_measure.additional_code.sid,
-                )
-
-        if (
-            len(measures) == len(measure_types) == len(additional_codes) == 1
-            or len(measure_types) > 1
-            or len(additional_codes) > 1
-        ):
-            out.append(self.duty_sentence)
-
-        return "".join(out)
 
     @property
     def duty_sentence(self) -> str:

--- a/measures/tests/test_forms.py
+++ b/measures/tests/test_forms.py
@@ -786,6 +786,7 @@ def test_measure_forms_conditions_form_actions_validation_skipped(
     code,
     valid,
     date_ranges,
+    duty_sentence_parser,
 ):
     """
     Tests that MeasureConditionsForm is valid when actions 1-4 is used and no
@@ -793,14 +794,23 @@ def test_measure_forms_conditions_form_actions_validation_skipped(
 
     Initialised with minimal required fields.
     """
-    code_with_certificate = factories.MeasureConditionCodeFactory()
+    certificate = factories.CertificateFactory.create()
+    code_with_certificate = factories.MeasureConditionCodeFactory(
+        accepts_certificate=True,
+    )
     action = factories.MeasureActionFactory.create(
         code=code,
     )
+    start_date = date_ranges.normal.lower
 
     data = {
         "condition_code": code_with_certificate.pk,
         "action": action.pk,
+        "required_certificate": certificate.pk,
+        "reference_price": "11 GBP / 100 kg",
+        "start_date_0": start_date.day,
+        "start_date_1": start_date.month,
+        "start_date_2": start_date.year,
     }
     # MeasureConditionsForm.__init__ expects prefix kwarg for instantiating crispy forms `Layout` object
     form = forms.MeasureConditionsForm(data, prefix="")

--- a/measures/tests/test_models.py
+++ b/measures/tests/test_models.py
@@ -42,7 +42,7 @@ def test_measure_conditions_list():
         .get(pk=cond.pk)
     )
     assert cond.reference_price_string == "48.100 EUR / 100 kg"
-    assert cond.condition_string == "2.500%"
+    assert cond.duty_sentence == "2.500%"
 
 
 def test_stringify_measure_condition():
@@ -88,7 +88,7 @@ def test_stringify_measure_condition():
         .get(pk=cond.pk)
     )
     assert cond.reference_price_string == "0.000 EUR / 100 kg"
-    assert cond.condition_string == "2.500% + 37.800 EUR / 100 kg"
+    assert cond.duty_sentence == "2.500% + 37.800 EUR / 100 kg"
 
 
 @pytest.fixture(

--- a/measures/tests/test_views.py
+++ b/measures/tests/test_views.py
@@ -858,6 +858,45 @@ def test_measure_update_remove_conditions(
     assert updated_measure.conditions.approved_up_to_transaction(tx).count() == 0
 
 
+def test_measure_update_negative_condition(
+    client,
+    valid_user,
+    measure_edit_conditions_and_negative_action_data,
+    duty_sentence_parser,
+    erga_omnes,
+):
+    """Tests that html contains appropriate form validation errors after posting
+    to measure edit endpoint with a valid applicable_duty string for the
+    negative action."""
+
+    measure_edit_conditions_and_negative_action_data[
+        f"{MEASURE_CONDITIONS_FORMSET_PREFIX}-1-applicable_duty"
+    ] = "3.5%"
+
+    measure = Measure.objects.first()
+    url = reverse("measure-ui-edit", args=(measure.sid,))
+    client.force_login(valid_user)
+    response = client.post(url, data=measure_edit_conditions_and_negative_action_data)
+
+    assert response.status_code == 302
+
+    tx = Transaction.objects.last()
+    updated_measure = Measure.objects.approved_up_to_transaction(tx).get(
+        sid=measure.sid,
+    )
+
+    assert updated_measure.conditions.approved_up_to_transaction(tx).count() == 2
+
+    condition = updated_measure.conditions.approved_up_to_transaction(tx).last()
+
+    components = condition.components.approved_up_to_transaction(tx).order_by(
+        *MeasureConditionComponent._meta.ordering
+    )
+
+    assert components.count() == 1
+    assert components.first().duty_amount == 3.5
+
+
 def test_measure_update_invalid_conditions(
     client,
     valid_user,
@@ -865,14 +904,9 @@ def test_measure_update_invalid_conditions(
     duty_sentence_parser,
     erga_omnes,
 ):
-    """
-    Tests that html contains appropriate form validation errors after posting to
-    measure edit endpoint with compound reference_price and an invalid
-    applicable_duty string.
-
-    Also tests form validation on negative action code's checking that
-    reference_price, required_certificate & applicable_duty must be empty
-    """
+    """Tests that html contains appropriate form validation errors after posting
+    to measure edit endpoint with compound reference_price and an invalid
+    applicable_duty string."""
     measure_edit_conditions_and_negative_action_data[
         f"{MEASURE_CONDITIONS_FORMSET_PREFIX}-0-reference_price"
     ] = "3.5% + 11 GBP / 100 kg"
@@ -914,12 +948,6 @@ def test_measure_update_invalid_conditions(
     assert (
         a_tags[2].text
         == "A MeasureCondition cannot be created with a compound reference price (e.g. 3.5% + 11 GBP / 100 kg)"
-    )
-
-    assert a_tags[3].attrs["href"] == f"#{MEASURE_CONDITIONS_FORMSET_PREFIX}-1-__all__"
-    assert (
-        a_tags[3].text
-        == "If the action code is negative you do not need to enter ‘reference price or quantity’, ‘certificate, licence or document’ or ‘duty’."
     )
 
 

--- a/measures/validators.py
+++ b/measures/validators.py
@@ -124,7 +124,7 @@ def validate_duties(duties, measure_start_date):
         raise ValidationError("Enter a valid duty sentence.")
 
 
-def validate_conditions_formset(cleaned_data):
+def validate_conditions_formset(cleaned_data, negative_actions):
     """
     Checks condition formset level errors using set checks:
 
@@ -162,11 +162,7 @@ def validate_conditions_formset(cleaned_data):
         condition_negative_action_bool.append(
             (
                 condition["condition_code"],
-                not (
-                    bool(condition["reference_price"])
-                    | bool(condition["required_certificate"])
-                    | bool(condition["applicable_duty"])
-                ),
+                condition["action"].id in negative_actions,
             ),
         )
         condition_action_tuple.append(

--- a/measures/views.py
+++ b/measures/views.py
@@ -1013,7 +1013,7 @@ class MeasureUpdateBase(
                         value = value.pk
                     initial_dict[field] = value
 
-            initial_dict["applicable_duty"] = condition.condition_string
+            initial_dict["applicable_duty"] = condition.duty_sentence
             initial_dict["reference_price"] = condition.reference_price_string
             initial_dict["condition_sid"] = condition.sid
             conditions_formset.initial.append(initial_dict)


### PR DESCRIPTION
# TP2000-1070 Address negative action edge case
<!---
 * Include the JIRA ticket number, eg TP-123, to automatically link.
 * Use 50 characters maximum.
 * Do not end with a full-stop.
--->

## Why
There's an edge case condition where a duty should be applied if there is no certificate present. The negative actions in a condition currently block you populating the certificate, price or applicable duty fields. This requires remove from the edit screen to support.

## What
- removed validation on fields certificate, price or applicable duty on the negative action code conditions in the edit measures screen
- removed condition_string as it is redundant and causing display bugs for single duty values (3.5%) and measures without additional codes.
- set .current() for conditions_list so it will display changes in the current worbasket when viewing conditions in list displays

<img width="972" alt="image" src="https://github.com/uktrade/tamato/assets/16708670/afd1c44f-2897-49c2-a292-2004568691d7">
<img width="972" alt="image" src="https://github.com/uktrade/tamato/assets/16708670/1580c488-3ad9-4dfd-b197-f74ab47531d2">
<img width="991" alt="image" src="https://github.com/uktrade/tamato/assets/16708670/6e7911f5-097d-4288-a7e2-7fc6f0919e5d">

<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
## Checklist
- Requires migrations?
- Requires dependency updates?
--->

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
