### PR TITLE
TP2000-1219  Prevent maintenance mode errors

### DIFF
--- a/.profile
+++ b/.profile
@@ -3,8 +3,13 @@
 # ref - https://docs.cloudfoundry.org/devguide/deploy-apps/deploy-app.html
 
 echo "---- RUNNING release tasks (.profile) ------"
-echo "---- Apply Migrations ------"
-python manage.py migrate
+
+if [[ "$MAINTENANCE_MODE" != "True" && "$MAINTENANCE_MODE" != "true" ]] ; then
+  echo "---- Apply Migrations ------"
+  python manage.py migrate
+else
+  echo "---- Skip Applying Migrations (Maintenance Mode) ------"
+fi
 
 echo "---- Collect Static Files ------"
 OUTPUT=$(python manage.py collectstatic --noinput --clear)

--- a/common/jinja2/common/maintenance.jinja
+++ b/common/jinja2/common/maintenance.jinja
@@ -2,8 +2,9 @@
 
 {% set page_title = "Sorry, the service is unavailable" %}
 
-{% block header %}
+{% set workbasket_html %}{% endset %}
 
+{% block header %}
 {{ govukHeader({
   "homepageUrl": "https://gov.uk/",
   "serviceName": service_name,

--- a/common/jinja2/layouts/layout.jinja
+++ b/common/jinja2/layouts/layout.jinja
@@ -66,7 +66,7 @@
     "meta": {
       "items": [
         {
-          "href": "https://workspace.trade.gov.uk/working-at-dit/policies-and-guidance/policies/tariff-application-privacy-policy/",
+          "href": "https://workspace.trade.gov.uk/working-at-dbt/policies-and-guidance/policies/tariff-application-privacy-policy/",
           "text": "Privacy policy"
         },
         {

--- a/common/tests/test_views.py
+++ b/common/tests/test_views.py
@@ -195,7 +195,7 @@ def test_index_displays_footer_links(valid_user_client):
     assert "Privacy policy" in a_tags[0].text
     assert (
         a_tags[0].attrs["href"]
-        == "https://workspace.trade.gov.uk/working-at-dit/policies-and-guidance/policies/tariff-application-privacy-policy/"
+        == "https://workspace.trade.gov.uk/working-at-dbt/policies-and-guidance/policies/tariff-application-privacy-policy/"
     )
 
 

--- a/settings/common.py
+++ b/settings/common.py
@@ -156,7 +156,7 @@ MIDDLEWARE = [
     "csp.middleware.CSPMiddleware",
 ]
 
-if SSO_ENABLED:
+if SSO_ENABLED and not MAINTENANCE_MODE:
     MIDDLEWARE += [
         "authbroker_client.middleware.ProtectAllViewsMiddleware",
     ]


### PR DESCRIPTION
# TP2000-1219  Prevent maintenance mode errors

## Why
The recent activation of maintenance mode raised the following errors:
1. `ImproperlyConfigured("settings.DATABASES is improperly configured. ")`
2. `AttributeError: 'WSGIRequest' object has no attribute 'user'`

## What
1. Skips running python migrate command in the custom initialisation task script upon deployment since the database routes have been removed in maintenance mode
2. Disables `ProtectAllViewsMiddleware` in maintenance mode, preventing attempts to access the missing user attribute from the request object as a result of `AuthenticationMiddleware` being disabled too

