### PR TITLE
TP2000-1131 Increase pagination value for transaction order view

### DIFF
--- a/workbaskets/views/ui.py
+++ b/workbaskets/views/ui.py
@@ -604,7 +604,7 @@ class WorkBasketTransactionOrderView(PermissionRequiredMixin, FormView):
     permission_required = "workbaskets.view_workbasket"
     template_name = "workbaskets/transaction_order.jinja"
     form_class = forms.SelectableObjectsForm
-    paginate_by = 20
+    paginate_by = 100
 
     form_action_redirect_map = {
         "page-prev": "workbaskets:workbasket-ui-transaction-order",


### PR DESCRIPTION
# TP2000-1131 Increase pagination value for transaction order view

## Why
The transaction order view only loads 20 transactions at a time. This number is too low for larger workbaskets. 

## What
- Sets the view's paginate_by value to 100