### PR TITLE
Tp2000 1147 bulk edit celery

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -3,3 +3,4 @@ worker: celery -A common.celery worker -O fair -l info -Q standard
 beat: celery -A common.celery beat
 rule-check-worker: celery -A common.celery worker -O fair -l info -Q rule-check
 importer-worker: celery -A common.celery worker -O fair -l info -Q importer
+bulk-create-edit-worker: celery -A common.celery worker -O fair -l info -Q bulk-create-edit

--- a/common/forms.py
+++ b/common/forms.py
@@ -284,13 +284,7 @@ class HomeForm(forms.Form):
         ):
             choices += ImportUserActions.choices
 
-        if (
-            self.user.has_perm("workbaskets.add_workbasket")
-            or self.user.has_perm("workbaskets.change_workbasket")
-        ) and (
-            self.user.has_perm("common.add_trackedmodel")
-            or self.user.has_perm("common.change_trackedmodel")
-        ):
+        if self.user.has_perm("workbaskets.view_workbasket"):
             choices += WorkbasketManagerActions.choices
 
         self.fields["workbasket_action"] = forms.ChoiceField(

--- a/common/tests/test_views.py
+++ b/common/tests/test_views.py
@@ -1,6 +1,9 @@
+import re
+
 import pytest
 from bs4 import BeautifulSoup
 from django.conf import settings
+from django.contrib.auth.models import Permission
 from django.urls import reverse
 
 from common.tests import factories
@@ -12,18 +15,31 @@ from common.views import handler500
 pytestmark = pytest.mark.django_db
 
 
-def test_index_displays_workbasket_action_form(valid_user_client):
-    response = valid_user_client.get(reverse("home"))
+@pytest.mark.parametrize(
+    ("action", "permission"),
+    [
+        ("Create new workbasket", "add_workbasket"),
+        ("Edit workbaskets", "add_workbasket"),
+        ("Package workbaskets", "manage_packaging_queue"),
+        ("Process envelopes", "consume_from_packaging_queue"),
+        ("Search the tariff", ""),
+        ("Import EU Taric files", "add_trackedmodel"),
+        ("Search for workbaskets", "view_workbasket"),
+    ],
+)
+def test_home_form_actions_match_permissions(action, permission, client):
+    """Tests that the workbasket action form on the home page displays the
+    appropriate radio options for the user's permissions."""
+    user = factories.UserFactory.create()
+    if permission:
+        user.user_permissions.add(Permission.objects.get(codename=permission))
+    client.force_login(user)
 
+    response = client.get(reverse("home"))
     assert response.status_code == 200
 
     page = BeautifulSoup(response.content.decode(response.charset), "html.parser")
-    assert "Create new workbasket" == page.select("label")[0].text.strip()
-    assert "Edit workbaskets" == page.select("label")[1].text.strip()
-    assert "Package workbaskets" == page.select("label")[2].text.strip()
-    assert "Process envelopes" == page.select("label")[3].text.strip()
-    assert "Search the tariff" == page.select("label")[4].text.strip()
-    assert "Import EU Taric files" == page.select("label")[5].text.strip()
+    assert page.find("label", class_="govuk-radios__label", string=re.compile(action))
 
 
 def test_index_displays_logout_buttons_correctly_SSO_off_logged_in(valid_user_client):
@@ -87,6 +103,18 @@ def test_index_displays_login_buttons_correctly_SSO_on(valid_user_client):
                 "workbasket_action": "SEARCH",
             },
             "search-page",
+        ),
+        (
+            {
+                "workbasket_action": "IMPORT",
+            },
+            "commodity_importer-ui-list",
+        ),
+        (
+            {
+                "workbasket_action": "WORKBASKET_LIST_ALL",
+            },
+            "workbaskets:workbasket-ui-list-all",
         ),
     ),
 )

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -67,6 +67,24 @@ services:
     depends_on:
       - celery-redis
 
+  # Celery worker for bulk creating and editing of objects
+  bulk-create-edit-celery:
+    build:
+      context: .
+      args:
+        - "ENV=${ENV:-prod}"
+    volumes:
+      - ./:/app/
+    command: ["celery", "-A" , "common.celery" ,"worker", "-O", "fair", "-l", "info", "-Q", "bulk-create-edit"]
+    env_file: 
+      - .env
+      - settings/envs/docker.env
+    restart: "${DOCKER_RESTART_POLICY:-unless-stopped}"
+    stdin_open: true
+    tty: true
+    depends_on:
+      - celery-redis
+
   importer-celery:
     build:
       context: .

--- a/manifest.yml
+++ b/manifest.yml
@@ -10,4 +10,6 @@ applications:
         memory: 4G
       - type: rule-check-worker
         memory: 6G
+      - type: bulk-create-edit
+        memory: 6G
     stack: cflinuxfs4

--- a/measures/bulk_handling.py
+++ b/measures/bulk_handling.py
@@ -1,0 +1,7 @@
+from common.celery import app
+
+
+@app.task
+def bulk_create_edit():
+    # Add a parameter for a PK or similar. This will be a PK ref to e.g. CreateMeasures table
+    pass

--- a/measures/forms.py
+++ b/measures/forms.py
@@ -1,6 +1,8 @@
 import datetime
 import logging
 from itertools import groupby
+from typing import Dict
+from typing import Optional
 
 from crispy_forms_gds.helper import FormHelper
 from crispy_forms_gds.layout import HTML
@@ -878,7 +880,58 @@ class MeasureCreateStartForm(forms.Form):
     pass
 
 
+class SerializableFormMixin:
+    """Form whose form data can be serialized."""
+
+    # Date format when in a string representation.
+    DATE_STRING_FORMAT = "%Y-%m-%d"
+
+    def serialize_date(self, date: Optional[datetime.date]) -> Optional[str]:
+        """
+        Serialize a date instance, which may be None, to a string representation
+        whose format DATE_STRING_FORMAT.
+
+        If `date` is None, then
+        None is returned.
+        """
+        if isinstance(date, datetime.date):
+            return date.strftime(self.DATE_STRING_FORMAT)
+        return None
+
+    def deserialize_date(self, str_date: str) -> Optional[datetime.date]:
+        """
+        Deserialize a string representation of a date with format
+        DATE_STRING_FORMAT.
+
+        If `str_date` is falsy, then a value of None is
+        returned.
+        """
+        if not str_date:
+            return None
+        # TODO: Invalid formats raise a ValueError. Decide how to handle them.
+        return datetime.datetime.strftime(self.date, self.DATE_STRING_FORMAT).date()
+
+    def serializable_cleaned_data(self) -> Dict:
+        """
+        Return a serializable version of cleaned_data that may be rendered to
+        JSON format.
+
+        The caller is responsible for ensuring that cleaned_data is valid.
+        """
+        raise NotImplementedError
+
+    @classmethod
+    def create_from_serializable_cleaned_data(
+        cls,
+        serializable_cleaned: Dict,
+    ) -> "MeasureDetailsForm":
+        """Given a serialized representation of this Form's data, create a new
+        instance and return it."""
+        raise NotImplementedError
+
+
 class MeasureDetailsForm(
+    SerializableFormMixin,
     ValidityPeriodForm,
     forms.Form,
 ):
@@ -948,6 +1001,27 @@ class MeasureDetailsForm(
                 )
 
         return cleaned_data
+
+    def serializable_cleaned_data(self) -> Dict:
+        cleaned_data = dict()
+        # TODO: Guard against KeyError exceptions and referencing attrs on None.
+        cleaned_data["measure_type"] = self.cleaned_data["measure_type"].pk
+        cleaned_data["valid_between_lower"] = self.serialize_date(
+            self.cleaned_data["valid_between"].lower,
+        )
+        cleaned_data["valid_between_upper"] = self.serialize_date(
+            self.cleaned_data["valid_between"].upper,
+        )
+        return cleaned_data
+
+    @classmethod
+    def create_from_serializable_cleaned_data(
+        cls,
+        serializable_cleaned: Dict,
+    ) -> "MeasureDetailsForm":
+        # TODO
+        obj = cls()
+        return obj
 
 
 class MeasureRegulationIdForm(forms.Form):

--- a/measures/views.py
+++ b/measures/views.py
@@ -42,6 +42,7 @@ from footnotes.models import Footnote
 from geo_areas.models import GeographicalArea
 from geo_areas.utils import get_all_members_of_geo_groups
 from measures import forms
+from measures.bulk_handling import bulk_create_edit
 from measures.conditions import show_step_geographical_area
 from measures.conditions import show_step_quota_origins
 from measures.constants import MEASURE_CONDITIONS_FORMSET_PREFIX
@@ -934,7 +935,7 @@ class MeasureCreateWizard(
 
     def done(self, form_list, **kwargs):
         serialized_cleaned_data = self.get_all_serialized_cleaned_data()
-
+        bulk_create_edit.apply_async()
         import json
 
         print()

--- a/workbaskets/views/ui.py
+++ b/workbaskets/views/ui.py
@@ -450,7 +450,7 @@ class WorkBasketList(PermissionRequiredMixin, WithPaginationListView):
     """UI endpoint for viewing and filtering workbaskets."""
 
     template_name = "workbaskets/list.jinja"
-    permission_required = "workbaskets.change_workbasket"
+    permission_required = "workbaskets.view_workbasket"
     filterset_class = WorkBasketFilter
     search_fields = [
         "title",


### PR DESCRIPTION
# TP-2000-1147-bulk-edit-celery-task

## Why
Currently, bulk editing occurs within the context of a web worker. Because an edit can take many seconds and even minutes to complete, the confirmation web page presented to a user is bounded at the lower end by the amount of time an edit takes. It’s not the best approach to performing this type of computation for a number of reasons, including:

- Generally, users are accustomed to web pages loading in the order of milliseconds or a few seconds in the worst case, so a long delay is frustrating.
- Errors may be accumulate through spurious UI interaction with an in-progress creation process.
- Proxy server time-outs may occur during edit measure processing - the TAP team and SRE do not have the necessary access permissions to extend the proxy server’s timeout period.

## What
This PR contains the Celery infrastructure for processing the task asynchronously.

## QA

1.  Pull this branch and open on local
2. Start your docker demon
3. Enter the following in your terminal `docker-compose up -d cache-redis celery-redis celery rule-check-celery bulk-create-edit-celery s3`
4. Go to the docker demon & click in to the celery task. Confirm the logs show
the queue: `bulk-create-edit exchange=bulk-create-edit(direct) key=bulk-create-edit` 
and the task: `measures.bulk_handling.bulk_create_edit`

Optional: if you want to confirm the task runs as expected, add in a print() statement inside the task in measures/bulk_handling.py and proceed through the user journey for creating a new measure. When you click create at the end, the browser will eventually time out with a `Go no further!` message. Switch in to the Docker demon and you should see your print statement in the task logs.