### PR TITLE
TP2000-1168 Add sub-quota, blocking period & suspension period nested review tabs

### DIFF
--- a/workbaskets/jinja2/includes/workbaskets/review-quota-blocking-periods.jinja
+++ b/workbaskets/jinja2/includes/workbaskets/review-quota-blocking-periods.jinja
@@ -13,6 +13,7 @@
   {% endset %}
 
   {{ table_rows.append([
+    {"text": obj.sid},
     {"html": quota_link},
     {"html": quota_definition_link},
     {"text": "{:%d %b %Y}".format(obj.valid_between.lower)},
@@ -24,6 +25,7 @@
 
 {{ govukTable({
   "head": [
+    {"text": "Blocking period SID"},
     {"text": "Order number"},
     {"text": "Quota definition SID"},
     {"text": "Start date"},

--- a/workbaskets/jinja2/includes/workbaskets/review-quota-blocking-periods.jinja
+++ b/workbaskets/jinja2/includes/workbaskets/review-quota-blocking-periods.jinja
@@ -1,0 +1,35 @@
+{% set table_rows = [] %}
+{% for obj in object_list %}
+  {% set quota_link %}
+    <a class="govuk-link" href="{{ obj.quota_definition.order_number.get_url() or "#" }}">
+      {{ obj.quota_definition.order_number.order_number }}
+    </a>
+  {% endset %}
+
+  {% set quota_definition_link %}
+    <a class="govuk-link" href="{{ obj.quota_definition.get_url() or "#" }}">
+      {{ obj.quota_definition.sid }}
+    </a>
+  {% endset %}
+
+  {{ table_rows.append([
+    {"html": quota_link},
+    {"html": quota_definition_link},
+    {"text": "{:%d %b %Y}".format(obj.valid_between.lower)},
+    {"text": "{:%d %b %Y}".format(obj.valid_between.upper) if obj.valid_between.upper else "-"},
+    {"text": obj.blocking_period_type},
+    {"text": obj.description if obj.description else "-", "classes": "govuk-!-width-one-quarter"},
+  ]) or "" }}
+{% endfor %}
+
+{{ govukTable({
+  "head": [
+    {"text": "Order number"},
+    {"text": "Quota definition SID"},
+    {"text": "Start date"},
+    {"text": "End date"},
+    {"text": "Blocking period type"},
+    {"text": "Description"},
+  ],
+  "rows": table_rows
+}) }}

--- a/workbaskets/jinja2/includes/workbaskets/review-quota-suspension-periods.jinja
+++ b/workbaskets/jinja2/includes/workbaskets/review-quota-suspension-periods.jinja
@@ -13,6 +13,7 @@
   {% endset %}
 
   {{ table_rows.append([
+    {"text": obj.sid},
     {"html": quota_link},
     {"html": quota_definition_link},
     {"text": "{:%d %b %Y}".format(obj.valid_between.lower)},
@@ -23,6 +24,7 @@
 
 {{ govukTable({
   "head": [
+    {"text": "Suspension period SID"},
     {"text": "Order number"},
     {"text": "Quota definition SID"},
     {"text": "Start date"},

--- a/workbaskets/jinja2/includes/workbaskets/review-quota-suspension-periods.jinja
+++ b/workbaskets/jinja2/includes/workbaskets/review-quota-suspension-periods.jinja
@@ -1,0 +1,33 @@
+{% set table_rows = [] %}
+{% for obj in object_list %}
+  {% set quota_link %}
+    <a class="govuk-link" href="{{ obj.quota_definition.order_number.get_url() or "#" }}">
+      {{ obj.quota_definition.order_number.order_number }}
+    </a>
+  {% endset %}
+
+  {% set quota_definition_link %}
+    <a class="govuk-link" href="{{ obj.quota_definition.get_url() or "#" }}">
+      {{ obj.quota_definition.sid }}
+    </a>
+  {% endset %}
+
+  {{ table_rows.append([
+    {"html": quota_link},
+    {"html": quota_definition_link},
+    {"text": "{:%d %b %Y}".format(obj.valid_between.lower)},
+    {"text": "{:%d %b %Y}".format(obj.valid_between.upper) if obj.valid_between.upper else "-"},
+    {"text": obj.description if obj.description else "-", "classes": "govuk-!-width-one-quarter"},
+  ]) or "" }}
+{% endfor %}
+
+{{ govukTable({
+  "head": [
+    {"text": "Order number"},
+    {"text": "Quota definition SID"},
+    {"text": "Start date"},
+    {"text": "End date"},
+    {"text": "Description"},
+  ],
+  "rows": table_rows
+}) }}

--- a/workbaskets/jinja2/includes/workbaskets/review-sub-quotas.jinja
+++ b/workbaskets/jinja2/includes/workbaskets/review-sub-quotas.jinja
@@ -1,0 +1,35 @@
+{% set table_rows = [] %}
+{% for obj in object_list %}
+  {% set sub_quota_link %}
+    <a class="govuk-link" href="{{ obj.sub_quota.order_number.get_url() or "#" }}">
+      {{ obj.sub_quota.order_number.order_number }}
+    </a>
+  {% endset %}
+
+  {% set main_quota_link %}
+    <a class="govuk-link" href="{{ obj.main_quota.order_number.get_url() or "#" }}">
+      {{ obj.main_quota.order_number.order_number }}
+    </a>
+  {% endset %}
+
+  {{ table_rows.append([
+    {"html": main_quota_link},
+    {"html": sub_quota_link},
+    {"text": "{:%d %b %Y}".format(obj.sub_quota.valid_between.lower) },
+    {"text": "{:%d %b %Y}".format(obj.sub_quota.valid_between.upper) if obj.sub_quota.valid_between.upper else "-"},
+    {"text": obj.sub_quota_relation_type},
+    {"text": obj.coefficient},
+  ]) or "" }}
+{% endfor %}
+
+{{ govukTable({
+  "head": [
+    {"text": "Order number"},
+    {"text": "Sub-quota order number"},
+    {"text": "Start date"},
+    {"text": "End date"},
+    {"text": "Relation type"},
+    {"text": "Co-efficient"},
+  ],
+  "rows": table_rows
+}) }}

--- a/workbaskets/jinja2/workbaskets/review-quotas.jinja
+++ b/workbaskets/jinja2/workbaskets/review-quotas.jinja
@@ -21,6 +21,11 @@
     "href": url("workbaskets:workbasket-ui-review-quota-blocking-periods", kwargs={"pk": workbasket.pk}),
     "selected": selected_nested_tab == "blocking-periods",
   },
+  {
+    "text": "Suspension periods",
+    "href": url("workbaskets:workbasket-ui-review-quota-suspension-periods", kwargs={"pk": workbasket.pk}),
+    "selected": selected_nested_tab == "suspension-periods",
+  },
   ]
 %}
 

--- a/workbaskets/jinja2/workbaskets/review-quotas.jinja
+++ b/workbaskets/jinja2/workbaskets/review-quotas.jinja
@@ -16,6 +16,11 @@
     "href": url("workbaskets:workbasket-ui-review-sub-quotas", kwargs={"pk": workbasket.pk}),
     "selected": selected_nested_tab == "sub-quotas",
   },
+  {
+    "text": "Blocking periods",
+    "href": url("workbaskets:workbasket-ui-review-quota-blocking-periods", kwargs={"pk": workbasket.pk}),
+    "selected": selected_nested_tab == "blocking-periods",
+  },
   ]
 %}
 

--- a/workbaskets/jinja2/workbaskets/review-quotas.jinja
+++ b/workbaskets/jinja2/workbaskets/review-quotas.jinja
@@ -11,6 +11,11 @@
     "href": url("workbaskets:workbasket-ui-review-quota-definitions", kwargs={"pk": workbasket.pk}),
     "selected": selected_nested_tab == "quota-definitions",
   },
+  {
+    "text": "Sub-quota associations",
+    "href": url("workbaskets:workbasket-ui-review-sub-quotas", kwargs={"pk": workbasket.pk}),
+    "selected": selected_nested_tab == "sub-quotas",
+  },
   ]
 %}
 

--- a/workbaskets/jinja2/workbaskets/review.jinja
+++ b/workbaskets/jinja2/workbaskets/review.jinja
@@ -114,7 +114,7 @@
       {% if object_list %}
         {% include tab_template %}
       {% else %}
-        <p class="govuk-body govuk-!-margin-top-5">0 {{ view.model._meta.verbose_name_plural }} available to review.</p>
+        <p class="govuk-body govuk-!-margin-top-5">0 {{ selected_nested_tab.replace("-", " ") if selected_nested_tab else selected_tab }} available to review.</p>
       {% endif %}
       {% include "includes/common/pagination.jinja" %}
     {% endblock %}

--- a/workbaskets/tests/test_views.py
+++ b/workbaskets/tests/test_views.py
@@ -462,12 +462,12 @@ def test_workbasket_review_tabs_without_permission(url, client):
         (
             "workbaskets:workbasket-ui-review-quota-blocking-periods",
             lambda: factories.QuotaBlockingFactory.create(),
-            6,
+            7,
         ),
         (
             "workbaskets:workbasket-ui-review-quota-suspension-periods",
             lambda: factories.QuotaSuspensionFactory.create(),
-            5,
+            6,
         ),
         (
             "workbaskets:workbasket-ui-review-regulations",

--- a/workbaskets/tests/test_views.py
+++ b/workbaskets/tests/test_views.py
@@ -455,6 +455,11 @@ def test_workbasket_review_tabs_without_permission(url, client):
             11,
         ),
         (
+            "workbaskets:workbasket-ui-review-sub-quotas",
+            lambda: factories.QuotaAssociationFactory.create(),
+            6,
+        ),
+        (
             "workbaskets:workbasket-ui-review-regulations",
             lambda: factories.RegulationFactory.create(),
             6,

--- a/workbaskets/tests/test_views.py
+++ b/workbaskets/tests/test_views.py
@@ -465,6 +465,11 @@ def test_workbasket_review_tabs_without_permission(url, client):
             6,
         ),
         (
+            "workbaskets:workbasket-ui-review-quota-suspension-periods",
+            lambda: factories.QuotaSuspensionFactory.create(),
+            5,
+        ),
+        (
             "workbaskets:workbasket-ui-review-regulations",
             lambda: factories.RegulationFactory.create(),
             6,

--- a/workbaskets/tests/test_views.py
+++ b/workbaskets/tests/test_views.py
@@ -460,6 +460,11 @@ def test_workbasket_review_tabs_without_permission(url, client):
             6,
         ),
         (
+            "workbaskets:workbasket-ui-review-quota-blocking-periods",
+            lambda: factories.QuotaBlockingFactory.create(),
+            6,
+        ),
+        (
             "workbaskets:workbasket-ui-review-regulations",
             lambda: factories.RegulationFactory.create(),
             6,

--- a/workbaskets/urls.py
+++ b/workbaskets/urls.py
@@ -107,6 +107,11 @@ ui_patterns = [
         name="workbasket-ui-review-quota-blocking-periods",
     ),
     path(
+        f"<pk>/review-quota-suspension-periods/",
+        ui_views.WorkBasketReviewQuotaSuspensionView.as_view(),
+        name="workbasket-ui-review-quota-suspension-periods",
+    ),
+    path(
         f"<pk>/review-regulations/",
         ui_views.WorkBasketReviewRegulationsView.as_view(),
         name="workbasket-ui-review-regulations",

--- a/workbaskets/urls.py
+++ b/workbaskets/urls.py
@@ -97,6 +97,11 @@ ui_patterns = [
         name="workbasket-ui-review-quota-definitions",
     ),
     path(
+        f"<pk>/review-sub-quotas/",
+        ui_views.WorkBasketReviewSubQuotasView.as_view(),
+        name="workbasket-ui-review-sub-quotas",
+    ),
+    path(
         f"<pk>/review-regulations/",
         ui_views.WorkBasketReviewRegulationsView.as_view(),
         name="workbasket-ui-review-regulations",

--- a/workbaskets/urls.py
+++ b/workbaskets/urls.py
@@ -102,6 +102,11 @@ ui_patterns = [
         name="workbasket-ui-review-sub-quotas",
     ),
     path(
+        f"<pk>/review-quota-blocking-periods/",
+        ui_views.WorkBasketReviewQuotaBlockingView.as_view(),
+        name="workbasket-ui-review-quota-blocking-periods",
+    ),
+    path(
         f"<pk>/review-regulations/",
         ui_views.WorkBasketReviewRegulationsView.as_view(),
         name="workbasket-ui-review-regulations",

--- a/workbaskets/views/ui.py
+++ b/workbaskets/views/ui.py
@@ -49,6 +49,7 @@ from measures.models import Measure
 from notifications.models import Notification
 from notifications.models import NotificationTypeChoices
 from publishing.models import PackagedWorkBasket
+from quotas.models import QuotaAssociation
 from quotas.models import QuotaDefinition
 from quotas.models import QuotaOrderNumber
 from regulations.models import Regulation
@@ -1475,6 +1476,22 @@ class WorkBasketReviewQuotaDefinitionsView(WorkBasketReviewView):
         context["selected_tab"] = "quotas"
         context["selected_nested_tab"] = "quota-definitions"
         context["tab_template"] = "includes/workbaskets/review-quota-definitions.jinja"
+        return context
+
+
+class WorkBasketReviewSubQuotasView(WorkBasketReviewView):
+    """UI endpoint for reviewing sub-quota association changes in a
+    workbasket."""
+
+    model = QuotaAssociation
+    template_name = "workbaskets/review-quotas.jinja"
+
+    def get_context_data(self, *args, **kwargs):
+        context = super().get_context_data(*args, **kwargs)
+        context["tab_page_title"] = "Review sub-quota associations"
+        context["selected_tab"] = "quotas"
+        context["selected_nested_tab"] = "sub-quotas"
+        context["tab_template"] = "includes/workbaskets/review-sub-quotas.jinja"
         return context
 
 

--- a/workbaskets/views/ui.py
+++ b/workbaskets/views/ui.py
@@ -53,6 +53,7 @@ from quotas.models import QuotaAssociation
 from quotas.models import QuotaBlocking
 from quotas.models import QuotaDefinition
 from quotas.models import QuotaOrderNumber
+from quotas.models import QuotaSuspension
 from regulations.models import Regulation
 from workbaskets import forms
 from workbaskets.models import DataRow
@@ -1511,6 +1512,24 @@ class WorkBasketReviewQuotaBlockingView(WorkBasketReviewView):
         context[
             "tab_template"
         ] = "includes/workbaskets/review-quota-blocking-periods.jinja"
+        return context
+
+
+class WorkBasketReviewQuotaSuspensionView(WorkBasketReviewView):
+    """UI endpoint for reviewing quota suspension period changes in a
+    workbasket."""
+
+    model = QuotaSuspension
+    template_name = "workbaskets/review-quotas.jinja"
+
+    def get_context_data(self, *args, **kwargs):
+        context = super().get_context_data(*args, **kwargs)
+        context["tab_page_title"] = "Review quota suspension periods"
+        context["selected_tab"] = "quotas"
+        context["selected_nested_tab"] = "suspension-periods"
+        context[
+            "tab_template"
+        ] = "includes/workbaskets/review-quota-suspension-periods.jinja"
         return context
 
 

--- a/workbaskets/views/ui.py
+++ b/workbaskets/views/ui.py
@@ -50,6 +50,7 @@ from notifications.models import Notification
 from notifications.models import NotificationTypeChoices
 from publishing.models import PackagedWorkBasket
 from quotas.models import QuotaAssociation
+from quotas.models import QuotaBlocking
 from quotas.models import QuotaDefinition
 from quotas.models import QuotaOrderNumber
 from regulations.models import Regulation
@@ -1492,6 +1493,24 @@ class WorkBasketReviewSubQuotasView(WorkBasketReviewView):
         context["selected_tab"] = "quotas"
         context["selected_nested_tab"] = "sub-quotas"
         context["tab_template"] = "includes/workbaskets/review-sub-quotas.jinja"
+        return context
+
+
+class WorkBasketReviewQuotaBlockingView(WorkBasketReviewView):
+    """UI endpoint for reviewing quota blocking period changes in a
+    workbasket."""
+
+    model = QuotaBlocking
+    template_name = "workbaskets/review-quotas.jinja"
+
+    def get_context_data(self, *args, **kwargs):
+        context = super().get_context_data(*args, **kwargs)
+        context["tab_page_title"] = "Review quota blocking periods"
+        context["selected_tab"] = "quotas"
+        context["selected_nested_tab"] = "blocking-periods"
+        context[
+            "tab_template"
+        ] = "includes/workbaskets/review-quota-blocking-periods.jinja"
         return context
 
 


### PR DESCRIPTION
# TP2000-1168 Add sub-quota, blocking period & suspension period nested review tabs

## Why
Users are unable to review changes to sub-quotas, blocking periods and suspension periods on the workbasket review view.

## What
- Adds new views and templates for sub-quotas, blocking periods and suspension periods nested review tabs
- Adds the nested review tabs under the quotas review tab
- Updates review view unit test

##
<img width="500" alt="sub-quotas-tab" src="https://github.com/uktrade/tamato/assets/118175145/8da85072-03a4-4a70-bb02-23b928feea2a">

<img width="500" alt="blocking-periods-tab" src="https://github.com/uktrade/tamato/assets/118175145/b169da3c-1739-4f7f-bc6f-414ae7f8c93e">

<img width="500" alt="suspension-periods-tab" src="https://github.com/uktrade/tamato/assets/118175145/d30a5520-235e-4eca-8343-f62c5ac42fd2">
