### PR TITLE
TP2000 1147 bulk edit celery task

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -3,3 +3,4 @@ worker: celery -A common.celery worker -O fair -l info -Q standard
 beat: celery -A common.celery beat
 rule-check-worker: celery -A common.celery worker -O fair -l info -Q rule-check
 importer-worker: celery -A common.celery worker -O fair -l info -Q importer
+bulk-create-edit-worker: celery -A common.celery worker -O fair -l info -Q bulk-create-edit

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -67,6 +67,24 @@ services:
     depends_on:
       - celery-redis
 
+  # Celery worker for bulk creating and editing of objects
+  bulk-create-edit-celery:
+    build:
+      context: .
+      args:
+        - "ENV=${ENV:-prod}"
+    volumes:
+      - ./:/app/
+    command: ["celery", "-A" , "common.celery" ,"worker", "-O", "fair", "-l", "info", "-Q", "bulk-create-edit"]
+    env_file: 
+      - .env
+      - settings/envs/docker.env
+    restart: "${DOCKER_RESTART_POLICY:-unless-stopped}"
+    stdin_open: true
+    tty: true
+    depends_on:
+      - celery-redis
+
   importer-celery:
     build:
       context: .

--- a/manifest.yml
+++ b/manifest.yml
@@ -10,4 +10,6 @@ applications:
         memory: 4G
       - type: rule-check-worker
         memory: 6G
+      - type: bulk-create-edit
+        memory: 6G
     stack: cflinuxfs4

--- a/measures/bulk_handling.py
+++ b/measures/bulk_handling.py
@@ -1,0 +1,7 @@
+from common.celery import app
+
+
+@app.task
+def bulk_create_edit():
+    # Add a parameter for a PK or similar. This will be a PK ref to e.g. CreateMeasures table
+    pass

--- a/measures/views.py
+++ b/measures/views.py
@@ -43,6 +43,7 @@ from footnotes.models import Footnote
 from geo_areas.models import GeographicalArea
 from geo_areas.utils import get_all_members_of_geo_groups
 from measures import forms
+from measures.bulk_handling import bulk_create_edit
 from measures.conditions import show_step_geographical_area
 from measures.conditions import show_step_quota_origins
 from measures.constants import MEASURE_CONDITIONS_FORMSET_PREFIX
@@ -934,18 +935,8 @@ class MeasureCreateWizard(
         return created_measures
 
     def done(self, form_list, **kwargs):
-        cleaned_data = self.get_all_cleaned_data()
-
-        created_measures = self.create_measures(cleaned_data)
-        created_measures[0].transaction.workbasket.save_to_session(self.request.session)
-
-        context = self.get_context_data(
-            form=None,
-            created_measures=created_measures,
-            **kwargs,
-        )
-
-        return render(self.request, "measures/confirm-create-multiple.jinja", context)
+        bulk_create_edit.apply_async()
+        # call new celery task here, passing in id of CreateMeasures object
 
     def get_all_cleaned_data(self):
         """

--- a/settings/common.py
+++ b/settings/common.py
@@ -556,6 +556,9 @@ CELERY_ROUTES = {
     re.compile(r"(exporter|notifications|publishing)\.tasks\..*"): {
         "queue": "standard",
     },
+    "measures.bulk_handling.bulk_create_edit": {
+        "queue": "bulk-create-edit",
+    },
 }
 
 SQLITE_EXCLUDED_APPS = [


### PR DESCRIPTION
# TP-2000-1147-bulk-edit-celery-task

## Why
Currently, bulk editing occurs within the context of a web worker. Because an edit can take many seconds and even minutes to complete, the confirmation web page presented to a user is bounded at the lower end by the amount of time an edit takes. It’s not the best approach to performing this type of computation for a number of reasons, including:

- Generally, users are accustomed to web pages loading in the order of milliseconds or a few seconds in the worst case, so a long delay is frustrating.
- Errors may be accumulate through spurious UI interaction with an in-progress creation process.
- Proxy server time-outs may occur during edit measure processing - the TAP team and SRE do not have the necessary access permissions to extend the proxy server’s timeout period.

## What
This PR contains the Celery infrastructure for processing the task asynchronously.

## QA

1.  Pull this branch and open on local
2. Start your docker demon
3. Enter the following in your terminal `docker-compose up -d cache-redis celery-redis celery rule-check-celery bulk-create-edit-celery s3`
4. Go to the docker demon & click in to the celery task. Confirm the logs show
the queue: `bulk-create-edit exchange=bulk-create-edit(direct) key=bulk-create-edit` 
and the task: `measures.bulk_handling.bulk_create_edit`

Optional: if you want to confirm the task runs as expected, add in a print() statement inside the task in measures/bulk_handling.py and proceed through the user journey for creating a new measure. When you click create at the end, the browser will eventually time out with a `Go no further!` message. Switch in to the Docker demon and you should see your print statement in the task logs.