### PR TITLE
TP2000-1179 Serialize commodities and duties formset

### DIFF
--- a/common/serializers.py
+++ b/common/serializers.py
@@ -1,3 +1,4 @@
+import datetime
 import io
 import logging
 import os
@@ -385,3 +386,34 @@ class AutoCompleteSerializer(serializers.BaseSerializer):
             "value": instance.pk,
             "label": instance.autocomplete_label,
         }
+
+
+SERIALIZED_DATE_FORMAT = "%Y-%m-%d"
+
+
+def serialize_date(date: Optional[datetime.date]) -> Optional[str]:
+    """
+    Serialize a date instance, which may be None, to a string representation
+    whose format SERIALIZED_DATE_FORMAT.
+
+    If `date` is None, then None is returned.
+    """
+
+    if isinstance(date, datetime.date):
+        return date.strftime(SERIALIZED_DATE_FORMAT)
+
+    return None
+
+
+def deserialize_date(str_date: Optional[str]) -> Optional[datetime.date]:
+    """
+    Deserialize a string representation of a date with format
+    SERIALIZED_DATE_FORMAT.
+
+    If `str_date` is falsy, then a value of None is returned.
+    """
+
+    if not str_date:
+        return None
+
+    return datetime.datetime.strptime(str_date, SERIALIZED_DATE_FORMAT).date()

--- a/common/tests/test_serializers.py
+++ b/common/tests/test_serializers.py
@@ -1,3 +1,4 @@
+import datetime
 import io
 import os
 import random
@@ -9,6 +10,8 @@ from pytest_django.asserts import assertQuerysetEqual  # noqa
 
 from common.models import Transaction
 from common.serializers import EnvelopeSerializer
+from common.serializers import deserialize_date
+from common.serializers import serialize_date
 from common.tests import factories
 from common.tests.factories import ApprovedTransactionFactory
 from common.tests.factories import QueuedWorkBasketFactory
@@ -271,3 +274,24 @@ def test_transaction_envelope_serializer_counters(queued_workbasket):
         actual_value = int(element.get("id"))
         assert actual_value == expected_id_2
         expected_id_2 += 1
+
+
+@pytest.mark.parametrize(
+    "test_date, serialized_truthiness",
+    [
+        (datetime.date.today(), True),
+        (datetime.date(1900, 1, 1), True),
+        (datetime.date(1970, 1, 1), True),
+        (datetime.date(3000, 1, 1), True),
+        (None, False),
+    ],
+)
+def test_date_serialization(
+    test_date: datetime.date,
+    serialized_truthiness: bool,
+):
+    serialized_date = serialize_date(test_date)
+    assert bool(serialized_date) == serialized_truthiness
+
+    deserialized_date = deserialize_date(serialized_date)
+    assert deserialized_date == test_date

--- a/measures/forms.py
+++ b/measures/forms.py
@@ -111,7 +111,7 @@ class SerializableFormMixin:
         Return serializable form data that can be serialized / stored as, say,
         `django.db.models.JSONField` which can be used to recreate a valid form.
 
-        if `remove_key_prefix` is a non-empty string, then the keys in the
+        If `remove_key_prefix` is a non-empty string, then the keys in the
         returned dictionary will be stripped of that string where it appears as
         a key prefix in the origin `data` dictionary.
 

--- a/measures/forms.py
+++ b/measures/forms.py
@@ -84,8 +84,8 @@ class SerializableFormMixin:
         "MAX_NUM_FORMS$",
     ]
     """
-    Regexs of keys that may appear in a Form's `data` attribute and which should
-    be ignored when creating a serializable version of `data`.
+    Regexs of keys that may appear in a Form's `data` dictionary attribute and
+    which should be ignored when creating a serializable version of `data`.
 
     Override this on a per form basis if there are other, redundant keys that
     should be ignored. See the default implementation of

--- a/measures/forms.py
+++ b/measures/forms.py
@@ -1207,6 +1207,7 @@ class MeasureQuotaOriginsForm(
 
 
 class MeasureGeographicalAreaForm(
+    SerializableFormMixin,
     MeasureGeoAreaInitialDataMixin,
     BindNestedFormMixin,
     forms.Form,

--- a/measures/forms.py
+++ b/measures/forms.py
@@ -69,9 +69,9 @@ logger = logging.getLogger(__name__)
 
 
 class SerializableFormMixin:
-    """Provides a default implementation of serializable() that can be used to
-    obtain form data that can be serialized, or more specifically, stored to a
-    forms.JSONField."""
+    """Provides a default implementation of `serializable_data()` that can be
+    used to obtain form data that can be serialized, or more specifically,
+    stored to a `JSONField` field."""
 
     ignored_data_key_regexs = [
         "^csrfmiddlewaretoken$",
@@ -98,17 +98,18 @@ class SerializableFormMixin:
         Default implementation returning a list of the `Form.data` attribute's
         keys used when serializing `data`.
 
-        Override this function if neither `ignored_data_key_regexs` or this default
-        implementation is sufficient for identifying which of `Form.data`'s keys
-        should be used during a call to this mixin's `serializable()` method.
+        Override this function if neither `ignored_data_key_regexs` or this
+        default implementation is sufficient for identifying which of
+        `Form.data`'s keys should be used during a call to this mixin's
+        `serializable_data()` method.
         """
         combined_regexs = "(" + ")|(".join(self.ignored_data_key_regexs) + ")"
         return [k for k in self.data.keys() if not re.search(combined_regexs, k)]
 
-    def serializable(self, remove_key_prefix: str = "") -> Dict:
+    def serializable_data(self, remove_key_prefix: str = "") -> Dict:
         """
         Return serializable form data that can be serialized / stored as, say,
-        django.db.models.JSONField which can be used to recreate a valid form.
+        `django.db.models.JSONField` which can be used to recreate a valid form.
 
         if `remove_key_prefix` is a non-empty string, then the keys in the
         returned dictionary will be stripped of that string where it appears as
@@ -155,8 +156,9 @@ class SerializableFormMixin:
         """
         Get a dictionary of arguments for use in initialising the form.
 
-        The 'form_kwargs` parameter is the serialized version of the form's
-        kwargs that require deserializing to their Python representation.
+        The 'form_kwargs` parameter is the serialized (actually, serializable)
+        version of the form's kwargs that require deserializing to their Python
+        representation.
         """
         return {}
 

--- a/measures/models.py
+++ b/measures/models.py
@@ -1065,8 +1065,21 @@ class MeasuresBulkCreator(models.Model):
                     f"{form_class.__name__} has {len(form.errors)} unexpected "
                     f"errors.",
                 )
-                for error in form.errors:
-                    logger.error(f"{error}")
+
+                # Form.errors is a dictionary of errors, but FormSet.errors is a
+                # list of dictionaries of Form.errors. Access their errors in
+                # a uniform manner.
+                errors = []
+                from django.forms.formsets import BaseFormSet
+
+                if isinstance(form, BaseFormSet):
+                    errors = [{"formset_errors": form.non_form_errors()}] + form.errors
+                else:
+                    errors = [form.errors]
+
+                for form_errors in errors:
+                    for error_key, error_values in form_errors.items():
+                        logger.error(f"{error_key}: {error_values}")
 
         # TODO: Create the measures.
 

--- a/measures/models.py
+++ b/measures/models.py
@@ -1041,12 +1041,10 @@ class MeasuresBulkCreator(models.Model):
         # Avoid circular import.
         from measures.views import MeasureCreateWizard
 
-        # TODO: Revert to using MeasureCreateWizard.form_list.
-        # for form_key, form_class in MeasureCreateWizard.form_list:
-        for form_key, form_class in MeasureCreateWizard.test_form_list:
+        for form_key, form_class in MeasureCreateWizard.data_form_list:
             if form_key not in self.form_data:
-                # Some forms / steps are only conditionally included when
-                # creating measures - see `MeasureCreateWizard.condition_dict`
+                # Not all forms / steps are used to create measures. Some are
+                # only conditionally included - see `MeasureCreateWizard.condition_dict`
                 # and `MeasureCreateWizard.show_step()` for details.
                 continue
 
@@ -1065,6 +1063,14 @@ class MeasuresBulkCreator(models.Model):
                     f"{form_class.__name__} has {len(form.errors)} unexpected "
                     f"errors.",
                 )
+
+                # Debug.
+                import json
+
+                print(f"*** data:")
+                print(f"{json.dumps(data, indent=4, default=str)}")
+                print(f"*** kwargs:")
+                print(f"{json.dumps(kwargs, indent=4, default=str)}")
 
                 # Form.errors is a dictionary of errors, but FormSet.errors is a
                 # list of dictionaries of Form.errors. Access their errors in

--- a/measures/tests/test_forms.py
+++ b/measures/tests/test_forms.py
@@ -1714,7 +1714,7 @@ def test_measure_commodities_and_duties_form_set_serialization(
     )
     assert form_set.is_valid()
 
-    serializable_form_data = form_set.serializable()
+    serializable_form_data = form_set.serializable_data()
     serializable_form_kwargs = form_set.serializable_init_kwargs(form_kwargs)
 
     # Form validation as would be performed after form data has been serialized

--- a/measures/tests/test_forms.py
+++ b/measures/tests/test_forms.py
@@ -1656,3 +1656,26 @@ def test_measure_geographical_area_exclusions_form_invalid_choice():
     assert form.errors["excluded_area"] == [
         "Select a valid choice. That choice is not one of the available choices.",
     ]
+
+
+def test_get_serializable_data_keys():
+    from measures.forms import SerializableFormMixin
+
+    class TestSerializableForm(SerializableFormMixin):
+        def __init__(self, data):
+            self.data = data
+
+    serializable_data = {
+        "valid_key": "",
+        "another_valid_key": "",
+    }
+    ignorable_data = {
+        "csrfmiddlewaretoken": "",
+        "measure_create_wizard-current_step": "",
+        "submit": "",
+        "some_kind_of_autocomplete": "",
+    }
+    form_data = {**ignorable_data, **serializable_data}
+    test_form = TestSerializableForm(data=form_data)
+
+    assert test_form.get_serializable_data_keys() == list(serializable_data.keys())

--- a/measures/tests/test_forms.py
+++ b/measures/tests/test_forms.py
@@ -1676,6 +1676,10 @@ def test_get_serializable_data_keys():
         "measure_create_wizard-current_step": "",
         "submit": "",
         "some_kind_of_autocomplete": "",
+        "test-formset-TOTAL_FORMS": 1,
+        "test-formset-INITIAL_FORMS": 1,
+        "test-formset-MIN_NUM_FORMS": "0",
+        "test-formset-MAX_NUM_FORMS": "1000",
     }
     form_data = {**ignorable_data, **serializable_data}
     test_form = TestSerializableForm(data=form_data)

--- a/measures/tests/test_forms.py
+++ b/measures/tests/test_forms.py
@@ -1681,3 +1681,46 @@ def test_get_serializable_data_keys():
     test_form = TestSerializableForm(data=form_data)
 
     assert test_form.get_serializable_data_keys() == list(serializable_data.keys())
+
+
+def test_measure_commodities_and_duties_form_set_serialization(
+    duty_sentence_parser,
+):
+    commodity_1 = factories.GoodsNomenclatureFactory.create()
+    commodity_2 = factories.GoodsNomenclatureFactory.create()
+
+    form_data = {
+        f"{MEASURE_COMMODITIES_FORMSET_PREFIX}-0-commodity": commodity_1.pk,
+        f"{MEASURE_COMMODITIES_FORMSET_PREFIX}-0-duties": "4.0%",
+        f"{MEASURE_COMMODITIES_FORMSET_PREFIX}-1-commodity": commodity_2.pk,
+        f"{MEASURE_COMMODITIES_FORMSET_PREFIX}-1-duties": "40 GBP/100kg",
+    }
+    form_kwargs = {
+        "min_commodity_count": 1,
+        "measure_start_date": datetime.date(2025, 1, 1),
+        "form_kwargs": {
+            "measure_type": None,
+        },
+    }
+
+    # Form validation as would be performed via a POST submission from the web.
+    form_set = forms.MeasureCommodityAndDutiesFormSet(
+        data=form_data,
+        **form_kwargs,
+    )
+    assert form_set.is_valid()
+
+    serializable_form_data = form_set.serializable(form_data)
+    serializable_form_kwargs = form_set.serializable_init_kwargs(form_kwargs)
+
+    # Form validation as would be performed after form data has been serialized
+    # and then deserialized - for instance, when creating a bound for instance
+    # within a Celery task.
+    deserialized_form_kwargs = form_set.deserialize_init_kwargs(
+        serializable_form_kwargs,
+    )
+    form_set = forms.MeasureCommodityAndDutiesFormSet(
+        data=serializable_form_data,
+        **deserialized_form_kwargs,
+    )
+    assert form_set.is_valid()

--- a/measures/tests/test_forms.py
+++ b/measures/tests/test_forms.py
@@ -19,6 +19,7 @@ from measures.forms import MeasureConditionsFormSet
 from measures.forms import MeasureEndDateForm
 from measures.forms import MeasureForm
 from measures.forms import MeasureStartDateForm
+from measures.forms import SerializableFormMixin
 from measures.models import Measure
 from measures.validators import MeasureExplosionLevel
 
@@ -1659,7 +1660,8 @@ def test_measure_geographical_area_exclusions_form_invalid_choice():
 
 
 def test_get_serializable_data_keys():
-    from measures.forms import SerializableFormMixin
+    """Test that the SerializableFormMixin.get_serializable_data_keys() behaves
+    correctly and as expected."""
 
     class TestSerializableForm(SerializableFormMixin):
         def __init__(self, data):

--- a/measures/tests/test_forms.py
+++ b/measures/tests/test_forms.py
@@ -1714,7 +1714,7 @@ def test_measure_commodities_and_duties_form_set_serialization(
     )
     assert form_set.is_valid()
 
-    serializable_form_data = form_set.serializable(form_data)
+    serializable_form_data = form_set.serializable()
     serializable_form_kwargs = form_set.serializable_init_kwargs(form_kwargs)
 
     # Form validation as would be performed after form data has been serialized

--- a/measures/views.py
+++ b/measures/views.py
@@ -811,7 +811,8 @@ class MeasureCreateWizard(
         The list is generated dynamically because conditions in condition_list
         may be dynamic.
 
-        This is essentially a filtered version of WizardView.get_form_list().
+        Essentially, version of `WizardView.get_form_list()` filtering in only
+        those list items appearing in `data_form_list`.
         """
         data_form_keys = [key for key, form in self.data_form_list]
         return {

--- a/measures/views.py
+++ b/measures/views.py
@@ -977,25 +977,8 @@ class MeasureCreateWizard(
         return created_measures
 
     def done(self, form_list, **kwargs):
-        # DEBUG
-        print()
-        print(f"*** MeasureCreateWizard.done()")
-        print(f"*** All form data:")
-        for form_key, form_class in self.form_list.items():
-            data = self.storage.get_step_data(form_key)
-            print(f"{form_key=}")
-            print(f"{json.dumps(data, indent=4, default=str)}")
-            print()
-
         serializable_data = self.all_serializable_form_data()
         serializable_form_kwargs = self.all_serializable_form_kwargs()
-
-        # DEBUG
-        print(f"*** serializable_data:")
-        print(json.dumps(serializable_data, indent=4))
-        print(f"*** serializable_form_kwargs:")
-        print(json.dumps(serializable_form_kwargs, indent=4))
-        print()
 
         measures_bulk_creator = MeasuresBulkCreator.objects.create(
             form_data=serializable_data,

--- a/measures/views.py
+++ b/measures/views.py
@@ -723,7 +723,7 @@ class MeasureCreateWizard(
         (QUOTA_ORDER_NUMBER, forms.MeasureQuotaOrderNumberForm),
         (QUOTA_ORIGINS, forms.MeasureQuotaOriginsForm),
         # (GEOGRAPHICAL_AREA, forms.MeasureGeographicalAreaForm),
-        # (COMMODITIES, forms.MeasureCommodityAndDutiesFormSet),
+        (COMMODITIES, forms.MeasureCommodityAndDutiesFormSet),
         (ADDITIONAL_CODE, forms.MeasureAdditionalCodeForm),
         (CONDITIONS, forms.MeasureConditionsWizardStepFormSet),
         (FOOTNOTES, forms.MeasureFootnotesFormSet),

--- a/measures/views.py
+++ b/measures/views.py
@@ -1015,7 +1015,7 @@ class MeasureCreateWizard(
             files=self.storage.get_step_files(step),
         )
 
-        return form_obj.serializable(remove_key_prefix=step)
+        return form_obj.serializable_data(remove_key_prefix=step)
 
     def all_serializable_form_kwargs(self) -> Dict:
         """Returns serializable kwargs for all wizard steps."""

--- a/measures/views.py
+++ b/measures/views.py
@@ -10,7 +10,6 @@ from urllib.parse import urlencode
 
 from crispy_forms.helper import FormHelper
 from django.contrib.auth.mixins import PermissionRequiredMixin
-from django.core.exceptions import ValidationError
 from django.db.transaction import atomic
 from django.http import HttpRequest
 from django.http import HttpResponse
@@ -702,8 +701,7 @@ class MeasureCreateWizard(
     SUMMARY = "summary"
     COMPLETE = "complete"
 
-    form_list = [
-        (START, forms.MeasureCreateStartForm),
+    data_form_list = [
         (MEASURE_DETAILS, forms.MeasureDetailsForm),
         (REGULATION_ID, forms.MeasureRegulationIdForm),
         (QUOTA_ORDER_NUMBER, forms.MeasureQuotaOrderNumberForm),
@@ -713,21 +711,20 @@ class MeasureCreateWizard(
         (ADDITIONAL_CODE, forms.MeasureAdditionalCodeForm),
         (CONDITIONS, forms.MeasureConditionsWizardStepFormSet),
         (FOOTNOTES, forms.MeasureFootnotesFormSet),
-        (SUMMARY, forms.MeasureReviewForm),
     ]
+    """Forms in this wizard's steps that collect user data."""
 
-    # TODO: remove after testing.
-    test_form_list = [
-        (MEASURE_DETAILS, forms.MeasureDetailsForm),
-        (REGULATION_ID, forms.MeasureRegulationIdForm),
-        (QUOTA_ORDER_NUMBER, forms.MeasureQuotaOrderNumberForm),
-        (QUOTA_ORIGINS, forms.MeasureQuotaOriginsForm),
-        # (GEOGRAPHICAL_AREA, forms.MeasureGeographicalAreaForm),
-        (COMMODITIES, forms.MeasureCommodityAndDutiesFormSet),
-        (ADDITIONAL_CODE, forms.MeasureAdditionalCodeForm),
-        (CONDITIONS, forms.MeasureConditionsWizardStepFormSet),
-        (FOOTNOTES, forms.MeasureFootnotesFormSet),
-    ]
+    form_list = (
+        [
+            (START, forms.MeasureCreateStartForm),
+        ]
+        + data_form_list
+        + [
+            (SUMMARY, forms.MeasureReviewForm),
+        ]
+    )
+    """All Forms in this wizard's steps, including both those that collect user
+    data and those that don't."""
 
     templates = {
         START: "measures/create-start.jinja",
@@ -805,6 +802,23 @@ class MeasureCreateWizard(
     """Override of dictionary that maps steps to either callables that return a
     boolean or boolean values that indicate whether a wizard step should be
     shown."""
+
+    def get_data_form_list(self) -> dict:
+        """
+        Returns a form list based on form_list, conditionally including only
+        those items as per condition_list and also appearing in data_form_list.
+
+        The list is generated dynamically because conditions in condition_list
+        may be dynamic.
+
+        This is essentially a filtered version of WizardView.get_form_list().
+        """
+        data_form_keys = [key for key, form in self.data_form_list]
+        return {
+            form_key: form_class
+            for form_key, form_class in self.get_form_list().items()
+            if form_key in data_form_keys
+        }
 
     def show_step(self, step) -> bool:
         """Convenience function to check whether a wizard step should be shown
@@ -962,15 +976,25 @@ class MeasureCreateWizard(
         return created_measures
 
     def done(self, form_list, **kwargs):
+        # DEBUG
+        print()
         print(f"*** MeasureCreateWizard.done()")
+        print(f"*** All form data:")
+        for form_key, form_class in self.form_list.items():
+            data = self.storage.get_step_data(form_key)
+            print(f"{form_key=}")
+            print(f"{json.dumps(data, indent=4, default=str)}")
+            print()
 
         serializable_data = self.all_serializable_form_data()
         serializable_form_kwargs = self.all_serializable_form_kwargs()
 
+        # DEBUG
         print(f"*** serializable_data:")
         print(json.dumps(serializable_data, indent=4))
         print(f"*** serializable_form_kwargs:")
         print(json.dumps(serializable_form_kwargs, indent=4))
+        print()
 
         measures_bulk_creator = MeasuresBulkCreator.objects.create(
             form_data=serializable_data,
@@ -991,13 +1015,11 @@ class MeasureCreateWizard(
 
         all_data = {}
 
-        # TODO:
-        # for form_key in self.get_form_list():
-        #   As per self.get_all_cleaned_data() but using
-        #   self.serializable_form_data_for_step()
-        for form_key, _ in self.test_form_list:
-            if self.show_step(form_key):
-                all_data[form_key] = self.serializable_form_data_for_step(form_key)
+        for form_key in self.get_data_form_list().keys():
+            # TODO: remove once geo area form is done.
+            if form_key == self.GEOGRAPHICAL_AREA:
+                continue
+            all_data[form_key] = self.serializable_form_data_for_step(form_key)
 
         return all_data
 
@@ -1015,27 +1037,19 @@ class MeasureCreateWizard(
             data=self.storage.get_step_data(step),
             files=self.storage.get_step_files(step),
         )
-        # TODO:
-        # - Set to True for now, since form_obj.is_valid() failing on
-        #   QUOTA_ORIGINS due to form optionality.
-        # if form_obj.is_valid():
-        if True or form_obj.is_valid():
-            # TODO: with_prefix=True once all forms done and tested.
-            # return form_obj.serializable()
-            return form_obj.serializable(with_prefix=False)
 
-        raise ValidationError
+        return form_obj.serializable(remove_key_prefix=step)
 
     def all_serializable_form_kwargs(self) -> Dict:
         """Returns serializable kwargs for all wizard steps."""
 
         all_kwargs = {}
 
-        # TODO:
-        # for form_key in self.get_form_list():
-        for form_key, _ in self.test_form_list:
-            if self.show_step(form_key):
-                all_kwargs[form_key] = self.serializable_form_kwargs_for_step(form_key)
+        for form_key in self.get_data_form_list().keys():
+            # TODO: remove once geo area form is done.
+            if form_key == self.GEOGRAPHICAL_AREA:
+                continue
+            all_kwargs[form_key] = self.serializable_form_kwargs_for_step(form_key)
 
         return all_kwargs
 

--- a/measures/views.py
+++ b/measures/views.py
@@ -714,15 +714,11 @@ class MeasureCreateWizard(
     ]
     """Forms in this wizard's steps that collect user data."""
 
-    form_list = (
-        [
-            (START, forms.MeasureCreateStartForm),
-        ]
-        + data_form_list
-        + [
-            (SUMMARY, forms.MeasureReviewForm),
-        ]
-    )
+    form_list = [
+        (START, forms.MeasureCreateStartForm),
+        *data_form_list,
+        (SUMMARY, forms.MeasureReviewForm),
+    ]
     """All Forms in this wizard's steps, including both those that collect user
     data and those that don't."""
 
@@ -1000,9 +996,6 @@ class MeasureCreateWizard(
         all_data = {}
 
         for form_key in self.get_data_form_list().keys():
-            # TODO: remove once geo area form is done.
-            if form_key == self.GEOGRAPHICAL_AREA:
-                continue
             all_data[form_key] = self.serializable_form_data_for_step(form_key)
 
         return all_data
@@ -1030,9 +1023,6 @@ class MeasureCreateWizard(
         all_kwargs = {}
 
         for form_key in self.get_data_form_list().keys():
-            # TODO: remove once geo area form is done.
-            if form_key == self.GEOGRAPHICAL_AREA:
-                continue
             all_kwargs[form_key] = self.serializable_form_kwargs_for_step(form_key)
 
         return all_kwargs


### PR DESCRIPTION
# TP2000-1179 Serialize commodities and duties formset
<!---
 * Include the JIRA ticket number, eg TP-123, to automatically link.
 * Use 50 characters maximum.
 * Do not end with a full-stop.
--->

## Why
<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Use as many lines as you like.
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions or deliberately ignored edge-cases.
--->

Complete support for serialization / deserialization of `MeasureConditionsWizardStepFormSet` required.
Support for serialization / deserialization of `MeasureCommodityAndDutiesFormSet` required.
Supporting capability for serializing dates and associated tests required.
Further refinement of form serialization is desirable.
Removal of debug / temporary test capability is desirable.

## What
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Explain like I'm 5.
 * Use pictures if you can.
--->
This PR:

- More flexible handling of form data key serialization. `SerializableFormMixin.ignored_data_key_regexs` is now used to represent the default list of keys that should be skipped.
- Adds `SerializableFormMixin.get_serializable_data_keys()` which is used to get the non-ignored data keys of a Form instance.
- Provides unit test for `SerializableFormMixin.get_serializable_data_keys()`.
- Adds supporting capability for serializing and deserializing dates.
- Provides unit tests for date serialization / deserialization.
- Adds support for `serializable_init_kwargs()` and `deserialize_init_kwargs()` on `MeasureConditionsWizardStepFormSet`.
- Full support for serialization / deserialization of `MeasureCommodityAndDutiesFormSet`.
- Provides a temporary unit test `test_measure_commodities_and_duties_form_set_serialization()` to be superceded by a fuller suite of tests.
- Introduces a destinction between forms at wizard steps that collect user data and those that don't collect data. This allows serialization of only those data-providing forms. `MeasureCreateWizard.data_form_list` is used to hold the data forms and has an accompanying `MeasureCreateWizard.get_data_form_list()` function which is analogous to the base class's `WizardView.get_form_list()` - they get their associated form lists while applying the conditions filter in `MeasureCreateWizard.condition_dict`.

<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
--->
## Checklist
- Requires migrations? No
- Requires dependency updates? No

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
