### PR TITLE
feat: add origins to quotas expiring soon reports

### DIFF
--- a/reports/reports/expiring_quotas_with_no_definition_period.py
+++ b/reports/reports/expiring_quotas_with_no_definition_period.py
@@ -102,7 +102,7 @@ class Report(ReportBaseTable):
             {"text": "Sub-quota associations start date"},
             {"text": "Sub-quota associations end date"},
             {"text": "Definition period SID"},
-            {"text": "Quota order number origins"}
+            {"text": "Quota order number origins"},
         ]
 
     def row2(self, row) -> [dict]:

--- a/reports/reports/expiring_quotas_with_no_definition_period.py
+++ b/reports/reports/expiring_quotas_with_no_definition_period.py
@@ -27,6 +27,7 @@ class Report(ReportBaseTable):
             {"text": "Quota order number"},
             {"text": "Definition start date"},
             {"text": "Definition end date"},
+            {"text": "Quota order number origins"},
         ]
 
     def row(self, row) -> [dict]:
@@ -34,6 +35,7 @@ class Report(ReportBaseTable):
             {"text": self.link_renderer_for_quotas(row.order_number, row.order_number)},
             {"text": row.valid_between.lower},
             {"text": row.valid_between.upper},
+            {"text": origin for origin in row.order_number.origins.all()},
         ]
 
     def rows(self) -> [[dict]]:
@@ -100,6 +102,7 @@ class Report(ReportBaseTable):
             {"text": "Sub-quota associations start date"},
             {"text": "Sub-quota associations end date"},
             {"text": "Definition period SID"},
+            {"text": "Quota order number origins"}
         ]
 
     def row2(self, row) -> [dict]:
@@ -129,6 +132,7 @@ class Report(ReportBaseTable):
                         "#definition-details",
                     ),
                 },
+                {"text": origin for origin in row.order_number.origins.all()},
             )
 
         return sub_quotas_array
@@ -172,6 +176,7 @@ class Report(ReportBaseTable):
             {"text": "Blocking period start date"},
             {"text": "Blocking period end date"},
             {"text": "Definition period SID"},
+            {"text": "Quota order number origins"},
         ]
 
     def row3(self, row) -> [dict]:
@@ -200,6 +205,7 @@ class Report(ReportBaseTable):
                     "#definition-details",
                 ),
             },
+            {"text": origin for origin in row.order_number.origins.all()},
         ]
 
     def rows3(self) -> [[dict]]:
@@ -246,6 +252,7 @@ class Report(ReportBaseTable):
             {"text": "Suspension period start date"},
             {"text": "Suspension period end date"},
             {"text": "Definition period SID"},
+            {"text": "Quota order number origins"},
         ]
 
     def row4(self, row) -> [dict]:
@@ -274,6 +281,7 @@ class Report(ReportBaseTable):
                     "#definition-details",
                 ),
             },
+            {"text": origin for origin in row.order_number.origins.all()},
         ]
 
     def rows4(self) -> [[dict]]:


### PR DESCRIPTION
# Add quota order number origins to the quotas expiring soon reports
<!---
 * Include the JIRA ticket number, eg TP-123, to automatically link.
 * Use 50 characters maximum.
 * Do not end with a full-stop.
--->

## Why
Requested by product manager, small change to add a new column to show users the quota's associated origins for the expiring soon report
<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Use as many lines as you like.
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions or deliberately ignored edge-cases.
--->

## What
Adding in a new element to the existing array in the python script that generates the expiring soon report
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Explain like I'm 5.
 * Use pictures if you can.
--->

<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
## Checklist
- Requires migrations?
- Requires dependency updates?
--->

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
