### PR TITLE
TP2000-1127 Add geo memberships and quota definitions nested review tabs

### DIFF
--- a/workbaskets/jinja2/includes/workbaskets/review-geo-memberships.jinja
+++ b/workbaskets/jinja2/includes/workbaskets/review-geo-memberships.jinja
@@ -1,0 +1,29 @@
+{% set table_rows = [] %}
+  {% for obj in object_list %}
+    {% set object_link %}
+      <a class="govuk-link" href="{{ obj.member.get_url() or "#" }}">
+        {{ obj.member.area_id }}
+      </a>
+    {% endset %}
+
+    {{ table_rows.append([
+      {"html": object_link},
+      {"text": obj.member.get_description().description},
+      {"text": obj.member.get_area_code_display()},
+      {"text": "{:%d %b %Y}".format(obj.valid_between.lower)},
+      {"text": "{:%d %b %Y}".format(obj.valid_between.upper) if obj.valid_between.upper else "-"},
+      {"text": workbasket.get_status_display()},
+    ]) or "" }}
+  {% endfor %}
+
+{{ govukTable({
+  "head": [
+    {"text": "ID"},
+    {"text": "Description"},
+    {"text": "Area code"},
+    {"text": "Start date"},
+    {"text": "End date"},
+    {"text": "Status"}
+  ],
+  "rows": table_rows
+}) }}

--- a/workbaskets/jinja2/includes/workbaskets/review-quota-definitions.jinja
+++ b/workbaskets/jinja2/includes/workbaskets/review-quota-definitions.jinja
@@ -1,0 +1,36 @@
+{% set table_rows = [] %}
+{% for obj in object_list %}
+  {% set object_link %}
+    <a class="govuk-link" href="{{ obj.get_url() or "#" }}">
+      {{ obj.sid }}
+    </a>
+  {% endset %}
+  {{ table_rows.append([
+    {"html": object_link},
+    {"text": obj.description if obj.description else "-"},
+    {"text": intcomma(obj.initial_volume)},
+    {"text": intcomma(obj.volume)},
+    {"text": obj.measurement_unit.abbreviation|title},
+    {"text": obj.quota_critical_threshold ~ "%"},
+    {"text": "Yes" if obj.quota_critical else "No"},
+    {"text": "{:%d %b %Y}".format(obj.valid_between.lower)},
+    {"text": "{:%d %b %Y}".format(obj.valid_between.upper) if obj.valid_between.upper else "-"},
+    {"text": workbasket.get_status_display()},
+  ]) or "" }}
+{% endfor %}
+
+{{ govukTable({
+  "head": [
+    {"text": "ID"},
+    {"text": "Description"},
+    {"text": "Initial volume"},
+    {"text": "Volume"},
+    {"text": "Measurement unit"},
+    {"text": "Critical threshold"},
+    {"text": "Critical state"},
+    {"text": "Start date"},
+    {"text": "End date"},
+    {"text": "Status"}
+  ],
+  "rows": table_rows
+}) }}

--- a/workbaskets/jinja2/workbaskets/review-geo-areas.jinja
+++ b/workbaskets/jinja2/workbaskets/review-geo-areas.jinja
@@ -1,0 +1,20 @@
+{% extends "workbaskets/review.jinja" %}
+
+{% set nested_tab_links = [
+  {
+    "text": "Geographical areas",
+    "href": url("workbaskets:workbasket-ui-review-geo-areas", kwargs={"pk": workbasket.pk}),
+    "selected": selected_nested_tab == "geographical-areas",
+  },
+  {
+    "text": "Geographical area group memberships",
+    "href": url("workbaskets:workbasket-ui-review-geo-memberships", kwargs={"pk": workbasket.pk}),
+    "selected": selected_nested_tab == "geographical-memberships",
+  },
+  ]
+%}
+
+{% block review_tabs %}
+  {{ super() }}
+  {{ fake_tabs(nested_tab_links) }}
+{% endblock %}

--- a/workbaskets/jinja2/workbaskets/review-quotas.jinja
+++ b/workbaskets/jinja2/workbaskets/review-quotas.jinja
@@ -1,0 +1,20 @@
+{% extends "workbaskets/review.jinja" %}
+
+{% set nested_tab_links = [
+  {
+    "text": "Quota order numbers",
+    "href": url("workbaskets:workbasket-ui-review-quotas", kwargs={"pk": workbasket.pk}),
+    "selected": selected_nested_tab == "quotas",
+  },
+  {
+    "text": "Quota definition periods",
+    "href": url("workbaskets:workbasket-ui-review-quota-definitions", kwargs={"pk": workbasket.pk}),
+    "selected": selected_nested_tab == "quota-definitions",
+  },
+  ]
+%}
+
+{% block review_tabs %}
+  {{ super() }}
+  {{ fake_tabs(nested_tab_links) }}
+{% endblock %}

--- a/workbaskets/jinja2/workbaskets/review.jinja
+++ b/workbaskets/jinja2/workbaskets/review.jinja
@@ -10,7 +10,7 @@
   {% set page_title %} Workbasket {{ workbasket.id }} - {{ workbasket.status }} {% endset %}
 {% endif %}
 
-{% set links = [
+{% set main_tab_links = [
   {
     "text": "Additional codes",
     "href": url("workbaskets:workbasket-ui-review-additional-codes", kwargs={"pk": workbasket.pk}),
@@ -82,7 +82,9 @@
   {% endif %}
 
   <div id="workbasket-review-tabs">
-    {{ fake_tabs(links) }}
+    {% block review_tabs %}
+      {{ fake_tabs(main_tab_links) }}
+    {% endblock %}
   </div>
 
   <div class="govuk-tabs__panel {% block content_class %}{% endblock %}">
@@ -110,7 +112,7 @@
       {% if object_list %}
         {% include tab_template %}
       {% else %}
-        <p class="govuk-body govuk-!-margin-top-5">0 {{ selected_tab|replace("-", " ") }} available to review.</p>
+        <p class="govuk-body govuk-!-margin-top-5">0 {{ view.model._meta.verbose_name_plural }} available to review.</p>
       {% endif %}
       {% include "includes/common/pagination.jinja" %}
     {% endblock %}

--- a/workbaskets/jinja2/workbaskets/review.jinja
+++ b/workbaskets/jinja2/workbaskets/review.jinja
@@ -4,10 +4,12 @@
 {% from "includes/workbaskets/navigation.jinja" import navigation %}
 {% from "macros/fake_tabs.jinja" import fake_tabs %}
 
+{% set page_title %} Workbasket {{ workbasket.id }} - {{ tab_page_title }} {% endset %}
+
 {% if workbasket == session_workbasket %}
-  {% set page_title %}Workbasket {{ workbasket.id }} - Review changes{% endset %}
+  {% set page_heading %} Workbasket {{ workbasket.id }} - Review changes {% endset %}
 {% else %}
-  {% set page_title %} Workbasket {{ workbasket.id }} - {{ workbasket.status }} {% endset %}
+  {% set page_heading %} Workbasket {{ workbasket.id }} - {{ workbasket.status }} {% endset %}
 {% endif %}
 
 {% set main_tab_links = [
@@ -72,7 +74,7 @@
 
 {% block content %}
   <h1 class="govuk-heading-xl govuk-!-margin-bottom-3">
-    {{ page_title }}
+    {{ page_heading }}
   </h1>
 
   {% if workbasket == session_workbasket %}
@@ -90,7 +92,7 @@
   <div class="govuk-tabs__panel {% block content_class %}{% endblock %}">
     {% block filters %}
       <nav class="workbasket-filters">
-        <p class="govuk-body govuk-!-font-weight-bold">Filter by action:</p>
+        <h2 class="govuk-heading-s">Filter by action:</h2>
         <ul class="govuk-list">
           <li>
             <a href="{{ request.path }}?update_type=" class="govuk-link govuk-link--no-underline govuk-link--no-visited-state {% if not request.GET.update_type %}selected-link{% endif %}">All</a>

--- a/workbaskets/tests/test_views.py
+++ b/workbaskets/tests/test_views.py
@@ -489,6 +489,11 @@ def test_workbasket_review_tabs_without_permission(url, client):
             6,
         ),
         (
+            "workbaskets:workbasket-ui-review-geo-memberships",
+            lambda: factories.GeographicalMembershipFactory.create(),
+            6,
+        ),
+        (
             "workbaskets:workbasket-ui-review-measures",
             lambda: factories.MeasureFactory.create(),
             11,
@@ -497,6 +502,11 @@ def test_workbasket_review_tabs_without_permission(url, client):
             "workbaskets:workbasket-ui-review-quotas",
             lambda: factories.QuotaOrderNumberFactory.create(),
             6,
+        ),
+        (
+            "workbaskets:workbasket-ui-review-quota-definitions",
+            lambda: factories.QuotaDefinitionFactory.create(),
+            10,
         ),
         (
             "workbaskets:workbasket-ui-review-regulations",

--- a/workbaskets/urls.py
+++ b/workbaskets/urls.py
@@ -77,6 +77,11 @@ ui_patterns = [
         name="workbasket-ui-review-geo-areas",
     ),
     path(
+        f"<pk>/review-geographical-memberships/",
+        ui_views.WorkBasketReviewGeoMembershipsView.as_view(),
+        name="workbasket-ui-review-geo-memberships",
+    ),
+    path(
         f"<pk>/review-measures/",
         ui_views.WorkBasketReviewMeasuresView.as_view(),
         name="workbasket-ui-review-measures",

--- a/workbaskets/urls.py
+++ b/workbaskets/urls.py
@@ -92,6 +92,11 @@ ui_patterns = [
         name="workbasket-ui-review-quotas",
     ),
     path(
+        f"<pk>/review-quota-definitions/",
+        ui_views.WorkBasketReviewQuotaDefinitionsView.as_view(),
+        name="workbasket-ui-review-quota-definitions",
+    ),
+    path(
         f"<pk>/review-regulations/",
         ui_views.WorkBasketReviewRegulationsView.as_view(),
         name="workbasket-ui-review-regulations",

--- a/workbaskets/views/ui.py
+++ b/workbaskets/views/ui.py
@@ -44,6 +44,7 @@ from common.views import WithPaginationListView
 from exporter.models import Upload
 from footnotes.models import Footnote
 from geo_areas.models import GeographicalArea
+from geo_areas.models import GeographicalMembership
 from importer.goods_report import GoodsReporter
 from measures.models import Measure
 from notifications.models import Notification
@@ -1337,11 +1338,28 @@ class WorkBasketReviewGeoAreasView(WorkBasketReviewView):
     """UI endpoint for reviewing geographical area changes in a workbasket."""
 
     model = GeographicalArea
+    template_name = "workbaskets/review-geo-areas.jinja"
 
     def get_context_data(self, *args, **kwargs):
         context = super().get_context_data(*args, **kwargs)
         context["selected_tab"] = "geographical-areas"
+        context["selected_nested_tab"] = "geographical-areas"
         context["tab_template"] = "includes/geo_areas/list.jinja"
+        return context
+
+
+class WorkBasketReviewGeoMembershipsView(WorkBasketReviewView):
+    """UI endpoint for reviewing geographical membership changes in a
+    workbasket."""
+
+    model = GeographicalMembership
+    template_name = "workbaskets/review-geo-areas.jinja"
+
+    def get_context_data(self, *args, **kwargs):
+        context = super().get_context_data(*args, **kwargs)
+        context["selected_tab"] = "geographical-areas"
+        context["selected_nested_tab"] = "geographical-memberships"
+        context["tab_template"] = "includes/workbaskets/review-geo-memberships.jinja"
         return context
 
 

--- a/workbaskets/views/ui.py
+++ b/workbaskets/views/ui.py
@@ -1212,6 +1212,7 @@ class WorkBasketReviewAdditionalCodesView(WorkBasketReviewView):
 
     def get_context_data(self, *args, **kwargs):
         context = super().get_context_data(*args, **kwargs)
+        context["tab_page_title"] = "Review additional codes"
         context["selected_tab"] = "additional-codes"
         context["tab_template"] = "includes/additional_codes/list.jinja"
         return context
@@ -1224,6 +1225,7 @@ class WorkBasketReviewCertificatesView(WorkBasketReviewView):
 
     def get_context_data(self, *args, **kwargs):
         context = super().get_context_data(*args, **kwargs)
+        context["tab_page_title"] = "Review certificates"
         context["selected_tab"] = "certificates"
         context["tab_template"] = "includes/certificates/list.jinja"
         return context
@@ -1244,6 +1246,7 @@ class WorkbasketReviewGoodsView(
 
     def get_context_data(self, *args, **kwargs):
         context = super().get_context_data(*args, **kwargs)
+        context["tab_page_title"] = "Review commodities"
         context["selected_tab"] = "commodities"
         context["session_workbasket"] = WorkBasket.current(self.request)
         context["workbasket"] = self.workbasket
@@ -1330,6 +1333,7 @@ class WorkBasketReviewFootnotesView(WorkBasketReviewView):
 
     def get_context_data(self, *args, **kwargs):
         context = super().get_context_data(*args, **kwargs)
+        context["tab_page_title"] = "Review footnotes"
         context["selected_tab"] = "footnotes"
         context["tab_template"] = "includes/footnotes/list.jinja"
         return context
@@ -1343,6 +1347,7 @@ class WorkBasketReviewGeoAreasView(WorkBasketReviewView):
 
     def get_context_data(self, *args, **kwargs):
         context = super().get_context_data(*args, **kwargs)
+        context["tab_page_title"] = "Review geographical areas"
         context["selected_tab"] = "geographical-areas"
         context["selected_nested_tab"] = "geographical-areas"
         context["tab_template"] = "includes/geo_areas/list.jinja"
@@ -1358,6 +1363,7 @@ class WorkBasketReviewGeoMembershipsView(WorkBasketReviewView):
 
     def get_context_data(self, *args, **kwargs):
         context = super().get_context_data(*args, **kwargs)
+        context["tab_page_title"] = "Review geographical area group memberships"
         context["selected_tab"] = "geographical-areas"
         context["selected_nested_tab"] = "geographical-memberships"
         context["tab_template"] = "includes/workbaskets/review-geo-memberships.jinja"
@@ -1386,6 +1392,7 @@ class WorkBasketReviewMeasuresView(WorkBasketReviewView):
 
     def get_context_data(self, *args, **kwargs):
         context = super().get_context_data(*args, **kwargs)
+        context["tab_page_title"] = "Review measures"
         context["selected_tab"] = "measures"
         context["tab_template"] = "includes/measures/workbasket-measures.jinja"
         return context
@@ -1399,6 +1406,7 @@ class WorkBasketReviewQuotasView(WorkBasketReviewView):
 
     def get_context_data(self, *args, **kwargs):
         context = super().get_context_data(*args, **kwargs)
+        context["tab_page_title"] = "Review quota order numbers"
         context["selected_tab"] = "quotas"
         context["selected_nested_tab"] = "quotas"
         context["tab_template"] = "includes/quotas/list.jinja"
@@ -1414,6 +1422,7 @@ class WorkBasketReviewQuotaDefinitionsView(WorkBasketReviewView):
 
     def get_context_data(self, *args, **kwargs):
         context = super().get_context_data(*args, **kwargs)
+        context["tab_page_title"] = "Review quota definition periods"
         context["selected_tab"] = "quotas"
         context["selected_nested_tab"] = "quota-definitions"
         context["tab_template"] = "includes/workbaskets/review-quota-definitions.jinja"
@@ -1427,6 +1436,7 @@ class WorkBasketReviewRegulationsView(WorkBasketReviewView):
 
     def get_context_data(self, *args, **kwargs):
         context = super().get_context_data(*args, **kwargs)
+        context["tab_page_title"] = "Review regulations"
         context["selected_tab"] = "regulations"
         context["tab_template"] = "includes/regulations/list.jinja"
         return context

--- a/workbaskets/views/ui.py
+++ b/workbaskets/views/ui.py
@@ -49,6 +49,7 @@ from importer.goods_report import GoodsReporter
 from measures.models import Measure
 from notifications.models import Notification
 from notifications.models import NotificationTypeChoices
+from quotas.models import QuotaDefinition
 from quotas.models import QuotaOrderNumber
 from regulations.models import Regulation
 from workbaskets import forms
@@ -1394,11 +1395,28 @@ class WorkBasketReviewQuotasView(WorkBasketReviewView):
     """UI endpoint for reviewing quota changes in a workbasket."""
 
     model = QuotaOrderNumber
+    template_name = "workbaskets/review-quotas.jinja"
 
     def get_context_data(self, *args, **kwargs):
         context = super().get_context_data(*args, **kwargs)
         context["selected_tab"] = "quotas"
+        context["selected_nested_tab"] = "quotas"
         context["tab_template"] = "includes/quotas/list.jinja"
+        return context
+
+
+class WorkBasketReviewQuotaDefinitionsView(WorkBasketReviewView):
+    """UI endpoint for reviewing quota definition period changes in a
+    workbasket."""
+
+    model = QuotaDefinition
+    template_name = "workbaskets/review-quotas.jinja"
+
+    def get_context_data(self, *args, **kwargs):
+        context = super().get_context_data(*args, **kwargs)
+        context["selected_tab"] = "quotas"
+        context["selected_nested_tab"] = "quota-definitions"
+        context["tab_template"] = "includes/workbaskets/review-quota-definitions.jinja"
         return context
 
 


### PR DESCRIPTION
# TP2000-1127 Add geo memberships and quota definitions nested review tabs

## Why
Users are unable to review changes to geographical memberships or quota definitions on the workbasket review changes view.

## What
- Adds nested tabs for geographical memberships and quota definitions inside their respective parent tab
- Updates unit test for review tabs

##
<img width="500" alt="Screenshot 2023-11-20 at 16 24 25" src="https://github.com/uktrade/tamato/assets/118175145/c966b400-9708-497e-bed4-00a06f6669ca">

<img width="500" alt="Screenshot 2023-11-20 at 16 24 47" src="https://github.com/uktrade/tamato/assets/118175145/517e3c99-2cb8-48ad-9860-a9491d6a0f3d">

