### PR TITLE
feat: Quotas Definitions' That Are Expiring Soon

### DIFF
--- a/reports/reports/expiring_quotas_with_no_definition_period.py
+++ b/reports/reports/expiring_quotas_with_no_definition_period.py
@@ -9,10 +9,13 @@ from quotas.models import (
 )
 from measures.models import Measure, MeasureExcludedGeographicalArea
 
+
 class Report(ReportBaseTable):
     name = "Quotas Expiring Soon"
     enabled = True
-    description = "Quotas with definition periods about to expire and no future definition period"
+    description = (
+        "Quotas with definition periods about to expire and no future definition period"
+    )
 
     def headers(self) -> [dict]:
         return [
@@ -62,7 +65,6 @@ class Report(ReportBaseTable):
 
         return list(quotas_expiring_soon)
 
-
     def find_quotas_without_future_definition(self, expiring_quotas):
         matching_data = set()
 
@@ -78,6 +80,8 @@ class Report(ReportBaseTable):
         for quota in matching_data:
             quota.definition_start_date = quota.valid_between.lower
             quota.definition_end_date = quota.valid_between.upper
-            quota.reason = "Definition period about to expire with no future definition period"
+            quota.reason = (
+                "Definition period about to expire with no future definition period"
+            )
 
         return list(matching_data)

--- a/reports/reports/expiring_quotas_with_no_definition_period.py
+++ b/reports/reports/expiring_quotas_with_no_definition_period.py
@@ -22,15 +22,13 @@ class Report(ReportBaseTable):
             {"text": "Quota Order Number"},
             {"text": "Definition Start Date"},
             {"text": "Definition End Date"},
-            {"text": "Reason"},
         ]
 
     def row(self, row: QuotaDefinition) -> [dict]:
         return [
             {"text": row.order_number},
-            {"text": row.definition_start_date},
-            {"text": row.definition_end_date},
-            {"text": row.reason},
+            {"text": row.valid_between.lower},
+            {"text": row.valid_between.upper},
         ]
 
     def rows(self) -> [[dict]]:
@@ -80,8 +78,5 @@ class Report(ReportBaseTable):
         for quota in matching_data:
             quota.definition_start_date = quota.valid_between.lower
             quota.definition_end_date = quota.valid_between.upper
-            quota.reason = (
-                "Definition period about to expire with no future definition period"
-            )
 
         return list(matching_data)

--- a/reports/reports/expiring_quotas_with_no_definition_period.py
+++ b/reports/reports/expiring_quotas_with_no_definition_period.py
@@ -1,0 +1,83 @@
+import datetime
+from django.db.models import Exists, Q
+from reports.reports.base_table import ReportBaseTable
+from quotas.models import (
+    QuotaOrderNumber,
+    QuotaDefinition,
+    QuotaOrderNumberOriginExclusion,
+    QuotaOrderNumberOrigin,
+)
+from measures.models import Measure, MeasureExcludedGeographicalArea
+
+class Report(ReportBaseTable):
+    name = "Quotas Expiring Soon"
+    enabled = True
+    description = "Quotas with definition periods about to expire and no future definition period"
+
+    def headers(self) -> [dict]:
+        return [
+            {"text": "Quota Order Number"},
+            {"text": "Definition Start Date"},
+            {"text": "Definition End Date"},
+            {"text": "Reason"},
+        ]
+
+    def row(self, row: QuotaDefinition) -> [dict]:
+        return [
+            {"text": row.order_number},
+            {"text": row.definition_start_date},
+            {"text": row.definition_end_date},
+            {"text": row.reason},
+        ]
+
+    def rows(self) -> [[dict]]:
+        table_rows = []
+        for row in self.query():
+            table_rows.append(self.row(row))
+
+        return table_rows
+
+    def query(self):
+        expiring_quotas = self.find_quotas_expiring_soon()
+        quotas_without_future_definition = self.find_quotas_without_future_definition(
+            expiring_quotas
+        )
+        return quotas_without_future_definition
+
+    def find_quotas_expiring_soon(self):
+        current_time = datetime.datetime.now()
+        future_time = current_time + datetime.timedelta(weeks=5)
+
+        filter_query = (
+            Q(valid_between__endswith__gte=current_time)
+            | Q(valid_between__endswith=None)
+        ) & Q(
+            valid_between__isnull=False,
+            valid_between__endswith__lte=future_time,
+        )
+
+        quotas_expiring_soon = QuotaDefinition.objects.latest_approved().filter(
+            filter_query
+        )
+
+        return list(quotas_expiring_soon)
+
+
+    def find_quotas_without_future_definition(self, expiring_quotas):
+        matching_data = set()
+
+        for quota in expiring_quotas:
+            future_definitions = QuotaDefinition.objects.latest_approved().filter(
+                order_number=quota.order_number,
+                valid_between__startswith__gt=quota.valid_between.upper,
+            )
+
+            if not future_definitions.exists():
+                matching_data.add(quota)
+
+        for quota in matching_data:
+            quota.definition_start_date = quota.valid_between.lower
+            quota.definition_end_date = quota.valid_between.upper
+            quota.reason = "Definition period about to expire with no future definition period"
+
+        return list(matching_data)

--- a/reports/tests/test_expiring_quotas_with_no_definition_period.py
+++ b/reports/tests/test_expiring_quotas_with_no_definition_period.py
@@ -1,0 +1,71 @@
+import pytest
+import datetime
+from datetime import timedelta
+from dateutil.relativedelta import relativedelta
+from common.tests import factories
+from common.util import TaricDateRange
+from reports.reports.expiring_quotas_with_no_definition_period import Report
+from quotas.models import QuotaDefinition
+
+@pytest.fixture
+def quota_order_number(db):
+    return factories.QuotaOrderNumberFactory.create()
+
+@pytest.fixture
+def expired_quota_definition(quota_order_number):
+    return factories.QuotaDefinitionFactory.create(
+        order_number=quota_order_number,
+        valid_between=TaricDateRange(
+            datetime.datetime.today().date() + relativedelta(weeks=-2),
+            datetime.datetime.today().date() + relativedelta(weeks=-1)
+        ),
+    )
+
+@pytest.fixture
+def expiring_soon_quota_definition(quota_order_number):
+    return factories.QuotaDefinitionFactory.create(
+        order_number=quota_order_number,
+        valid_between=TaricDateRange(
+            datetime.datetime.today().date() + relativedelta(weeks=1),
+            datetime.datetime.today().date() + relativedelta(weeks=2)
+        ),
+    )
+
+@pytest.fixture
+def future_quota_definition(quota_order_number):
+    return factories.QuotaDefinitionFactory.create(
+        order_number=quota_order_number,
+        valid_between=TaricDateRange(
+            datetime.datetime.today().date() + relativedelta(weeks=3),
+            datetime.datetime.today().date() + relativedelta(weeks=4)
+        ),
+    )
+
+@pytest.mark.django_db
+class TestQuotasExpiringSoonReport:
+
+    def test_quotas_expiring_soon_report_logic(
+        self, quota_order_number,
+        expired_quota_definition, expiring_soon_quota_definition, future_quota_definition
+    ):
+        report = Report()
+        quotas = report.query()
+
+        assert len(quotas) == 1
+
+        assert future_quota_definition in quotas
+
+        assert expiring_soon_quota_definition not in quotas
+
+        assert expired_quota_definition not in quotas
+
+    def test_quotas_expiring_soon_report_row(self, quota_order_number, expiring_soon_quota_definition):
+        report = Report()
+        row_data = report.row(expiring_soon_quota_definition)
+
+        assert len(row_data) == 3
+
+        # Check if the correct columns are present
+        assert {"text": expiring_soon_quota_definition.valid_between.lower} in row_data
+        assert {"text": expiring_soon_quota_definition.valid_between.upper} in row_data
+

--- a/reports/tests/test_expiring_quotas_with_no_definition_period.py
+++ b/reports/tests/test_expiring_quotas_with_no_definition_period.py
@@ -7,9 +7,11 @@ from common.util import TaricDateRange
 from reports.reports.expiring_quotas_with_no_definition_period import Report
 from quotas.models import QuotaDefinition
 
+
 @pytest.fixture
 def quota_order_number(db):
     return factories.QuotaOrderNumberFactory.create()
+
 
 @pytest.fixture
 def expired_quota_definition(quota_order_number):
@@ -17,9 +19,10 @@ def expired_quota_definition(quota_order_number):
         order_number=quota_order_number,
         valid_between=TaricDateRange(
             datetime.datetime.today().date() + relativedelta(weeks=-2),
-            datetime.datetime.today().date() + relativedelta(weeks=-1)
+            datetime.datetime.today().date() + relativedelta(weeks=-1),
         ),
     )
+
 
 @pytest.fixture
 def expiring_soon_quota_definition(quota_order_number):
@@ -27,9 +30,10 @@ def expiring_soon_quota_definition(quota_order_number):
         order_number=quota_order_number,
         valid_between=TaricDateRange(
             datetime.datetime.today().date() + relativedelta(weeks=1),
-            datetime.datetime.today().date() + relativedelta(weeks=2)
+            datetime.datetime.today().date() + relativedelta(weeks=2),
         ),
     )
+
 
 @pytest.fixture
 def future_quota_definition(quota_order_number):
@@ -37,16 +41,19 @@ def future_quota_definition(quota_order_number):
         order_number=quota_order_number,
         valid_between=TaricDateRange(
             datetime.datetime.today().date() + relativedelta(weeks=3),
-            datetime.datetime.today().date() + relativedelta(weeks=4)
+            datetime.datetime.today().date() + relativedelta(weeks=4),
         ),
     )
 
+
 @pytest.mark.django_db
 class TestQuotasExpiringSoonReport:
-
     def test_quotas_expiring_soon_report_logic(
-        self, quota_order_number,
-        expired_quota_definition, expiring_soon_quota_definition, future_quota_definition
+        self,
+        quota_order_number,
+        expired_quota_definition,
+        expiring_soon_quota_definition,
+        future_quota_definition,
     ):
         report = Report()
         quotas = report.query()
@@ -59,7 +66,9 @@ class TestQuotasExpiringSoonReport:
 
         assert expired_quota_definition not in quotas
 
-    def test_quotas_expiring_soon_report_row(self, quota_order_number, expiring_soon_quota_definition):
+    def test_quotas_expiring_soon_report_row(
+        self, quota_order_number, expiring_soon_quota_definition
+    ):
         report = Report()
         row_data = report.row(expiring_soon_quota_definition)
 
@@ -68,4 +77,3 @@ class TestQuotasExpiringSoonReport:
         # Check if the correct columns are present
         assert {"text": expiring_soon_quota_definition.valid_between.lower} in row_data
         assert {"text": expiring_soon_quota_definition.valid_between.upper} in row_data
-


### PR DESCRIPTION
# TP2000-1169 - Quotas Definitions' That Are Expiring Soon Report
<!---
 * Include the JIRA ticket number, eg TP-123, to automatically link.
 * Use 50 characters maximum.
 * Do not end with a full-stop.
--->

## Why
<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Use as many lines as you like.
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions or deliberately ignored edge-cases.
--->
Generating a report where a definition period on a quota is about to expire (in say five week times) and there isn't another future definition period
## What
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Explain like I'm 5.
 * Use pictures if you can.
--->
Create new report with similar logic to that of the Quota Missing Data report to capture this.
<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
## Checklist
- Requires migrations?
- Requires dependency updates?
--->

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
