### PR TITLE
TP2000-1160 Fix publish_to_api task envelope ID error

### DIFF
--- a/publishing/models/packaged_workbasket.py
+++ b/publishing/models/packaged_workbasket.py
@@ -1,6 +1,7 @@
 import logging
 from datetime import datetime
 
+from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist
 from django.db.models import PROTECT
 from django.db.models import SET_NULL
@@ -406,7 +407,7 @@ class PackagedWorkBasket(TimestampedMixin):
         """
 
         previous_id = PackagedWorkBasket.objects.last_unpublished_envelope_id()
-        if self.envelope.envelope_id[2:] == "0001":
+        if self.envelope.envelope_id[2:] == settings.HMRC_PACKAGING_SEED_ENVELOPE_ID:
             year = int(self.envelope.envelope_id[:2])
             last_envelope = publishing_models.Envelope.objects.for_year(
                 year=year - 1,

--- a/settings/common.py
+++ b/settings/common.py
@@ -418,12 +418,11 @@ S3_ENDPOINT_URL = os.environ.get(
 )
 
 # Packaging automation.
-HMRC_PACKAGING_SEED_ENVELOPE_ID = int(
-    os.environ.get(
-        "HMRC_PACKAGING_SEED_ENVELOPE_ID",
-        "0001",
-    ),
+HMRC_PACKAGING_SEED_ENVELOPE_ID = os.environ.get(
+    "HMRC_PACKAGING_SEED_ENVELOPE_ID",
+    "0001",
 )
+
 HMRC_ENVELOPE_STORAGE_DIRECTORY = os.environ.get(
     "HMRC_ENVELOPE_STORAGE_DIRECTORY",
     "envelope/",


### PR DESCRIPTION
# TP2000-1160 Fix publish_to_api task envelope ID error

## Why
The `publish_to_api` task is unable to publish envelopes to the Channel Islands. It expects the currently erroring envelope ID either to match the seed envelope ID (0001) or to be equal to the previous envelope ID + 1. Because of an issue detailed in TP2000-1157 together with the change in year (2023 -> 2024), the current envelope ID does not meet either of these conditions. 

## What
- Use `HMRC_PACKAGING_SEED_ENVELOPE_ID` env variable as opposed to a hardcoded value in `next_expected_to_api()`, applying the value set in prod (until it can be amended in time for next year) or otherwise defaulting to 0001 as intended.
- Remove `int` conversion of `HMRC_PACKAGING_SEED_ENVELOPE_ID` env variable from settings so that it can be used to compare to an envelope ID (a str). The int conversion for this env variable is already made where it is required elsewhere in the app (for example, in `next_envelope_id`)

