### PR TITLE
update importer model matching to account for end dated objects.

### DIFF
--- a/taric_parsers/parsers/taric_parser.py
+++ b/taric_parsers/parsers/taric_parser.py
@@ -550,20 +550,19 @@ class BaseTaricParser:
                 if hasattr(model, "valid_between"):
                     # Check if this record is the most current
                     if len(filtered_models) > 0:
-                        # If the model does not have an end date, replace filtered models with non end dated model
-                        if model.valid_between.upper_inf:
-                            filtered_models = [model]
                         # if current filtered model has no end date, don't replace
-                        elif filtered_models[0].valid_between.upper_inf:
+                        if filtered_models[0].valid_between.upper_inf:
+                            continue
+                        # If the model does not have an end date, replace filtered models with non end dated model
+                        elif model.valid_between.upper_inf:
+                            filtered_models = [model]
+                        elif (
+                            filtered_models[0].valid_between.upper
+                            > model.valid_between.upper
+                        ):
                             continue
                         else:
-                            if (
-                                filtered_models[0].valid_between.upper
-                                > model.valid_between.upper
-                            ):
-                                continue
-                            else:
-                                filtered_models = [model]
+                            filtered_models = [model]
 
                     elif len(filtered_models) == 0:
                         filtered_models = [model]

--- a/taric_parsers/parsers/taric_parser.py
+++ b/taric_parsers/parsers/taric_parser.py
@@ -548,9 +548,25 @@ class BaseTaricParser:
             filtered_models = []
             for model in models:
                 if hasattr(model, "valid_between"):
-                    # Check if this record is current
-                    if date.today() in model.valid_between:
-                        filtered_models.append(model)
+                    # Check if this record is the most current
+                    if len(filtered_models) > 0:
+                        # If the model does not have an end date, replace filtered models with non end dated model
+                        if model.valid_between.upper_inf:
+                            filtered_models = [model]
+                        # if current filtered model has no end date, don't replace
+                        elif filtered_models[0].valid_between.upper_inf:
+                            continue
+                        else:
+                            if (
+                                filtered_models[0].valid_between.upper
+                                > model.valid_between.upper
+                            ):
+                                continue
+                            else:
+                                filtered_models = [model]
+
+                    elif len(filtered_models) == 0:
+                        filtered_models = [model]
 
                 elif hasattr(model, "validity_start"):
                     # check for latest
@@ -565,9 +581,15 @@ class BaseTaricParser:
             if len(filtered_models) == 1:
                 return filtered_models[0]
 
+            if len(filtered_models) > 1:
+                raise Exception(
+                    f"multiple models matched query for {related_model.__name__} using {fields_and_values}, please check data and query",
+                )
+
             raise Exception(
-                f"multiple models matched query for {related_model.__name__} using {fields_and_values}, please check data and query",
+                f"no models matched query for {related_model.__name__} using {fields_and_values}, please check data and query",
             )
+
         else:
             return None
 


### PR DESCRIPTION
# TP2000-1210 - bugfix for goods origin - where the goods is end dated 

## Why

Why is this change happening, e.g. goals, use cases, stories, etc.?
 * urgent bugfix for production issue encountered.
 * the changes have been tested and the issue is resolved.

## What
What is this PR doing, e.g. implementations, algorithms, etc.?
 * change the way that linked models are filtered, previously the current date was used to filter models validity, where in some circumstances this is not the correct approach, especially when origins and successors are redirecting goods that are also being end dated. The filter now takes the approach of using the most recent version of a model. 

## Checklist
- Requires migrations? No
- Requires dependency updates? No 

Links to relevant material
See: [Description](https://uktrade.atlassian.net/browse/TP2000-1210)
