### PR TITLE
feat: Allow table reports to be exported as a CSV

### DIFF
--- a/reports/jinja2/generics/export_report_to_csv.jinja
+++ b/reports/jinja2/generics/export_report_to_csv.jinja
@@ -1,0 +1,6 @@
+{% for row in report.rows() %}
+    {% for column in row %}
+        "{{ column.text }}"{% if not loop.last %},{% endif %}
+    {% endfor %}
+    {% if not loop.last %}{{ '\n' }}{% endif %}
+{% endfor %}

--- a/reports/jinja2/reports/report_table.jinja
+++ b/reports/jinja2/reports/report_table.jinja
@@ -10,14 +10,14 @@
 
 {% block content %}
     <h1 class="govuk-heading-xl govuk-!-margin-bottom-3">
-        Report: {{ report.name }}
+        Report: {{ report.name }}        
     </h1>
+                    <a class="govuk-button" href="{{ url("reports:export_report_to_csv", kwargs={"report_slug": report.slug()}) }}">Export to CSV</a>
     <span class="govuk-caption-xl govuk-!-margin-bottom-9">Table</span>
     <h2 class="govuk-body">
     {{ report.description|safe }}
     </h2>
     <div>
         {% include "generics/table.jinja" %}
-
     </div>
 {% endblock %}

--- a/reports/tests/test_report_views.py
+++ b/reports/tests/test_report_views.py
@@ -39,12 +39,9 @@ class TestReportViews:
             response = client.get(reverse(f"reports:{report.slug()}"))
             assert response.status_code == http_status
 
-   
     def test_export_report_to_csv(self, request):
         request = RequestFactory().get("/")
-        report_slug = (
-            "cds_rejections_in_the_last_12_months"
-        )
+        report_slug = "cds_rejections_in_the_last_12_months"
 
         response = export_report_to_csv(request, report_slug)
 

--- a/reports/tests/test_report_views.py
+++ b/reports/tests/test_report_views.py
@@ -1,8 +1,10 @@
 # Create your tests here.
 import pytest
 from django.urls import reverse
+from django.test import RequestFactory
 
 from reports.utils import get_reports
+from reports.views import export_report_to_csv
 
 pytestmark = pytest.mark.django_db
 
@@ -36,3 +38,19 @@ class TestReportViews:
         for report in reports:
             response = client.get(reverse(f"reports:{report.slug()}"))
             assert response.status_code == http_status
+
+   
+    def test_export_report_to_csv(self, request):
+        request = RequestFactory().get("/")
+        report_slug = (
+            "cds_rejections_in_the_last_12_months"
+        )
+
+        response = export_report_to_csv(request, report_slug)
+
+        assert response.status_code == 200
+        assert response["Content-Type"] == "text/csv"
+        assert (
+            response["Content-Disposition"]
+            == f'attachment; filename="{report_slug}_report.csv"'
+        )

--- a/reports/urls.py
+++ b/reports/urls.py
@@ -7,6 +7,11 @@ app_name = "reports"
 
 urlpatterns = [
     path("reports/", views.index, name="index"),
+    path(
+        "reports/<str:report_slug>/export-csv/",
+        views.export_report_to_csv,
+        name="export_report_to_csv",
+    ),
 ]
 
 for report in utils.get_reports():

--- a/reports/views.py
+++ b/reports/views.py
@@ -1,4 +1,7 @@
+import csv
+
 from django.contrib.auth.decorators import permission_required
+from django.http import HttpResponse
 from django.shortcuts import render
 
 import reports.reports.index as index_model
@@ -30,3 +33,27 @@ def report(request):
         utils.get_template_by_type(report_class.report_template),
         context,
     )
+
+
+def export_report_to_csv(request, report_slug):
+    report_class = utils.get_report_by_slug(report_slug)
+    report_instance = report_class()
+
+    response = HttpResponse(content_type="text/csv")
+    response["Content-Disposition"] = f'attachment; filename="{report_slug}_report.csv"'
+
+    writer = csv.writer(response)
+
+    # Check if the report is a table or a chart
+    if hasattr(report_instance, "headers"):
+        # For table reports
+        writer.writerow([header["text"] for header in report_instance.headers()])
+        for row in report_instance.rows():
+            writer.writerow([column["text"] for column in row])
+    else:
+        # For chart reports
+        writer.writerow(["Label", "Data"])
+        for label, data in zip(report_instance.labels(), report_instance.data()):
+            writer.writerow([label, data])
+
+    return response


### PR DESCRIPTION
# TP2000-1170 Allow table reports to be exported as a CSV
<!---
 * Include the JIRA ticket number, eg TP-123, to automatically link.
 * Use 50 characters maximum.
 * Do not end with a full-stop.
--->

## Why
<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Use as many lines as you like.
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions or deliberately ignored edge-cases.
--->
We want to allow users to export the data they can view in a report to a CSV file so they can manipulate it and build it out as they please
## What
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Explain like I'm 5.
 * Use pictures if you can.
--->
Integrating CSV package to the reports app to allow users to export the data. Exposing the endpoint via urls
<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
## Checklist
- Requires migrations?
- Requires dependency updates?
--->

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
