### PR TITLE
TP2000-1119 List view filtering

### DIFF
--- a/measures/filters.py
+++ b/measures/filters.py
@@ -25,6 +25,7 @@ from measures.forms import MeasureFilterForm
 from measures.models import Measure
 from measures.models import MeasureCondition
 from measures.models import MeasureType
+from measures.models.bulk_processing import MeasuresBulkCreator
 from quotas.models import QuotaOrderNumber
 from regulations.models import Regulation
 from workbaskets.models import WorkBasket
@@ -276,3 +277,14 @@ class MeasureFilter(TamatoFilter):
 
         # Defines the order shown in the form.
         fields = ["search", "sid"]
+
+
+class MeasureCreateTaskFilter(TamatoFilter):
+    """FilterSet for Bulk Measure Creation tasks."""
+
+    search_fields = "processing_state"
+    clear_url = reverse_lazy("measure-create-process-queue")
+
+    class Meta:
+        model = MeasuresBulkCreator
+        fields = ["processing_state"]

--- a/measures/jinja2/measures/create-process-queue.jinja
+++ b/measures/jinja2/measures/create-process-queue.jinja
@@ -17,7 +17,6 @@
   ) }}
 {% endblock %}
 
-{# NOTE: "?processing_state=AWAITING_PROCESSING,CURRENTLY_PROCESSING" returns neither Awaiting or Currently processing tasks #}
 {% set filter_links_list = [
   {
     "text": "All",

--- a/measures/jinja2/measures/create-process-queue.jinja
+++ b/measures/jinja2/measures/create-process-queue.jinja
@@ -26,7 +26,7 @@
   },
   {
     "text": "Processing",
-    "href": "?processing_state=AWAITING_PROCESSING&processing_state=CURRENTLY_PROCESSING",
+    "href": "?processing_state=PROCESSING",
     "selected": selected_link == "processing",
   },
   {

--- a/measures/jinja2/measures/create-process-queue.jinja
+++ b/measures/jinja2/measures/create-process-queue.jinja
@@ -22,27 +22,27 @@
   {
     "text": "All",
     "href": "?status=",
-    "selected": selected_filter == "all",
+    "selected": selected_link == "all",
   },
   {
     "text": "Processing",
-    "href": "?status=PROCESSING",
-    "selected": selected_filter == "processing",
+    "href": "?status=CURRENTLY_PROCESSING",
+    "selected": selected_link == "processing",
   },
   {
     "text": "Completed",
-    "href": "?status=COMPLETED",
-    "selected": selected_filter == "completed",
+    "href": "?status=SUCCESSFULLY_PROCESSED",
+    "selected": selected_link == "completed",
   },
   {
     "text": "Failed",
-    "href": "?status=FAILED",
-    "selected": selected_filter == "failed",
+    "href": "?status=FAILED_PROCESSING",
+    "selected": selected_link == "failed",
   },
   {
     "text": "Cancelled",
     "href": "?status=CANCELLED",
-    "selected": selected_filter == "cancelled",
+    "selected": selected_link == "cancelled",
   },
 ]%}
 

--- a/measures/jinja2/measures/create-process-queue.jinja
+++ b/measures/jinja2/measures/create-process-queue.jinja
@@ -17,31 +17,31 @@
   ) }}
 {% endblock %}
 
-
+{# NOTE: "?processing_state=AWAITING_PROCESSING,CURRENTLY_PROCESSING" returns neither Awaiting or Currently processing tasks #}
 {% set filter_links_list = [
   {
     "text": "All",
-    "href": "?status=",
+    "href": "?processing_state=",
     "selected": selected_link == "all",
   },
   {
     "text": "Processing",
-    "href": "?status=CURRENTLY_PROCESSING",
+    "href": "?processing_state=AWAITING_PROCESSING&processing_state=CURRENTLY_PROCESSING",
     "selected": selected_link == "processing",
   },
   {
     "text": "Completed",
-    "href": "?status=SUCCESSFULLY_PROCESSED",
+    "href": "?processing_state=SUCCESSFULLY_PROCESSED",
     "selected": selected_link == "completed",
   },
   {
     "text": "Failed",
-    "href": "?status=FAILED_PROCESSING",
+    "href": "?processing_state=FAILED_PROCESSING",
     "selected": selected_link == "failed",
   },
   {
     "text": "Cancelled",
-    "href": "?status=CANCELLED",
+    "href": "?processing_state=CANCELLED",
     "selected": selected_link == "cancelled",
   },
 ]%}

--- a/measures/tests/test_filters.py
+++ b/measures/tests/test_filters.py
@@ -1,12 +1,16 @@
 from datetime import date
 
 import pytest
+from bs4 import BeautifulSoup
+from django.urls import reverse
 
 from common.tests import factories
 from common.util import TaricDateRange
 from common.validators import UpdateType
 from measures.filters import MeasureFilter
 from measures.models import Measure
+from measures.models.bulk_processing import ProcessingState
+from measures.tests.factories import MeasuresBulkCreatorFactory
 
 pytestmark = pytest.mark.django_db
 
@@ -95,3 +99,100 @@ def test_filter_by_certificates(
     assert measure_no_certificate not in filtered_measures
     assert measure_with_different_certificate not in filtered_measures
     assert updated_measure in filtered_measures
+
+
+def test_measure_create_process_queue_filters(
+    valid_user_client,
+):
+    # TODO: Tidy this up
+    sp = MeasuresBulkCreatorFactory.create(
+        processing_state=ProcessingState.SUCCESSFULLY_PROCESSED,
+    )
+    ap = MeasuresBulkCreatorFactory.create(
+        processing_state=ProcessingState.AWAITING_PROCESSING,
+    )
+    cp = MeasuresBulkCreatorFactory.create(
+        processing_state=ProcessingState.CURRENTLY_PROCESSING,
+    )
+    MeasuresBulkCreatorFactory.create(
+        processing_state=ProcessingState.CANCELLED,
+    )
+    MeasuresBulkCreatorFactory.create(
+        processing_state=ProcessingState.FAILED_PROCESSING,
+    )
+    # TODO: And this
+    success_url = f"{reverse('measure-create-process-queue')}?processing_state=SUCCESSFULLY_PROCESSED"
+    processing_url = f"{reverse('measure-create-process-queue')}?processing_state=AWAITING_PROCESSING&processing_task=CURRENTLY_PROCESSING"
+    failed_url = (
+        f"{reverse('measure-create-process-queue')}?processing_state=FAILED_PROCESSED"
+    )
+    cancelled_url = (
+        f"{reverse('measure-create-process-queue')}?processing_state=CANCELLED"
+    )
+    all_url = f"{reverse('measure-create-process-queue')}?processing_state="
+    # TODO: And all of this
+    success_response = valid_user_client.get(success_url)
+    assert success_response.status_code == 200
+    page = BeautifulSoup(
+        success_response.content.decode(success_response.charset),
+        "html.parser",
+    )
+    assert page.find("span", class_="tamato-badge-light-green")
+
+    processing_response = valid_user_client.get(processing_url)
+    assert processing_response.status_code == 200
+    page = BeautifulSoup(
+        processing_response.content.decode(processing_response.charset),
+        "html.parser",
+    )
+    res = page.find_all("span", class_="tamato-badge-light-blue")
+    assert len(res) == 2
+
+    failed_response = valid_user_client.get(failed_url)
+    assert failed_response.status_code == 200
+    page = BeautifulSoup(
+        failed_response.content.decode(failed_response.charset),
+        "html.parser",
+    )
+    assert page.find("span", class_="tamato-badge-light-red")
+
+    cancelled_response = valid_user_client.get(cancelled_url)
+    assert cancelled_response.status_code == 200
+    page = BeautifulSoup(
+        cancelled_response.content.decode(cancelled_response.charset),
+        "html.parser",
+    )
+    assert page.find("span", class_="tamato-badge-light-yellow")
+
+    all_response = valid_user_client.get(all_url)
+    assert all_response.status_code == 200
+    page = BeautifulSoup(
+        all_response.content.decode(all_response.charset),
+        "html.parser",
+    )
+    assert page.find("span", class_="tamato-badge-light-green")
+    assert page.find("span", class_="tamato-badge-light-blue")
+    assert page.find("span", class_="tamato-badge-light-red")
+    assert page.find("span", class_="tamato-badge-light-yellow")
+
+    assert 0
+
+    # data={"measure_filters_modifier": "current"}
+    # queryset = MeasuresBulkCreator.objects.all()
+    # filter = MeasureCreateTaskFilter()
+    # filter.queryset = queryset
+    # filter.filters['processing_state'] is ChoiceFilter
+    # filter = MeasureCreateTaskFilter(
+    #     queryset,
+    #     filters={'processing_state': 'CANCELLED'}
+    #     )
+    # filter = MeasureCreateTaskFilter(
+    #     data={
+    #         "queryset": queryset,
+    #         "processing_state": 'CANCELLED_PROCESSING'
+    #     }
+    # )
+    # filter.filters = {'processing_state': 'CANCELLED_PROCESSING'}
+    # measure_filter = MeasureFilter(
+    #     data={"certificates": certificate.trackedmodel_ptr_id},
+    # )

--- a/measures/tests/test_filters.py
+++ b/measures/tests/test_filters.py
@@ -101,17 +101,28 @@ def test_filter_by_certificates(
     assert updated_measure in filtered_measures
 
 
+# paramtrise
+# state, query_string, class
+@pytest.mark.parametrize(
+    "query_string, css_class",
+    [
+        ("SUCCESSFULLY_PROCESSED", "tamato-badge-light-green"),
+        ("CANCELLED", "tamato-badge-light-yellow"),
+        ("FAILED_PROCESSING", "tamato-badge-light-red"),
+    ],
+)
 def test_measure_create_process_queue_filters(
+    query_string,
+    css_class,
     valid_user_client,
 ):
-    # TODO: Tidy this up
-    sp = MeasuresBulkCreatorFactory.create(
+    MeasuresBulkCreatorFactory.create(
         processing_state=ProcessingState.SUCCESSFULLY_PROCESSED,
     )
-    ap = MeasuresBulkCreatorFactory.create(
+    MeasuresBulkCreatorFactory.create(
         processing_state=ProcessingState.AWAITING_PROCESSING,
     )
-    cp = MeasuresBulkCreatorFactory.create(
+    MeasuresBulkCreatorFactory.create(
         processing_state=ProcessingState.CURRENTLY_PROCESSING,
     )
     MeasuresBulkCreatorFactory.create(
@@ -120,79 +131,42 @@ def test_measure_create_process_queue_filters(
     MeasuresBulkCreatorFactory.create(
         processing_state=ProcessingState.FAILED_PROCESSING,
     )
-    # TODO: And this
-    success_url = f"{reverse('measure-create-process-queue')}?processing_state=SUCCESSFULLY_PROCESSED"
-    processing_url = f"{reverse('measure-create-process-queue')}?processing_state=AWAITING_PROCESSING&processing_task=CURRENTLY_PROCESSING"
-    failed_url = (
-        f"{reverse('measure-create-process-queue')}?processing_state=FAILED_PROCESSED"
-    )
-    cancelled_url = (
-        f"{reverse('measure-create-process-queue')}?processing_state=CANCELLED"
-    )
-    all_url = f"{reverse('measure-create-process-queue')}?processing_state="
-    # TODO: And all of this
-    success_response = valid_user_client.get(success_url)
-    assert success_response.status_code == 200
+    url = f"{reverse('measure-create-process-queue')}?processing_state={query_string}"
+    response = valid_user_client.get(url)
+    assert response.status_code == 200
     page = BeautifulSoup(
-        success_response.content.decode(success_response.charset),
+        response.content.decode(response.charset),
         "html.parser",
     )
-    assert page.find("span", class_="tamato-badge-light-green")
+    assert page.find("span", class_=css_class)
 
-    processing_response = valid_user_client.get(processing_url)
-    assert processing_response.status_code == 200
+
+def test_measure_create_process_queue_filters_processing(
+    valid_user_client,
+):
+    MeasuresBulkCreatorFactory.create(
+        processing_state=ProcessingState.SUCCESSFULLY_PROCESSED,
+    )
+    MeasuresBulkCreatorFactory.create(
+        processing_state=ProcessingState.AWAITING_PROCESSING,
+    )
+    MeasuresBulkCreatorFactory.create(
+        processing_state=ProcessingState.CURRENTLY_PROCESSING,
+    )
+    MeasuresBulkCreatorFactory.create(
+        processing_state=ProcessingState.CANCELLED,
+    )
+    MeasuresBulkCreatorFactory.create(
+        processing_state=ProcessingState.FAILED_PROCESSING,
+    )
+    url = f"{reverse('measure-create-process-queue')}?processing_state=PROCESSING"
+    response = valid_user_client.get(url)
+    assert response.status_code == 200
     page = BeautifulSoup(
-        processing_response.content.decode(processing_response.charset),
+        response.content.decode(response.charset),
         "html.parser",
     )
-    res = page.find_all("span", class_="tamato-badge-light-blue")
-    assert len(res) == 2
-
-    failed_response = valid_user_client.get(failed_url)
-    assert failed_response.status_code == 200
-    page = BeautifulSoup(
-        failed_response.content.decode(failed_response.charset),
-        "html.parser",
-    )
-    assert page.find("span", class_="tamato-badge-light-red")
-
-    cancelled_response = valid_user_client.get(cancelled_url)
-    assert cancelled_response.status_code == 200
-    page = BeautifulSoup(
-        cancelled_response.content.decode(cancelled_response.charset),
-        "html.parser",
-    )
-    assert page.find("span", class_="tamato-badge-light-yellow")
-
-    all_response = valid_user_client.get(all_url)
-    assert all_response.status_code == 200
-    page = BeautifulSoup(
-        all_response.content.decode(all_response.charset),
-        "html.parser",
-    )
-    assert page.find("span", class_="tamato-badge-light-green")
-    assert page.find("span", class_="tamato-badge-light-blue")
-    assert page.find("span", class_="tamato-badge-light-red")
-    assert page.find("span", class_="tamato-badge-light-yellow")
-
-    assert 0
-
-    # data={"measure_filters_modifier": "current"}
-    # queryset = MeasuresBulkCreator.objects.all()
-    # filter = MeasureCreateTaskFilter()
-    # filter.queryset = queryset
-    # filter.filters['processing_state'] is ChoiceFilter
-    # filter = MeasureCreateTaskFilter(
-    #     queryset,
-    #     filters={'processing_state': 'CANCELLED'}
-    #     )
-    # filter = MeasureCreateTaskFilter(
-    #     data={
-    #         "queryset": queryset,
-    #         "processing_state": 'CANCELLED_PROCESSING'
-    #     }
-    # )
-    # filter.filters = {'processing_state': 'CANCELLED_PROCESSING'}
-    # measure_filter = MeasureFilter(
-    #     data={"certificates": certificate.trackedmodel_ptr_id},
-    # )
+    assert len(page.find_all("span", class_="tamato-badge-light-blue")) == 2
+    assert not page.find("span", class_="tamato-badge-light-green")
+    assert not page.find("span", class_="tamato-badge-light-red")
+    assert not page.find("span", class_="tamato-badge-light-yellow")

--- a/measures/tests/test_filters.py
+++ b/measures/tests/test_filters.py
@@ -101,8 +101,6 @@ def test_filter_by_certificates(
     assert updated_measure in filtered_measures
 
 
-# paramtrise
-# state, query_string, class
 @pytest.mark.parametrize(
     "query_string, css_class",
     [
@@ -139,6 +137,7 @@ def test_measure_create_process_queue_filters(
         "html.parser",
     )
     assert page.find("span", class_=css_class)
+    assert not page.find("span", class_="tamato-badge-light-blue")
 
 
 def test_measure_create_process_queue_filters_processing(

--- a/measures/views.py
+++ b/measures/views.py
@@ -13,6 +13,7 @@ from crispy_forms.helper import FormHelper
 from django.conf import settings
 from django.contrib.auth.mixins import PermissionRequiredMixin
 from django.contrib.auth.mixins import UserPassesTestMixin
+from django.db.models import Q
 from django.http import HttpRequest
 from django.http import HttpResponse
 from django.http import HttpResponseRedirect
@@ -1149,13 +1150,11 @@ class MeasuresCreateProcessQueue(
     def get_processing_queryset(self):
         """Returns a combined queryset of tasks either AWAITING_PROCESSING or
         CURRENTLY_PROCESSING."""
-        awaiting_processing = self.queryset.filter(
-            processing_state="AWAITING_PROCESSING",
+
+        return self.queryset.filter(
+            Q(processing_state=ProcessingState.AWAITING_PROCESSING)
+            | Q(processing_state=ProcessingState.CURRENTLY_PROCESSING),
         )
-        currently_processing = self.queryset.filter(
-            processing_state="CURRENTLY_PROCESSING",
-        )
-        return awaiting_processing.union(currently_processing)
 
     def is_task_failed(self, task: MeasuresBulkCreator) -> bool:
         """

--- a/measures/views.py
+++ b/measures/views.py
@@ -56,8 +56,6 @@ from measures.constants import MEASURE_CONDITIONS_FORMSET_PREFIX
 from measures.constants import START
 from measures.constants import MeasureEditSteps
 from measures.creators import MeasuresCreator
-
-# from measures.filters import MeasureCreateTaskFilter
 from measures.filters import MeasureCreateTaskFilter
 from measures.filters import MeasureFilter
 from measures.filters import MeasureTypeFilterBackend
@@ -1149,6 +1147,8 @@ class MeasuresCreateProcessQueue(
         return context
 
     def get_processing_queryset(self):
+        """Returns a combined queryset of tasks either AWAITING_PROCESSING or
+        CURRENTLY_PROCESSING."""
         awaiting_processing = self.queryset.filter(
             processing_state="AWAITING_PROCESSING",
         )

--- a/measures/views.py
+++ b/measures/views.py
@@ -56,6 +56,7 @@ from measures.constants import MEASURE_CONDITIONS_FORMSET_PREFIX
 from measures.constants import START
 from measures.constants import MeasureEditSteps
 from measures.creators import MeasuresCreator
+from measures.filters import MeasureCreateTaskFilter
 from measures.filters import MeasureFilter
 from measures.filters import MeasureTypeFilterBackend
 from measures.models import FootnoteAssociationMeasure
@@ -1116,43 +1117,32 @@ class MeasuresCreateProcessQueue(
         "common.change_trackedmodel",
     ]
     template_name = "measures/create-process-queue.jinja"
-    filter_by_fields = ["all", "processing", "completed", "failed"]
-    sort_by_fields = [
-        "workbasket_id",
-        "submitted_date",
-        "submitted_by",
-        "status",
-        "object_count",
-        "action",
-    ]
-
-    def get_queryset(self):
-        return MeasuresBulkCreator.objects.filter(
-            workbasket__status=WorkflowStatus.EDITING,
-        ).order_by("-created_at")
+    queryset = MeasuresBulkCreator.objects.filter(
+        workbasket__status=WorkflowStatus.EDITING,
+    ).order_by("-created_at")
+    filterset_class = MeasureCreateTaskFilter
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
 
-        processing_state = self.request.GET.get("processing_state")
-        context["selected_filter"] = "all"
+        context["selected_link"] = "all"
+        processing_state = self.request.GET.get("status")
+
         if processing_state in [
             ProcessingState.CURRENTLY_PROCESSING,
             ProcessingState.AWAITING_PROCESSING,
         ]:
-            context["selected_filter"] = "processing"
+            context["selected_link"] = "processing"
         elif processing_state == ProcessingState.CANCELLED:
-            context["selected_filter"] = "cancelled"
+            context["selected_link"] = "cancelled"
         elif processing_state == ProcessingState.FAILED_PROCESSING:
-            context["selected_filter"] = "failed"
+            context["selected_link"] = "failed"
         elif processing_state == ProcessingState.SUCCESSFULLY_PROCESSED:
-            context["selected_filter"] = "completed"
-
+            context["selected_link"] = "completed"
         # Provide template access to some UI / view utility functions.
         context["status_tag_generator"] = self.status_tag_generator
         context["can_cancel_task"] = self.can_cancel_task
         context["is_task_failed"] = self.is_task_failed
-
         # Apply the TAP standard date format within the UI.
         context["datetime_format"] = settings.DATETIME_FORMAT
 

--- a/measures/views.py
+++ b/measures/views.py
@@ -45,7 +45,7 @@ from common.views import SortingMixin
 from common.views import TamatoListView
 from common.views import TrackedModelDetailMixin
 from common.views import TrackedModelDetailView
-from common.views import WithPaginationListMixin
+from common.views import WithPaginationListView
 from footnotes.models import Footnote
 from geo_areas.models import GeographicalArea
 from geo_areas.utils import get_all_members_of_geo_groups
@@ -1107,8 +1107,7 @@ class MeasuresWizardCreateConfirm(TemplateView):
 
 class MeasuresCreateProcessQueue(
     PermissionRequiredMixin,
-    WithPaginationListMixin,
-    ListView,
+    WithPaginationListView,
 ):
     """UI endpoint for bulk creating Measures process queue."""
 
@@ -1126,12 +1125,14 @@ class MeasuresCreateProcessQueue(
         context = super().get_context_data(**kwargs)
 
         context["selected_link"] = "all"
-        processing_state = self.request.GET.get("status")
-
-        if processing_state in [
-            ProcessingState.CURRENTLY_PROCESSING,
-            ProcessingState.AWAITING_PROCESSING,
-        ]:
+        processing_state = self.request.GET.get("processing_state")
+        # NOT THIS if processing_state == ProcessingState.AWAITING_PROCESSING or processing_state == ProcessingState.CURRENTLY_PROCESSING:
+        # OR THIS if processing_state in [
+        #     ProcessingState.AWAITING_PROCESSING,
+        #     ProcessingState.CURRENTLY_PROCESSING
+        # ]:
+        # THIS DOESN'T WORK EITHER
+        if processing_state in ProcessingState.queued_states():
             context["selected_link"] = "processing"
         elif processing_state == ProcessingState.CANCELLED:
             context["selected_link"] = "cancelled"


### PR DESCRIPTION
# TP2000-1119 Task Queue view filtering

## Why
The new Task Queue view page requires users to be able to filter tasks by `ProcessingState`

## What
- adds functionality to filter for tasks which are Processing, ie. have a `ProcessingState` of `CURRENTLY_PROCESSING` or `AWAITING_PROCESSING`
- uses TamatoFilter to filter for the other states using the TamatoFilter
- tests that applying the filters displays the relevant task

Note: This PR has a work around for tasks which are Processing. We should investigate a refactor of/addition to the TamatoFilter that will allow querying using multiple parameters on the same filed, eg. a query of `?processing_state=AWAITING_PROCESSING&processing_state=CURRENTLY_PROCESSING` would return relevant tasks.
![image](https://github.com/uktrade/tamato/assets/46421052/a7defc21-0a93-40f3-b09a-80c8e3a0cfd8)
