### PR TITLE
TP2000-1226 Fix workbasket user assignment assignable users queryset

### DIFF
--- a/common/models/user.py
+++ b/common/models/user.py
@@ -2,20 +2,6 @@ from django.contrib.auth.models import AbstractUser
 from django.db import models
 
 
-class UserQuerySet(models.QuerySet):
-    def tariff_managers(self):
-        """Filter in active users who belong to one of the Tariff Manager
-        profile groups or who are marked as a superuser."""
-        return (
-            self.filter(
-                models.Q(groups__name__in=["Tariff Managers", "Tariff Lead Profile"])
-                | models.Q(is_superuser=True),
-            )
-            .filter(is_active=True)
-            .distinct()
-        )
-
-
 class User(AbstractUser):
     """Custom user model."""
 
@@ -25,8 +11,6 @@ class User(AbstractUser):
         null=True,
         blank=True,
     )
-
-    objects = UserQuerySet.as_manager()
 
     class Meta:
         db_table = "auth_user"

--- a/common/models/user.py
+++ b/common/models/user.py
@@ -2,6 +2,20 @@ from django.contrib.auth.models import AbstractUser
 from django.db import models
 
 
+class UserQuerySet(models.QuerySet):
+    def tariff_managers(self):
+        """Filter in active users who belong to one of the Tariff Manager
+        profile groups or who are marked as a superuser."""
+        return (
+            self.filter(
+                models.Q(groups__name__in=["Tariff Managers", "Tariff Lead Profile"])
+                | models.Q(is_superuser=True),
+            )
+            .filter(is_active=True)
+            .distinct()
+        )
+
+
 class User(AbstractUser):
     """Custom user model."""
 
@@ -11,6 +25,8 @@ class User(AbstractUser):
         null=True,
         blank=True,
     )
+
+    objects = UserQuerySet.as_manager()
 
     class Meta:
         db_table = "auth_user"

--- a/workbaskets/forms.py
+++ b/workbaskets/forms.py
@@ -7,7 +7,6 @@ from crispy_forms_gds.layout import Size
 from crispy_forms_gds.layout import Submit
 from django import forms
 from django.contrib.auth import get_user_model
-from django.db.models import Q
 
 from common.validators import AlphanumericValidator
 from common.validators import SymbolValidator
@@ -212,14 +211,9 @@ class WorkBasketAssignUsersForm(forms.Form):
         self.init_layout()
 
     def init_fields(self):
-        self.fields["users"].queryset = (
-            User.objects.filter(
-                Q(groups__name__in=["Tariff Managers", "Tariff Lead Profile"])
-                | Q(is_superuser=True),
-            )
-            .filter(is_active=True)
-            .distinct()
-            .order_by("first_name", "last_name")
+        self.fields["users"].queryset = User.objects.tariff_managers().order_by(
+            "first_name",
+            "last_name",
         )
 
         self.fields["users"].label_from_instance = lambda obj: obj.get_full_name()

--- a/workbaskets/forms.py
+++ b/workbaskets/forms.py
@@ -212,10 +212,15 @@ class WorkBasketAssignUsersForm(forms.Form):
         self.init_layout()
 
     def init_fields(self):
-        self.fields["users"].queryset = User.objects.filter(
-            Q(groups__name__in=["Tariff Managers", "Tariff Lead Profile"])
-            | Q(is_superuser=True),
-        ).order_by("first_name", "last_name")
+        self.fields["users"].queryset = (
+            User.objects.filter(
+                Q(groups__name__in=["Tariff Managers", "Tariff Lead Profile"])
+                | Q(is_superuser=True),
+            )
+            .filter(is_active=True)
+            .distinct()
+            .order_by("first_name", "last_name")
+        )
 
         self.fields["users"].label_from_instance = lambda obj: obj.get_full_name()
 

--- a/workbaskets/forms.py
+++ b/workbaskets/forms.py
@@ -7,6 +7,7 @@ from crispy_forms_gds.layout import Size
 from crispy_forms_gds.layout import Submit
 from django import forms
 from django.contrib.auth import get_user_model
+from django.db.models import Q
 
 from common.validators import AlphanumericValidator
 from common.validators import SymbolValidator
@@ -211,9 +212,14 @@ class WorkBasketAssignUsersForm(forms.Form):
         self.init_layout()
 
     def init_fields(self):
-        self.fields["users"].queryset = User.objects.tariff_managers().order_by(
-            "first_name",
-            "last_name",
+        self.fields["users"].queryset = (
+            User.objects.filter(
+                Q(groups__name__in=["Tariff Managers", "Tariff Lead Profile"])
+                | Q(is_superuser=True),
+            )
+            .filter(is_active=True)
+            .distinct()
+            .order_by("first_name", "last_name")
         )
 
         self.fields["users"].label_from_instance = lambda obj: obj.get_full_name()

--- a/workbaskets/views/ui.py
+++ b/workbaskets/views/ui.py
@@ -429,10 +429,15 @@ class CurrentWorkBasket(TemplateView):
             )
         ]
 
-        users = User.objects.filter(
-            Q(groups__name__in=["Tariff Managers", "Tariff Lead Profile"])
-            | Q(is_superuser=True),
-        ).order_by("first_name", "last_name")
+        users = (
+            User.objects.filter(
+                Q(groups__name__in=["Tariff Managers", "Tariff Lead Profile"])
+                | Q(is_superuser=True),
+            )
+            .filter(is_active=True)
+            .distinct()
+            .order_by("first_name", "last_name")
+        )
         assignable_users = [
             {"pk": user.pk, "name": user.get_full_name()} for user in users
         ]

--- a/workbaskets/views/ui.py
+++ b/workbaskets/views/ui.py
@@ -14,6 +14,7 @@ from django.core.exceptions import ObjectDoesNotExist
 from django.core.paginator import Paginator
 from django.db.models import F
 from django.db.models import ProtectedError
+from django.db.models import Q
 from django.db.transaction import atomic
 from django.http import Http404
 from django.http import HttpResponseRedirect
@@ -428,12 +429,17 @@ class CurrentWorkBasket(TemplateView):
             )
         ]
 
-        assignable_users = [
-            {"pk": user.pk, "name": user.get_full_name()}
-            for user in User.objects.tariff_managers().order_by(
-                "first_name",
-                "last_name",
+        users = (
+            User.objects.filter(
+                Q(groups__name__in=["Tariff Managers", "Tariff Lead Profile"])
+                | Q(is_superuser=True),
             )
+            .filter(is_active=True)
+            .distinct()
+            .order_by("first_name", "last_name")
+        )
+        assignable_users = [
+            {"pk": user.pk, "name": user.get_full_name()} for user in users
         ]
 
         # set to true if there is an associated goods import batch with an unsent notification

--- a/workbaskets/views/ui.py
+++ b/workbaskets/views/ui.py
@@ -14,7 +14,6 @@ from django.core.exceptions import ObjectDoesNotExist
 from django.core.paginator import Paginator
 from django.db.models import F
 from django.db.models import ProtectedError
-from django.db.models import Q
 from django.db.transaction import atomic
 from django.http import Http404
 from django.http import HttpResponseRedirect
@@ -429,17 +428,12 @@ class CurrentWorkBasket(TemplateView):
             )
         ]
 
-        users = (
-            User.objects.filter(
-                Q(groups__name__in=["Tariff Managers", "Tariff Lead Profile"])
-                | Q(is_superuser=True),
-            )
-            .filter(is_active=True)
-            .distinct()
-            .order_by("first_name", "last_name")
-        )
         assignable_users = [
-            {"pk": user.pk, "name": user.get_full_name()} for user in users
+            {"pk": user.pk, "name": user.get_full_name()}
+            for user in User.objects.tariff_managers().order_by(
+                "first_name",
+                "last_name",
+            )
         ]
 
         # set to true if there is an associated goods import batch with an unsent notification


### PR DESCRIPTION
# TP2000-1226 Fix workbasket user assignment assignable users queryset

## Why
The queryset used to populate selectable users for workbasket user assignment includes inactive and duplicate user profiles. 

## What
- Adds `.filter(is_active=True)` to the users queryset to filter out inactive users
- Adds `.distinct()` to prevent duplicate user objects being included in the queryset (users who belong to both TM and TM Lead user groups)