### PR TITLE
TP2000-1143  Fix permission for Search for workbaskets home form action

### DIFF
--- a/common/forms.py
+++ b/common/forms.py
@@ -284,13 +284,7 @@ class HomeForm(forms.Form):
         ):
             choices += ImportUserActions.choices
 
-        if (
-            self.user.has_perm("workbaskets.add_workbasket")
-            or self.user.has_perm("workbaskets.change_workbasket")
-        ) and (
-            self.user.has_perm("common.add_trackedmodel")
-            or self.user.has_perm("common.change_trackedmodel")
-        ):
+        if self.user.has_perm("workbaskets.view_workbasket"):
             choices += WorkbasketManagerActions.choices
 
         self.fields["workbasket_action"] = forms.ChoiceField(

--- a/common/tests/test_views.py
+++ b/common/tests/test_views.py
@@ -1,6 +1,9 @@
+import re
+
 import pytest
 from bs4 import BeautifulSoup
 from django.conf import settings
+from django.contrib.auth.models import Permission
 from django.urls import reverse
 
 from common.tests import factories
@@ -12,18 +15,31 @@ from common.views import handler500
 pytestmark = pytest.mark.django_db
 
 
-def test_index_displays_workbasket_action_form(valid_user_client):
-    response = valid_user_client.get(reverse("home"))
+@pytest.mark.parametrize(
+    ("action", "permission"),
+    [
+        ("Create new workbasket", "add_workbasket"),
+        ("Edit workbaskets", "add_workbasket"),
+        ("Package workbaskets", "manage_packaging_queue"),
+        ("Process envelopes", "consume_from_packaging_queue"),
+        ("Search the tariff", ""),
+        ("Import EU Taric files", "add_trackedmodel"),
+        ("Search for workbaskets", "view_workbasket"),
+    ],
+)
+def test_home_form_actions_match_permissions(action, permission, client):
+    """Tests that the workbasket action form on the home page displays the
+    appropriate radio options for the user's permissions."""
+    user = factories.UserFactory.create()
+    if permission:
+        user.user_permissions.add(Permission.objects.get(codename=permission))
+    client.force_login(user)
 
+    response = client.get(reverse("home"))
     assert response.status_code == 200
 
     page = BeautifulSoup(response.content.decode(response.charset), "html.parser")
-    assert "Create new workbasket" == page.select("label")[0].text.strip()
-    assert "Edit workbaskets" == page.select("label")[1].text.strip()
-    assert "Package workbaskets" == page.select("label")[2].text.strip()
-    assert "Process envelopes" == page.select("label")[3].text.strip()
-    assert "Search the tariff" == page.select("label")[4].text.strip()
-    assert "Import EU Taric files" == page.select("label")[5].text.strip()
+    assert page.find("label", class_="govuk-radios__label", string=re.compile(action))
 
 
 def test_index_displays_logout_buttons_correctly_SSO_off_logged_in(valid_user_client):
@@ -87,6 +103,18 @@ def test_index_displays_login_buttons_correctly_SSO_on(valid_user_client):
                 "workbasket_action": "SEARCH",
             },
             "search-page",
+        ),
+        (
+            {
+                "workbasket_action": "IMPORT",
+            },
+            "commodity_importer-ui-list",
+        ),
+        (
+            {
+                "workbasket_action": "WORKBASKET_LIST_ALL",
+            },
+            "workbaskets:workbasket-ui-list-all",
         ),
     ),
 )

--- a/workbaskets/views/ui.py
+++ b/workbaskets/views/ui.py
@@ -450,7 +450,7 @@ class WorkBasketList(PermissionRequiredMixin, WithPaginationListView):
     """UI endpoint for viewing and filtering workbaskets."""
 
     template_name = "workbaskets/list.jinja"
-    permission_required = "workbaskets.change_workbasket"
+    permission_required = "workbaskets.view_workbasket"
     filterset_class = WorkBasketFilter
     search_fields = [
         "title",


### PR DESCRIPTION
# TP2000-1143  Fix permission for Search for workbaskets home form action

## Why
Users with HMRC profiles are unable to see the "Search for workbaskets" radio option on the workbasket actions form on the home page.

## What
- Amends the requisite permission for the "Search for workbaskets" radio option to `workbaskets.view_workbasket`
- Updates unit tests
