### PR TITLE
TP2000-1289 Process queue link on home page

### DIFF
--- a/common/jinja2/common/homepage.jinja
+++ b/common/jinja2/common/homepage.jinja
@@ -114,6 +114,20 @@
       </article>
     {% endif %}
 
+    {% if can_view_processing_queues %}
+      <article class="homepage-card">
+        <h3 class="govuk-heading-m">Processing queues</h3>
+        <p class="govuk-body">
+          <a href="{{ url('measure-create-process-queue') }}"
+            class="govuk-link"
+          >Measures process queue</a>
+          <br>
+          This queue shows the status of measures that you submitted for
+          creation.
+        </p>
+      </article>
+    {% endif %}
+
     <article class="homepage-card">
       <h3 class="govuk-heading-m">Resources</h3>
       <p class="govuk-body">

--- a/common/jinja2/layouts/layout.jinja
+++ b/common/jinja2/layouts/layout.jinja
@@ -40,6 +40,7 @@
 {% set can_import_taric = request.user.has_perm("common.add_trackedmodel") %}
 {% set can_manage_packaging = request.user.has_perm("publishing.manage_packaging_queue") %}
 {% set can_consume_packaging = request.user.has_perm("publishing.consume_from_packaging_queue") %}
+{% set can_view_processing_queues = request.user.has_perm("common.add_trackedmodel") %}
 
 {% block header %}
   <header class="govuk-header" role="banner" data-module="govuk-header">

--- a/common/tests/test_views.py
+++ b/common/tests/test_views.py
@@ -210,6 +210,7 @@ def test_homepage_cards_contain_expected_links(superuser_client):
         "Search for workbaskets": "workbaskets:workbasket-ui-list-all",
         "View EU import list": "commodity_importer-ui-list",
         "Process envelopes": "publishing:envelope-queue-ui-list",
+        "Measures process queue": "measure-create-process-queue",
         "Application information": "app-info",
         "Importer V1": "import_batch-ui-list",
         "Importer V2": "taric_parser_import_ui_list",


### PR DESCRIPTION
# TP2000-1289 Process queue link on home page
<!---
 * Include the JIRA ticket number, eg TP-123, to automatically link.
 * Use 50 characters maximum.
 * Do not end with a full-stop.
--->

## Why
<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Use as many lines as you like.
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions or deliberately ignored edge-cases.
--->

Users need a way to easily navigating to the “Measures process queue”.


## What
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Explain like I'm 5.
 * Use pictures if you can.
--->

This PR:
- Adds a "Processing queues" card to the home page.
- Add a link to the "Measures process queue" page within the card.
- Adds explanatory text below associated link.
- Includes a check for the link in an existing unit test.

<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
--->
## Checklist
- Requires migrations? No
- Requires dependency updates? No

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
