### PR TITLE
Updated NIG5 to correctly handle only goods create and update and NIG5_origin to only handle origin deletions. Also added NIG11 skip delete

### DIFF
--- a/commodities/business_rules.py
+++ b/commodities/business_rules.py
@@ -164,18 +164,70 @@ class NIG5(BusinessRule):
 
         from commodities.models.orm import GoodsNomenclatureOrigin
 
-        if not (
-            good.code.is_chapter
-            or GoodsNomenclatureOrigin.objects.filter(
-                new_goods_nomenclature__sid=good.sid,
-            )
-            .approved_up_to_transaction(good.transaction)
+        if good.code.is_chapter:
+            return
+
+        if (
+            GoodsNomenclatureOrigin.objects.filter(new_goods_nomenclature__sid=good.sid)
+            .approved_up_to_transaction(self.transaction)
             .exists()
         ):
-            raise self.violation(
-                model=good,
-                message="Non top-level goods must have an origin specified.",
+            return
+
+        raise self.violation(
+            model=good,
+            message="Non top-level goods must have an origin specified.",
+        )
+
+
+@skip_when_not_deleted
+class NIG5_origin(BusinessRule):
+    """
+    related to NIG5:
+
+    MIG5 text:
+        When creating a goods nomenclature code, an origin must exist.
+        This rule is only applicable to update extractions.
+
+    When an origin is deleted, the goods nomenclature should be validated, if it has not been deleted
+    then it should have an origin, provided it's not a chapter and was created after 1/1/2010
+    """
+
+    def validate(self, origin):
+        """
+        Only used when deleting an origin.
+
+        Verify:
+            * It has an origin after deletion of this origin
+            * or that the goods code is a chapter
+            * or it was created before 1/1/2010
+            * or the code was deleted in same or previous transaction
+
+        If it does not meet these criteria it's a validation fail
+        """
+
+        from commodities.models.orm import GoodsNomenclatureOrigin
+
+        if origin.new_goods_nomenclature.valid_between.lower < date(2021, 1, 1):
+            return
+
+        # is it a chapter?
+        if origin.new_goods_nomenclature.code.is_chapter:
+            return
+
+        if (
+            GoodsNomenclatureOrigin.objects.approved_up_to_transaction(
+                origin.transaction,
             )
+            .filter(new_goods_nomenclature__sid=origin.new_goods_nomenclature.sid)
+            .exists()
+        ):
+            return
+
+        raise self.violation(
+            model=origin,
+            message="Non top-level goods must have an origin specified. None remain if this origin is deleted",
+        )
 
 
 class NIG7(BusinessRule):
@@ -236,6 +288,7 @@ class NIG10(BusinessRule):
             )
 
 
+@skip_when_deleted
 class NIG11(ValidityStartDateRules):
     """
     At least one indent record is mandatory.

--- a/commodities/models/orm.py
+++ b/commodities/models/orm.py
@@ -297,8 +297,7 @@ class GoodsNomenclatureOrigin(TrackedModel):
         "derived_from_goods_nomenclature__sid",
     )
 
-    indirect_business_rules = (business_rules.NIG5,)
-    business_rules = (business_rules.NIG7, UpdateValidity)
+    business_rules = (business_rules.NIG7, UpdateValidity, business_rules.NIG5_origin)
 
     def __str__(self):
         return (

--- a/commodities/tests/business_rules/test_NIG11.py
+++ b/commodities/tests/business_rules/test_NIG11.py
@@ -1,0 +1,85 @@
+import pytest
+
+from commodities import business_rules
+from common.business_rules import BusinessRuleViolation
+from common.tests import factories
+from common.validators import UpdateType
+
+pytestmark = pytest.mark.django_db
+
+
+def test_NIG11_one_indent_mandatory():
+    """At least one indent record is mandatory."""
+
+    good = factories.GoodsNomenclatureFactory.create(indent=None)
+    with pytest.raises(BusinessRuleViolation):
+        business_rules.NIG11(good.transaction).validate(good)
+
+
+def test_NIG11_first_indent_must_have_same_start_date(date_ranges):
+    """The start date of the first indentation must be equal to the start date
+    of the nomenclature."""
+
+    indent = factories.GoodsNomenclatureIndentFactory.create(
+        indented_goods_nomenclature__valid_between=date_ranges.normal,
+        validity_start=date_ranges.overlap_normal.lower,
+    )
+
+    with pytest.raises(BusinessRuleViolation):
+        business_rules.NIG11(indent.transaction).validate(
+            indent.indented_goods_nomenclature,
+        )
+
+
+def test_NIG11_no_overlapping_indents():
+    """No two associated indentations may have the same start date."""
+
+    existing = factories.GoodsNomenclatureIndentFactory.create()
+    duplicate = factories.GoodsNomenclatureIndentFactory.create(
+        indented_goods_nomenclature=existing.indented_goods_nomenclature,
+        validity_start=existing.validity_start,
+    )
+    with pytest.raises(BusinessRuleViolation):
+        business_rules.NIG11(duplicate.transaction).validate(
+            existing.indented_goods_nomenclature,
+        )
+
+
+def test_NIG11_start_date_less_than_end_date(date_ranges):
+    """The start date must be less than or equal to the end date of the
+    nomenclature."""
+
+    indent = factories.GoodsNomenclatureIndentFactory.create(
+        indented_goods_nomenclature__valid_between=date_ranges.normal,
+        validity_start=date_ranges.later.lower,
+    )
+
+    with pytest.raises(BusinessRuleViolation):
+        business_rules.NIG11(indent.transaction).validate(
+            indent.indented_goods_nomenclature,
+        )
+
+
+def test_NIG11_skips_when_goods_deleted(date_ranges):
+    """Example failure,"""
+
+    # Create goods nomenclature
+    goods = factories.GoodsNomenclatureFactory.create(indent=None)
+
+    # create new workbasket
+    editable_workbasket = factories.WorkBasketFactory()
+
+    # create transaction
+    editable_transaction = factories.TransactionFactory.create(
+        workbasket=editable_workbasket,
+        order=2,
+    )
+
+    # delete the goods nomenclature
+    delete_goods = goods.new_version(
+        transaction=editable_transaction,
+        update_type=UpdateType.DELETE,
+        workbasket=editable_workbasket,
+    )
+
+    business_rules.NIG11(editable_transaction).validate(delete_goods)

--- a/commodities/tests/business_rules/test_NIG5.py
+++ b/commodities/tests/business_rules/test_NIG5.py
@@ -1,0 +1,90 @@
+import pytest
+
+from commodities import business_rules
+from commodities.models import GoodsNomenclatureOrigin
+from common.business_rules import BusinessRuleViolation
+from common.tests import factories
+from common.validators import UpdateType
+
+pytestmark = pytest.mark.django_db
+
+
+def test_NIG5(workbasket):
+    """
+    When creating a goods nomenclature code, an origin must exist.
+
+    This rule is only applicable to update extractions.
+    """
+    origin = factories.GoodsNomenclatureFactory.create(item_id="2000000000")
+    bad_good = factories.GoodsNomenclatureFactory.create(
+        item_id="2000000010",
+        origin=None,
+        indent__indent=1,
+    )
+
+    with pytest.raises(BusinessRuleViolation):
+        business_rules.NIG5(bad_good.transaction).validate(bad_good)
+
+    deleted_good = bad_good.new_version(workbasket, update_type=UpdateType.DELETE)
+    business_rules.NIG5(deleted_good.transaction).validate(deleted_good)
+
+    good_good = factories.GoodsNomenclatureFactory.create(
+        origin__derived_from_goods_nomenclature=origin,
+        indent__indent=1,
+    )
+
+    business_rules.NIG5(good_good.transaction).validate(good_good)
+
+
+def test_NIG5_allow_origin_create():
+    """
+    When creating a goods nomenclature code, an origin must exist.
+
+    This rule is only applicable to update extractions.
+    """
+
+    # create published workbasket with goods nomenclature without origin
+    published_workbasket = factories.PublishedWorkBasketFactory()
+
+    approved_transaction = factories.ApprovedTransactionFactory.create(
+        workbasket=published_workbasket,
+        order=1,
+    )
+
+    approved_transaction_2 = factories.ApprovedTransactionFactory.create(
+        workbasket=published_workbasket,
+        order=2,
+    )
+
+    old_good_no_origin = factories.GoodsNomenclatureFactory.create(
+        item_id="2000000010",
+        origin=None,
+        indent__indent=1,
+        update_type=UpdateType.CREATE,
+        transaction_id=approved_transaction.id,
+    )
+
+    old_goods_should_be_origin_for_above = factories.GoodsNomenclatureFactory.create(
+        item_id="2000000000",
+        update_type=UpdateType.CREATE,
+        transaction_id=approved_transaction_2.id,
+    )
+
+    # create edit workbasket with correction to add in origin
+    editable_workbasket = factories.WorkBasketFactory()
+
+    editable_transaction = factories.TransactionFactory.create(
+        workbasket=editable_workbasket,
+        order=3,
+    )
+
+    new_origin = GoodsNomenclatureOrigin.objects.create(
+        transaction=editable_transaction,
+        derived_from_goods_nomenclature=old_good_no_origin,
+        update_type=UpdateType.CREATE,
+        new_goods_nomenclature=old_goods_should_be_origin_for_above,
+    )
+
+    business_rules.NIG5(new_origin.transaction).validate(
+        old_goods_should_be_origin_for_above,
+    )

--- a/commodities/tests/business_rules/test_NIG5_origin.py
+++ b/commodities/tests/business_rules/test_NIG5_origin.py
@@ -1,0 +1,140 @@
+import pytest
+
+from commodities import business_rules
+from commodities.models import GoodsNomenclatureOrigin
+from common.business_rules import BusinessRuleViolation
+from common.tests import factories
+from common.validators import UpdateType
+
+pytestmark = pytest.mark.django_db
+
+
+def test_NIG5_origin_raises_violation_when_only_origin_is_deleted(workbasket):
+    """
+    When deleting an origin there must still be an origin for the goods,
+    provided the goods is not also being deleted in the same transaction.
+
+    This rule is only applicable when origins are deleted.
+    """
+    # Setup data
+    published_workbasket = factories.PublishedWorkBasketFactory()
+
+    approved_transaction = factories.ApprovedTransactionFactory.create(
+        workbasket=published_workbasket,
+        order=1,
+    )
+
+    approved_transaction_2 = factories.ApprovedTransactionFactory.create(
+        workbasket=published_workbasket,
+        order=2,
+    )
+
+    goods_chapter = factories.GoodsNomenclatureFactory.create(
+        item_id="2000000000",
+        transaction=approved_transaction,
+    )
+
+    # This is the goods we are going to delete the origin from
+    goods = factories.GoodsNomenclatureFactory.create(
+        item_id="2000000010",
+        origin__derived_from_goods_nomenclature=goods_chapter,
+        indent__indent=1,
+        transaction=approved_transaction_2,
+    )
+
+    editable_workbasket = factories.WorkBasketFactory()
+
+    editable_transaction = factories.TransactionFactory.create(
+        workbasket=editable_workbasket,
+        order=3,
+    )
+
+    origin_delete = (
+        GoodsNomenclatureOrigin.objects.approved_up_to_transaction(
+            approved_transaction_2,
+        )
+        .get(
+            new_goods_nomenclature=goods,
+            derived_from_goods_nomenclature=goods_chapter,
+        )
+        .new_version(
+            transaction=editable_transaction,
+            update_type=UpdateType.DELETE,
+            workbasket=editable_workbasket,
+        )
+    )
+
+    with pytest.raises(BusinessRuleViolation):
+        business_rules.NIG5_origin(editable_transaction).validate(origin_delete)
+
+
+def test_NIG5_origin_does_not_raise_violation_when_origin_still_exists(workbasket):
+    """
+    When deleting an origin there must still be an origin for the goods,
+    provided the goods is not also being deleted in the same transaction.
+
+    This rule is only applicable when origins are deleted.
+    """
+    # Setup data
+    published_workbasket = factories.PublishedWorkBasketFactory()
+
+    approved_transaction = factories.ApprovedTransactionFactory.create(
+        workbasket=published_workbasket,
+        order=1,
+    )
+
+    approved_transaction_2 = factories.ApprovedTransactionFactory.create(
+        workbasket=published_workbasket,
+        order=2,
+    )
+
+    approved_transaction_3 = factories.ApprovedTransactionFactory.create(
+        workbasket=published_workbasket,
+        order=3,
+    )
+
+    goods_chapter = factories.GoodsNomenclatureFactory.create(
+        item_id="2000000000",
+        transaction=approved_transaction,
+    )
+
+    # This is the goods we are going to delete the origin from
+    goods = factories.GoodsNomenclatureFactory.create(
+        item_id="2000000010",
+        origin__derived_from_goods_nomenclature=goods_chapter,
+        indent__indent=1,
+        transaction=approved_transaction_2,
+    )
+
+    # create a second origin
+    GoodsNomenclatureOrigin.objects.create(
+        derived_from_goods_nomenclature=goods_chapter,
+        new_goods_nomenclature=goods,
+        update_type=UpdateType.CREATE,
+        transaction=approved_transaction_3,
+    )
+
+    editable_workbasket = factories.WorkBasketFactory()
+
+    editable_transaction = factories.TransactionFactory.create(
+        workbasket=editable_workbasket,
+        order=4,
+    )
+
+    origin_delete = (
+        GoodsNomenclatureOrigin.objects.approved_up_to_transaction(
+            approved_transaction_2,
+        )
+        .filter(
+            new_goods_nomenclature=goods,
+            derived_from_goods_nomenclature=goods_chapter,
+        )
+        .first()
+        .new_version(
+            transaction=editable_transaction,
+            update_type=UpdateType.DELETE,
+            workbasket=editable_workbasket,
+        )
+    )
+
+    business_rules.NIG5_origin(editable_transaction).validate(origin_delete)

--- a/notifications/tests/test_models.py
+++ b/notifications/tests/test_models.py
@@ -1,3 +1,4 @@
+from datetime import date
 from unittest.mock import patch
 
 import factory
@@ -69,7 +70,7 @@ def test_create_packaging_notification(ready_for_packaging_notification):
 
     content = notification.get_personalisation()
     assert content == {
-        "envelope_id": "230001",
+        "envelope_id": f"{str(date.today().year)[2:]}0001",
         "description": "",
         "download_url": "http://localhost/publishing/envelope-queue/",
         "theme": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
@@ -100,7 +101,10 @@ def test_create_accepted_envelope(accepted_packaging_notification):
     )
 
     content = notification.get_personalisation()
-    assert "envelope_id" in content and content["envelope_id"] == "230001"
+    assert (
+        "envelope_id" in content
+        and content["envelope_id"] == f"{str(date.today().year)[2:]}0001"
+    )
     assert "transaction_count" in content and content["transaction_count"] == 1
     assert (
         "loading_report_message" in content
@@ -131,7 +135,10 @@ def test_create_rejected_envelope(rejected_packaging_notification):
     )
 
     content = notification.get_personalisation()
-    assert "envelope_id" in content and content["envelope_id"] == "230001"
+    assert (
+        "envelope_id" in content
+        and content["envelope_id"] == f"{str(date.today().year)[2:]}0001"
+    )
     assert "transaction_count" in content and content["transaction_count"] == 1
     assert (
         "loading_report_message" in content
@@ -162,7 +169,7 @@ def test_create_successful_publishing_notification(successful_publishing_notific
     )
 
     content = notification.get_personalisation()
-    assert content == {"envelope_id": "230001"}
+    assert content == {"envelope_id": f"{str(date.today().year)[2:]}0001"}
 
 
 def test_create_failed_publishing_notification(failed_publishing_notification):
@@ -186,7 +193,7 @@ def test_create_failed_publishing_notification(failed_publishing_notification):
     )
 
     content = notification.get_personalisation()
-    assert content == {"envelope_id": "230001"}
+    assert content == {"envelope_id": f"{str(date.today().year)[2:]}0001"}
 
 
 def test_send_notification_emails(ready_for_packaging_notification):

--- a/publishing/tests/test_model_envelope.py
+++ b/publishing/tests/test_model_envelope.py
@@ -1,3 +1,4 @@
+from datetime import date
 from unittest import mock
 
 import freezegun
@@ -117,12 +118,12 @@ def test_queryset_for_year(successful_envelope_factory, settings):
     # unit testing envelope not notification integration
     settings.ENABLE_PACKAGING_NOTIFICATIONS = False
 
-    with freeze_time("2022-01-01"):
+    with freeze_time(f"{str(date.today().year - 1)}-01-01"):
         envelope = successful_envelope_factory()
-    with freeze_time("2023-01-01"):
+    with freeze_time(f"{str(date.today().year)}-01-01"):
         envelope2 = successful_envelope_factory()
     current_year_envelopes = Envelope.objects.for_year()
-    previous_year_envelopes = Envelope.objects.for_year(2022)
+    previous_year_envelopes = Envelope.objects.for_year(int(date.today().year) - 1)
 
     assert envelope not in current_year_envelopes
     assert envelope in previous_year_envelopes
@@ -194,7 +195,7 @@ def test_next_envelope_id(successful_envelope_factory, settings):
     settings.ENABLE_PACKAGING_NOTIFICATIONS = False
 
     successful_envelope_factory()
-    assert Envelope.next_envelope_id() == "230002"
+    assert Envelope.next_envelope_id() == f"{str(date.today().year)[2:]}0002"
 
 
 def test_upload_envelope_handles_validate_envelope(packaged_workbasket_factory):


### PR DESCRIPTION
# TP2000-1158 : Updated NIG5, create NIG5_origin, added skip delete to NIG11

 * NIG5 should not be triggered when an origin is added, but validate on the goods transaction not the origins transaction
 * NIG11 should not trigger if a goods is being deleted
 * Full details on ticket 

## Why
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Both NIG5 and NIG11 recently triggered false positives for an EU update. 
 * Upon investigation it was observed that NIG5 was associated with Goods origins as an indirect business rule, but the validate method used the goods transaction not the origins transaction so would fail if both goods and origin were not present in the same transaction. 
 * NIG11 triggered and failed on a goods deletion

## What
 * Updated the query for the validation method for NIG5 to use the current transaction 
 * Added an NIG5_origin rule, to run against the origin on deletion to prevent updates that leave goods with no origin.
 * Added tests to cover the scenarios identified as issues for both NIG5 and NIG11 
 * Updated tests to work in 2024, some didn't age well

## Checklist
- Requires migrations? No
- Requires dependency updates? No

Links to relevant material
See: [Description](https://uktrade.atlassian.net/browse/TP2000-1158)
