### PR TITLE
docker db managing improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,11 @@ DEV=true
 #default run can be replaced with exec
 DOCKER_RUN?=run --rm
 #db import file name
-DUMP_FILE?=tamato_db.sql
+DB_DUMP?=${PROJECT}_db.sql
+DB_NAME?=${PROJECT}
+DB_USER?=postgres
+DATE=$(shell date '+%Y_%m_%d')
+TEMPLATE_NAME?="${DB_NAME}_${DATE}" 
 
 -include .env
 export
@@ -16,7 +20,7 @@ SPHINXOPTS    ?=
 .PHONY: help clean clean-bytecode clean-static collectstatic compilescss dependencies \
 	 docker-clean docker-deep-clean docker-down docker-up-db docker-down docker-image \
 	 docker-db-dump docker-test node_modules run test test-fast docker-makemigrations \
-	 docker-checkmigrations docker-migrate build-docs 
+	 docker-checkmigrations docker-migrate build-docs docker-restore-db docker-import-new-db 
 
 
 
@@ -157,14 +161,28 @@ docker-up-db:
 	@sleep 15; 
 	@echo "Database Ready for connections!"
 
+## docker-import-new-db: Import new db DB_DUMP into new TEMPLATE_NAME in Docker container db must be running 
+docker-import-new-db: docker-up-db
+	@${COMPOSE_LOCAL} exec -u ${DB_USER} db psql -c "DROP DATABASE ${TEMPLATE_NAME}" || true  
+	@${COMPOSE_LOCAL} exec -u ${DB_USER} db psql -c "CREATE DATABASE ${TEMPLATE_NAME} TEMPLATE template0"  
+	@echo "> Running db dump: ${DB_DUMP}  in docker..."
+	@cat ${DB_DUMP} | ${COMPOSE_LOCAL} exec -T db psql  -U ${DB_USER} -d ${TEMPLATE_NAME} 	
+	@sleep 5; 
+
+## docker-restore-db: Resotre db in Docker container set DB_NAME to rename db must be running  
+docker-restore-db: docker-down docker-up-db
+	@${COMPOSE_LOCAL} exec -u ${DB_USER} db psql -c "DROP DATABASE ${DB_NAME}" || true  
+	@${COMPOSE_LOCAL} exec -u ${DB_USER} db psql -c "CREATE DATABASE ${DB_NAME} TEMPLATE ${TEMPLATE_NAME}"  
+	@sleep 5;
+
 ## docker-db-dump: Run db dump to import data into Docker
 docker-db-dump: docker-up-db
 	@echo "> Running db dump in docker..."
-	@cat ${DUMP_FILE} | ${COMPOSE_LOCAL} exec -T db psql -U postgres 
+	@cat ${DB_DUMP} | ${COMPOSE_LOCAL} exec -T db psql -U ${DB_USER} -d ${DB_NAME} 	
 
 ## docker-first-use: Run application for first time in Docker 
-docker-first-use: docker-down docker-clean node_modules compilescss docker-build docker-db-dump \
-	docker-migrate docker-superuser docker-up 
+docker-first-use: docker-down docker-clean node_modules compilescss docker-build docker-import-new-db \
+	docker-restore-db docker-migrate docker-superuser docker-up 
 
 ## docker-makemigrations: Run django makemigrations in Docker
 docker-makemigrations: 

--- a/README.rst
+++ b/README.rst
@@ -145,6 +145,10 @@ Prerequisites:
     - A local instance of the tool can be run using `Docker <https://www.docker.com/>`__.
     - A database dump - contact the TAP team for a database snapshot.
 
+Guidance for running tamato via docker in Pycharm (follow initial set up below first)
+`Docker in PyCharm https://www.jetbrains.com/help/pycharm/using-docker-as-a-remote-interpreter.html#run`__.
+
+https://testdriven.io/blog/django-debugging-pycharm/
 
 Download the codebase:
 
@@ -161,7 +165,7 @@ Build and Run for the first time:
         # Not used will be used for specific local docker stuff
         # cp docker-compose.override.yml.example docker-compose.override.yml
 
-    # to overwrite default db dump name pass in DUMP_FILE=db_dump.sql
+    # to overwrite default db dump name pass in DB_DUMP=tamato_db.sql
     $ make docker-first-use
         # take a tea break to import the db dump then
         # enter super user details when prompted 
@@ -180,9 +184,18 @@ Import from a dump of the database:
 
 .. code:: sh
 
-    # to overwrite default db dump name pass in DUMP_FILE=tamato_db.sql
+    # to overwrite defaults
+    #   DB_DUMP=tamato_db.sql
+    #   DB_NAME=tamato
+    #   DB_USER=postgres
+    #   TEMPLATE_NAME={DB_NAME}_{DATE}
     # this overwrites the default file set in the makefile variable
-    $ make docker-db-dump
+    # docker-import-new-db will create a new template with the provided DB dump
+    # can override the name of the template at TEMPLATE_NAME
+    $ make docker-import-new-db
+
+    # Will restore the db DB_NAME with the provided TEMPLATE_NAME 
+    $ make docker-restore-db
 
 Sometimes docker gets clogged up and we need to clean it:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,8 @@ services:
       - "127.0.0.1:5431:5432"
     restart: "${DOCKER_RESTART_POLICY:-unless-stopped}"
     shm_size: 32g
+    stdin_open: true
+    tty: true  
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U postgres"]
       interval: 5s
@@ -43,6 +45,8 @@ services:
       - .env
       - settings/envs/docker.env
     restart: "${DOCKER_RESTART_POLICY:-unless-stopped}"
+    stdin_open: true
+    tty: true
     depends_on:
       - celery-redis
 
@@ -58,6 +62,8 @@ services:
       - .env
       - settings/envs/docker.env
     restart: "${DOCKER_RESTART_POLICY:-unless-stopped}"
+    stdin_open: true
+    tty: true
     depends_on:
       - celery-redis
 
@@ -88,6 +94,8 @@ services:
       - .env
       - settings/envs/docker.env
     restart: "${DOCKER_RESTART_POLICY:-unless-stopped}"
+    stdin_open: true
+    tty: true
     depends_on:
       - celery-redis
 

--- a/sample.env
+++ b/sample.env
@@ -32,9 +32,13 @@ COMMODITY_IMPORTER_ENVELOPE_STORAGE_DIRECTORY=commodity-envelope/
 # S3 Bucket for SQLite uploads.
 SQLITE_STORAGE_BUCKET_NAME=sqlite
 
-# Minio - local s3 server
-MINIO_ACCESS_KEY=minio_access_key
-MINIO_SECRET_KEY=minio_secret_key
+# Minio - local s3 server 
+# ROOT vars required for docker version of minio
+MINIO_ROOT_USER=minio_access_key
+MINIO_ROOT_PASSWORD=minio_access_key
+# if using older version of minio
+# MINIO_ACCESS_KEY=minio_access_key
+# MINIO_SECRET_KEY=minio_access_key
 
 # Tariff API envelope publishing automation
 ENABLE_CROWN_DEPENDENCIES_PUBLISHING=True

--- a/settings/envs/docker.env
+++ b/settings/envs/docker.env
@@ -1,4 +1,4 @@
 CELERY_BROKER_URL=redis://celery-redis 
 CACHE_URL=redis://cache-redis  
-DATABASE_URL=postgres://postgres@db/postgres
+DATABASE_URL=postgres://postgres@db/tamato
 S3_ENDPOINT_URL=http://s3:9000


### PR DESCRIPTION
# TP-??? Docker Db managing improvement
<!---
 * Include the JIRA ticket number, eg TP-123, to automatically link.
 * Use 50 characters maximum.
 * Do not end with a full-stop.
--->

## Why
When working with TAP DB's you may not always want to work with just a single db or run a db dump everytime you need to clear down the database. This is especially relevant to data engineers 

## What
- added two new make commands `docker-import-new-db` which imports a new db into a template name & `docker-restore-db` which loads a template into the db (deafult name tamato)
- updated readme
- corrected sample.env around minio

<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
## Checklist
- Requires migrations?
- Requires dependency updates?
--->

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
