### PR TITLE
Clear ContentType cache before applying migrations in unit test.

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -22,7 +22,9 @@ from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Group
 from django.contrib.auth.models import Permission
 from django.contrib.contenttypes.management import create_contenttypes
+from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ValidationError
+from django.db import DEFAULT_DB_ALIAS
 from django.test.client import RequestFactory
 from django.test.html import parse_html
 from django.urls import reverse
@@ -143,6 +145,41 @@ def spanning_dates(request, date_ranges):
         getattr(date_ranges, contained_validity),
         container_spans_contained,
     )
+
+
+@pytest.fixture
+def tap_migrator_factory(migrator_factory):
+    """
+    This fixture is an override of the django-test-migrations fixture of
+    `django_test_migrations.contrib.pytest_plugin.migrator_factory()`.
+
+    One or two issues in Django, and / or related libraries that TAP uses for
+    its migration unit testing, continues to cause problems in migration unit
+    tests. A couple of examples of the reported issue:
+    https://code.djangoproject.com/ticket/10827
+    https://github.com/wemake-services/django-test-migrations/blob/93db540c00a830767eeab5f90e2eef1747c940d4/django_test_migrations/migrator.py#L73
+
+    An initial migration must reference ContentType instances (in the DB).
+    This can occur when inserting Permission objects during
+    `migrator.apply_initial_migration()` execution.
+
+    At that point, a stale ContentType cache can give an incorrect account of
+    ContentType DB table state, so attempts by an initial migration to insert
+    those Permission objects fails on foreign key violations because they're
+    referencing missing ContentType objects (they're not in the database, only
+    in the ContentType cache).
+    """
+    ContentType.objects.clear_cache()
+    return migrator_factory
+
+
+@pytest.fixture
+def migrator(tap_migrator_factory):
+    """Override of `django_test_migrations.contrib.pytest_plugin.migrator()`,
+    substituting a call to
+    `django_test_migrations.contrib.pytest_plugin.migrator_factory()` with a
+    locally overriden instance, `tap_migrator_factory()`."""
+    return tap_migrator_factory(DEFAULT_DB_ALIAS)
 
 
 @pytest.fixture

--- a/publishing/tests/test_migrations.py
+++ b/publishing/tests/test_migrations.py
@@ -1,5 +1,4 @@
 import pytest
-from django.contrib.contenttypes.models import ContentType
 
 
 @pytest.mark.django_db()
@@ -7,16 +6,6 @@ def test_add_packaged_workbasket_to_loading_report(migrator):
     """Test that packaged workbaskets with a loading report are added to the
     newly-created `packaged_workbasket` field on the associated `LoadingReport`
     model before `loading_report` field is removed from `PackagedWorkBasket`."""
-
-    # The initial migration must reference ContentType instances (in the DB)
-    # when inserting Permission object during migrator.apply_initial_migration()
-    # execution.
-    # A (stale) ContentType cache gives an incorrect account of ContentType
-    # DB table state, so attempts by the initial migration to insert those
-    # Permission objects fails on foreign key violations because they're
-    # referencing missing ContentType objects (they're not in the database, only
-    # in the ContentType cache).
-    ContentType.objects.clear_cache()
 
     # Before migration
     old_state = migrator.apply_initial_migration(


### PR DESCRIPTION
# TP2000-1090 Migration tests fail due to stale ContentType cache
<!---
 * Include the JIRA ticket number, eg TP-123, to automatically link.
 * Use 50 characters maximum.
 * Do not end with a full-stop.
--->

## Why
<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Use as many lines as you like.
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions or deliberately ignored edge-cases.
--->
Migration tests fail due to stale `ContentType` cache, causing references to non-existant content type instances in the database.

## What
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Explain like I'm 5.
 * Use pictures if you can.
--->
Override the `migrator_factory` and `migrator` fixtures from the [django-test-migrations](https://github.com/wemake-services/django-test-migrations/) package in order to clear the `ContentType` cache in a timely manner - prior to performing migrations in migration tests. This ensures correct `ContentTypeManager` state when manipulating migrations in unit tests.

<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
--->
## Checklist
- Requires migrations? No
- Requires dependency updates? No

<!---
See: [Description](https://example.com/...)
--->
Links to relevant material:
https://code.djangoproject.com/ticket/10827
https://github.com/wemake-services/django-test-migrations/blob/93db540c00a830767eeab5f90e2eef1747c940d4/django_test_migrations/migrator.py