### PR TITLE
TP2000-1255 Correct homepage card permission

### DIFF
--- a/common/jinja2/common/homepage.jinja
+++ b/common/jinja2/common/homepage.jinja
@@ -32,7 +32,9 @@
                 class="govuk-button homepage-workbasket-action"
               >Create a <br> workbasket</a>
             </div>
+          {% endif %}
 
+          {% if can_edit_workbasket %}
             <div class="govuk-grid-column-one-half">
               <a
                 href="{{ url('workbaskets:workbasket-ui-list') }}"
@@ -60,7 +62,7 @@
       </article>
     {% endif %}
 
-    {% if can_add_workbasket %}
+    {% if can_edit_workbasket %}
       <article class="homepage-card">
         <h3 class="govuk-heading-m">Currently working on</h3>
         {% if not assigned_workbaskets %}

--- a/common/jinja2/common/homepage.jinja
+++ b/common/jinja2/common/homepage.jinja
@@ -58,7 +58,9 @@
           </div>
         </div>
       </article>
+    {% endif %}
 
+    {% if can_add_workbasket %}
       <article class="homepage-card">
         <h3 class="govuk-heading-m">Currently working on</h3>
         {% if not assigned_workbaskets %}

--- a/common/tests/test_views.py
+++ b/common/tests/test_views.py
@@ -181,7 +181,7 @@ def test_maintenance_mode_page_content(valid_user_client):
     ("card", "permission"),
     [
         ("What would you like to do?", "view_workbasket"),
-        ("Currently working on", "view_workbasket"),
+        ("Currently working on", "add_workbasket"),
         ("EU TARIC files", "add_trackedmodel"),
         ("Envelopes", "consume_from_packaging_queue"),
         ("Resources", ""),

--- a/common/tests/test_views.py
+++ b/common/tests/test_views.py
@@ -181,7 +181,7 @@ def test_maintenance_mode_page_content(valid_user_client):
     ("card", "permission"),
     [
         ("What would you like to do?", "view_workbasket"),
-        ("Currently working on", "add_workbasket"),
+        ("Currently working on", "change_workbasket"),
         ("EU TARIC files", "add_trackedmodel"),
         ("Envelopes", "consume_from_packaging_queue"),
         ("Resources", ""),

--- a/common/views.py
+++ b/common/views.py
@@ -97,6 +97,9 @@ class HomeView(LoginRequiredMixin, FormView):
                 "can_add_workbasket": self.request.user.has_perm(
                     "workbaskets.add_workbasket",
                 ),
+                "can_edit_workbasket": self.request.user.has_perm(
+                    "workbaskets.change_workbasket",
+                ),
                 "can_view_reports": self.request.user.has_perm(
                     "reports.view_report_index",
                 ),


### PR DESCRIPTION
# TP2000-1255 Correct homepage card permission

## Why
The ‘Currently working on’ card, which details a user’s assigned workbaskets, is shown to all users with the ‘view workbaskets' permission. However, not all users who can view workbaskets can be assigned to them.

## What
- Changes permission from 'can_view_workbasket' to 'can_edit_workbasket' (i.e 'workbaskets.change_workbasket') so that only the users who can be assigned to work on and to review workbaskets can see card

