### PR TITLE
TP2000-1250 Rename assign_to_user() to avoid confusion with user assignment

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -329,7 +329,7 @@ def client_with_current_workbasket(client, valid_user):
     workbasket = factories.WorkBasketFactory.create(
         status=WorkflowStatus.EDITING,
     )
-    workbasket.assign_to_user(valid_user)
+    workbasket.set_as_current(valid_user)
     return client
 
 
@@ -342,7 +342,7 @@ def client_with_current_workbasket_no_permissions(client):
     workbasket = factories.WorkBasketFactory.create(
         status=WorkflowStatus.EDITING,
     )
-    workbasket.assign_to_user(user)
+    workbasket.set_as_current(user)
     return client
 
 
@@ -391,7 +391,7 @@ def api_client_with_current_workbasket(api_client, valid_user) -> APIClient:
     workbasket = factories.WorkBasketFactory.create(
         status=WorkflowStatus.EDITING,
     )
-    workbasket.assign_to_user(valid_user)
+    workbasket.set_as_current(valid_user)
     return api_client
 
 
@@ -453,7 +453,7 @@ def user_workbasket(client, valid_user, assigned_workbasket) -> WorkBasket:
     """Returns a workbasket which has been assigned to a valid logged-in
     user."""
     client.force_login(valid_user)
-    assigned_workbasket.assign_to_user(valid_user)
+    assigned_workbasket.set_as_current(valid_user)
     return assigned_workbasket
 
 
@@ -463,7 +463,7 @@ def user_empty_workbasket(client, valid_user) -> WorkBasket:
     workbasket = factories.WorkBasketFactory.create(
         status=WorkflowStatus.EDITING,
     )
-    workbasket.assign_to_user(valid_user)
+    workbasket.set_as_current(valid_user)
     return workbasket
 
 
@@ -1548,7 +1548,7 @@ def session_request_with_workbasket(client, valid_user):
     workbasket = factories.WorkBasketFactory.create(
         status=WorkflowStatus.EDITING,
     )
-    workbasket.assign_to_user(valid_user)
+    workbasket.set_as_current(valid_user)
 
     session = client.session
     session.save()

--- a/measures/views.py
+++ b/measures/views.py
@@ -937,7 +937,7 @@ class MeasureCreateWizard(
         cleaned_data = self.get_all_cleaned_data()
 
         created_measures = self.create_measures(cleaned_data)
-        created_measures[0].transaction.workbasket.assign_to_user(self.request.user)
+        created_measures[0].transaction.workbasket.set_as_current(self.request.user)
 
         context = self.get_context_data(
             form=None,

--- a/publishing/tests/test_views.py
+++ b/publishing/tests/test_views.py
@@ -85,7 +85,7 @@ def test_packaged_workbasket_create_form(client, valid_user, workbasket):
     """Tests that Packaged WorkBasket Create returns 302 and redirects to
     confirm create page on success."""
     client.force_login(valid_user)
-    workbasket.assign_to_user(valid_user)
+    workbasket.set_as_current(valid_user)
     with workbasket.new_transaction() as transaction:
         TransactionCheckFactory.create(
             transaction=transaction,
@@ -133,7 +133,7 @@ def test_packaged_workbasket_create_form_rule_check_violations(client, valid_use
     workbasket = factories.WorkBasketFactory.create(
         status=WorkflowStatus.EDITING,
     )
-    workbasket.assign_to_user(valid_user)
+    workbasket.set_as_current(valid_user)
     with workbasket.new_transaction() as transaction:
         TransactionCheckFactory.create(
             transaction=transaction,
@@ -169,7 +169,7 @@ def test_create_duplicate_awaiting_instances(client, valid_user, workbasket):
     packaged workbasket queue page when trying to package a workbasket that is
     already on the queue."""
     client.force_login(valid_user)
-    workbasket.assign_to_user(valid_user)
+    workbasket.set_as_current(valid_user)
     with workbasket.new_transaction() as transaction:
         TransactionCheckFactory.create(
             transaction=transaction,

--- a/workbaskets/models.py
+++ b/workbaskets/models.py
@@ -504,8 +504,8 @@ class WorkBasket(TimestampedMixin):
         """WorkBasket is ready to be worked on again after being rejected by
         CDS."""
 
-    def assign_to_user(self, user) -> None:
-        """Assigns this instance as `user`'s current workbasket."""
+    def set_as_current(self, user) -> None:
+        """Set as the user's current workbasket."""
         user.current_workbasket = self
         user.save()
 

--- a/workbaskets/tests/test_models.py
+++ b/workbaskets/tests/test_models.py
@@ -445,10 +445,11 @@ def test_invalid_workbasket_purge_transactions(workbasket_status):
     assert workbasket.transactions.count() == 2
 
 
-def test_workbasket_assign_to_user(valid_user, workbasket):
-    """Test assign_to_user() sets the user's current workbasket."""
+def test_workbasket_set_as_current(valid_user, workbasket):
+    """Test that set_as_current() sets the workbasket instance as the user's
+    current workbasket."""
     assert not valid_user.current_workbasket
-    workbasket.assign_to_user(valid_user)
+    workbasket.set_as_current(valid_user)
     assert valid_user.current_workbasket == workbasket
 
 

--- a/workbaskets/tests/test_views.py
+++ b/workbaskets/tests/test_views.py
@@ -313,7 +313,7 @@ def test_workbasket_views_without_permission(url_name, client, user_workbasket):
     )
     user = factories.UserFactory.create()
     client.force_login(user)
-    user_workbasket.assign_to_user(user)
+    user_workbasket.set_as_current(user)
     response = client.get(url)
 
     assert response.status_code == 403
@@ -1009,7 +1009,7 @@ def test_violation_detail_page_superuser_override_last_violation(
         transaction_check__successful=False,
     )
     client.force_login(superuser)
-    model_check.transaction_check.transaction.workbasket.assign_to_user(
+    model_check.transaction_check.transaction.workbasket.set_as_current(
         superuser,
     )
 
@@ -1041,7 +1041,7 @@ def test_violation_detail_page_superuser_override_one_of_two_violation(
         transaction_check__successful=False,
     )
     client.force_login(superuser)
-    model_check.transaction_check.transaction.workbasket.assign_to_user(
+    model_check.transaction_check.transaction.workbasket.set_as_current(
         superuser,
     )
 
@@ -1093,7 +1093,7 @@ def test_violation_detail_page_non_superuser_override_violation(
         transaction_check__successful=False,
     )
     client.force_login(valid_user)
-    model_check.transaction_check.transaction.workbasket.assign_to_user(
+    model_check.transaction_check.transaction.workbasket.set_as_current(
         valid_user,
     )
 

--- a/workbaskets/views/ui.py
+++ b/workbaskets/views/ui.py
@@ -104,7 +104,7 @@ class WorkBasketCreate(PermissionRequiredMixin, CreateView):
         self.object = form.save(commit=False)
         self.object.author = self.request.user
         self.object.save()
-        self.object.assign_to_user(self.request.user)
+        self.object.set_as_current(self.request.user)
         return redirect(
             reverse(
                 "workbaskets:workbasket-ui-confirm-create",
@@ -189,7 +189,7 @@ class SelectWorkbasketView(PermissionRequiredMixin, WithPaginationListView):
                 workbasket.restore()
                 workbasket.save()
 
-            workbasket.assign_to_user(request.user)
+            workbasket.set_as_current(request.user)
 
             if workbasket_tab:
                 view = workbasket_tab_map[workbasket_tab]
@@ -473,7 +473,7 @@ class CurrentWorkBasket(TemplateView):
             if result.status != "SUCCESS":
                 context.update({"rule_check_in_progress": True})
             else:
-                self.workbasket.assign_to_user(self.request.user)
+                self.workbasket.set_as_current(self.request.user)
 
             num_completed, total = self.workbasket.rule_check_progress()
             context.update(
@@ -1249,7 +1249,7 @@ class WorkBasketChecksView(FormView):
             if result.status != "SUCCESS":
                 context.update({"rule_check_in_progress": True})
             else:
-                self.workbasket.assign_to_user(self.request.user)
+                self.workbasket.set_as_current(self.request.user)
 
             num_completed, total = self.workbasket.rule_check_progress()
             context.update(


### PR DESCRIPTION
# TP2000-1250 Rename assign_to_user() to avoid confusion with user assignment

## Why
We recently introduced the ability for users to be assigned workbaskets, where assignments are created using `UserAssignment` and `Task` models.

Separate from assigned workbaskets, users may have a `current_workbasket`. The method used to save a workbasket instance as the user’s current workbasket is `assign_to_user(self, user: User)`.

To avoid confusion between user assignments and current workbaskets, the method might be more suitably renamed.

## What
- Renames all occurrences to `set_as_current()` 
