### PR TITLE
TP2000-1101 Missing measures in certificate results fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -145,8 +145,6 @@ webpack-stats.json
 # PyCharm
 .idea/
 
-# VS Code
-.vscode/
 
 *.gz
 
@@ -166,4 +164,5 @@ _dumped_cache.pkl
 # Vim
 .swp
 
-tamato_*.sql
+# Database dumps
+*.sql

--- a/certificates/tests/test_views.py
+++ b/certificates/tests/test_views.py
@@ -313,11 +313,10 @@ def test_certificate_detail_measures_view_lists_measures(valid_user_client):
 
 def test_certificate_detail_measures_view_lists_measures_latest_version(
     valid_user_client,
-    user_workbasket,
 ):
-    """Test that `CertificateDetailMeasures` view displays a paginated list of
-    the latest measures for a certificate when the condition is related to the
-    ."""
+    """Test that `CertificateDetailMeasures` view displays a  list of the latest
+    measures for a certificate when the condition is related to an older version
+    of the dependant measure."""
     certificate = factories.CertificateFactory.create()
     tnx = certificate.transaction
     workbasket = certificate.transaction.workbasket

--- a/certificates/tests/test_views.py
+++ b/certificates/tests/test_views.py
@@ -311,6 +311,56 @@ def test_certificate_detail_measures_view_lists_measures(valid_user_client):
     assert page.find("nav", class_="pagination").find_next("a", href="?page=2")
 
 
+def test_certificate_detail_measures_view_lists_measures_latest_version(
+    valid_user_client,
+    user_workbasket,
+):
+    """Test that `CertificateDetailMeasures` view displays a paginated list of
+    the latest measures for a certificate when the condition is related to the
+    ."""
+    certificate = factories.CertificateFactory.create()
+    tnx = certificate.transaction
+    workbasket = certificate.transaction.workbasket
+    measures = []
+    new_measures = []
+    for measure_with_condition in range(10):
+        measure = factories.MeasureFactory.create(
+            transaction=tnx,
+        )
+        factories.MeasureConditionFactory.create(
+            dependent_measure=measure,
+            required_certificate=certificate,
+            transaction=tnx,
+        )
+        new_measure = measure.new_version(
+            workbasket=workbasket,
+            update_type=UpdateType.UPDATE,
+        )
+        measures.append(measure)
+        new_measures.append(new_measure)
+
+    url = reverse(
+        "certificate-ui-detail-measures",
+        kwargs={
+            "sid": certificate.sid,
+            "certificate_type__sid": certificate.certificate_type.sid,
+        },
+    )
+    response = valid_user_client.get(url)
+    page = BeautifulSoup(
+        response.content.decode(response.charset),
+        "html.parser",
+    )
+
+    table_rows = page.select(".govuk-table tbody tr")
+    assert len(table_rows) == 10
+
+    table_measure_sids = {
+        int(sid.text) for sid in page.select(".govuk-table tbody tr td:first-child")
+    }
+    assert table_measure_sids == {m.sid for m in new_measures}
+
+
 def test_certificate_detail_measures_view_sorting_commodity(valid_user_client):
     """Test that measures listed on `CertificateDetailMeasures` view can be
     sorted by commodity code in ascending or descending order."""

--- a/certificates/views.py
+++ b/certificates/views.py
@@ -195,7 +195,7 @@ class CertificateDetailMeasures(SortingMixin, WithPaginationListMixin, ListView)
 
         for condition in measure_conditions:
             measure_ids.append(
-                condition.dependent_measure.current_version.trackedmodel_ptr_id,
+                condition.dependent_measure.get_versions().current().get().pk,
             )
 
         queryset = Measure.objects.current().filter(id__in=measure_ids)

--- a/certificates/views.py
+++ b/certificates/views.py
@@ -180,6 +180,13 @@ class CertificateDetailMeasures(SortingMixin, WithPaginationListMixin, ListView)
         )
 
     def get_queryset(self):
+        """
+        Collects the measure from MeasureCondition, filtered on value a
+        Certificate object for Measures associated with that Certificate via
+        MeasureCondition.
+
+        Ensuring it returns the latest version of the associated Measures.
+        """
         measure_conditions = MeasureCondition.objects.current().filter(
             required_certificate__version_group=self.certificate.version_group,
         )

--- a/certificates/views.py
+++ b/certificates/views.py
@@ -180,10 +180,19 @@ class CertificateDetailMeasures(SortingMixin, WithPaginationListMixin, ListView)
         )
 
     def get_queryset(self):
-        measure_ids = MeasureCondition.objects.filter(
-            required_certificate=self.certificate.trackedmodel_ptr_id,
-        ).values_list("dependent_measure_id", flat=True)
-        queryset = Measure.objects.all().current().filter(id__in=measure_ids)
+        measure_conditions = MeasureCondition.objects.current().filter(
+            required_certificate__version_group=self.certificate.version_group,
+        )
+
+        measure_ids = []
+
+        for condition in measure_conditions:
+            measure_ids.append(
+                condition.dependent_measure.current_version.trackedmodel_ptr_id,
+            )
+
+        queryset = Measure.objects.current().filter(id__in=measure_ids)
+
         ordering = self.get_ordering()
         if ordering:
             if isinstance(ordering, str):

--- a/measures/filters.py
+++ b/measures/filters.py
@@ -261,9 +261,15 @@ class MeasureFilter(TamatoFilter):
         Certificate object) Filters the queryset for Measures associated with
         that Certificate via MeasureCondition."""
         if value:
-            measure_ids = MeasureCondition.objects.filter(
-                required_certificate=value,
-            ).values_list("dependent_measure_id", flat=True)
+            measure_conditions = MeasureCondition.objects.current().filter(
+                required_certificate__version_group=value.version_group,
+            )
+
+            measure_ids = []
+            for condition in measure_conditions:
+                measure_ids.append(
+                    condition.dependent_measure.current_version.trackedmodel_ptr_id,
+                )
 
             queryset = queryset.filter(id__in=measure_ids)
 

--- a/measures/filters.py
+++ b/measures/filters.py
@@ -273,7 +273,7 @@ class MeasureFilter(TamatoFilter):
             measure_ids = []
             for condition in measure_conditions:
                 measure_ids.append(
-                    condition.dependent_measure.current_version.trackedmodel_ptr_id,
+                    condition.dependent_measure.get_versions().current().get().pk,
                 )
 
             queryset = queryset.filter(id__in=measure_ids)

--- a/measures/filters.py
+++ b/measures/filters.py
@@ -257,9 +257,14 @@ class MeasureFilter(TamatoFilter):
         return queryset
 
     def certificates_filter(self, queryset, name, value):
-        """Collects the measure_ids from MeasureCondition, filtered on value (a
+        """
+        Collects the measure_ids from MeasureCondition, filtered on value (a
         Certificate object) Filters the queryset for Measures associated with
-        that Certificate via MeasureCondition."""
+        that Certificate via MeasureCondition.
+
+        Queryset ensures that it returns the measure_ids for the latest version
+        of the assosiated measure.
+        """
         if value:
             measure_conditions = MeasureCondition.objects.current().filter(
                 required_certificate__version_group=value.version_group,

--- a/measures/tests/test_filters.py
+++ b/measures/tests/test_filters.py
@@ -2,6 +2,7 @@ from datetime import date
 
 import pytest
 
+from common.models.utils import override_current_transaction
 from common.tests import factories
 from common.util import TaricDateRange
 from common.validators import UpdateType
@@ -82,11 +83,13 @@ def test_filter_by_certificates(
     measure_filter = MeasureFilter(
         data={"certificates": certificate.trackedmodel_ptr_id},
     )
-    filtered_measures = measure_filter.certificates_filter(
-        queryset=qs,
-        name="certificates",
-        value=certificate,
-    )
+
+    with override_current_transaction(new_transaction):
+        filtered_measures = measure_filter.certificates_filter(
+            queryset=qs,
+            name="certificates",
+            value=certificate,
+        )
 
     sids = [measure.sid for measure in filtered_measures]
 


### PR DESCRIPTION
# TP2000-1101 Missing measures in certificate results fix


## Why
<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Use as many lines as you like.
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions or deliberately ignored edge-cases.
--->
This PR addresses the UI side of an issue where when viewing measures connected to a certificate (via the related measure condition) some measures were missing. This is due to how versioning works in TAP and how we were retrieving the measures for a particular certificate. 
Simply for a particular certificate it's related `MeasureCondition` has a field `dependent_measure` which is a foreign key to a `Measure`. The `dependent_measure` connected to a `MeasureCondition` **DOES NOT** have to be the latest version of the measure but when we return measures we should returned the **latest** version of the `Measure`.
In a sketch:
```
measure v1 --- measure condition v1 --- certificate
measure v2 
```
As the above shows the measure condition has the relationship to the first version of the measure, while the latest version of the measure does not maintain the relationship. This means when querying for the dependent measure we should surface the latest version of that measure.
Currently for some certificates when trying to view their related measures in the measure search or measure tab in the certificates page they are not displayed. This can be seen in certificate 912Y and 9120 at:
- `/certificates/912Y/measures/`
<img width="909" alt="image" src="https://github.com/uktrade/tamato/assets/16708670/5c026f67-ad49-4b7b-92bf-978b5ec04466">

- `/certificates/9120/measures/`
<img width="909" alt="image" src="https://github.com/uktrade/tamato/assets/16708670/20ba1823-6af8-4bfb-9728-4b50e695f072">

- `/measures/?goods_nomenclature=&sid=&regulation=&footnote=&goods_nomenclature__item_id=&additional_code=&measure_type=&order_number=&certificates=10530023&geographical_area=&start_date_0=&start_date_1=&start_date_2=&end_date_0=&end_date_1=&end_date_2=&submit=`
<img width="1182" alt="image" src="https://github.com/uktrade/tamato/assets/16708670/a4150f24-560e-4c8f-b4e7-3c8804872214">

- `/measures/?goods_nomenclature=&sid=&regulation=&footnote=&goods_nomenclature__item_id=&additional_code=&measure_type=&order_number=&certificates=9733946&geographical_area=&start_date_0=&start_date_1=&start_date_2=&end_date_0=&end_date_1=&end_date_2=&submit=`
<img width="1215" alt="image" src="https://github.com/uktrade/tamato/assets/16708670/aed38cf7-aac1-4813-bc8c-860da67f3132">


## What
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Explain like I'm 5.
 * Use pictures if you can.
--->
- a fix to the measure search page so when searching by a certificate it returns the measure id's for the latest version of the measure
- a fix to the measure tab in a certificate view so it returns the latest version of the measure 
- test when applying the certificate filter with newer measure versions
- test for the measure tab in the certificate screen with measures which have newer versions

### Results after fix
- `/certificates/912Y/measures/`
<img width="1182" alt="image" src="https://github.com/uktrade/tamato/assets/16708670/49f62039-1036-4dc7-ba78-ae7cc5bc02a7">

- `/certificates/9120/measures/`
<img width="1182" alt="image" src="https://github.com/uktrade/tamato/assets/16708670/7f4dfd3a-3b31-4428-8a8d-8bb172af8cd2">

- `/measures/?goods_nomenclature=&sid=&regulation=&footnote=&goods_nomenclature__item_id=&additional_code=&measure_type=&order_number=&certificates=10530023&geographical_area=&start_date_0=&start_date_1=&start_date_2=&end_date_0=&end_date_1=&end_date_2=&submit=`
<img width="1182" alt="image" src="https://github.com/uktrade/tamato/assets/16708670/93cdf226-03b3-4734-8653-13a6c6954e1b">

- `/measures/?goods_nomenclature=&sid=&regulation=&footnote=&goods_nomenclature__item_id=&additional_code=&measure_type=&order_number=&certificates=9733946&geographical_area=&start_date_0=&start_date_1=&start_date_2=&end_date_0=&end_date_1=&end_date_2=&submit=`

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
