### PR TITLE
TP2000-1133  Fix editing geographical memberships to allow members to be re-added

### DIFF
--- a/geo_areas/forms.py
+++ b/geo_areas/forms.py
@@ -305,17 +305,26 @@ class GeographicalMembershipEditForm(
 
         self.fields["membership"].queryset = self.instance.get_current_memberships()
 
-        self.fields["membership"].label_from_instance = (
-            lambda obj: f"{obj.member.area_id} - {obj.member.structure_description} ({obj.valid_between.lower} - {obj.valid_between.upper})"
-            if self.instance.is_group()
-            else f"{obj.geo_group.area_id} - {obj.geo_group.structure_description} ({obj.valid_between.lower} - {obj.valid_between.upper})"
-        )
+        self.fields["membership"].label_from_instance = self.label_from_instance
 
         self.fields["membership"].help_text = (
             "Select a country or region from the dropdown to edit the membership of this area group."
             if self.instance.is_group()
             else "Select an area group from the dropdown to edit the membership of this country or region."
         )
+
+    def label_from_instance(self, obj):
+        validity_period = f" ({obj.valid_between.lower} - {obj.valid_between.upper})"
+        if self.instance.is_group():
+            return (
+                f"{obj.member.area_id} - {obj.member.structure_description}"
+                + validity_period
+            )
+        else:
+            return (
+                f"{obj.geo_group.area_id} - {obj.geo_group.structure_description}"
+                + validity_period
+            )
 
     def clean(self):
         cleaned_data = super().clean()

--- a/geo_areas/forms.py
+++ b/geo_areas/forms.py
@@ -225,6 +225,12 @@ class GeographicalMembershipAddForm(
         start_date = cleaned_data["new_membership_valid_between"].lower
         end_date = cleaned_data["new_membership_valid_between"].upper
 
+        if not start_date and area_group and member:
+            self.add_error(
+                "new_membership_start_date",
+                "A start date is required.",
+            )
+
         if area_group and member and start_date:
             # Check if membership already exists
             is_member = (
@@ -254,22 +260,17 @@ class GeographicalMembershipAddForm(
                     "The selected area group already has this country or region as a member.",
                 )
 
-        if not start_date:
-            self.add_error(
-                "new_membership_start_date",
-                "A start date is required.",
+            self.validate_dates(
+                field="new_membership_start_date",
+                start_date=start_date,
+                container_start_date=area_group.valid_between.lower,
             )
-        self.validate_dates(
-            field="new_membership_start_date",
-            start_date=start_date,
-            container_start_date=area_group.valid_between.lower,
-        )
-        self.validate_dates(
-            field="new_membership_end_date",
-            start_date=start_date,
-            end_date=end_date,
-            container_end_date=area_group.valid_between.upper,
-        )
+            self.validate_dates(
+                field="new_membership_end_date",
+                start_date=start_date,
+                end_date=end_date,
+                container_end_date=area_group.valid_between.upper,
+            )
 
         return cleaned_data
 

--- a/geo_areas/forms.py
+++ b/geo_areas/forms.py
@@ -316,15 +316,10 @@ class GeographicalMembershipEditForm(
     def label_from_instance(self, obj):
         validity_period = f" ({obj.valid_between.lower} - {obj.valid_between.upper})"
         if self.instance.is_group():
-            return (
-                f"{obj.member.area_id} - {obj.member.structure_description}"
-                + validity_period
-            )
+            label = f"{obj.member.area_id} - {obj.member.structure_description}"
         else:
-            return (
-                f"{obj.geo_group.area_id} - {obj.geo_group.structure_description}"
-                + validity_period
-            )
+            label = f"{obj.geo_group.area_id} - {obj.geo_group.structure_description}"
+        return label + validity_period
 
     def clean(self):
         cleaned_data = super().clean()

--- a/geo_areas/forms.py
+++ b/geo_areas/forms.py
@@ -225,7 +225,7 @@ class GeographicalMembershipAddForm(
         start_date = cleaned_data["new_membership_valid_between"].lower
         end_date = cleaned_data["new_membership_valid_between"].upper
 
-        if area_group and member:
+        if area_group and member and start_date:
             # Check if membership already exists
             is_member = (
                 GeographicalMembership.objects.filter(
@@ -254,22 +254,22 @@ class GeographicalMembershipAddForm(
                     "The selected area group already has this country or region as a member.",
                 )
 
-            if not start_date:
-                self.add_error(
-                    "new_membership_start_date",
-                    "A start date is required.",
-                )
-            self.validate_dates(
-                field="new_membership_start_date",
-                start_date=start_date,
-                container_start_date=area_group.valid_between.lower,
+        if not start_date:
+            self.add_error(
+                "new_membership_start_date",
+                "A start date is required.",
             )
-            self.validate_dates(
-                field="new_membership_end_date",
-                start_date=start_date,
-                end_date=end_date,
-                container_end_date=area_group.valid_between.upper,
-            )
+        self.validate_dates(
+            field="new_membership_start_date",
+            start_date=start_date,
+            container_start_date=area_group.valid_between.lower,
+        )
+        self.validate_dates(
+            field="new_membership_end_date",
+            start_date=start_date,
+            end_date=end_date,
+            container_end_date=area_group.valid_between.upper,
+        )
 
         return cleaned_data
 

--- a/geo_areas/forms.py
+++ b/geo_areas/forms.py
@@ -305,9 +305,9 @@ class GeographicalMembershipEditForm(
         self.fields["membership"].queryset = self.instance.get_current_memberships()
 
         self.fields["membership"].label_from_instance = (
-            lambda obj: f"{obj.member.area_id} - {obj.member.structure_description}"
+            lambda obj: f"{obj.member.area_id} - {obj.member.structure_description} ({obj.valid_between.lower} - {obj.valid_between.upper})"
             if self.instance.is_group()
-            else f"{obj.geo_group.area_id} - {obj.geo_group.structure_description}"
+            else f"{obj.geo_group.area_id} - {obj.geo_group.structure_description} ({obj.valid_between.lower} - {obj.valid_between.upper})"
         )
 
         self.fields["membership"].help_text = (

--- a/geo_areas/forms.py
+++ b/geo_areas/forms.py
@@ -227,13 +227,21 @@ class GeographicalMembershipAddForm(
 
         if area_group and member:
             # Check if membership already exists
-            is_member = GeographicalMembership.objects.filter(
-                geo_group=self.instance,
-                member=member,
+            is_member = (
+                GeographicalMembership.objects.filter(
+                    geo_group=self.instance,
+                    member=member,
+                )
+                .current()
+                .as_at_and_beyond(start_date)
             )
-            has_member = GeographicalMembership.objects.filter(
-                geo_group=area_group,
-                member=self.instance,
+            has_member = (
+                GeographicalMembership.objects.filter(
+                    geo_group=area_group,
+                    member=self.instance,
+                )
+                .current()
+                .as_at_and_beyond(start_date)
             )
             if is_member:
                 self.add_error(

--- a/geo_areas/tests/test_forms.py
+++ b/geo_areas/tests/test_forms.py
@@ -130,14 +130,20 @@ def test_geographical_membership_add_form_invalid_dates(date_ranges):
     form_data = {
         "member": "COUNTRY",
         "country": country.pk,
-        "new_membership_end_date_0": area_group.valid_between.upper.day + 1,
-        "new_membership_end_date_1": area_group.valid_between.upper.month + 1,
+        "new_membership_start_date_0": area_group.valid_between.lower.day,
+        "new_membership_start_date_1": area_group.valid_between.lower.month,
+        "new_membership_start_date_2": area_group.valid_between.lower.year - 1,
+        "new_membership_end_date_0": area_group.valid_between.upper.day,
+        "new_membership_end_date_1": area_group.valid_between.upper.month,
         "new_membership_end_date_2": area_group.valid_between.upper.year + 1,
     }
     with override_current_transaction(Transaction.objects.last()):
         form = forms.GeographicalAreaEditForm(data=form_data, instance=area_group)
         assert not form.is_valid()
-        assert "A start date is required." in form.errors["new_membership_start_date"]
+        assert (
+            "The start date must be the same as or after the area group's start date."
+            in form.errors["new_membership_start_date"]
+        )
         assert (
             "The end date must be the same as or before the area group's end date."
             in form.errors["new_membership_end_date"]
@@ -150,14 +156,21 @@ def test_geographical_membership_add_form_invalid_selection(date_ranges):
     membership = factories.GeographicalMembershipFactory.create(
         geo_group=area_group,
         member=country,
+        valid_between=date_ranges.normal,
     )
 
     country_form_data = {
         "member": "COUNTRY",
         "country": country.pk,
+        "new_membership_start_date_0": membership.valid_between.lower.day,
+        "new_membership_start_date_1": membership.valid_between.lower.month,
+        "new_membership_start_date_2": membership.valid_between.lower.year,
     }
     group_form_data = {
         "geo_group": area_group.pk,
+        "new_membership_start_date_0": membership.valid_between.lower.day,
+        "new_membership_start_date_1": membership.valid_between.lower.month,
+        "new_membership_start_date_2": membership.valid_between.lower.year,
     }
 
     with override_current_transaction(Transaction.objects.last()):


### PR DESCRIPTION
# TP2000-1133  Fix editing geographical memberships to allow members to be re-added


## Why
Geo areas that were once members of an area group but have been end dated are unable to be re-added with new validity periods.

## What
- Uses `current().as_at_and_beyond()` when checking if a geo area is already a member to allow for members to be re-added only with non-overlapping validity periods.
- Adds validity period to dropdown labels to help users distinguish between old and new when selecting to edit an existing membership

##
<img width="500" alt="Screenshot 2023-11-22 at 17 14 48" src="https://github.com/uktrade/tamato/assets/118175145/9bf6818a-d5d1-40d9-9e33-4c4b593c6f20">

<img width="500" alt="Screenshot 2023-11-22 at 17 10 50" src="https://github.com/uktrade/tamato/assets/118175145/1f1f9ff6-c718-4c6a-8668-7b01bcfb64d8">
