### PR TITLE
TP2000-1249 Archive empty, previously assigned workbaskets upon deletion

### DIFF
--- a/workbaskets/views/ui.py
+++ b/workbaskets/views/ui.py
@@ -1087,13 +1087,13 @@ class WorkBasketDelete(PermissionRequiredMixin, DeleteView):
 
     def form_valid(self, form):
         if (
-            not PackagedWorkBasket.objects.filter(workbasket=self.object).exists()
-            and not self.object.tasks.exists()
+            PackagedWorkBasket.objects.filter(workbasket=self.object).exists()
+            or self.object.tasks.exists()
         ):
-            self.object.delete()
-        else:
             self.object.archive()
             self.object.save()
+        else:
+            self.object.delete()
         return redirect(self.get_success_url())
 
 

--- a/workbaskets/views/ui.py
+++ b/workbaskets/views/ui.py
@@ -1086,7 +1086,10 @@ class WorkBasketDelete(PermissionRequiredMixin, DeleteView):
         return kwargs
 
     def form_valid(self, form):
-        if not PackagedWorkBasket.objects.filter(workbasket=self.object).exists():
+        if (
+            not PackagedWorkBasket.objects.filter(workbasket=self.object).exists()
+            and not self.object.tasks.exists()
+        ):
             self.object.delete()
         else:
             self.object.archive()


### PR DESCRIPTION
# TP2000-1249 Archive empty, previously assigned workbaskets upon deletion

## Why
Users with the requisite permission are able to delete a workbasket with `EDITING` status once its `Transactions` and `TrackedModels` have been removed. However, a workbasket that has previously been assigned to a user will have a non-nullable `Task` instance associated with it, preventing deletion.

## What
- Archives empty, previously assigned workbaskets, giving the appearance of workbasket deletion while preventing a `ProtectedError` from being raised
