### PR TITLE
TP2000-1115 Fix flaky unit tests in measures/tests

### DIFF
--- a/measures/tests/test_forms.py
+++ b/measures/tests/test_forms.py
@@ -506,17 +506,17 @@ def test_measure_geographical_area_form_quota_order_number(date_ranges):
         expected_cleaned_data = [
             {
                 "geo_area": new_origin_1.geographical_area,
-                "exclusions": list(new_origin_1.excluded_areas.all()),
+                "exclusions": set(new_origin_1.excluded_areas.all()),
             },
             {
                 "geo_area": new_origin_2.geographical_area,
-                "exclusions": [],
+                "exclusions": set(),
             },
         ]
-        assert sorted(
-            form.cleaned_data["geo_areas_and_exclusions"],
-            key=lambda d: sorted(d.items()),
-        ) == sorted(expected_cleaned_data, key=lambda d: sorted(d.items()))
+
+        for data in form.cleaned_data["geo_areas_and_exclusions"]:
+            data["exclusions"] = set(data["exclusions"])
+            assert data in expected_cleaned_data
 
 
 def test_measure_forms_details_invalid_data():

--- a/measures/tests/test_measure_snapshot.py
+++ b/measures/tests/test_measure_snapshot.py
@@ -41,19 +41,14 @@ def test_init(seed_database_with_indented_goods):
 
 
 def test_get_branch_measures(seed_database_with_indented_goods):
-    goods = GoodsNomenclature.objects.all().get(item_id="2903691900")
-    commodities_collection = CommodityCollectionLoader(prefix="2903").load()
+    goods = GoodsNomenclature.objects.get(item_id="2903691900")
+    commodities_collection = CommodityCollectionLoader(prefix="2903").load().commodities
 
     target_commodity = None
-
-    for commodity in commodities_collection.commodities:
-        if commodity.item_id == "2903691900":
+    for commodity in commodities_collection:
+        if commodity.item_id == goods.item_id:
             target_commodity = commodity
-
-    archived_transaction = factories.TransactionFactory.create(archived=True)
-    old_regulation = factories.RegulationFactory.create(
-        valid_between=TaricDateRange(date(1982, 1, 1), date(1982, 12, 31)),
-    )
+    assert target_commodity
 
     draft_transaction = factories.TransactionFactory.create(draft=True)
     draft_measure = factories.MeasureFactory.create(
@@ -61,25 +56,16 @@ def test_get_branch_measures(seed_database_with_indented_goods):
         valid_between=TaricDateRange(date.today() + timedelta(days=-100)),
     )
 
-    # call get_dependent_measures and check archived measure does not exist in results
-
     sn_date = date.today()
     moment = SnapshotMoment(draft_transaction, sn_date)
 
-    # used the loader to simplify the commodities list generation
-    ccl = CommodityCollectionLoader(prefix="2903")
-    commodities = ccl.load().commodities
-    edges = {}
-    ancestors = {}
-    descendants = {}
-    tree = CommodityTreeSnapshot(commodities, moment, edges, ancestors, descendants)
+    tree = CommodityTreeSnapshot(
+        commodities_collection,
+        moment,
+        edges={},
+        ancestors={},
+        descendants={},
+    )
 
     target = MeasureSnapshot(moment, tree)
-
     assert target.get_branch_measures(target_commodity).count() == 1
-    assert len(target.tree.descendants) == 4
-    assert len(target.tree.edges) == 6
-    assert len(target.tree.commodities) == 6
-    assert len(target.tree.ancestors) == 6
-
-    assert target.extent == TaricDateRange(date.today())

--- a/measures/tests/test_measure_snapshot.py
+++ b/measures/tests/test_measure_snapshot.py
@@ -21,7 +21,7 @@ def test_init(seed_database_with_indented_goods):
     moment = SnapshotMoment(transaction, sn_date)
 
     # used the loader to simplify the commodities list generation
-    ccl = CommodityCollectionLoader(prefix="29")
+    ccl = CommodityCollectionLoader(prefix="2903")
     commodities = ccl.load().commodities
     edges = {}
     ancestors = {}
@@ -67,7 +67,7 @@ def test_get_branch_measures(seed_database_with_indented_goods):
     moment = SnapshotMoment(draft_transaction, sn_date)
 
     # used the loader to simplify the commodities list generation
-    ccl = CommodityCollectionLoader(prefix="29")
+    ccl = CommodityCollectionLoader(prefix="2903")
     commodities = ccl.load().commodities
     edges = {}
     ancestors = {}

--- a/measures/tests/test_measure_snapshot.py
+++ b/measures/tests/test_measure_snapshot.py
@@ -15,12 +15,6 @@ from measures.snapshots import MeasureSnapshot
 pytestmark = pytest.mark.django_db
 
 
-@pytest.fixture
-def related_measure_dates(request, date_ranges):
-    callable, date_overlap = request.param
-    return callable(date_ranges), date_overlap
-
-
 def test_init(seed_database_with_indented_goods):
     transaction = Transaction.objects.last()
     sn_date = date(2023, 1, 1)


### PR DESCRIPTION
# TP2000-1115 Fix flaky unit tests in measures/tests

## Why
A few unit tests fail intermittently requiring CI tests to be rerun:

`FAILED measures/tests/test_forms.py::test_measure_geographical_area_form_quota_order_number` [Example](https://github.com/uktrade/tamato/actions/runs/6615735968/job/17968517801)

`FAILED measures/tests/test_measure_snapshot.py::test_get_branch_measures` [Example](https://github.com/uktrade/tamato/actions/runs/6893445289/job/18753027522)

`FAILED measures/tests/test_measure_snapshot.py::test_init` [Example](https://github.com/uktrade/tamato/actions/runs/6639741721/job/18038725097)


## What
`test_measure_geographical_area_form_quota_order_number`
- Use sets not lists to store geographical area objects allowing data comparisons based on value alone not value and order.

`test_get_branch_measures` and `test_init`
- Use a more specific prefix to initialise the CommodityCollectionLoader to ensure it includes only the goods created by the test's fixture (near eliminating the chances of artefacts from other tests)
