### PR TITLE
Remove import com code link from add edit workbasket

### DIFF
--- a/workbaskets/jinja2/workbaskets/edit-workbasket.jinja
+++ b/workbaskets/jinja2/workbaskets/edit-workbasket.jinja
@@ -66,7 +66,6 @@
   </div>
   <div class="govuk-grid-row">
     {{ workbasket_column("Commodities", [
-      {"text": "Import commodities", "url": url('commodity_importer-ui-create')},
       {"text": "Find commodities", "url": url('commodity-ui-list')},
       ])
     }}


### PR DESCRIPTION
# TP2000-1122 Remove import com code link from add edit workbasket
<!---
 * Include the JIRA ticket number, eg TP-123, to automatically link.
 * Use 50 characters maximum.
 * Do not end with a full-stop.
--->

## Why
the import com code journey now properly begins on the TAP homepage

## What
- remove link from commodity code import link from add/edit workbasket tab on the view workbasket page

<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
## Checklist
- Requires migrations?
- Requires dependency updates?
--->

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
