### PR TITLE
TP2000-1078  Implement transaction order tab

### DIFF
--- a/certificates/views.py
+++ b/certificates/views.py
@@ -17,7 +17,6 @@ from certificates.models import Certificate
 from certificates.serializers import CertificateTypeSerializer
 from common.models import TrackedModel
 from common.serializers import AutoCompleteSerializer
-from common.validators import UpdateType
 from common.views import DescriptionDeleteMixin
 from common.views import SortingMixin
 from common.views import TamatoListView
@@ -87,26 +86,14 @@ class CertificateCreate(CreateTaricCreateView):
     form_class = forms.CertificateCreateForm
 
     @transaction.atomic
-    def form_valid(self, form):
-        transaction = self.get_transaction()
-        transaction.save()
-        self.object = form.save(commit=False)
-        self.object.update_type = UpdateType.CREATE
-        self.object.transaction = transaction
-        self.object.save()
-
-        return super().form_valid(form)
-
-    @transaction.atomic
     def get_result_object(self, form):
-        object = super().get_result_object(form)
+        certificate = super().get_result_object(form)
         description = form.cleaned_data["certificate_description"]
-        description.described_certificate = self.object
-        description.update_type = UpdateType.CREATE
-        description.transaction = object.transaction
+        description.described_certificate = certificate
+        description.update_type = self.update_type
+        description.transaction = certificate.transaction
         description.save()
-
-        return object
+        return certificate
 
     def get_form_kwargs(self):
         kwargs = super().get_form_kwargs()

--- a/workbaskets/forms.py
+++ b/workbaskets/forms.py
@@ -119,7 +119,7 @@ class SelectableObjectsForm(forms.Form):
     FIELD_NAME_PREFIX = "selectableobject_"
 
     def __init__(self, *args, **kwargs):
-        objects = kwargs.pop("objects")
+        objects = kwargs.pop("objects", [])
 
         super().__init__(*args, **kwargs)
 

--- a/workbaskets/jinja2/includes/workbaskets/navigation.jinja
+++ b/workbaskets/jinja2/includes/workbaskets/navigation.jinja
@@ -29,6 +29,9 @@
     <li class="{% if active_tab == "changes" %}active{% endif %}">
       <a href="{{ url("workbaskets:workbasket-ui-changes", args=[workbasket.pk]) }}" class="govuk-link">Changes</a>
     </li>
+    <li class="{% if active_tab == "transaction-order" %}active{% endif %}">
+      <a href="{{ url("workbaskets:workbasket-ui-transaction-order", args=[workbasket.pk]) }}" class="govuk-link">Transaction order</a>
+    </li>
     <li class="{% if active_tab == "review" %}active{% endif %}">
       <a href="{{ url("workbaskets:workbasket-ui-review-measures", args=[workbasket.pk]) }}" class="govuk-link">Review</a>
     </li>

--- a/workbaskets/jinja2/workbaskets/macros/load_more_pagination.jinja
+++ b/workbaskets/jinja2/workbaskets/macros/load_more_pagination.jinja
@@ -1,0 +1,17 @@
+{% macro load_more_pagination(current_count, total_count, item="item") %}
+  <nav id="workbasket-items" class="pagination" role="navigation" aria-label="Pagination navigation">
+    <p class="govuk-body govuk-!-margin-0">
+      You've viewed {{current_count}} out of {{"{0:,}".format(total_count)}} {{item}}{{ total_count|pluralize }}
+    </p>
+
+    <progress value="{{current_count}}" max="{{total_count}}" role="progressbar"></progress>
+
+    {% if page_obj.has_next() %}
+      {{ govukButton({
+        "text": "Load more",
+        "name": "form-action",
+        "value": "page-next",
+      }) }}
+    {% endif %}
+  </nav>
+{% endmacro %}

--- a/workbaskets/jinja2/workbaskets/macros/transaction_details.jinja
+++ b/workbaskets/jinja2/workbaskets/macros/transaction_details.jinja
@@ -2,7 +2,7 @@
   <span class="details">Transaction: {{ transaction.pk }}</span>
 
   <div id="transaction-order-actions">
-    {% if is_transaction_first_in_workbasket(transaction) or not user_can_delete_items %}
+    {% if transaction == first_transaction_in_workbasket or not user_can_delete_items %}
       <span class="govuk-link disabled promote">Move up &#9206;</span>
     {% else %}
       <button name="form-action"
@@ -12,7 +12,7 @@
         >Move up &#9206;</button>
     {% endif %}
 
-    {% if is_transaction_last_in_workbasket(transaction) or not user_can_delete_items %}
+    {% if transaction == last_transaction_in_workbasket or not user_can_delete_items %}
       <span class="govuk-link disabled demote">Move down &#9207;</span>
     {% else %}
       <button name="form-action"

--- a/workbaskets/jinja2/workbaskets/macros/transaction_details.jinja
+++ b/workbaskets/jinja2/workbaskets/macros/transaction_details.jinja
@@ -1,0 +1,25 @@
+{% macro transaction_details(transaction) %}
+  <span class="details">Transaction: {{ transaction.pk }}</span>
+
+  <div id="transaction-order-actions">
+    {% if is_transaction_first_in_workbasket(transaction) or not user_can_delete_items %}
+      <span class="govuk-link disabled promote">Move up &#9206;</span>
+    {% else %}
+      <button name="form-action"
+        value="promote-transaction__{{ transaction.pk }}"
+        class="govuk-link fake-link promote"
+        data-module="govuk-button"
+        >Move up &#9206;</button>
+    {% endif %}
+
+    {% if is_transaction_last_in_workbasket(transaction) or not user_can_delete_items %}
+      <span class="govuk-link disabled demote">Move down &#9207;</span>
+    {% else %}
+      <button name="form-action"
+        value="demote-transaction__{{ transaction.pk }}"
+        class="govuk-link fake-link demote"
+        data-module="govuk-button"
+        >Move down &#9207;</button>
+    {% endif %}
+  </div>
+{% endmacro %}

--- a/workbaskets/jinja2/workbaskets/transaction_order.jinja
+++ b/workbaskets/jinja2/workbaskets/transaction_order.jinja
@@ -1,11 +1,11 @@
 {% extends "layouts/layout.jinja" %}
-{% from "components/create_sortable_anchor.jinja" import create_sortable_anchor %}
 {% from "components/breadcrumbs.jinja" import breadcrumbs %}
 {% from "components/button/macro.njk" import govukButton %}
 {% from "components/table/macro.njk" import govukTable %}
 {% from "includes/workbaskets/navigation.jinja" import create_workbasket_detail_navigation with context %}
 {% from "macros/checkbox_item.jinja" import checkbox_item %}
 {% from "workbaskets/macros/load_more_pagination.jinja" import load_more_pagination with context %}
+{% from "workbaskets/macros/transaction_details.jinja" import transaction_details with context %}
 
 {% set page_title %} Workbasket {{ workbasket.id }} - {{ workbasket.status }} {% endset %}
 
@@ -21,19 +21,7 @@
   <div id="check-all-checkbox"></div>
 {% endset %}
 
-{% set base_url = url("workbaskets:workbasket-ui-changes", args=[workbasket.pk]) ~ "?page=" ~ page_obj.number %}
-
-{% set component %}
-  {{ create_sortable_anchor(request, "component", "Component", base_url, True) }}
-{% endset %}
-
-{% set action %}
-  {{ create_sortable_anchor(request, "action", "Action", base_url, True) }}
-{% endset %}
-
-{% set activity_date %}
-  {{ create_sortable_anchor(request, "activity_date", "Activity date", base_url, True) }}
-{% endset %}
+{% set base_url = url("workbaskets:workbasket-ui-transaction-order", args=[workbasket.pk]) ~ "?page=" ~ page_obj.number %}
 
 {% set current_count = page_obj|length + ((page_obj.number - 1) * view.paginate_by) %}
 {% set total_count = page_obj.paginator.count %}
@@ -41,23 +29,15 @@
 {% block content %}
   <h1 class="govuk-heading-xl govuk-!-margin-bottom-3">{{ page_title }}</h1>
 
-  {{ create_workbasket_detail_navigation(active_tab="changes") }}
+  {{ create_workbasket_detail_navigation(active_tab="transaction-order") }}
 
-  <h2 class="govuk-heading-m">Changes</h2>
+  <h2 class="govuk-heading-m">Transaction order</h2>
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
 
     {% if not workbasket.tracked_models.count() %}
-      <p class="govuk-body">There are no changes in the workbasket.</p>
-
-      {% if user_can_delete_workbasket %}
-        {{ govukButton({
-          "text": "Delete workbasket",
-          "href": url("workbaskets:workbasket-ui-delete", kwargs={"pk": workbasket.pk}),
-          "classes": "govuk-button--warning"
-        }) }}
-      {% endif %}
+      <p class="govuk-body">There are no transactions in the workbasket.</p>
 
     {% elif workbasket.status == "EDITING" and user_can_delete_items %}
       <p class="govuk-body">Select to remove or click on the ID link to edit:</p>
@@ -77,34 +57,60 @@
               {{ obj.structure_description if obj.structure_description else "-" }}
             {% endset %}
 
+            {# Above each transaction add transaction info and actions. #}
+            {% if loop.first or is_obj_first_in_transaction(obj) %}
+              {{ table_rows.append([
+                { "text": "", "classes": "transaction-start first-cell"},
+                {
+                  "html": transaction_details(obj.transaction),
+                  "colspan": 7,
+                  "classes": "transaction-start last-cell",
+                },
+              ]) or "" }}
+            {% endif %}
+
+            {# TrackedModel instance. #}
             {{ table_rows.append([
+              {"text": "", "classes": "item first-cell"},
               {"html": checkbox},
               {"html": object_link, "classes": "govuk-!-width-one-quarter"},
-              {"text": obj._meta.verbose_name.title(), "classes": "govuk-!-width-one-quarter"},
+              {"text": obj._meta.verbose_name.title()},
               {"text": obj.update_type_str},
-              {"text": object_description, "classes": "govuk-!-width-one-quarter"},
-              {"text": "{:%d %b %Y}".format(obj.transaction.updated_at), "classes": "govuk-!-width-one-quarter"},
+              {"html": object_description, "classes": "govuk-!-width-one-quarter"},
+              {"text": "{:%d %b %Y}".format(obj.transaction.updated_at), "classes": "govuk-!-width-one-quarter item last-cell"},
             ]) or "" }}
+
+            {# Below each transaction add a spacer line. #}
+            {% if not loop.last and is_obj_last_in_transaction(obj) %}
+              {{ table_rows.append([
+                {
+                  "text": "",
+                  "colspan": 7,
+                  "classes": "transaction-end",
+                },
+              ]) or "" }}
+            {% endif  %}
           {% endfor %}
 
           {{ govukTable({
             "head": [
+              {"text": ""},
               {"html": checkbox_check_all},
               {"text": "ID"},
-              {"text": component},
-              {"text": action },
+              {"text": "Component"},
+              {"text": "Action"},
               {"text": "Description"},
-              {"text": activity_date},
+              {"text": "Activity date"},
             ],
-              "rows": table_rows
-            }) }}
+            "rows": table_rows,
+            "classes": "workbasket-items",
+          }) }}
         {% endif %}
 
         <div class="govuk-button-group">
           <button value="remove-selected" name="form-action" class="govuk-button govuk-button--secondary" data-module="govuk-button">Remove</button>
-          <button value="remove-all" name="form-action" class="govuk-button govuk-button--warning" data-module="govuk-button">Remove all workbasket changes</button>
         </div>
-        
+
         {{ load_more_pagination(current_count, total_count) }}
       </form>
 
@@ -119,29 +125,59 @@
         {% set object_description -%}
           {{ obj.structure_description if obj.structure_description else "-" }}
         {% endset %}
+        {% set transaction_detail %}
+          <span class="details">Transaction: {{ obj.transaction.pk }}</span>
+        {% endset %}
 
+        {# Above each transaction add transaction info. #}
+        {% if loop.first or is_obj_first_in_transaction(obj) %}
+          {{ table_rows.append([
+            {"text": "", "classes": "transaction-start first-cell"},
+            {
+              "html": transaction_detail,
+              "colspan": 7,
+              "classes": "transaction-start last-cell",
+            },
+           ]) or "" }}
+        {% endif %}
+
+        {# TrackedModel instance. #}
         {{ table_rows.append([
+          {"text": "", "classes": "item first-cell"},
           {"html": object_link},
           {"text": obj._meta.verbose_name.title()},
           {"text": obj.update_type_str},
-          {"text": object_description},
-          {"text": "{:%d %b %Y}".format(obj.transaction.updated_at)},
+          {"text": object_description, "classes": "govuk-!-width-one-third"},
+          {"text": "{:%d %b %Y}".format(obj.transaction.updated_at), "classes": "govuk-!-width-one-quarter item last-cell"},
         ]) or "" }}
+
+        {# Below each transaction add a spacer line. #}
+        {% if not loop.last and is_obj_last_in_transaction(obj) %}
+          {{ table_rows.append([
+            {
+              "text": "",
+              "colspan": 7,
+              "classes": "transaction-end",
+            },
+          ]) or "" }}
+        {% endif  %}
       {% endfor %}
 
       <form method="post">
         <input type="hidden" name="csrfmiddlewaretoken" value="{{ csrf_token }}">
         {{ govukTable({
           "head": [
+            {"text": ""},
             {"text": "ID"},
-            {"text": component},
-            {"text": action},
+            {"text": "Component"},
+            {"text": "Action"},
             {"text": "Description"},
-            {"text": activity_date},
+            {"text": "Activity date"},
           ],
-          "rows": table_rows
+          "rows": table_rows,
+          "classes": "workbasket-items",
         }) }}
-        
+
         {{ load_more_pagination(current_count, total_count) }}
 
       </form>

--- a/workbaskets/jinja2/workbaskets/transaction_order.jinja
+++ b/workbaskets/jinja2/workbaskets/transaction_order.jinja
@@ -58,7 +58,7 @@
             {% endset %}
 
             {# Above each transaction add transaction info and actions. #}
-            {% if loop.first or is_obj_first_in_transaction(obj) %}
+            {% if loop.first or obj.pk in tracked_models_first_in_transactions %}
               {{ table_rows.append([
                 { "text": "", "classes": "transaction-start first-cell"},
                 {
@@ -81,7 +81,7 @@
             ]) or "" }}
 
             {# Below each transaction add a spacer line. #}
-            {% if not loop.last and is_obj_last_in_transaction(obj) %}
+            {% if not loop.last and obj.pk in tracked_models_last_in_transactions %}
               {{ table_rows.append([
                 {
                   "text": "",
@@ -130,7 +130,7 @@
         {% endset %}
 
         {# Above each transaction add transaction info. #}
-        {% if loop.first or is_obj_first_in_transaction(obj) %}
+        {% if loop.first or obj.pk in tracked_models_first_in_transactions %}
           {{ table_rows.append([
             {"text": "", "classes": "transaction-start first-cell"},
             {
@@ -152,7 +152,7 @@
         ]) or "" }}
 
         {# Below each transaction add a spacer line. #}
-        {% if not loop.last and is_obj_last_in_transaction(obj) %}
+        {% if not loop.last and obj.pk in tracked_models_last_in_transactions %}
           {{ table_rows.append([
             {
               "text": "",

--- a/workbaskets/static/workbaskets/scss/_workbaskets.scss
+++ b/workbaskets/static/workbaskets/scss/_workbaskets.scss
@@ -1,28 +1,70 @@
 #workbasket-review-tabs .govuk-tabs__list-item, 
 #workbasket-review-tabs .govuk-tabs__list-item--selected {
-    font-size: 1rem;
+  font-size: 1rem;
 }
 
 nav#workbasket-items {
-    display: grid;
-    align-content: center;
-    justify-content: center;
-    justify-items: center;
-    row-gap: govuk-spacing(2);
+  display: grid;
+  align-content: center;
+  justify-content: center;
+  justify-items: center;
+  row-gap: govuk-spacing(2);
 
-    progress {
-        width: 125%;
-        height: 0.25rem;
-        appearance: none;
-        -moz-appearance: none;
-        -webkit-appearance: none;
+  progress {
+    width: 125%;
+    height: 0.25rem;
+    appearance: none;
+    -moz-appearance: none;
+    -webkit-appearance: none;
+  }
+
+  progress::-webkit-progress-value {
+    background-color: govuk-colour("blue");
+  }
+
+  progress::-webkit-progress-bar {
+    background-color: govuk-colour("light-grey");
+  }
+}
+
+table.workbasket-items tbody {
+  .transaction-start {
+    font-size: 1rem;
+    background-color: govuk-colour("light-grey");
+
+    .details {
+      font-weight: bold;
     }
 
-    progress::-webkit-progress-value {
-        background-color: govuk-colour("blue");
+    .demote,
+    .promote {
+      display: inline-block;
+      margin-left: 1rem;
     }
+  }
 
-    progress::-webkit-progress-bar {
-        background-color: govuk-colour("light-grey");
+  .transaction-start.first-cell,
+  .item.first-cell {
+    border-left: 1px solid govuk-colour("mid-grey");
+  }
+
+  .transaction-start.last-cell{
+    #transaction-order-actions{
+      float: right;
+      margin-right: govuk-spacing(3);
     }
+  }
+
+  .transaction-start.last-cell,
+  .item.last-cell {
+    border-right: 1px solid govuk-colour("mid-grey");
+  }
+
+  .transaction-end {
+    height: 1.5rem;
+  }
+
+  .govuk-link.disabled {
+    color: govuk-colour("mid-grey");
+  }
 }

--- a/workbaskets/tests/test_views.py
+++ b/workbaskets/tests/test_views.py
@@ -1470,10 +1470,10 @@ def test_workbasket_changes_view_remove_selected(valid_user_client):
     assert workbasket.tracked_models.count() == 0
 
 
-def test_workbasket_transaction_order_view_with_move_permission(valid_user_client):
+def test_workbasket_transaction_order_view_with_reorder_permission(valid_user_client):
     """Test that `WorkBasketTransactionOrderView` returns status code 200,
-    displaying tabs, table and buttons to users with permission to move
-    transactions."""
+    displaying tabs, table and buttons to users with the requisite
+    permission."""
 
     workbasket = factories.WorkBasketFactory.create()
     factories.TestModel1Factory.create(transaction=workbasket.new_transaction())
@@ -1499,9 +1499,9 @@ def test_workbasket_transaction_order_view_with_move_permission(valid_user_clien
     assert move_up_button and move_down_button
 
 
-def test_workbasket_transaction_order_view_without_move_permission(client):
-    """Tests that users without the requisite permissions cannot re-order
-    transactions `WorkBasketTransactionOrderView`."""
+def test_workbasket_transaction_order_view_without_reorder_permission(client):
+    """Tests that users without the requisite permission cannot reorder
+    transactions on `WorkBasketTransactionOrderView`."""
 
     workbasket = factories.WorkBasketFactory.create()
     factories.TestModel1Factory.create(transaction=workbasket.new_transaction())
@@ -1527,8 +1527,8 @@ def test_workbasket_transaction_order_view_without_move_permission(client):
 
 def test_workbasket_transaction_order_view_promote_transaction():
     """Tests that `WorkBasketTransactionOrderView.promote_transaction()` swaps
-    transaction order of the promoted transaction with the transaction above it
-    (demoted transaction) while other transactions remain in place."""
+    transaction order of the promoted transaction with the (demoted) transaction
+    above it while others remain in place."""
 
     workbasket = factories.WorkBasketFactory.create()
     factories.TestModel1Factory.create(transaction=workbasket.new_transaction())
@@ -1565,8 +1565,8 @@ def test_workbasket_transaction_order_view_promote_transaction():
 
 def test_workbasket_transaction_order_view_demote_transaction():
     """Tests that `WorkBasketTransactionOrderView.demote_transaction()` swaps
-    transaction order of the demoted transaction with the transaction below it
-    (promoted transaction) while other transactions remain in place."""
+    transaction order of the demoted transaction with the (promoted) transaction
+    below it while others remain in place."""
 
     workbasket = factories.WorkBasketFactory.create()
     factories.TestModel1Factory.create(transaction=workbasket.new_transaction())

--- a/workbaskets/tests/test_views.py
+++ b/workbaskets/tests/test_views.py
@@ -1670,10 +1670,10 @@ def test_workbasket_transaction_order_first_or_last_transaction_in_workbasket():
     assert view.last_transaction_in_workbasket != model_1.transaction
 
 
-def test_workbasket_transaction_order_is_obj_first_or_last_in_transaction():
+def test_workbasket_transaction_order_tracked_models_first_or_last_in_transactions():
     """Tests that `WorkBasketTransactionOrderView`'s
-    `is_obj_first_in_transaction()` and `is_obj_last_in_transaction()` return
-    the expected boolean result."""
+    `tracked_models_first_in_transactions` and
+    `tracked_models_last_in_transactions` return the expected tracked models."""
     workbasket = factories.WorkBasketFactory.create()
     with workbasket.new_transaction() as transaction:
         model_1, model_2 = factories.TestModel1Factory.create_batch(
@@ -1692,11 +1692,11 @@ def test_workbasket_transaction_order_is_obj_first_or_last_in_transaction():
         kwargs={"pk": workbasket.pk},
     )
 
-    assert view.is_obj_first_in_transaction(model_1) == True
-    assert view.is_obj_first_in_transaction(model_2) == False
+    assert model_1.pk in view.tracked_models_first_in_transactions
+    assert model_2.pk not in view.tracked_models_first_in_transactions
 
-    assert view.is_obj_last_in_transaction(model_2) == True
-    assert view.is_obj_last_in_transaction(model_1) == False
+    assert model_2.pk in view.tracked_models_last_in_transactions
+    assert model_1.pk not in view.tracked_models_last_in_transactions
 
 
 def test_successfully_delete_workbasket(

--- a/workbaskets/tests/test_views.py
+++ b/workbaskets/tests/test_views.py
@@ -1238,11 +1238,13 @@ def test_violation_list_page_sorting_ignores_invalid_params(
     (
         "workbaskets:workbasket-ui-detail",
         "workbaskets:workbasket-ui-changes",
+        "workbaskets:workbasket-ui-transaction-order",
     ),
 )
-def test_workbasket_detail_views_without_permission(url_name, client):
-    """Tests that `WorkBasketDetailView` and `WorkBasketChangesView` return 403
-    to users without `view_workbasket` permission."""
+def test_workbasket_detail_views_without_view_permission(url_name, client):
+    """Tests that `WorkBasketDetailView`, `WorkBasketChangesView` and
+    `WorkBasketTransactionOrderView` return 403 to users without
+    `view_workbasket` permission."""
 
     workbasket = factories.WorkBasketFactory.create()
     url = reverse(url_name, kwargs={"pk": workbasket.pk})
@@ -1466,6 +1468,235 @@ def test_workbasket_changes_view_remove_selected(valid_user_client):
     assert response.status_code == 302
     assert response.url == confirm_delete_url
     assert workbasket.tracked_models.count() == 0
+
+
+def test_workbasket_transaction_order_view_with_move_permission(valid_user_client):
+    """Test that `WorkBasketTransactionOrderView` returns status code 200,
+    displaying tabs, table and buttons to users with permission to move
+    transactions."""
+
+    workbasket = factories.WorkBasketFactory.create()
+    factories.TestModel1Factory.create(transaction=workbasket.new_transaction())
+    factories.TestModel1Factory.create(transaction=workbasket.new_transaction())
+    factories.TestModel1Factory.create(transaction=workbasket.new_transaction())
+
+    url = reverse(
+        "workbaskets:workbasket-ui-transaction-order",
+        kwargs={"pk": workbasket.pk},
+    )
+    response = valid_user_client.get(url)
+    assert response.status_code == 200
+
+    page = BeautifulSoup(str(response.content), "html.parser")
+    table_rows = page.select("table > tbody > tr > td.item.first-cell")
+    checkboxes = page.select(".govuk-checkboxes__input")
+    remove_button = page.find("button", value="remove-selected")
+    move_up_button = page.select("button.promote")
+    move_down_button = page.select("button.demote")
+
+    assert len(table_rows) == workbasket.tracked_models.count()
+    assert checkboxes and remove_button
+    assert move_up_button and move_down_button
+
+
+def test_workbasket_transaction_order_view_without_move_permission(client):
+    """Tests that users without the requisite permissions cannot re-order
+    transactions `WorkBasketTransactionOrderView`."""
+
+    workbasket = factories.WorkBasketFactory.create()
+    factories.TestModel1Factory.create(transaction=workbasket.new_transaction())
+    factories.TestModel1Factory.create(transaction=workbasket.new_transaction())
+    factories.TestModel1Factory.create(transaction=workbasket.new_transaction())
+
+    user = factories.UserFactory.create()
+    user.user_permissions.add(Permission.objects.get(codename="view_workbasket"))
+    client.force_login(user)
+
+    url = reverse(
+        "workbaskets:workbasket-ui-transaction-order",
+        kwargs={"pk": workbasket.pk},
+    )
+    response = client.get(url)
+    assert response.status_code == 200
+
+    page = BeautifulSoup(response.content, "html.parser")
+    move_up_button = page.select("button.promote")
+    move_down_button = page.select("button.demote")
+    assert not move_up_button and not move_down_button
+
+
+def test_workbasket_transaction_order_view_promote_transaction():
+    """Tests that `WorkBasketTransactionOrderView.promote_transaction()` swaps
+    transaction order of the promoted transaction with the transaction above it
+    (demoted transaction) while other transactions remain in place."""
+
+    workbasket = factories.WorkBasketFactory.create()
+    factories.TestModel1Factory.create(transaction=workbasket.new_transaction())
+    factories.TestModel1Factory.create(transaction=workbasket.new_transaction())
+    with workbasket.new_transaction() as transaction:
+        factories.TestModel1Factory.create_batch(2, transaction=transaction)
+
+    transaction_1, transaction_2, transaction_3 = list(
+        workbasket.transactions.all().order_by("order"),
+    )
+
+    request = RequestFactory()
+    url = reverse(
+        "workbaskets:workbasket-ui-transaction-order",
+        kwargs={"pk": workbasket.pk},
+    )
+    data = {"form-action": f"promote-transaction__{transaction_2.pk}"}
+    post_request = request.post(url, data=data)
+
+    view = ui.WorkBasketTransactionOrderView(
+        request=post_request,
+        kwargs={"pk": workbasket.pk},
+    )
+    view.promote_transaction(form_action=data["form-action"])
+
+    new_transaction_1, new_transaction_2, new_transaction_3 = list(
+        workbasket.transactions.all().order_by("order"),
+    )
+
+    assert new_transaction_1 == transaction_2
+    assert new_transaction_2 == transaction_1
+    assert new_transaction_3 == transaction_3
+
+
+def test_workbasket_transaction_order_view_demote_transaction():
+    """Tests that `WorkBasketTransactionOrderView.demote_transaction()` swaps
+    transaction order of the demoted transaction with the transaction below it
+    (promoted transaction) while other transactions remain in place."""
+
+    workbasket = factories.WorkBasketFactory.create()
+    factories.TestModel1Factory.create(transaction=workbasket.new_transaction())
+    factories.TestModel1Factory.create(transaction=workbasket.new_transaction())
+    with workbasket.new_transaction() as transaction:
+        factories.TestModel1Factory.create_batch(2, transaction=transaction)
+
+    transaction_1, transaction_2, transaction_3 = list(
+        workbasket.transactions.all().order_by("order"),
+    )
+
+    request = RequestFactory()
+    url = reverse(
+        "workbaskets:workbasket-ui-transaction-order",
+        kwargs={"pk": workbasket.pk},
+    )
+    data = {"form-action": f"demote-transaction__{transaction_2.pk}"}
+    post_request = request.post(url, data=data)
+
+    view = ui.WorkBasketTransactionOrderView(
+        request=post_request,
+        kwargs={"pk": workbasket.pk},
+    )
+    view.demote_transaction(form_action=data["form-action"])
+
+    new_transaction_1, new_transaction_2, new_transaction_3 = list(
+        workbasket.transactions.all().order_by("order"),
+    )
+
+    assert new_transaction_1 == transaction_1
+    assert new_transaction_2 == transaction_3
+    assert new_transaction_3 == transaction_2
+
+
+@pytest.mark.parametrize(
+    "form_action, redirect_url, page_param",
+    [
+        ("remove-selected", "workbaskets:workbasket-ui-changes-delete", False),
+        ("move-transaction", "workbaskets:workbasket-ui-transaction-order", True),
+    ],
+)
+def test_workbasket_transaction_order_form_action_redirect(
+    form_action,
+    redirect_url,
+    page_param,
+    session_workbasket,
+):
+    """Tests that `WorkBasketTransactionOrderView.get_success_url()` maps
+    `form_action` to its corresponding redirect URL."""
+    request = RequestFactory()
+    view_url = reverse(
+        "workbaskets:workbasket-ui-transaction-order",
+        kwargs={"pk": session_workbasket.pk},
+    )
+    data = {"form-action": form_action}
+    post_request = request.post(view_url, data)
+
+    view = ui.WorkBasketTransactionOrderView(
+        request=post_request,
+        kwargs={"pk": session_workbasket.pk},
+    )
+    if not page_param:
+        assert view.get_success_url() == reverse(
+            redirect_url,
+            kwargs={"pk": session_workbasket.pk},
+        )
+    else:
+        assert (
+            view.get_success_url()
+            == reverse(redirect_url, kwargs={"pk": session_workbasket.pk}) + "?page=1"
+        )
+
+
+def test_workbasket_transaction_order_is_transaction_first_or_last_in_workbasket():
+    """Tests that `WorkBasketTransactionOrderView`'s
+    `is_transaction_first_in_workbasket()` and
+    `is_transaction_last_in_workbasket()` return the expected boolean result."""
+    workbasket = factories.WorkBasketFactory.create()
+    model_1 = factories.TestModel1Factory.create(
+        transaction=workbasket.new_transaction(),
+    )
+    model_2 = factories.TestModel1Factory.create(
+        transaction=workbasket.new_transaction(),
+    )
+
+    request = RequestFactory()
+    url = reverse(
+        "workbaskets:workbasket-ui-transaction-order",
+        kwargs={"pk": workbasket.pk},
+    )
+    request = request.get(url)
+    view = ui.WorkBasketTransactionOrderView(
+        request=request,
+        kwargs={"pk": workbasket.pk},
+    )
+
+    assert view.is_transaction_first_in_workbasket(model_1.transaction) == True
+    assert view.is_transaction_first_in_workbasket(model_2.transaction) == False
+
+    assert view.is_transaction_last_in_workbasket(model_2.transaction) == True
+    assert view.is_transaction_last_in_workbasket(model_1.transaction) == False
+
+
+def test_workbasket_transaction_order_is_obj_first_or_last_in_transaction():
+    """Tests that `WorkBasketTransactionOrderView`'s
+    `is_obj_first_in_transaction()` and `is_obj_last_in_transaction()` return
+    the expected boolean result."""
+    workbasket = factories.WorkBasketFactory.create()
+    with workbasket.new_transaction() as transaction:
+        model_1, model_2 = factories.TestModel1Factory.create_batch(
+            2,
+            transaction=transaction,
+        )
+
+    request = RequestFactory()
+    url = reverse(
+        "workbaskets:workbasket-ui-transaction-order",
+        kwargs={"pk": workbasket.pk},
+    )
+    request = request.get(url)
+    view = ui.WorkBasketTransactionOrderView(
+        request=request,
+        kwargs={"pk": workbasket.pk},
+    )
+
+    assert view.is_obj_first_in_transaction(model_1) == True
+    assert view.is_obj_first_in_transaction(model_2) == False
+
+    assert view.is_obj_last_in_transaction(model_2) == True
+    assert view.is_obj_last_in_transaction(model_1) == False
 
 
 def test_successfully_delete_workbasket(

--- a/workbaskets/tests/test_views.py
+++ b/workbaskets/tests/test_views.py
@@ -1640,10 +1640,10 @@ def test_workbasket_transaction_order_form_action_redirect(
         )
 
 
-def test_workbasket_transaction_order_is_transaction_first_or_last_in_workbasket():
+def test_workbasket_transaction_order_first_or_last_transaction_in_workbasket():
     """Tests that `WorkBasketTransactionOrderView`'s
-    `is_transaction_first_in_workbasket()` and
-    `is_transaction_last_in_workbasket()` return the expected boolean result."""
+    `first_transaction_in_workbasket` and `last_transaction_in_workbasket`
+    return the expected transaction."""
     workbasket = factories.WorkBasketFactory.create()
     model_1 = factories.TestModel1Factory.create(
         transaction=workbasket.new_transaction(),
@@ -1663,11 +1663,11 @@ def test_workbasket_transaction_order_is_transaction_first_or_last_in_workbasket
         kwargs={"pk": workbasket.pk},
     )
 
-    assert view.is_transaction_first_in_workbasket(model_1.transaction) == True
-    assert view.is_transaction_first_in_workbasket(model_2.transaction) == False
+    assert view.first_transaction_in_workbasket == model_1.transaction
+    assert view.first_transaction_in_workbasket != model_2.transaction
 
-    assert view.is_transaction_last_in_workbasket(model_2.transaction) == True
-    assert view.is_transaction_last_in_workbasket(model_1.transaction) == False
+    assert view.last_transaction_in_workbasket == model_2.transaction
+    assert view.last_transaction_in_workbasket != model_1.transaction
 
 
 def test_workbasket_transaction_order_is_obj_first_or_last_in_transaction():

--- a/workbaskets/urls.py
+++ b/workbaskets/urls.py
@@ -127,6 +127,11 @@ ui_patterns = [
         name="workbasket-ui-changes-confirm-delete",
     ),
     path(
+        f"<pk>/transaction-order/",
+        ui_views.WorkBasketTransactionOrderView.as_view(),
+        name="workbasket-ui-transaction-order",
+    ),
+    path(
         f"<wb_pk>/violations/<pk>/",
         ui_views.WorkBasketViolationDetail.as_view(),
         name="workbasket-ui-violation-detail",

--- a/workbaskets/views/ui.py
+++ b/workbaskets/views/ui.py
@@ -645,7 +645,7 @@ class WorkBasketChangesView(SortingMixin, WorkBasketChangesMixin):
 
 
 class WorkBasketTransactionOrderView(WorkBasketChangesMixin):
-    """UI endpoint for re-ordering transactions in a workbasket."""
+    """UI endpoint for reordering transactions in a workbasket."""
 
     template_name = "workbaskets/transaction_order.jinja"
 
@@ -754,7 +754,7 @@ class WorkBasketTransactionOrderView(WorkBasketChangesMixin):
     @atomic
     def promote_transaction(self, form_action):
         """Swap the transaction order of the promoted transaction with the
-        transaction above it (now demoted_transaction)."""
+        (demoted) transaction above it."""
         promoted_transaction = self._get_transaction_pk_from_form_action(form_action)
         demoted_transaction = (
             self.workbasket_transactions()
@@ -780,7 +780,7 @@ class WorkBasketTransactionOrderView(WorkBasketChangesMixin):
     @atomic
     def demote_transaction(self, form_action):
         """Swap the transaction order of the demoted transaction with the
-        transaction below it (now promoted transaction)."""
+        (promoted) transaction below it."""
         demoted_transaction = self._get_transaction_pk_from_form_action(form_action)
         promoted_transaction = (
             self.workbasket_transactions()

--- a/workbaskets/views/ui.py
+++ b/workbaskets/views/ui.py
@@ -814,7 +814,7 @@ class WorkBasketTransactionOrderView(WorkBasketChangesMixin):
     def last_transaction_in_workbasket(self):
         return self.workbasket_transactions().last()
 
-    @cached_property
+    @property
     def tracked_models_first_in_transactions(self):
         """Returns a list of pks of tracked models that are first in their
         parent transaction."""
@@ -824,7 +824,7 @@ class WorkBasketTransactionOrderView(WorkBasketChangesMixin):
             .values_list("first_tracked_models", flat=True)
         )
 
-    @cached_property
+    @property
     def tracked_models_last_in_transactions(self):
         """Returns a list of pks of tracked models that are last in their parent
         transaction."""

--- a/workbaskets/views/ui.py
+++ b/workbaskets/views/ui.py
@@ -339,7 +339,9 @@ class CurrentWorkBasket(FormView):
     @property
     def paginator(self):
         return Paginator(
-            self.workbasket.tracked_models.with_transactions_and_models(),
+            self.workbasket.tracked_models.with_transactions_and_models().order_by(
+                "transaction__order",
+            ),
             per_page=50,
         )
 

--- a/workbaskets/views/ui.py
+++ b/workbaskets/views/ui.py
@@ -1,5 +1,6 @@
 import logging
 import re
+from functools import cached_property
 
 import boto3
 from botocore.client import Config
@@ -666,8 +667,8 @@ class WorkBasketTransactionOrderView(WorkBasketChangesMixin):
         context = super().get_context_data(**kwargs)
         context.update(
             {
-                "is_transaction_first_in_workbasket": self.is_transaction_first_in_workbasket,
-                "is_transaction_last_in_workbasket": self.is_transaction_last_in_workbasket,
+                "first_transaction_in_workbasket": self.first_transaction_in_workbasket,
+                "last_transaction_in_workbasket": self.last_transaction_in_workbasket,
                 "is_obj_first_in_transaction": self.is_obj_first_in_transaction,
                 "is_obj_last_in_transaction": self.is_obj_last_in_transaction,
             },
@@ -803,15 +804,13 @@ class WorkBasketTransactionOrderView(WorkBasketChangesMixin):
 
         return HttpResponseRedirect(self.get_success_url())
 
-    def is_transaction_first_in_workbasket(self, transaction):
-        """Returns `True` if the transaction is the first in the workbasket,
-        `False` otherwise."""
-        return self.workbasket_transactions().first() == transaction
+    @cached_property
+    def first_transaction_in_workbasket(self):
+        return self.workbasket_transactions().first()
 
-    def is_transaction_last_in_workbasket(self, transaction):
-        """Returns `True` if the transaction is the last in the current
-        workbasket, `False` otherwise."""
-        return self.workbasket_transactions().last() == transaction
+    @cached_property
+    def last_transaction_in_workbasket(self):
+        return self.workbasket_transactions().last()
 
     def is_obj_first_in_transaction(self, tracked_model):
         """Returns `True` if the object is the first TrackedModel instance in

--- a/workbaskets/views/ui.py
+++ b/workbaskets/views/ui.py
@@ -818,21 +818,17 @@ class WorkBasketTransactionOrderView(WorkBasketChangesMixin):
     def tracked_models_first_in_transactions(self):
         """Returns a list of pks of tracked models that are first in their
         parent transaction."""
-        return (
-            self.workbasket_transactions()
-            .annotate(first_tracked_models=Min("tracked_models__pk"))
-            .values_list("first_tracked_models", flat=True)
-        )
+        return self.workbasket.transactions.annotate(
+            first_tracked_models=Min("tracked_models__pk"),
+        ).values_list("first_tracked_models", flat=True)
 
     @property
     def tracked_models_last_in_transactions(self):
         """Returns a list of pks of tracked models that are last in their parent
         transaction."""
-        return (
-            self.workbasket_transactions()
-            .annotate(last_tracked_models=Max("tracked_models__pk"))
-            .values_list("last_tracked_models", flat=True)
-        )
+        return self.workbasket.transactions.annotate(
+            last_tracked_models=Max("tracked_models__pk"),
+        ).values_list("last_tracked_models", flat=True)
 
 
 class WorkBasketViolations(SortingMixin, WithPaginationListView):


### PR DESCRIPTION
# TP2000-1078  Implement transaction order tab

## Why
A feature improvement to workbaskets is to introduce the capability to reorder workbasket transactions, allowing users to resolve business rule violations related to transaction ordering.

## What
**This PR is based on the experimental branch created by Paul**: [EXPERIMENTAL--move-tranx-within-workbasket](https://github.com/uktrade/tamato/compare/master...EXPERIMENTAL--move-tranx-within-workbasket)

- Creates a new tab on workbasket detail view to allow users with the requisite permissions to view transactions and reorder transactions in workbaskets in an editing state

- Adds view unit tests

- Stops an empty transaction from being left behind when creating a new certificate

## 
<img width="500" alt="Screenshot 2023-10-20 at 14 01 34" src="https://github.com/uktrade/tamato/assets/118175145/3cc13a0a-06c9-44d0-8c02-a0a192096a1d">

