### PR TITLE
TP2000-1128: View all workbaskets option, accessibility and content fixes

### DIFF
--- a/common/forms.py
+++ b/common/forms.py
@@ -237,11 +237,11 @@ class FormSetField(forms.Field):
 
 class WorkbasketActions(TextChoices):
     CREATE = "CREATE", "Create new workbasket"
-    EDIT = "EDIT", "Select an existing workbasket"
+    EDIT = "EDIT", "Edit workbaskets"
 
 
 class DITTariffManagerActions(TextChoices):
-    PACKAGE_WORKBASKETS = "PACKAGE_WORKBASKETS", "Package Workbaskets"
+    PACKAGE_WORKBASKETS = "PACKAGE_WORKBASKETS", "Package workbaskets"
 
 
 class HMRCCDSManagerActions(TextChoices):
@@ -255,6 +255,10 @@ class CommonUserActions(TextChoices):
 
 class ImportUserActions(TextChoices):
     IMPORT = "IMPORT", "Import EU Taric files"
+
+
+class WorkbasketManagerActions(TextChoices):
+    WORKBASKET_LIST_ALL = "WORKBASKET_LIST_ALL", "Search for workbaskets"
 
 
 class HomeForm(forms.Form):
@@ -276,9 +280,18 @@ class HomeForm(forms.Form):
         choices += CommonUserActions.choices
 
         if self.user.has_perm("common.add_trackedmodel") or self.user.has_perm(
-            "common.change_trackedmodel"
+            "common.change_trackedmodel",
         ):
             choices += ImportUserActions.choices
+
+        if (
+            self.user.has_perm("workbaskets.add_workbasket")
+            or self.user.has_perm("workbaskets.change_workbasket")
+        ) and (
+            self.user.has_perm("common.add_trackedmodel")
+            or self.user.has_perm("common.change_trackedmodel")
+        ):
+            choices += WorkbasketManagerActions.choices
 
         self.fields["workbasket_action"] = forms.ChoiceField(
             label="",
@@ -290,14 +303,13 @@ class HomeForm(forms.Form):
         self.helper = FormHelper(self)
         self.helper.layout = Layout(
             Fieldset(
+                HTML.h3("What would you like to do?"),
                 HTML.details(
                     "What is a workbasket?",
                     "A workbasket is used to collect all the changes you make to the UK's Import and Export Tariff data. "
                     "Workbaskets group these changes so they can be checked by Customs Declaration Service (CDS) before going live.",
                 ),
                 "workbasket_action",
-                legend="What would you like to do?",
-                legend_size=Size.LARGE,
             ),
             Submit(
                 "submit",

--- a/common/jinja2/common/workbasket_action.jinja
+++ b/common/jinja2/common/workbasket_action.jinja
@@ -3,7 +3,7 @@
 {% set page_title = "Tariff Management Tool" %}
 
 {% block content %}
-    <h1 class="govuk-heading-xl govuk-!-margin-bottom-3">{{ page_title }}</h1>
+    <h2 class="govuk-heading-xl govuk-!-margin-bottom-3">Tariff management tool</h2>
     <span class="govuk-caption-xl govuk-!-margin-bottom-9">This service lets you manage UK trade tariffs</span>
 
     {% block form %}

--- a/common/jinja2/layouts/layout.jinja
+++ b/common/jinja2/layouts/layout.jinja
@@ -82,10 +82,6 @@
           "text": "Application information"
         },
         {
-          "href": url("workbaskets:workbasket-ui-list-all"),
-          "text": "Workbasket finder"
-        },
-        {
           "href": url("import_batch-ui-list"),
           "text": "Master importer"
         },

--- a/common/tests/test_views.py
+++ b/common/tests/test_views.py
@@ -18,19 +18,12 @@ def test_index_displays_workbasket_action_form(valid_user_client):
     assert response.status_code == 200
 
     page = BeautifulSoup(response.content.decode(response.charset), "html.parser")
-    labels = [label.text.strip() for label in page.select("label")]
-    expected = [
-        "Create new workbasket",
-        "Edit workbaskets",
-        "Package workbaskets",
-        "Process envelopes",
-        "Search the tariff",
-        "Import EU Taric files",
-        "Search for workbaskets",
-    ]
-    assert set(expected) == set(labels)
-    for label, exp in zip(labels, expected):
-        assert label == exp
+    assert "Create new workbasket" == page.select("label")[0].text.strip()
+    assert "Edit workbaskets" == page.select("label")[1].text.strip()
+    assert "Package workbaskets" == page.select("label")[2].text.strip()
+    assert "Process envelopes" == page.select("label")[3].text.strip()
+    assert "Search the tariff" == page.select("label")[4].text.strip()
+    assert "Import EU Taric files" == page.select("label")[5].text.strip()
 
 
 def test_index_displays_logout_buttons_correctly_SSO_off_logged_in(valid_user_client):

--- a/common/tests/test_views.py
+++ b/common/tests/test_views.py
@@ -28,6 +28,7 @@ def test_index_displays_workbasket_action_form(valid_user_client):
         "Import EU Taric files",
         "Search for workbaskets",
     ]
+    assert set(expected) == set(labels)
     for label, exp in zip(labels, expected):
         assert label == exp
 

--- a/common/tests/test_views.py
+++ b/common/tests/test_views.py
@@ -17,13 +17,19 @@ def test_index_displays_workbasket_action_form(valid_user_client):
 
     assert response.status_code == 200
 
-    page = BeautifulSoup(str(response.content), "html.parser")
-    assert "Create new workbasket" in page.select("label")[0].text
-    assert "Select an existing workbasket" in page.select("label")[1].text
-    assert "Package Workbaskets" in page.select("label")[2].text
-    assert "Process envelopes" in page.select("label")[3].text
-    assert "Search the tariff" in page.select("label")[4].text
-    assert "Import EU Taric files" in page.select("label")[5].text
+    page = BeautifulSoup(response.content.decode(response.charset), "html.parser")
+    labels = [label.text.strip() for label in page.select("label")]
+    expected = [
+        "Create new workbasket",
+        "Edit workbaskets",
+        "Package workbaskets",
+        "Process envelopes",
+        "Search the tariff",
+        "Import EU Taric files",
+        "Search for workbaskets",
+    ]
+    for label, exp in zip(labels, expected):
+        assert label == exp
 
 
 def test_index_displays_logout_buttons_correctly_SSO_off_logged_in(valid_user_client):
@@ -161,7 +167,7 @@ def test_index_displays_footer_links(valid_user_client):
     page = BeautifulSoup(str(response.content), "html.parser")
     a_tags = page.select("footer a")
 
-    assert len(a_tags) == 7
+    assert len(a_tags) == 6
     assert "Privacy policy" in a_tags[0].text
     assert (
         a_tags[0].attrs["href"]

--- a/common/views.py
+++ b/common/views.py
@@ -51,24 +51,25 @@ class HomeView(FormView, View):
     template_name = "common/workbasket_action.jinja"
     form_class = forms.HomeForm
 
+    REDIRECT_MAPPING = {
+        "EDIT": "workbaskets:workbasket-ui-list",
+        "CREATE": "workbaskets:workbasket-ui-create",
+        "PACKAGE_WORKBASKETS": "publishing:packaged-workbasket-queue-ui-list",
+        "PROCESS_ENVELOPES": "publishing:envelope-queue-ui-list",
+        "SEARCH": "search-page",
+        "IMPORT": "commodity_importer-ui-list",
+        "WORKBASKET_LIST_ALL": "workbaskets:workbasket-ui-list-all",
+    }
+
     def get_form_kwargs(self):
         kwargs = super().get_form_kwargs()
         kwargs["user"] = self.request.user
         return kwargs
 
     def form_valid(self, form):
-        if form.cleaned_data["workbasket_action"] == "EDIT":
-            return redirect(reverse("workbaskets:workbasket-ui-list"))
-        elif form.cleaned_data["workbasket_action"] == "CREATE":
-            return redirect(reverse("workbaskets:workbasket-ui-create"))
-        elif form.cleaned_data["workbasket_action"] == "PACKAGE_WORKBASKETS":
-            return redirect(reverse("publishing:packaged-workbasket-queue-ui-list"))
-        elif form.cleaned_data["workbasket_action"] == "PROCESS_ENVELOPES":
-            return redirect(reverse("publishing:envelope-queue-ui-list"))
-        elif form.cleaned_data["workbasket_action"] == "SEARCH":
-            return redirect(reverse("search-page"))
-        elif form.cleaned_data["workbasket_action"] == "IMPORT":
-            return redirect(reverse("commodity_importer-ui-list"))
+        return redirect(
+            reverse(self.REDIRECT_MAPPING[form.cleaned_data["workbasket_action"]]),
+        )
 
 
 class SearchPageView(TemplateView):


### PR DESCRIPTION
# TP2000-1128: View all workbaskets option, accessibility and content fixes
<!---
 * Include the JIRA ticket number, eg TP-123, to automatically link.
 * Use 50 characters maximum.
 * Do not end with a full-stop.
--->

## Why
<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Use as many lines as you like.
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions or deliberately ignored edge-cases.
--->
* Now that we’ve made the Workbasket finder (in the footer) a useable feature within TAP, with functionality to reorder items, review changes and provide a full audit trail. We should remove the Workbasket finder from the footer and replace it with a selectable option for specific user groups (for now).

## What
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Explain like I'm 5.
 * Use pictures if you can.
--->
* Adds an option to "Search for workbaskets" to the homepage that links to workbaskets/list-all 
* Removes this link from the footer
* Accessibility fixes for heading levels
* Content fixes. Use sentence case as per GDS guidelines

<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
## Checklist
- Requires migrations?
- Requires dependency updates?
--->

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
<img width="599" alt="Screenshot 2023-11-29 at 16 12 00" src="https://github.com/uktrade/tamato/assets/25905279/b2074f29-4e94-4c70-b7eb-c1dac832bd65">
