### PR TITLE
TP2000-1236  Improve measure search performance

### DIFF
--- a/common/pagination.py
+++ b/common/pagination.py
@@ -2,6 +2,7 @@ from typing import List
 
 from django.conf import settings
 from django.core.paginator import Paginator
+from django.utils.functional import cached_property
 
 
 def build_pagination_list(
@@ -66,7 +67,7 @@ class LimitedPaginator(Paginator):
 
     max_count = settings.LIMITED_PAGINATOR_MAX_COUNT
 
-    @property
+    @cached_property
     def limit_breached(self):
         """If the number of paginated objects breaches the
         LIMITED_PAGINATOR_MAX_COUNT, then return True, otherwise False."""
@@ -76,7 +77,7 @@ class LimitedPaginator(Paginator):
         except IndexError:
             return False
 
-    @property
+    @cached_property
     def count(self):
         """Return the precise number of paginated objects up to
         LIMITED_PAGINATOR_MAX_COUNT, or LIMITED_PAGINATOR_MAX_COUNT if that

--- a/common/static/common/js/openCloseAccordion.js
+++ b/common/static/common/js/openCloseAccordion.js
@@ -1,16 +1,17 @@
 // TODO: adjust the pathname filter to account for all objects search/filter pages
 const initOpenCloseAccordionSection = () => {
-    document.addEventListener('DOMContentLoaded', function() {
-
-        let expandedSection = document.getElementById('accordion-open-close-section')
-        let pathname = window.location.pathname
-        if(expandedSection){
-            if (!pathname.includes('search')){
-                expandedSection.classList.remove('govuk-accordion__section--expanded');
-            }
-        }
+  document.addEventListener("DOMContentLoaded", function () {
+    let button = document.querySelector(".govuk-accordion__open-all");
+    let expandedSection = document.getElementById("accordion-open-close-section");
+    let pathname = window.location.pathname;
+    if (expandedSection) {
+      if (!pathname.includes('search')) {
+        button.innerHTML = "Open all";
+        button.setAttribute("aria-expanded", "false");
+        expandedSection.classList.remove('govuk-accordion__section--expanded');
+      }
     }
-    )
-}
+  });
+};
 
 export default initOpenCloseAccordionSection;

--- a/measures/jinja2/includes/measures/list.jinja
+++ b/measures/jinja2/includes/measures/list.jinja
@@ -116,9 +116,9 @@
   <div class="govuk-details__text">
   {% if measure_selections %}
     {% set table_rows = [] %}
-      {% for measure in measure_selections %}
+      {% for sid in measure_selections %}
         {% set measure_link %}
-          <a class="govuk-link govuk-!-font-weight-bold" href="{{measure.get_url()}}">{{measure.sid}}</a>
+          <a class="govuk-link govuk-!-font-weight-bold" href="{{ url('measure-ui-detail', args=[sid]) }}">{{sid}}</a>
         {% endset %}
         {{ table_rows.append([
           {"html": measure_link},

--- a/measures/jinja2/measures/list.jinja
+++ b/measures/jinja2/measures/list.jinja
@@ -49,7 +49,7 @@
 
         <hr/>
       {% endif %}
-      {% if object_list %}
+      {% if results_count %}
         {% include list_include %}
       {% else %}
         <p class="govuk-body">There are no results for your search, please:</p>

--- a/measures/jinja2/measures/list.jinja
+++ b/measures/jinja2/measures/list.jinja
@@ -7,7 +7,7 @@
 {% set form_url = "measure-ui-list" %}
 {% set list_include = "includes/measures/list.jinja" %}
 
-{% set page_title = "Find and edit " ~ object_list.model._meta.verbose_name_plural %}
+{% set page_title = "Find and edit measures" %}
 
 
 {% block content %}

--- a/measures/pagination.py
+++ b/measures/pagination.py
@@ -1,4 +1,5 @@
 from django.conf import settings
+from django.utils.functional import cached_property
 
 from common.pagination import LimitedPaginator
 
@@ -13,3 +14,14 @@ class MeasurePaginator(LimitedPaginator):
     """
 
     max_count = settings.MEASURES_PAGINATOR_MAX_COUNT
+
+    @cached_property
+    def count(self):
+        """Override `LimitedPaginator.count` to avoid performing slow `.count()`
+        operations on measure querysets chained with the filter
+        `.with_effective_valid_between()`."""
+
+        if self.limit_breached:
+            return self.max_count
+        else:
+            return len(self.object_list)

--- a/measures/views.py
+++ b/measures/views.py
@@ -303,7 +303,17 @@ class MeasureList(
     def paginator(self):
         filterset_class = self.get_filterset_class()
         self.filterset = self.get_filterset(filterset_class)
-        return MeasurePaginator(self.filterset.qs, per_page=40)
+        return MeasurePaginator(
+            self.filterset.qs.select_related(
+                "additional_code",
+                "generating_regulation",
+                "geographical_area",
+                "goods_nomenclature",
+                "measure_type",
+                "order_number",
+            ),
+            per_page=40,
+        )
 
     def get_context_data(self, **kwargs):
         # References to page or pagination in the template were heavily increasing load time. By setting everything we need in the context,

--- a/measures/views.py
+++ b/measures/views.py
@@ -334,7 +334,6 @@ class MeasureList(
                 "has_next_page": page.has_next(),
                 "page_number": page.number,
                 "list_items_count": self.paginator.per_page,
-                "object_list": page.object_list,
                 "page_links": build_pagination_list(
                     page.number,
                     page.paginator.num_pages,

--- a/measures/views.py
+++ b/measures/views.py
@@ -17,6 +17,7 @@ from django.http import JsonResponse
 from django.shortcuts import redirect
 from django.shortcuts import render
 from django.utils.decorators import method_decorator
+from django.utils.functional import cached_property
 from django.views import View
 from django.views.generic.base import TemplateView
 from django.views.generic.edit import FormView
@@ -298,7 +299,7 @@ class MeasureList(
 
         return selected_filters_lists
 
-    @property
+    @cached_property
     def paginator(self):
         filterset_class = self.get_filterset_class()
         self.filterset = self.get_filterset(filterset_class)

--- a/measures/views.py
+++ b/measures/views.py
@@ -56,7 +56,6 @@ from measures.pagination import MeasurePaginator
 from measures.parsers import DutySentenceParser
 from measures.patterns import MeasureCreationPattern
 from measures.util import diff_components
-from quotas.models import QuotaOrderNumber
 from regulations.models import Regulation
 from workbaskets.forms import SelectableObjectsForm
 from workbaskets.models import WorkBasket
@@ -218,16 +217,12 @@ class MeasureList(
             )
 
         if "order_number" in selected_filters:
-            quota = QuotaOrderNumber.objects.current().get(
-                id=selected_filters["order_number"],
-            )
             selected_filters_strings.append(
-                f"Quota Order Number {quota.structure_code}",
+                f"Quota Order Number {selected_filters['order_number']}",
             )
 
         if "sid" in selected_filters:
-            measure = models.Measure.objects.current().get(sid=selected_filters["sid"])
-            selected_filters_strings.append(f"ID {measure.sid}")
+            selected_filters_strings.append(f"ID {selected_filters['sid']}")
 
         if "additional_code" in selected_filters:
             code = AdditionalCode.objects.current().get(
@@ -267,7 +262,10 @@ class MeasureList(
             footnote = Footnote.objects.current().get(id=selected_filters["footnote"])
             selected_filters_strings.append(f"Footnote {footnote.structure_code}")
 
-        if "start_date_0" and "start_date_1" and "start_date_2" in selected_filters:
+        if all(
+            sf in selected_filters
+            for sf in ("start_date_0", "start_date_1", "start_date_1")
+        ):
             if selected_filters["start_date_modifier"] == "exact":
                 modifier = ""
             else:
@@ -276,7 +274,9 @@ class MeasureList(
                 f"Start date: {modifier} {selected_filters['start_date_0']}/{selected_filters['start_date_1']}/{selected_filters['start_date_2']}",
             )
 
-        if "end_date_0" and "end_date_1" and "end_date_2" in selected_filters:
+        if all(
+            sf in selected_filters for sf in ("end_date_0", "end_date_1", "end_date_2")
+        ):
             if selected_filters["end_date_modifier"] == "exact":
                 modifier = ""
             else:

--- a/measures/views.py
+++ b/measures/views.py
@@ -346,13 +346,10 @@ class MeasureList(
         if context["has_next_page"]:
             context["next_page_number"] = page.next_page_number()
 
-        measure_selections = [
-            SelectableObjectsForm.object_id_from_field_name(name)
-            for name in self.measure_selections
-        ]
         context["measure_selections"] = models.Measure.objects.filter(
-            pk__in=measure_selections,
-        )
+            pk__in=self.measure_selections,
+        ).values_list("sid", flat=True)
+
         context["query_params"] = True
         context[
             "base_url"


### PR DESCRIPTION
# TP2000-1236  Improve measure search performance

## Why
Searching for measures using the end date filter can result in slow loading times and eventual timeouts: (1) calls to the view's paginator are duplicated many times over and (2) performing a `.count()` operation on a measure queryset chained with the filter `.with_effective_valid_between()` (added to enable filtering by end date) appear to be contributing to performance issues.

## What
- Caches `limit_breached` and `count` paginator methods
- Caches the view's `paginator` property
- Evaluates the paginator's queryset to determine its length as a faster alternative to the slow count() operation (and without affecting non-end-date-filtered searches)
- Chains a `.select_related()` filter on the queryset to fetch objects used in the template
- Removes `object_list` from the view's context as the view's form is used to handle the resulting measure objects
- Passes the sids of any selected measures to the template rather than measure objects
- Fixes a couple `KeyError`s resulting from missing filter values (for instance, searching for a measure SID that doesn't exist or not entering all date values in a date filter)
- Amends the button text and aria label of the filter accordion to reflect whether it is expanded or not

## Screenshots

**Before**:
Using the search criteria detailed in the ticket, loading times on a local dev env sat around 5 minutes
<img width="200" alt="Screenshot 2024-03-22 at 14 40 23" src="https://github.com/uktrade/tamato/assets/118175145/fb87276a-a717-4583-861f-d8e4e5c557f3"> <img width="200" alt="Screenshot 2024-03-22 at 14 40 30" src="https://github.com/uktrade/tamato/assets/118175145/a0b54ead-901b-4e29-8e53-b490756c210e">
<img width="800" alt="Screenshot 2024-03-22 at 11 29 16" src="https://github.com/uktrade/tamato/assets/118175145/9c7acdac-b813-4ea6-ad18-ff9d60a28cff">

**After**:
Using the search criteria detailed in the ticket, loading times on a local dev env now sit around 10 seconds
<img width="200" alt="Screenshot 2024-03-22 at 14 43 19" src="https://github.com/uktrade/tamato/assets/118175145/7ec92ab3-b917-41d7-b3f2-c3788eb43850"> <img width="200" alt="Screenshot 2024-03-22 at 14 43 12" src="https://github.com/uktrade/tamato/assets/118175145/b176318c-259c-4548-a792-1bb131be8962">

