### PR TITLE
TP2000-1161 : Update to remove validate_taric_xml_record_order as a requirement for export / publishing of TARIC data

### DIFF
--- a/common/serializers.py
+++ b/common/serializers.py
@@ -23,7 +23,6 @@ from common.renderers import counter_generator
 from common.util import TaricDateRange
 from common.util import get_taric_template
 from common.util import parse_xml
-from common.xml.namespaces import nsmap
 
 logger = logging.getLogger(__name__)
 
@@ -186,12 +185,11 @@ class EnvelopeSerializer:
     """
     Streaming Envelope Serializer.
 
-    This is not a Django Restful Framework Serializer.
-    EnvelopeSerializer calls DRF serializers for the TrackedModels
-    it needs to output.
+    This is not a Django Restful Framework Serializer. EnvelopeSerializer calls
+    DRF serializers for the TrackedModels it needs to output.
 
-    Transaction and message ids are handled and data may be split
-    across multiple envelopes based on a size threshold.
+    Transaction and message ids are handled and data may be split across
+    multiple envelopes based on a size threshold.
     """
 
     MIN_ENVELOPE_SIZE = 4096  # 4k is arbitrary - the size is chosen for template size + min size of records.
@@ -371,26 +369,6 @@ def validate_envelope(envelope_file, skip_declaration=False):
         except etree.DocumentInvalid as e:
             logger.error("Envelope did not validate against XSD: %s", str(e.error_log))
             raise
-        try:
-            validate_taric_xml_record_order(xml)
-        except TaricDataAssertionError as e:
-            logger.error(e.args[0])
-            raise
-
-
-def validate_taric_xml_record_order(xml):
-    """Raise AssertionError if any record codes are not in order."""
-    for transaction in xml.findall(".//env:transaction", namespaces=nsmap):
-        last_code = "00000"
-        for record in transaction.findall(".//oub:record", namespaces=nsmap):
-            record_code = record.findtext(".//oub:record.code", namespaces=nsmap)
-            subrecord_code = record.findtext(".//oub:subrecord.code", namespaces=nsmap)
-            full_code = record_code + subrecord_code
-            if full_code < last_code:
-                raise TaricDataAssertionError(
-                    f"Elements out of order in XML: {last_code}, {full_code}",
-                )
-            last_code = full_code
 
 
 class AutoCompleteSerializer(serializers.BaseSerializer):

--- a/common/tests/util.py
+++ b/common/tests/util.py
@@ -35,7 +35,6 @@ from common.business_rules import BusinessRule
 from common.models.trackedmodel import TrackedModel
 from common.models.transactions import Transaction
 from common.renderers import counter_generator
-from common.serializers import validate_taric_xml_record_order
 from common.tariffs_api import Endpoints
 from common.tests import factories
 from common.util import TaricDateRange
@@ -595,7 +594,6 @@ def validate_taric_xml(
     factory=None,
     instance=None,
     factory_kwargs=None,
-    check_order=True,
 ):
     """
     Decorator that creates a fixture named 'xml' and validates end-to-end from
@@ -635,9 +633,6 @@ def validate_taric_xml(
             taric_schema.validate(xml)
 
             assert not taric_schema.error_log, f"XML errors: {taric_schema.error_log}"
-
-            if check_order:
-                validate_taric_xml_record_order(xml)
 
             kwargs = {"xml": xml, **kwargs}
 

--- a/exporter/tests/test_exporter_commands.py
+++ b/exporter/tests/test_exporter_commands.py
@@ -9,7 +9,6 @@ from common.tests.factories import FootnoteTypeFactory
 from common.tests.factories import RegulationFactory
 from common.tests.factories import WorkBasketFactory
 from common.tests.util import taric_xml_record_codes
-from common.tests.util import validate_taric_xml_record_order
 from workbaskets.validators import WorkflowStatus
 
 pytestmark = pytest.mark.django_db
@@ -48,8 +47,6 @@ def test_upload_command_uploads_queued_workbasket_to_s3(
     envelope = s3.get_object(Bucket=expected_bucket, Key=expected_key)["Body"].read()
     xml = etree.XML(envelope)
 
-    validate_taric_xml_record_order(xml)
-
     # tuples of (record_code, subrecord_code).
     expected_codes = [
         ("100", "00"),  # FootnoteType
@@ -77,8 +74,6 @@ def test_dump_command_outputs_queued_workbasket(approved_transaction, capsys):
     envelope_bytes, _ = capsys.readouterr()
     with capsys.disabled():
         xml = etree.XML(envelope_bytes.encode("utf-8"))
-
-        validate_taric_xml_record_order(xml)
 
         # tuples of (record_code, subrecord_code).
         expected_codes = [

--- a/exporter/tests/test_exporter_tasks.py
+++ b/exporter/tests/test_exporter_tasks.py
@@ -11,7 +11,6 @@ from common.tests.factories import ApprovedTransactionFactory
 from common.tests.factories import FootnoteTypeFactory
 from common.tests.factories import RegulationFactory
 from common.tests.util import taric_xml_record_codes
-from common.tests.util import validate_taric_xml_record_order
 from exporter.tasks import upload_workbaskets
 
 pytestmark = pytest.mark.django_db
@@ -62,8 +61,6 @@ def test_upload_workbaskets_uploads_queued_workbasket_to_s3(
 
     envelope = s3_object["Body"].read()
     xml = etree.XML(envelope)
-
-    validate_taric_xml_record_order(xml)
 
     # tuples of (record_code, subrecord_code).
     expected_codes = [

--- a/measures/tests/test_xml.py
+++ b/measures/tests/test_xml.py
@@ -30,7 +30,7 @@ def test_footnote_association_measure_xml(xml):
     assert xml.find(".//oub:footnote.association.measure", nsmap) is not None
 
 
-@validate_taric_xml(factories.MeasureWithQuotaFactory, check_order=False)
+@validate_taric_xml(factories.MeasureWithQuotaFactory)
 def test_measure_xml(xml):
     assert xml.find(".//oub:measure", nsmap) is not None
 

--- a/publishing/tests/test_tasks.py
+++ b/publishing/tests/test_tasks.py
@@ -8,7 +8,6 @@ from requests import Response
 
 from common.tests import factories
 from common.tests.util import taric_xml_record_codes
-from common.tests.util import validate_taric_xml_record_order
 from publishing.models import CrownDependenciesPublishingTask
 from publishing.models import PackagedWorkBasket
 from publishing.models.state import ApiPublishingState
@@ -57,8 +56,6 @@ def test_create_and_upload_envelope(
     envelope = s3_object["Body"].read()
     xml = etree.XML(envelope)
 
-    validate_taric_xml_record_order(xml)
-
     # tuples of (record_code, subrecord_code).
     expected_codes = [
         ("100", "00"),  # FootnoteType
@@ -82,35 +79,6 @@ def test_create_and_upload_envelope_fails(
     packaged_work_basket = packaged_workbasket_factory(
         workbasket=queued_workbasket,
     )
-
-    with mock.patch(
-        "publishing.storages.EnvelopeStorage.save",
-        wraps=mock.MagicMock(side_effect=envelope_storage.save),
-    ) as mock_save:
-        create_xml_envelope_file.apply(
-            (packaged_work_basket.pk, True),
-        )
-        # assert not called as it didn't pass validate
-        mock_save.assert_not_called()
-
-
-def test_create_and_upload_envelope_fails_record_order(
-    queued_workbasket,
-    packaged_workbasket_factory,
-    envelope_storage,
-):
-    """Verify EnvelopeStorage is not called as there are validation errors."""
-
-    packaged_work_basket = packaged_workbasket_factory(
-        workbasket=queued_workbasket,
-    )
-
-    approved_transaction = queued_workbasket.transactions.approved().last()
-
-    # out of order
-    factories.FootnoteTypeFactory(transaction=approved_transaction)
-    factories.FootnoteDescriptionFactory(transaction=approved_transaction)
-    factories.FootnoteFactory(transaction=approved_transaction)
 
     with mock.patch(
         "publishing.storages.EnvelopeStorage.save",

--- a/publishing/tests/test_util.py
+++ b/publishing/tests/test_util.py
@@ -278,34 +278,6 @@ def test_validate_envelope_fails_for_missing_tracked_model(queued_workbasket_fac
         assert "Missing records in XML" in e
 
 
-def test_validate_envelope_records_out_of_order(queued_workbasket):
-    """Test that the checker provides the right error messages for failing
-    envelope checks."""
-
-    approved_transaction = queued_workbasket.transactions.approved().last()
-
-    factories.FootnoteTypeFactory(transaction=approved_transaction)
-    factories.FootnoteDescriptionFactory(transaction=approved_transaction)
-    factories.FootnoteFactory(transaction=approved_transaction)
-
-    # Make a envelope from the files
-    output_file_constructor = dit_file_generator("/tmp", 230001)
-    serializer = MultiFileEnvelopeTransactionSerializer(
-        output_file_constructor,
-        envelope_id=230001,
-    )
-
-    workbaskets = WorkBasket.objects.filter(pk=queued_workbasket.pk)
-    transactions = workbaskets.ordered_transactions()
-
-    envelope = list(serializer.split_render_transactions(transactions))[0]
-    envelope_file = envelope.output
-    with pytest.raises(TaricDataAssertionError) as e:
-        envelope_file.seek(0, os.SEEK_SET)
-        validate_envelope(envelope_file, workbaskets=workbaskets)
-        assert "Elements out of order in XML:" in e
-
-
 def test_validate_envelope_no_declaration(caplog):
     """Test that validated envelopes containing no XML declaration element
     correctly log a warning message."""

--- a/publishing/util.py
+++ b/publishing/util.py
@@ -73,8 +73,7 @@ class TaricDataAssertionError(AssertionError):
 # These validate functions are extracted from exporter/serializers.py
 # This is due to the fact the serializer is set up to support multiple enevelope renders
 # and the workbaskets checks break such an implementation
-# without a refeactor of the serializer, the calling function and
-# all the tests that use validate_taric_xml_record_order to test xml results
+# without a refeactor of the serializer.
 
 # To support multiple envelopes the functions would have to return the envelope metadata
 # extract the workbaskets check into the function that loops over the list of envelopes
@@ -121,7 +120,7 @@ def validate_envelope(
         raise
 
     try:
-        validate_taric_xml_record_order(xml, workbaskets)
+        validate_taric_xml_records(xml, workbaskets)
     except TaricDataAssertionError as e:
         logger.error(e.args[0])
         raise
@@ -138,17 +137,15 @@ def get_expected_model_taric_record_count(tracked_model):
     return expected_count
 
 
-def validate_taric_xml_record_order(xml, workbaskets):
+def validate_taric_xml_records(xml, workbaskets):
     """
     Raise AssertionError if:
 
-    - any record codes are not in order
     - missing transactions (non-empty transactions only)
     - missing tracked_models (record)
     """
 
     # only validate against workbasket if workbasket available
-
     expected_record_count = 0
     workbasket_transaction_count = 0
     for transaction in workbaskets.ordered_transactions():
@@ -165,20 +162,11 @@ def validate_taric_xml_record_order(xml, workbaskets):
     envelope_transaction_count = 0
 
     for transaction in xml.findall(".//env:transaction", namespaces=nsmap):
-        last_code = "00000"
         # Count the number of records to compare with the workbasket tracked models
         envelope_transaction_count += 1
-        records = transaction.findall(".//oub:record", namespaces=nsmap)
-        envelope_record_count += len(records)
-        for record in records:
-            record_code = record.findtext(".//oub:record.code", namespaces=nsmap)
-            subrecord_code = record.findtext(".//oub:subrecord.code", namespaces=nsmap)
-            full_code = record_code + subrecord_code
-            if full_code < last_code:
-                raise TaricDataAssertionError(
-                    f"Elements out of order in XML: {last_code}, {full_code}",
-                )
-            last_code = full_code
+        envelope_record_count += len(
+            transaction.findall(".//oub:record", namespaces=nsmap),
+        )
 
     if not envelope_transaction_count:
         raise TaricDataAssertionError(


### PR DESCRIPTION


# TP2000-1161
* A while back a PR contained a validation step for export that checked that record code + subrecord code were ordered within a transaction. There is no documentation about this requirement and upon research from EU data 95% + taric updates from the EU do not respect this ordering.
* Removing this check will still produce valid taric data and  it's unclear why this was initially introduced. 
* It is not a TARIC requirement for the records to be in sequential order. 


## Why
 * Because of the way that goods nomenclature description periods are created (and other description periods) on export, if two description updates exist in the same transaction this issue will occur again because both the description and the description period are generated by one template, so we could easily end up with (record code 400, subrecord code) 40010, 40015, 40010, 40015 within one transaction which will again trigger the check to fail.
 * We have no logical basis for maintaining this behaviour and its causing issues when exporting. 
 * We need to remove the check and verify that all tests pass.

## What
 * Remove the checks that verifies record code + subrecord code are ordered lowest to highest
 * Update all the tests so they pass

## Checklist
- Requires migrations? No
- Requires dependency updates? No

Links to relevant material
See: [Description](https://uktrade.atlassian.net/browse/TP2000-1161)
