### PR TITLE
TP2000-1084 Archive empty, previously queued workbaskets on attempt to delete

### DIFF
--- a/workbaskets/models.py
+++ b/workbaskets/models.py
@@ -401,7 +401,7 @@ class WorkBasket(TimestampedMixin):
 
     @transition(
         field=status,
-        source=WorkflowStatus.EDITING,
+        source=[WorkflowStatus.EDITING, WorkflowStatus.QUEUED],
         target=WorkflowStatus.ARCHIVED,
         conditions=[archive_workbasket_condition_is_empty],
         custom={"label": "Archive"},

--- a/workbaskets/models.py
+++ b/workbaskets/models.py
@@ -401,7 +401,7 @@ class WorkBasket(TimestampedMixin):
 
     @transition(
         field=status,
-        source=[WorkflowStatus.EDITING, WorkflowStatus.QUEUED],
+        source=WorkflowStatus.EDITING,
         target=WorkflowStatus.ARCHIVED,
         conditions=[archive_workbasket_condition_is_empty],
         custom={"label": "Archive"},

--- a/workbaskets/models.py
+++ b/workbaskets/models.py
@@ -395,10 +395,15 @@ class WorkBasket(TimestampedMixin):
     def __str__(self):
         return f"({self.pk}) [{self.status}]"
 
+    def archive_workbasket_condition_is_empty(self) -> bool:
+        """Django FSM condition: workbasket must be empty (no tracked models and no transactions) to transition to ARCHIVED status."""
+        return not self.tracked_models.exists() and not self.transactions.exists()
+
     @transition(
         field=status,
         source=WorkflowStatus.EDITING,
         target=WorkflowStatus.ARCHIVED,
+        conditions=[archive_workbasket_condition_is_empty],
         custom={"label": "Archive"},
     )
     def archive(self):

--- a/workbaskets/tests/test_models.py
+++ b/workbaskets/tests/test_models.py
@@ -360,6 +360,18 @@ def test_workbasket_transition_methods(method, source, target):
     assert wb.status == getattr(WorkflowStatus, target)
 
 
+def test_workbasket_transition_archive_not_empty():
+    """Tests that a non-empty workbasket cannot be transitioned to ARCHIVED
+    status."""
+    workbasket = factories.WorkBasketFactory.create(status=WorkflowStatus.EDITING)
+    footnote = factories.FootnoteFactory.create(
+        transaction=workbasket.new_transaction(),
+    )
+    with pytest.raises(TransitionNotAllowed):
+        workbasket.archive()
+        assert workbasket.status == WorkflowStatus.EDITING
+
+
 def test_queue(valid_user, unapproved_checked_transaction):
     """Test that approve transitions workbasket from EDITING to QUEUED, setting
     approver and shifting transaction from DRAFT to REVISION partition."""

--- a/workbaskets/tests/test_views.py
+++ b/workbaskets/tests/test_views.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock
 from unittest.mock import mock_open
 from unittest.mock import patch
 
+import factory
 import pytest
 from bs4 import BeautifulSoup
 from django.contrib.auth.models import Permission
@@ -1835,7 +1836,11 @@ def test_workbasket_delete_previously_queued_workbasket(
         Permission.objects.get(codename="delete_workbasket"),
     )
 
-    packaged_workbasket = factories.QueuedPackagedWorkBasketFactory.create()
+    with patch(
+        "publishing.tasks.create_xml_envelope_file.apply_async",
+        return_value=MagicMock(id=factory.Faker("uuid4")),
+    ):
+        packaged_workbasket = factories.QueuedPackagedWorkBasketFactory.create()
     packaged_workbasket.abandon()
 
     workbasket = packaged_workbasket.workbasket

--- a/workbaskets/tests/test_views.py
+++ b/workbaskets/tests/test_views.py
@@ -1824,6 +1824,36 @@ def test_application_access_after_workbasket_delete(
     assert not page.select("header nav a.workbasket-link")
 
 
+def test_workbasket_delete_previously_queued_workbasket(
+    valid_user_client,
+    valid_user,
+):
+    """Tests that an empty, previously queued workbasket transitions to ARCHIVED
+    status when a user attempts to delete the workbasket."""
+
+    valid_user.user_permissions.add(
+        Permission.objects.get(codename="delete_workbasket"),
+    )
+    packaged_workbasket = factories.QueuedPackagedWorkBasketFactory.create()
+
+    workbasket = packaged_workbasket.workbasket
+    workbasket.transactions.all().delete()
+
+    url = reverse(
+        "workbaskets:workbasket-ui-delete",
+        kwargs={"pk": workbasket.pk},
+    )
+    response = valid_user_client.post(url, {})
+    assert response.status_code == 302
+    assert response.url == reverse(
+        "workbaskets:workbasket-ui-delete-done",
+        kwargs={"deleted_pk": workbasket.pk},
+    )
+
+    workbasket.refresh_from_db()
+    assert workbasket.status == WorkflowStatus.ARCHIVED
+
+
 def test_workbasket_compare_200(valid_user_client, session_workbasket):
     url = reverse("workbaskets:workbasket-check-ui-compare")
     response = valid_user_client.get(url)

--- a/workbaskets/tests/test_views.py
+++ b/workbaskets/tests/test_views.py
@@ -1834,7 +1834,9 @@ def test_workbasket_delete_previously_queued_workbasket(
     valid_user.user_permissions.add(
         Permission.objects.get(codename="delete_workbasket"),
     )
+
     packaged_workbasket = factories.QueuedPackagedWorkBasketFactory.create()
+    packaged_workbasket.abandon()
 
     workbasket = packaged_workbasket.workbasket
     workbasket.transactions.all().delete()

--- a/workbaskets/views/ui.py
+++ b/workbaskets/views/ui.py
@@ -46,6 +46,7 @@ from importer.goods_report import GoodsReporter
 from measures.models import Measure
 from notifications.models import Notification
 from notifications.models import NotificationTypeChoices
+from publishing.models import PackagedWorkBasket
 from quotas.models import QuotaOrderNumber
 from regulations.models import Regulation
 from workbaskets import forms
@@ -1039,7 +1040,11 @@ class WorkBasketDelete(PermissionRequiredMixin, FormMixin, DeleteView):
             return self.form_invalid(form)
 
     def form_valid(self, form):
-        self.object.delete()
+        if not PackagedWorkBasket.objects.filter(workbasket=self.object).exists():
+            self.object.delete()
+        else:
+            self.object.archive()
+            self.object.save()
         return redirect(self.get_success_url())
 
 


### PR DESCRIPTION
# TP2000-1084  Archive empty, previously queued workbaskets on attempt to delete

## Why
A workbasket that has previously been packaged, and then removed from the packaging queue, will have a non-nullable PackagedWorkBasket instance associated with it, preventing deletion owing to a ProtectedError exception. Users should however be given the appearance of a successful workbasket deletion.

## What
- Adds a Django FSM condition to prevent non-empty workbaskets from being archived
- Checks whether a PackagedWorkBasket exists for a workbasket, archiving the workbasket instead of attempting to delete it if so.

