### PR TITLE
feat: Add both CSV and excel types for charts exporting

### DIFF
--- a/common/static/common/scss/_button.scss
+++ b/common/static/common/scss/_button.scss
@@ -13,3 +13,7 @@ button.no-background {
     float:right;
     margin-top:-70px
 }
+
+.float-elements-right {
+    float: right;
+}

--- a/reports/jinja2/reports/report_chart_timescale.jinja
+++ b/reports/jinja2/reports/report_chart_timescale.jinja
@@ -85,6 +85,8 @@
     <h2 class="govuk-body">
     {{ report.description|safe }}
     </h2>
+    <a id="exportToCSVLink" class="govuk-button" href="{{ url("reports:export_report_to_csv", kwargs={"report_slug": report.slug() }) }}">Export to CSV</a>
+    <a id="exportToExcelLink" class="govuk-button" href="{{ url("reports:export_report_to_excel", kwargs={"report_slug": report.slug() }) }}">Export to Excel</a>
     <div>
         <div id="container" style="width: 75%;">
             <canvas id="chart"></canvas>

--- a/reports/jinja2/reports/report_chart_timescale.jinja
+++ b/reports/jinja2/reports/report_chart_timescale.jinja
@@ -85,7 +85,7 @@
     <h2 class="govuk-body">
     {{ report.description|safe }}
     </h2>
-    <div style="float:right" class="govuk-!-margin-left-1">
+    <div class="float-elements-right govuk-!-margin-left-1">
     <a id="exportToCSVLink" class="govuk-button govuk-!-margin-right-3" href="{{ url("reports:export_report_to_csv", kwargs={"report_slug": report.slug() }) }}">Export to CSV</a>
     <a id="exportToExcelLink" class="govuk-button" href="{{ url("reports:export_report_to_excel", kwargs={"report_slug": report.slug() }) }}">Export to Excel</a>
     </div>

--- a/reports/jinja2/reports/report_chart_timescale.jinja
+++ b/reports/jinja2/reports/report_chart_timescale.jinja
@@ -85,8 +85,10 @@
     <h2 class="govuk-body">
     {{ report.description|safe }}
     </h2>
-    <a id="exportToCSVLink" class="govuk-button" href="{{ url("reports:export_report_to_csv", kwargs={"report_slug": report.slug() }) }}">Export to CSV</a>
+    <div style="float:right" class="govuk-!-margin-left-1">
+    <a id="exportToCSVLink" class="govuk-button govuk-!-margin-right-3" href="{{ url("reports:export_report_to_csv", kwargs={"report_slug": report.slug() }) }}">Export to CSV</a>
     <a id="exportToExcelLink" class="govuk-button" href="{{ url("reports:export_report_to_excel", kwargs={"report_slug": report.slug() }) }}">Export to Excel</a>
+    </div>
     <div>
         <div id="container" style="width: 75%;">
             <canvas id="chart"></canvas>

--- a/reports/reports/expiring_quotas_with_no_definition_period.py
+++ b/reports/reports/expiring_quotas_with_no_definition_period.py
@@ -66,8 +66,8 @@ class Report(ReportBaseTable):
         # Filter out quota definitions with associated future definitions
         filtered_quotas = []
         for quota in expiring_quotas:
-            future_definitions = QuotaOrderNumber.objects.latest_approved().filter(
-                order_number=quota.order_number,
+            future_definitions = QuotaDefinition.objects.latest_approved().filter(
+                order_number__order_number=quota.order_number,
                 valid_between__startswith__gt=quota.valid_between.upper,
             )
 

--- a/reports/tests/test_report_views.py
+++ b/reports/tests/test_report_views.py
@@ -43,7 +43,6 @@ class TestReportViews:
             assert response.status_code == http_status
 
     def test_export_report_to_csv(self, request):
-        request = RequestFactory().get("/")
         report_slug = "blank_goods_nomenclature_descriptions"
 
         response = export_report_to_csv(request, report_slug)
@@ -55,8 +54,7 @@ class TestReportViews:
             == f'attachment; filename="{report_slug}_report.csv"'
         )
 
-    def test_export_report_invalid_tab(self):
-        request = RequestFactory().get("/")
+    def test_export_report_invalid_tab(self, request):
         report_slug = Report.slug()
         invalid_tab = "Invalid tab"
 
@@ -66,7 +64,6 @@ class TestReportViews:
             export_report_to_csv(request, report_slug, current_tab=invalid_tab)
 
     def test_export_report_to_excel(self, request):
-        request = RequestFactory().get("/")
         report_slug = ChartReport.slug()
 
         response = export_report_to_excel(request, report_slug)

--- a/reports/tests/test_report_views.py
+++ b/reports/tests/test_report_views.py
@@ -1,10 +1,7 @@
 # Create your tests here.
-import os
 import pytest
-import tempfile
 from django.urls import reverse
 from django.test import RequestFactory
-from openpyxl import load_workbook
 
 from reports.utils import get_reports
 from reports.views import export_report_to_csv, export_report_to_excel

--- a/reports/urls.py
+++ b/reports/urls.py
@@ -8,12 +8,17 @@ app_name = "reports"
 urlpatterns = [
     path("reports/", views.index, name="index"),
     path(
-        "reports/<str:report_slug>/",
+        "reports/<str:report_slug>/export-to-csv",
         views.export_report_to_csv,
         name="export_report_to_csv",
     ),
     path(
-        "reports/<str:report_slug>/<str:current_tab>/export-csv/",
+        "reports/<str:report_slug>/export-to-excel",
+        views.export_report_to_excel,
+        name="export_report_to_excel",
+    ),
+    path(
+        "reports/<str:report_slug>/<str:current_tab>/export-report-with-tabs-to-csv/",
         views.export_report_to_csv,
         name="export_report_with_tabs_to_csv",
     ),


### PR DESCRIPTION
# TP-??? - Add CSV and Excel exports for chart reports
<!---
 * Include the JIRA ticket number, eg TP-123, to automatically link.
 * Use 50 characters maximum.
 * Do not end with a full-stop.
--->

## Why
<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Use as many lines as you like.
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions or deliberately ignored edge-cases.
--->
We don't currently have the functionality to export data for charts as we do for tables, this PR is here to implement the ability to export charts in either an excel format with a graph already built, or csv which will just be a table of all the data, which users can then turn into a chart easily in their preferred application.
## What
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Explain like I'm 5.
 * Use pictures if you can.
--->
Using openpyxl package and the csv import, I am writing two functions for the users to either:
- export to csv which is a simple writer of the data the report contains
- export to excel, using openpyxl to initialise a bar graph. In future if we start using other kinds of graphs, some more work will have to be done on this function to identify the type of graph and plot correctly.

<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
## Checklist
- Requires migrations?
- Requires dependency updates?
--->

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
