### PR TITLE
Tp2000 1055 update import status labels

### DIFF
--- a/common/static/common/scss/_badges.scss
+++ b/common/static/common/scss/_badges.scss
@@ -35,24 +35,24 @@
 
 .status-badge-purple {
   @extend .status-badge;
-  color: #3d2375;
-  background-color: #dbd5e9;
+  color: govuk-shade(govuk-colour("purple"), 20);
+  background: govuk-tint(govuk-colour("purple"), 80);
 }
 
 .status-badge-grey {
   @extend .status-badge;
-  color: #383f43;
-  background-color: #eeefef;
+  color: govuk-shade(govuk-colour("dark-grey", $legacy: "grey-1"), 30);
+  background: govuk-tint(govuk-colour("dark-grey", $legacy: "grey-1"), 90);
 }
 
 .status-badge-red {
   @extend .status-badge;
-  color: #942514;
-  background-color: #f6d7d2;
+  color: govuk-shade(govuk-colour("red"), 30);
+  background: govuk-tint(govuk-colour("red"), 80);
 }
 
 .status-badge-green {
   @extend .status-badge;
-  color: #005a30;
-  background-color: #cce2d8;
+  color: govuk-shade(govuk-colour("green"), 20);
+  background: govuk-tint(govuk-colour("green"), 80);
 }

--- a/common/static/common/scss/_badges.scss
+++ b/common/static/common/scss/_badges.scss
@@ -1,4 +1,3 @@
-
 .tamato-badge {
   display: inline-block;
   padding: 0.2rem 0.4rem;
@@ -8,7 +7,7 @@
 
 .tamato-badge-light-grey {
   @extend .tamato-badge;
-  background-color: rgb(200, 200, 200,);
+  background-color: rgb(200, 200, 200);
   color: rgb(80, 80, 80);
 }
 .tamato-badge-light-purple {
@@ -25,4 +24,35 @@
   @extend .tamato-badge;
   background-color: rgb(237, 192, 204);
   color: rgb(146, 53, 80);
+}
+
+.status-badge {
+  font-weight: bold;
+  color: govuk-colour("white");
+  background-color: govuk-colour("blue");
+  padding: 0px 10px;
+}
+
+.status-badge-purple {
+  @extend .status-badge;
+  color: #3d2375;
+  background-color: #dbd5e9;
+}
+
+.status-badge-grey {
+  @extend .status-badge;
+  color: #383f43;
+  background-color: #eeefef;
+}
+
+.status-badge-red {
+  @extend .status-badge;
+  color: #942514;
+  background-color: #f6d7d2;
+}
+
+.status-badge-green {
+  @extend .status-badge;
+  color: #005a30;
+  background-color: #cce2d8;
 }

--- a/common/static/common/scss/_text.scss
+++ b/common/static/common/scss/_text.scss
@@ -1,34 +1,3 @@
-.status-badge {
-  font-weight: bold;
-  color: govuk-colour("white");
-  background-color: govuk-colour("blue");
-  padding: 0px 10px;
-}
-
-.status-badge-purple {
-  @extend .status-badge;
-  color: #3d2375;
-  background-color: #dbd5e9;
-}
-
-.status-badge-grey {
-  @extend .status-badge;
-  color: #383f43;
-  background-color: #eeefef;
-}
-
-.status-badge-red {
-  @extend .status-badge;
-  color: #942514;
-  background-color: #f6d7d2;
-}
-
-.status-badge-green {
-  @extend .status-badge;
-  color: #005a30;
-  background-color: #cce2d8;
-}
-
 // makes a button or input element look like a hyperlink
 .button-link {
   background: none;

--- a/common/static/common/scss/_text.scss
+++ b/common/static/common/scss/_text.scss
@@ -1,9 +1,32 @@
-
 .status-badge {
   font-weight: bold;
   color: govuk-colour("white");
   background-color: govuk-colour("blue");
   padding: 0px 10px;
+}
+
+.status-badge-purple {
+  @extend .status-badge;
+  color: #3d2375;
+  background-color: #dbd5e9;
+}
+
+.status-badge-grey {
+  @extend .status-badge;
+  color: #383f43;
+  background-color: #eeefef;
+}
+
+.status-badge-red {
+  @extend .status-badge;
+  color: #942514;
+  background-color: #f6d7d2;
+}
+
+.status-badge-green {
+  @extend .status-badge;
+  color: #005a30;
+  background-color: #cce2d8;
 }
 
 // makes a button or input element look like a hyperlink

--- a/importer/forms.py
+++ b/importer/forms.py
@@ -205,7 +205,7 @@ class CommodityImportForm(ImportFormMixin, forms.Form):
         label="Upload a TARIC file",
         help_text=(
             "Valid TARIC files contain XML and usually have a .xml file name "
-            "extension. They contain goods nomenclure items and related "
+            "extension. They contain goods nomenclature items and related "
             "items."
         ),
     )

--- a/importer/forms.py
+++ b/importer/forms.py
@@ -188,14 +188,6 @@ class CommodityImportForm(ImportFormMixin, forms.Form):
     """Form used to create new instances of ImportBatch via upload of a
     commodity code file."""
 
-    taric_file = forms.FileField(
-        label="Upload a TARIC file",
-        help_text=(
-            "Valid TARIC files contain XML and usually have a .xml file name "
-            "extension. They contain goods nomenclure items and related "
-            "items."
-        ),
-    )
     workbasket_title = forms.CharField(
         max_length=255,
         validators=[tops_jira_number_validator],
@@ -209,6 +201,14 @@ class CommodityImportForm(ImportFormMixin, forms.Form):
             "number. "
         ),
     )
+    taric_file = forms.FileField(
+        label="Upload a TARIC file",
+        help_text=(
+            "Valid TARIC files contain XML and usually have a .xml file name "
+            "extension. They contain goods nomenclure items and related "
+            "items."
+        ),
+    )
     xsd_file = settings.PATH_XSD_COMMODITIES_TARIC
 
     def __init__(self, *args, **kwargs):
@@ -219,8 +219,8 @@ class CommodityImportForm(ImportFormMixin, forms.Form):
         self.helper.label_size = Size.SMALL
         self.helper.legend_size = Size.SMALL
         self.helper.layout = Layout(
-            "taric_file",
             "workbasket_title",
+            "taric_file",
             Submit(
                 "submit",
                 "Upload",

--- a/importer/jinja2/components/create-status-tag.jinja
+++ b/importer/jinja2/components/create-status-tag.jinja
@@ -2,7 +2,11 @@
 {% macro create_status_tag(object, status_tag_generator) %}
   {% if object %}
     {% set status = status_tag_generator(object)%}
-    <span class="{{status.tag_class}}">{{status.text}}</span>
+      {% if status.text==""%}
+        <span></span>
+      {%else%}
+        <span class="{{status.tag_class}}">{{status.text}}</span>
+      {%endif%}
   {%endif%}
 
 {% endmacro %}

--- a/importer/jinja2/components/create-status-tag.jinja
+++ b/importer/jinja2/components/create-status-tag.jinja
@@ -1,0 +1,8 @@
+
+{% macro create_status_tag(object, status_tag_generator) %}
+  {% if object %}
+    {% set status = status_tag_generator(object)%}
+    <span class="{{status.tag_class}}">{{status.text}}</span>
+  {%endif%}
+
+{% endmacro %}

--- a/importer/jinja2/eu-importer/import-success.jinja
+++ b/importer/jinja2/eu-importer/import-success.jinja
@@ -22,8 +22,8 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
       {{ govukPanel({
-        "titleText": "TARIC ID " ~ object.name ~ " has been uploaded",
-        "text": "You can view " ~ object.name ~ " import progress from the import list.",
+        "titleText": "TARIC ID " ~ object.name ~ " is being imported.",
+        "text": "You can check its status from the EU TARIC import list.",
         "classes": "govuk-!-margin-bottom-7"
       }) }}
 

--- a/importer/jinja2/eu-importer/select-imports.jinja
+++ b/importer/jinja2/eu-importer/select-imports.jinja
@@ -19,9 +19,9 @@
       "selected": selected_link == "importing"
     },
     {
-      "text": "Completed",
+      "text": "Ready",
       "href": "?status=SUCCEEDED&workbasket__status=EDITING",
-      "selected": selected_link == "completed"
+      "selected": selected_link == "ready"
     },
     {
       "text": "Published",
@@ -34,9 +34,9 @@
       "selected": selected_link == "empty"
     },
     {
-      "text": "Errored",
+      "text": "Failed",
       "href": "?status=FAILED",
-      "selected": selected_link == "errored"
+      "selected": selected_link == "failed"
     },
   ]
 %}

--- a/importer/jinja2/includes/taric_importer_list.jinja
+++ b/importer/jinja2/includes/taric_importer_list.jinja
@@ -17,7 +17,7 @@
         <input type="submit" class="button-link" name="submit" value="View Workbasket {{object.workbasket.pk}}">
       </form>
     {% elif goods_status(object) == "no_goods" %}
-      <span>N/A</span>
+      <span>No action</span>
     {%- else -%}
       <span></span>
     {%- endif -%}

--- a/importer/jinja2/includes/taric_importer_list.jinja
+++ b/importer/jinja2/includes/taric_importer_list.jinja
@@ -17,7 +17,7 @@
         <input type="submit" class="button-link" name="submit" value="View Workbasket {{object.workbasket.pk}}">
       </form>
     {% elif goods_status(object) == "no_goods" %}
-      <span>0 goods items</span>
+      <span>N/A</span>
     {%- else -%}
       <span></span>
     {%- endif -%}

--- a/importer/jinja2/includes/taric_importer_list.jinja
+++ b/importer/jinja2/includes/taric_importer_list.jinja
@@ -2,7 +2,7 @@
 
 {% for object in object_list %}
   {%- set import_status_cell -%}
-    <span class="status-badge">{{object.status}}</a>
+    <span class="status-badge">{{status_label(object)}}</span>
   {%- endset -%}
 
   {%- set goods_status_cell -%}
@@ -11,7 +11,7 @@
         <input type="hidden" name="csrfmiddlewaretoken" value="{{ csrf_token }}">
         <input type="hidden" name="workbasket" value="{{ object.workbasket.pk }}">
         <input type="hidden" name="workbasket-tab" value="review-goods">
-        <input type="submit" class="button-link" name="submit" value="Edit/View workbasket">
+        <input type="submit" class="button-link" name="submit" value="View Workbasket {{object.workbasket.pk}}">
       </form>
     {% elif goods_status(object) == "no_goods" %}
       <span>0 goods items</span>

--- a/importer/jinja2/includes/taric_importer_list.jinja
+++ b/importer/jinja2/includes/taric_importer_list.jinja
@@ -1,9 +1,12 @@
+{% from "components/create-status-tag.jinja" import create_status_tag%}
+
 {% set table_rows = [] %}
 
 {% for object in object_list %}
   {%- set import_status_cell -%}
-    <span class="status-badge">{{status_label(object)}}</span>
+    {{ create_status_tag(object, status_tag_generator) }}
   {%- endset -%}
+
 
   {%- set goods_status_cell -%}
     {% if goods_status(object) == "editable_goods" %}

--- a/importer/jinja2/includes/taric_importer_list.jinja
+++ b/importer/jinja2/includes/taric_importer_list.jinja
@@ -48,8 +48,8 @@
     {"text": "Taric ID number"},
     {"text": "Date added"},
     {"text": "Uploaded by"},
-    {"text": "Importer status"},
-    {"text": ""},
+    {"text": "Status"},
+    {"text": "Action"},
   ],
   "rows": table_rows
 }) }}

--- a/importer/views.py
+++ b/importer/views.py
@@ -108,7 +108,7 @@ class CommodityImportListView(
             context["selected_link"] = "failed"
 
         context["goods_status"] = self.goods_status
-        context["status_label"] = self.status_label
+        context["status_tag_generator"] = self.status_tag_generator
 
         return context
 
@@ -138,35 +138,38 @@ class CommodityImportListView(
             return "empty"
 
     @classmethod
-    def status_label(cls, import_batch: ImportBatchFilter) -> str:
-        """Returns a ui friendly label for an import batch."""
+    def status_tag_generator(cls, import_batch: ImportBatchFilter) -> str:
+        """Returns a dict with text and a css class for a ui friendly label for
+        an import batch."""
         workbasket = import_batch.workbasket
 
         if (
             import_batch.status == ImportBatchStatus.SUCCEEDED
             and workbasket.status == WorkflowStatus.EDITING
         ):
-            return "READY"
+            return {"text": "READY", "tag_class": "govuk-tag govuk-tag--purple"}
         elif (
             import_batch.status == ImportBatchStatus.SUCCEEDED
             and workbasket.status == WorkflowStatus.PUBLISHED
         ):
-            return "PUBLISHED"
+            return {"text": "PUBLISHED", "tag_class": "govuk-tag govuk-tag--green"}
         elif (
             import_batch.status == ImportBatchStatus.SUCCEEDED
             and workbasket.status == WorkflowStatus.ARCHIVED
         ):
-            return "EMPTY"
+            return {"text": "EMPTY", "tag_class": "govuk-tag govuk-tag--grey"}
         elif (
             import_batch.status == ImportBatchStatus.IMPORTING
             and workbasket.status == None
         ):
-            return "IMPORTING"
+            return {"text": "IMPORTING", "tag_class": "govuk-tag govuk-tag--blue"}
         elif (
             import_batch.status == ImportBatchStatus.FAILED
             and workbasket.status == None
         ):
-            return "FAILED"
+            return {"text": "FAILED", "tag_class": "govuk-tag govuk-tag--red"}
+        else:
+            return {"text": "NONE", "tag_class": "govuk-tag govuk-tag--blue"}
 
 
 class CommodityImportCreateView(

--- a/importer/views.py
+++ b/importer/views.py
@@ -105,9 +105,10 @@ class CommodityImportListView(
         elif import_status == ImportBatchStatus.IMPORTING and workbasket_status == None:
             context["selected_link"] = "importing"
         elif import_status == ImportBatchStatus.FAILED and workbasket_status == None:
-            context["selected_link"] = "errored"
+            context["selected_link"] = "failed"
 
         context["goods_status"] = self.goods_status
+        context["status_label"] = self.status_label
 
         return context
 
@@ -135,6 +136,37 @@ class CommodityImportListView(
         else:
             # All other statuses are considered empty.
             return "empty"
+
+    @classmethod
+    def status_label(cls, import_batch: ImportBatchFilter) -> str:
+        """Returns a ui friendly label for an import batch."""
+        workbasket = import_batch.workbasket
+
+        if (
+            import_batch.status == ImportBatchStatus.SUCCEEDED
+            and workbasket.status == WorkflowStatus.EDITING
+        ):
+            return "READY"
+        elif (
+            import_batch.status == ImportBatchStatus.SUCCEEDED
+            and workbasket.status == WorkflowStatus.PUBLISHED
+        ):
+            return "PUBLISHED"
+        elif (
+            import_batch.status == ImportBatchStatus.SUCCEEDED
+            and workbasket.status == WorkflowStatus.ARCHIVED
+        ):
+            return "EMPTY"
+        elif (
+            import_batch.status == ImportBatchStatus.IMPORTING
+            and workbasket.status == None
+        ):
+            return "IMPORTING"
+        elif (
+            import_batch.status == ImportBatchStatus.FAILED
+            and workbasket.status == None
+        ):
+            return "FAILED"
 
 
 class CommodityImportCreateView(

--- a/importer/views.py
+++ b/importer/views.py
@@ -142,6 +142,7 @@ class CommodityImportListView(
         """Returns a dict with text and a css class for a ui friendly label for
         an import batch."""
         workbasket = import_batch.workbasket
+
         if import_batch.status:
             if import_batch.status == ImportBatchStatus.IMPORTING:
                 return {"text": "IMPORTING", "tag_class": "status-badge"}
@@ -149,7 +150,7 @@ class CommodityImportListView(
             elif import_batch.status == ImportBatchStatus.FAILED:
                 return {"text": "FAILED", "tag_class": "status-badge-red"}
 
-            if workbasket.status:
+            if workbasket:
                 if (
                     import_batch.status == ImportBatchStatus.SUCCEEDED
                     and workbasket.status == WorkflowStatus.EDITING
@@ -168,8 +169,8 @@ class CommodityImportListView(
                 ):
                     return {"text": "EMPTY", "tag_class": "status-badge-grey"}
 
-        else:
-            return {"text": "NONE", "tag_class": "status-badge"}
+            else:
+                return {"text": "NONE", "tag_class": "status-badge"}
 
 
 class CommodityImportCreateView(

--- a/importer/views.py
+++ b/importer/views.py
@@ -170,7 +170,7 @@ class CommodityImportListView(
                     return {"text": "EMPTY", "tag_class": "status-badge-grey"}
 
             else:
-                return {"text": "NONE", "tag_class": "status-badge"}
+                return {"text": ""}
 
 
 class CommodityImportCreateView(

--- a/importer/views.py
+++ b/importer/views.py
@@ -142,30 +142,31 @@ class CommodityImportListView(
         """Returns a dict with text and a css class for a ui friendly label for
         an import batch."""
         workbasket = import_batch.workbasket
+        if import_batch.status:
+            if import_batch.status == ImportBatchStatus.IMPORTING:
+                return {"text": "IMPORTING", "tag_class": "status-badge"}
 
-        if (
-            import_batch.status == ImportBatchStatus.SUCCEEDED
-            and workbasket.status == WorkflowStatus.EDITING
-        ):
-            return {"text": "READY", "tag_class": "status-badge-purple"}
+            elif import_batch.status == ImportBatchStatus.FAILED:
+                return {"text": "FAILED", "tag_class": "status-badge-red"}
 
-        elif (
-            import_batch.status == ImportBatchStatus.SUCCEEDED
-            and workbasket.status == WorkflowStatus.PUBLISHED
-        ):
-            return {"text": "PUBLISHED", "tag_class": "status-badge-green"}
+            if workbasket.status:
+                if (
+                    import_batch.status == ImportBatchStatus.SUCCEEDED
+                    and workbasket.status == WorkflowStatus.EDITING
+                ):
+                    return {"text": "READY", "tag_class": "status-badge-purple"}
 
-        elif (
-            import_batch.status == ImportBatchStatus.SUCCEEDED
-            and workbasket.status == WorkflowStatus.ARCHIVED
-        ):
-            return {"text": "EMPTY", "tag_class": "status-badge-grey"}
+                elif (
+                    import_batch.status == ImportBatchStatus.SUCCEEDED
+                    and workbasket.status == WorkflowStatus.PUBLISHED
+                ):
+                    return {"text": "PUBLISHED", "tag_class": "status-badge-green"}
 
-        elif import_batch.status == ImportBatchStatus.IMPORTING:
-            return {"text": "IMPORTING", "tag_class": "status-badge"}
-
-        elif import_batch.status == ImportBatchStatus.FAILED:
-            return {"text": "FAILED", "tag_class": "status-badge-red"}
+                elif (
+                    import_batch.status == ImportBatchStatus.SUCCEEDED
+                    and workbasket.status == WorkflowStatus.ARCHIVED
+                ):
+                    return {"text": "EMPTY", "tag_class": "status-badge-grey"}
 
         else:
             return {"text": "NONE", "tag_class": "status-badge"}

--- a/importer/views.py
+++ b/importer/views.py
@@ -147,26 +147,26 @@ class CommodityImportListView(
             import_batch.status == ImportBatchStatus.SUCCEEDED
             and workbasket.status == WorkflowStatus.EDITING
         ):
-            return {"text": "READY", "tag_class": "govuk-tag govuk-tag--purple"}
+            return {"text": "READY", "tag_class": "status-badge-purple"}
         elif (
             import_batch.status == ImportBatchStatus.SUCCEEDED
             and workbasket.status == WorkflowStatus.PUBLISHED
         ):
-            return {"text": "PUBLISHED", "tag_class": "govuk-tag govuk-tag--green"}
+            return {"text": "PUBLISHED", "tag_class": "status-badge-green"}
         elif (
             import_batch.status == ImportBatchStatus.SUCCEEDED
             and workbasket.status == WorkflowStatus.ARCHIVED
         ):
-            return {"text": "EMPTY", "tag_class": "govuk-tag govuk-tag--grey"}
+            return {"text": "EMPTY", "tag_class": "status-badge-grey"}
         elif (
             import_batch.status == ImportBatchStatus.IMPORTING
             and workbasket.status == None
         ):
-            return {"text": "IMPORTING", "tag_class": "govuk-tag govuk-tag--blue"}
+            return {"text": "IMPORTING", "tag_class": "status-badge"}
         elif import_batch.status == ImportBatchStatus.FAILED:
-            return {"text": "FAILED", "tag_class": "govuk-tag govuk-tag--red"}
+            return {"text": "FAILED", "tag_class": "status-badge-red"}
         else:
-            return {"text": "NONE", "tag_class": "govuk-tag govuk-tag--blue"}
+            return {"text": "NONE", "tag_class": "status-badge"}
 
 
 class CommodityImportCreateView(

--- a/importer/views.py
+++ b/importer/views.py
@@ -102,9 +102,9 @@ class CommodityImportListView(
             and workbasket_status == WorkflowStatus.ARCHIVED
         ):
             context["selected_link"] = "empty"
-        elif import_status == ImportBatchStatus.IMPORTING and workbasket_status == None:
+        elif import_status == ImportBatchStatus.IMPORTING:
             context["selected_link"] = "importing"
-        elif import_status == ImportBatchStatus.FAILED and workbasket_status == None:
+        elif import_status == ImportBatchStatus.FAILED:
             context["selected_link"] = "failed"
 
         context["goods_status"] = self.goods_status
@@ -148,23 +148,25 @@ class CommodityImportListView(
             and workbasket.status == WorkflowStatus.EDITING
         ):
             return {"text": "READY", "tag_class": "status-badge-purple"}
+
         elif (
             import_batch.status == ImportBatchStatus.SUCCEEDED
             and workbasket.status == WorkflowStatus.PUBLISHED
         ):
             return {"text": "PUBLISHED", "tag_class": "status-badge-green"}
+
         elif (
             import_batch.status == ImportBatchStatus.SUCCEEDED
             and workbasket.status == WorkflowStatus.ARCHIVED
         ):
             return {"text": "EMPTY", "tag_class": "status-badge-grey"}
-        elif (
-            import_batch.status == ImportBatchStatus.IMPORTING
-            and workbasket.status == None
-        ):
+
+        elif import_batch.status == ImportBatchStatus.IMPORTING:
             return {"text": "IMPORTING", "tag_class": "status-badge"}
+
         elif import_batch.status == ImportBatchStatus.FAILED:
             return {"text": "FAILED", "tag_class": "status-badge-red"}
+
         else:
             return {"text": "NONE", "tag_class": "status-badge"}
 

--- a/importer/views.py
+++ b/importer/views.py
@@ -91,7 +91,7 @@ class CommodityImportListView(
             import_status == ImportBatchStatus.SUCCEEDED
             and workbasket_status == WorkflowStatus.EDITING
         ):
-            context["selected_link"] = "completed"
+            context["selected_link"] = "ready"
         elif (
             import_status == ImportBatchStatus.SUCCEEDED
             and workbasket_status == WorkflowStatus.PUBLISHED
@@ -138,7 +138,7 @@ class CommodityImportListView(
             return "empty"
 
     @classmethod
-    def status_tag_generator(cls, import_batch: ImportBatchFilter) -> str:
+    def status_tag_generator(cls, import_batch: ImportBatchFilter) -> dict:
         """Returns a dict with text and a css class for a ui friendly label for
         an import batch."""
         workbasket = import_batch.workbasket
@@ -163,10 +163,7 @@ class CommodityImportListView(
             and workbasket.status == None
         ):
             return {"text": "IMPORTING", "tag_class": "govuk-tag govuk-tag--blue"}
-        elif (
-            import_batch.status == ImportBatchStatus.FAILED
-            and workbasket.status == None
-        ):
+        elif import_batch.status == ImportBatchStatus.FAILED:
             return {"text": "FAILED", "tag_class": "govuk-tag govuk-tag--red"}
         else:
             return {"text": "NONE", "tag_class": "govuk-tag govuk-tag--blue"}


### PR DESCRIPTION
# TP2000-1055 Update import Status Labels

In order to align TAP to GDS standards, a few tweaks to the importer pages have been added: 
- Change the status labels to rainbow colours (very cute) 
- Change status label text from 'Completed' to 'Ready'
- Change status label text from 'Errored' to 'Failed'
- Change top filters to match the new status name
- Rename Importer Status column to Status and add "Action" to the last column which was previously nameless
- Swap around the form fields on the upload page
- Update the copy on the success page



## Checklist
- Requires migrations? - no
- Requires dependency updates? - no



