### PR TITLE
TP2000-980: Quota definition create

### DIFF
--- a/quotas/forms.py
+++ b/quotas/forms.py
@@ -391,7 +391,6 @@ class QuotaDefinitionCreateForm(
     class Meta:
         model = models.QuotaDefinition
         fields = [
-            "order_number",
             "valid_between",
             "description",
             "volume",
@@ -444,13 +443,8 @@ class QuotaDefinitionCreateForm(
     maximum_precision = forms.IntegerField(
         widget=forms.HiddenInput(),
     )
-    order_number = forms.ModelChoiceField(
-        queryset=models.QuotaOrderNumber.objects.all(),
-        widget=forms.HiddenInput(),
-    )
 
     def __init__(self, *args, **kwargs):
-        self.order_number = kwargs.pop("order_number")
         super().__init__(*args, **kwargs)
         self.init_layout()
         self.init_fields()
@@ -459,8 +453,6 @@ class QuotaDefinitionCreateForm(
         # This is always set to 3 for current definitions
         # see https://uktrade.github.io/tariff-data-manual/documentation/data-structures/quotas.html#the-quota-definition-table
         self.fields["maximum_precision"].initial = 3
-
-        self.fields["order_number"].initial = self.order_number
 
         # Set these as the default values
         self.fields["quota_critical"].initial = False

--- a/quotas/forms.py
+++ b/quotas/forms.py
@@ -287,17 +287,26 @@ class QuotaDefinitionUpdateForm(
     volume = forms.DecimalField(
         label="Current volume",
         widget=forms.TextInput(),
-        error_messages={"invalid": "Volume must be a number"},
+        error_messages={
+            "invalid": "Volume must be a number",
+            "required": "Enter the volume",
+        },
     )
     initial_volume = forms.DecimalField(
         widget=forms.TextInput(),
-        error_messages={"invalid": "Initial volume must be a number"},
+        error_messages={
+            "invalid": "Initial volume must be a number",
+            "required": "Enter the initial volume",
+        },
     )
     quota_critical_threshold = forms.DecimalField(
         label="Threshold",
         help_text="The point at which this quota definition period becomes critical, as a percentage of the total volume.",
         widget=forms.TextInput(),
-        error_messages={"invalid": "Critical threshold must be a number"},
+        error_messages={
+            "invalid": "Critical threshold must be a number",
+            "required": "Enter the critical threshold",
+        },
     )
     quota_critical = forms.TypedChoiceField(
         label="Is the quota definition period in a critical state?",
@@ -305,6 +314,7 @@ class QuotaDefinitionUpdateForm(
         coerce=lambda value: value == "True",
         choices=((True, "Yes"), (False, "No")),
         widget=forms.RadioSelect(),
+        error_messages={"required": "Critical state must be set"},
     )
 
     def __init__(self, *args, **kwargs):
@@ -359,6 +369,142 @@ class QuotaDefinitionUpdateForm(
                     "quota_critical",
                 ),
                 css_class="govuk-!-width-two-thirds",
+            ),
+            Submit(
+                "submit",
+                "Save",
+                data_module="govuk-button",
+                data_prevent_double_click="true",
+            ),
+        )
+
+
+class QuotaDefinitionCreateForm(
+    ValidityPeriodForm,
+    forms.ModelForm,
+):
+    class Meta:
+        model = models.QuotaDefinition
+        fields = [
+            "order_number",
+            "valid_between",
+            "description",
+            "volume",
+            "initial_volume",
+            "measurement_unit",
+            "measurement_unit_qualifier",
+            "quota_critical_threshold",
+            "quota_critical",
+            "maximum_precision",
+        ]
+
+    description = forms.CharField(label="", widget=forms.Textarea(), required=False)
+    volume = forms.DecimalField(
+        label="Current volume",
+        widget=forms.TextInput(),
+        error_messages={
+            "invalid": "Volume must be a number",
+            "required": "Enter the volume",
+        },
+    )
+    initial_volume = forms.DecimalField(
+        widget=forms.TextInput(),
+        error_messages={
+            "invalid": "Initial volume must be a number",
+            "required": "Enter the initial volume",
+        },
+    )
+    quota_critical_threshold = forms.DecimalField(
+        label="Threshold",
+        help_text="The point at which this quota definition period becomes critical, as a percentage of the total volume.",
+        widget=forms.TextInput(),
+        error_messages={
+            "invalid": "Critical threshold must be a number",
+            "required": "Enter the critical threshold",
+        },
+    )
+    quota_critical = forms.TypedChoiceField(
+        label="Is the quota definition period in a critical state?",
+        help_text="This determines if a trader needs to pay securities when utilising the quota.",
+        coerce=lambda value: value == "True",
+        choices=((True, "Yes"), (False, "No")),
+        widget=forms.RadioSelect(),
+        error_messages={"required": "Critical state must be set"},
+    )
+
+    maximum_precision = forms.IntegerField(
+        widget=forms.HiddenInput(),
+    )
+
+    order_number = forms.ModelChoiceField(
+        queryset=models.QuotaOrderNumber.objects.all(),
+        widget=forms.HiddenInput(),
+    )
+
+    def __init__(self, *args, **kwargs):
+        self.order_number = kwargs.pop("order_number")
+        super().__init__(*args, **kwargs)
+        self.init_layout()
+        self.init_fields()
+
+    def init_fields(self):
+        # This is always set to 3 for current definitions
+        # see https://uktrade.github.io/tariff-data-manual/documentation/data-structures/quotas.html#the-quota-definition-table
+        self.fields["maximum_precision"].initial = 3
+
+        self.fields["order_number"].initial = self.order_number
+
+        # Set these as the default values
+        self.fields["quota_critical"].initial = False
+        self.fields["quota_critical_threshold"].initial = 90
+
+        self.fields["measurement_unit"].queryset = self.fields[
+            "measurement_unit"
+        ].queryset.order_by("code")
+        self.fields[
+            "measurement_unit"
+        ].label_from_instance = lambda obj: f"{obj.code} - {obj.description}"
+
+        self.fields["measurement_unit_qualifier"].queryset = self.fields[
+            "measurement_unit_qualifier"
+        ].queryset.order_by("code")
+        self.fields[
+            "measurement_unit_qualifier"
+        ].label_from_instance = lambda obj: f"{obj.code} - {obj.description}"
+
+    def init_layout(self):
+        self.helper = FormHelper(self)
+        self.helper.label_size = Size.SMALL
+        self.helper.legend_size = Size.SMALL
+
+        self.helper.layout = Layout(
+            Accordion(
+                AccordionSection(
+                    "Description",
+                    "description",
+                    "order_number",
+                ),
+                AccordionSection(
+                    "Validity period",
+                    "start_date",
+                    "end_date",
+                ),
+                AccordionSection(
+                    "Measurements",
+                    Field("measurement_unit", css_class="govuk-!-width-full"),
+                    Field("measurement_unit_qualifier", css_class="govuk-!-width-full"),
+                ),
+                AccordionSection(
+                    "Volume",
+                    "initial_volume",
+                    "volume",
+                    "maximum_precision",
+                ),
+                AccordionSection(
+                    "Criticality",
+                    "quota_critical_threshold",
+                    "quota_critical",
+                ),
             ),
             Submit(
                 "submit",

--- a/quotas/forms.py
+++ b/quotas/forms.py
@@ -301,7 +301,7 @@ class QuotaDefinitionUpdateForm(
         },
     )
     measurement_unit = forms.ModelChoiceField(
-        queryset=MeasurementUnit.objects.all(),
+        queryset=MeasurementUnit.objects.current(),
         error_messages={"required": "Select the measurement unit"},
     )
     quota_critical_threshold = forms.DecimalField(
@@ -419,7 +419,7 @@ class QuotaDefinitionCreateForm(
         },
     )
     measurement_unit = forms.ModelChoiceField(
-        queryset=MeasurementUnit.objects.all(),
+        queryset=MeasurementUnit.objects.current(),
         error_messages={"required": "Select the measurement unit"},
     )
 

--- a/quotas/forms.py
+++ b/quotas/forms.py
@@ -21,6 +21,7 @@ from common.forms import delete_form_for
 from common.forms import formset_factory
 from common.forms import unprefix_formset_data
 from geo_areas.models import GeographicalArea
+from measures.models import MeasurementUnit
 from quotas import models
 from quotas import validators
 from quotas.constants import QUOTA_ORIGIN_EXCLUSIONS_FORMSET_PREFIX
@@ -299,6 +300,10 @@ class QuotaDefinitionUpdateForm(
             "required": "Enter the initial volume",
         },
     )
+    measurement_unit = forms.ModelChoiceField(
+        queryset=MeasurementUnit.objects.all(),
+        error_messages={"required": "Select the measurement unit"},
+    )
     quota_critical_threshold = forms.DecimalField(
         label="Threshold",
         help_text="The point at which this quota definition period becomes critical, as a percentage of the total volume.",
@@ -414,6 +419,11 @@ class QuotaDefinitionCreateForm(
             "required": "Enter the initial volume",
         },
     )
+    measurement_unit = forms.ModelChoiceField(
+        queryset=MeasurementUnit.objects.all(),
+        error_messages={"required": "Select the measurement unit"},
+    )
+
     quota_critical_threshold = forms.DecimalField(
         label="Threshold",
         help_text="The point at which this quota definition period becomes critical, as a percentage of the total volume.",
@@ -431,11 +441,9 @@ class QuotaDefinitionCreateForm(
         widget=forms.RadioSelect(),
         error_messages={"required": "Critical state must be set"},
     )
-
     maximum_precision = forms.IntegerField(
         widget=forms.HiddenInput(),
     )
-
     order_number = forms.ModelChoiceField(
         queryset=models.QuotaOrderNumber.objects.all(),
         widget=forms.HiddenInput(),

--- a/quotas/jinja2/includes/quotas/actions.jinja
+++ b/quotas/jinja2/includes/quotas/actions.jinja
@@ -3,7 +3,10 @@
       <h2 class="govuk-heading-s" id="subsection-title">Actions</h2>
       <ul class="govuk-list govuk-!-font-size-16">
             <li><a class="govuk-link" href="{{ url('quota-definitions', args=[object.sid]) }}">View definition periods</a></li>
+            <li><a class="govuk-link" href="{{ url('quota_definition-ui-create', args=[object.sid]) }}">Create definition period</a></li>
+            <br>
             <li><a class="govuk-link" href="{{ measures_url }}">View all measures</a></li>
+            <br>
           {% set edit_url = object.get_url('edit') %}
           {% if edit_url %}
             <li><a class="govuk-link" href="{{ edit_url }}">Edit this {{object._meta.verbose_name}}</a></li>

--- a/quotas/jinja2/quota-definitions/confirm-create.jinja
+++ b/quotas/jinja2/quota-definitions/confirm-create.jinja
@@ -1,0 +1,26 @@
+{% extends "common/confirm_create.jinja" %}
+{% from "components/breadcrumbs.jinja" import breadcrumbs %}
+{% from "components/button/macro.njk" import govukButton %}
+
+
+{% block breadcrumb %}
+  {{ breadcrumbs(request, [
+      {"text": "Find and edit quotas", "href": url("quota-ui-list")},
+      {"text": object.order_number._meta.verbose_name|capitalize ~ ": " ~ object.order_number|string, "href": object.order_number.get_url() ~ "#definitions"},
+      {"text": page_title}
+    ])
+  }}
+{% endblock %}
+
+{% block main_button %}
+{{ govukButton({
+  "text": "Create another",
+  "href": url("quota_definition-ui-create", args=[object.order_number.sid]),
+  "classes": "govuk-button--primary"
+}) }}
+{% endblock%}
+
+{% block actions %}
+<li><a class="govuk-link" href="{{ object.order_number.get_url() }}">View this definition's quota order number</a></li>
+<li><a href="{{ object.order_number.get_url('list') }}">Find and edit quotas</a></li>
+{% endblock %}

--- a/quotas/jinja2/quota-definitions/create.jinja
+++ b/quotas/jinja2/quota-definitions/create.jinja
@@ -5,7 +5,7 @@
 {% block breadcrumb %}
   {{ breadcrumbs(request, [
       {"text": "Find and edit quotas", "href": url("quota-ui-list")},
-      {"text": order_number._meta.verbose_name|capitalize ~ ": " ~ order_number|string, "href": order_number.get_url() ~ "#definitions"},
+      {"text": "Quota order number", "href": url("quota-ui-detail", args=[view.kwargs.sid]) ~ "#definitions"},
       {"text": page_title}
     ])
   }}

--- a/quotas/jinja2/quota-definitions/create.jinja
+++ b/quotas/jinja2/quota-definitions/create.jinja
@@ -1,0 +1,12 @@
+{% extends "layouts/create.jinja" %}
+
+{% set page_title = "Create a new quota definition period" %}
+
+{% block breadcrumb %}
+  {{ breadcrumbs(request, [
+      {"text": "Find and edit quotas", "href": url("quota-ui-list")},
+      {"text": order_number._meta.verbose_name|capitalize ~ ": " ~ order_number|string, "href": order_number.get_url() ~ "#definitions"},
+      {"text": page_title}
+    ])
+  }}
+{% endblock %}

--- a/quotas/tests/test_views.py
+++ b/quotas/tests/test_views.py
@@ -1127,3 +1127,62 @@ def test_quota_order_number_update_view(
     )
 
     assert response.status_code == 200
+
+
+def test_create_new_quota_definition(
+    valid_user_client,
+    approved_transaction,
+    date_ranges,
+    mock_quota_api_no_data,
+):
+    quota = factories.QuotaOrderNumberFactory.create(
+        valid_between=date_ranges.no_end,
+        transaction=approved_transaction,
+    )
+
+    measurement_unit = factories.MeasurementUnitFactory.create()
+
+    form_data = {
+        "start_date_0": date_ranges.later.lower.day,
+        "start_date_1": date_ranges.later.lower.month,
+        "start_date_2": date_ranges.later.lower.year,
+        "description": "Lorem ipsum",
+        "volume": "1000000",
+        "initial_volume": "1000000",
+        "quota_critical_threshold": "90",
+        "quota_critical": "False",
+        "order_number": quota.pk,
+        "maximum_precision": "3",
+        "measurement_unit": measurement_unit.pk,
+    }
+
+    # sanity check
+    assert not models.QuotaDefinition.objects.all()
+
+    url = reverse("quota_definition-ui-create", kwargs={"sid": quota.sid})
+    response = valid_user_client.post(url, form_data)
+    assert response.status_code == 302
+
+    created_definition = models.QuotaDefinition.objects.last()
+    assert response.url == reverse(
+        "quota_definition-ui-confirm-create",
+        kwargs={"sid": created_definition.sid},
+    )
+
+    # check definition is listed on quota order number's definition tab
+    url = reverse("quota-ui-detail", kwargs={"sid": quota.sid})
+    response = valid_user_client.get(url)
+    soup = BeautifulSoup(response.content.decode(response.charset), "html.parser")
+    definitions_tab = soup.find(id="definition-details")
+    details = [
+        dd.text.strip() for dd in definitions_tab.select(".govuk-summary-list dd")
+    ]
+    assert f"{created_definition.sid}" in details
+    assert created_definition.description in details
+    assert created_definition.valid_between.lower.strftime("%d %b %Y") in details
+    assert intcomma(created_definition.initial_volume) in details
+    assert intcomma(created_definition.volume) in details
+    # critical state
+    assert "No" in details
+    assert f"{created_definition.quota_critical_threshold}%" in details
+    assert created_definition.measurement_unit.abbreviation.capitalize() in details

--- a/quotas/tests/test_views.py
+++ b/quotas/tests/test_views.py
@@ -116,7 +116,12 @@ def test_quota_detail_views(
 ):
     """Verify that quota detail views are under the url quotas and don't return
     an error."""
-    assert_model_view_renders(view, url_pattern, valid_user_client)
+    assert_model_view_renders(
+        view,
+        url_pattern,
+        valid_user_client,
+        override_models={"quotas.views.QuotaDefinitionCreate": models.QuotaOrderNumber},
+    )
 
 
 def test_quota_detail(valid_user_client, date_ranges, mock_quota_api_no_data):

--- a/quotas/urls.py
+++ b/quotas/urls.py
@@ -50,6 +50,16 @@ urlpatterns = [
         name="quota-definitions",
     ),
     path(
+        f"quotas/<sid>/quota_definitions/create/",
+        views.QuotaDefinitionCreate.as_view(),
+        name="quota_definition-ui-create",
+    ),
+    path(
+        f"quota_definitions/<sid>/confirm-create/",
+        views.QuotaDefinitionConfirmCreate.as_view(),
+        name="quota_definition-ui-confirm-create",
+    ),
+    path(
         f"quotas/<sid>/quota_definitions/confirm-delete/",
         views.QuotaDefinitionConfirmDelete.as_view(),
         name="quota_definition-ui-confirm-delete",

--- a/quotas/views.py
+++ b/quotas/views.py
@@ -502,22 +502,10 @@ class QuotaDefinitionCreate(QuotaDefinitionUpdateMixin, CreateTaricCreateView):
     template_name = "quota-definitions/create.jinja"
     form_class = forms.QuotaDefinitionCreateForm
 
-    @property
-    def order_number(self):
-        tx = WorkBasket.get_current_transaction(self.request)
-        return models.QuotaOrderNumber.objects.approved_up_to_transaction(tx).get(
-            sid=self.kwargs["sid"],
-        )
-
-    def get_form_kwargs(self):
-        kwargs = super().get_form_kwargs()
-        kwargs["order_number"] = self.order_number
-        return kwargs
-
-    def get_context_data(self, **kwargs):
-        context = super().get_context_data(**kwargs)
-        context["order_number"] = self.order_number
-        return context
+    def form_valid(self, form):
+        quota = models.QuotaOrderNumber.objects.current().get(sid=self.kwargs["sid"])
+        form.instance.order_number = quota
+        return super().form_valid(form)
 
 
 class QuotaDefinitionConfirmCreate(

--- a/quotas/views.py
+++ b/quotas/views.py
@@ -498,6 +498,35 @@ class QuotaDefinitionUpdate(
     pass
 
 
+class QuotaDefinitionCreate(QuotaDefinitionUpdateMixin, CreateTaricCreateView):
+    template_name = "quota-definitions/create.jinja"
+    form_class = forms.QuotaDefinitionCreateForm
+
+    @property
+    def order_number(self):
+        tx = WorkBasket.get_current_transaction(self.request)
+        return models.QuotaOrderNumber.objects.approved_up_to_transaction(tx).get(
+            sid=self.kwargs["sid"],
+        )
+
+    def get_form_kwargs(self):
+        kwargs = super().get_form_kwargs()
+        kwargs["order_number"] = self.order_number
+        return kwargs
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["order_number"] = self.order_number
+        return context
+
+
+class QuotaDefinitionConfirmCreate(
+    QuotaDefinitionMixin,
+    TrackedModelDetailView,
+):
+    template_name = "quota-definitions/confirm-create.jinja"
+
+
 class QuotaDefinitionDelete(
     QuotaDefinitionUpdateMixin,
     CreateTaricDeleteView,


### PR DESCRIPTION
# TP2000-980: Quota definition create
<!---
 * Include the JIRA ticket number, eg TP-123, to automatically link.
 * Use 50 characters maximum.
 * Do not end with a full-stop.
--->

## Why
<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Use as many lines as you like.
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions or deliberately ignored edge-cases.
--->
* Users need the ability to create new definition periods for an existing quota order number

## What
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Explain like I'm 5.
 * Use pictures if you can.
--->
* Link to create a new definition on the quota order number detail page under the "Actions" list
* Single page form to create a new definition
* Success page

<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
## Checklist
- Requires migrations?
- Requires dependency updates?
--->

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
![FireShot Capture 064 - Create a new quota definition period - Manage Trade Tariffs - localhost](https://github.com/uktrade/tamato/assets/25905279/d308ca45-6a2c-4f8d-9f68-b8682b75ef5a)
<img width="798" alt="Screenshot 2023-10-16 at 15 44 22" src="https://github.com/uktrade/tamato/assets/25905279/273744b9-c828-48a9-8e58-0793c2a51292">
