### PR TITLE
feat: implement URLs for quota reports to ease navigation

### DIFF
--- a/reports/reports/base_table.py
+++ b/reports/reports/base_table.py
@@ -1,4 +1,6 @@
 from abc import abstractmethod
+from django.urls import reverse
+from django.utils.safestring import mark_safe
 
 from reports.reports.base import ReportBase
 
@@ -10,6 +12,13 @@ class ReportBaseTable(ReportBase):
 
     def __init__(self):
         pass
+
+    def link_renderer_for_quotas(self, order_number, text, fragment=None):
+        url = reverse("quota-ui-detail", args=[order_number.sid])
+        href = url + fragment if fragment else url
+        return mark_safe(
+            f"<a class='govuk-link govuk-!-font-weight-bold' href='{href}'>{text}</a>"
+        )
 
     @abstractmethod
     def query(self):

--- a/reports/reports/expiring_quotas_with_no_definition_period.py
+++ b/reports/reports/expiring_quotas_with_no_definition_period.py
@@ -30,7 +30,7 @@ class Report(ReportBaseTable):
 
     def row(self, row) -> [dict]:
         return [
-            {"text": row.order_number},
+            {"text": self.link_renderer_for_quotas(row.order_number, row.order_number)},
             {"text": row.valid_between.lower},
             {"text": row.valid_between.upper},
         ]
@@ -106,11 +106,23 @@ class Report(ReportBaseTable):
 
         for sub_quotas in row.sub_quotas.all():
             sub_quotas_array.append(
-                {"text": row.order_number},
-                {"text": sub_quotas.sid},
+                {
+                    "text": self.link_renderer_for_quotas(
+                        row.order_number, row.order_number
+                    )
+                },
+                {
+                    "text": self.link_renderer_for_quotas(
+                        row.order_number, sub_quotas.sid, "#sub-quotas"
+                    )
+                },
                 {"text": sub_quotas.valid_between.lower},
                 {"text": sub_quotas.valid_between.upper},
-                {"text": row.sid},
+                {
+                    "text": self.link_renderer_for_quotas(
+                        row.order_number, row.sid, "#definition-details"
+                    )
+                },
             )
 
         return sub_quotas_array
@@ -158,8 +170,13 @@ class Report(ReportBaseTable):
 
     def row3(self, row) -> [dict]:
         return [
-            {"text": row.order_number},
-            {"text": blocking.sid for blocking in row.quotablocking_set.all()},
+            {"text": self.link_renderer_for_quotas(row.order_number, row.order_number)},
+            {
+                "text": self.link_renderer_for_quotas(
+                    row.order_number, blocking.sid, "#blocking-periods"
+                )
+                for blocking in row.quotablocking_set.all()
+            },
             {
                 "text": blocking.valid_between.lower
                 for blocking in row.quotablocking_set.all()
@@ -168,7 +185,11 @@ class Report(ReportBaseTable):
                 "text": blocking.valid_between.upper
                 for blocking in row.quotablocking_set.all()
             },
-            {"text": row.sid},
+            {
+                "text": self.link_renderer_for_quotas(
+                    row.order_number, row.sid, "#definition-details"
+                )
+            },
         ]
 
     def rows3(self) -> [[dict]]:
@@ -219,8 +240,13 @@ class Report(ReportBaseTable):
 
     def row4(self, row) -> [dict]:
         return [
-            {"text": row.order_number},
-            {"text": suspension.sid for suspension in row.quotasuspension_set.all()},
+            {"text": self.link_renderer_for_quotas(row.order_number, row.order_number)},
+            {
+                "text": self.link_renderer_for_quotas(
+                    row.order_number, suspension.sid, "#blocking-periods"
+                )
+                for suspension in row.quotasuspension_set.all()
+            },
             {
                 "text": suspension.valid_between.lower
                 for suspension in row.quotasuspension_set.all()
@@ -229,7 +255,11 @@ class Report(ReportBaseTable):
                 "text": suspension.valid_between.upper
                 for suspension in row.quotasuspension_set.all()
             },
-            {"text": row.sid},
+            {
+                "text": self.link_renderer_for_quotas(
+                    row.order_number, row.sid, "#definition-details"
+                )
+            },
         ]
 
     def rows4(self) -> [[dict]]:

--- a/reports/reports/quotas_cannot_be_used.py
+++ b/reports/reports/quotas_cannot_be_used.py
@@ -28,7 +28,7 @@ class Report(ReportBaseTable):
 
     def row(self, row: QuotaDefinition) -> [dict]:
         return [
-            {"text": row.order_number},
+            {"text": self.link_renderer_for_quotas(row, row.order_number)},
             {"text": row.valid_between.lower},
             {"text": row.valid_between.upper},
             {"text": row.reason},
@@ -118,20 +118,19 @@ class Report(ReportBaseTable):
                                     break
                                 else:
                                     matching_data.add(quota.order_number)
-
-        for quota in matching_data:
+        for quota_order_number in matching_data:
             matching_definition = next(
                 (
                     quota_definition
                     for quota_definition in quotas_with_definition_periods
-                    if quota_definition.order_number == quota
+                    if quota_definition.order_number == quota_order_number
                 ),
                 None,
             )
 
             if matching_definition:
-                quota.reason = "Geographical area/exclusions data does not have any measures with matching data"
+                quota_order_number.reason = "Geographical area/exclusions data does not have any measures with matching data"
             else:
-                quota.reason = "Definition period has not been set"
+                quota_order_number.reason = "Definition period has not been set"
 
         return list(matching_data)

--- a/reports/tests/test_report_utils.py
+++ b/reports/tests/test_report_utils.py
@@ -1,6 +1,9 @@
 # Create your tests here.
 import pytest
+from django.urls import reverse
+from django.utils.safestring import SafeString
 
+from common.tests import factories
 from reports.reports.base import ReportBase
 from reports.reports.base_table import ReportBaseTable
 from reports.reports.blank_goods_nomenclature_descriptions import Report
@@ -45,3 +48,26 @@ class TestUtils:
         with pytest.raises(Exception) as ex:
             get_template_by_type("werwer")
             assert str(ex) == "Unknown chart type : werwer"
+
+    @pytest.mark.django_db
+    def test_link_renderer_for_quotas(self, db):
+        order_number_obj = factories.QuotaOrderNumberFactory.create()
+
+        report_instance = Report()
+
+        # Test without fragment
+        result = report_instance.link_renderer_for_quotas(order_number_obj, "Test Text")
+        expected_url = reverse("quota-ui-detail", args=[order_number_obj.sid])
+        expected_output = f"<a class='govuk-link govuk-!-font-weight-bold' href='{expected_url}'>Test Text</a>"
+        assert result == SafeString(expected_output)
+
+        # Test with fragment
+        result = report_instance.link_renderer_for_quotas(
+            order_number_obj, "Test Text", fragment="#blocking-periods"
+        )
+        expected_url = (
+            reverse("quota-ui-detail", args=[order_number_obj.sid])
+            + "#blocking-periods"
+        )
+        expected_output = f"<a class='govuk-link govuk-!-font-weight-bold' href='{expected_url}'>Test Text</a>"
+        assert result == SafeString(expected_output)


### PR DESCRIPTION
# TP2000-1169 - implement URLs for quota reports to ease navigation
<!---
 * Include the JIRA ticket number, eg TP-123, to automatically link.
 * Use 50 characters maximum.
 * Do not end with a full-stop.
--->

## Why
<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Use as many lines as you like.
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions or deliberately ignored edge-cases.
--->
At the moment if a quota appears in the report (or its relevant dependants) its too difficult to figure out and track down why/create something to fix the quota and remove it from the report. So I'm adding in links to make it easier for users to click through and journey to the relevant part of TAP.

## What
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Explain like I'm 5.
 * Use pictures if you can.
--->
Creating a new versatile function that can be used across multiple reports that will navigate a user to the quota detail list and an optional argument to get them to a specific tab within this quota detail. Also adding some tests and updating a previous report I worked on to be more explicit about the model in which we're using.
<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
## Checklist
- Requires migrations?
- Requires dependency updates?
--->

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
