### PR TITLE
Add codeowners file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,5 @@
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# @tamato will be requested for
+# review when someone opens a pull request.
+*       @uktrade/tamato


### PR DESCRIPTION
# Code owners
Add code owners file

## Why
To define individuals or teams that are responsible for code in a repository.

## What
Add CODEOWNERS file to the root of the codebase

Links to relevant material
See: [About code owners](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#about-code-owners)
