### PR TITLE
feat: link geo areas to origins on expiring quotas report

### DIFF
--- a/reports/reports/base_table.py
+++ b/reports/reports/base_table.py
@@ -21,6 +21,12 @@ class ReportBaseTable(ReportBase):
             f"<a class='govuk-link govuk-!-font-weight-bold' href='{href}'>{text}</a>",
         )
 
+    def link_renderer_for_quota_origin(self, origin):
+        url = reverse("geo_area-ui-detail", args=[origin.sid])
+        return mark_safe(
+            f"<a class='govuk-link govuk-!-font-weight-bold' href='{url}'>{origin}</a>",
+        )
+
     @abstractmethod
     def query(self):
         pass

--- a/reports/reports/expiring_quotas_with_no_definition_period.py
+++ b/reports/reports/expiring_quotas_with_no_definition_period.py
@@ -35,7 +35,10 @@ class Report(ReportBaseTable):
             {"text": self.link_renderer_for_quotas(row.order_number, row.order_number)},
             {"text": row.valid_between.lower},
             {"text": row.valid_between.upper},
-            {"text": origin for origin in row.order_number.origins.all()},
+            {
+                "text": self.link_renderer_for_quota_origin(origin)
+                for origin in row.order_number.origins.all()
+            },
         ]
 
     def rows(self) -> [[dict]]:
@@ -132,7 +135,10 @@ class Report(ReportBaseTable):
                         "#definition-details",
                     ),
                 },
-                {"text": origin for origin in row.order_number.origins.all()},
+                {
+                    "text": self.link_renderer_for_quota_origin(origin)
+                    for origin in row.order_number.origins.all()
+                },
             )
 
         return sub_quotas_array
@@ -205,7 +211,10 @@ class Report(ReportBaseTable):
                     "#definition-details",
                 ),
             },
-            {"text": origin for origin in row.order_number.origins.all()},
+            {
+                "text": self.link_renderer_for_quota_origin(origin)
+                for origin in row.order_number.origins.all()
+            },
         ]
 
     def rows3(self) -> [[dict]]:
@@ -281,7 +290,10 @@ class Report(ReportBaseTable):
                     "#definition-details",
                 ),
             },
-            {"text": origin for origin in row.order_number.origins.all()},
+            {
+                "text": self.link_renderer_for_quota_origin(origin)
+                for origin in row.order_number.origins.all()
+            },
         ]
 
     def rows4(self) -> [[dict]]:

--- a/reports/views.py
+++ b/reports/views.py
@@ -1,4 +1,5 @@
 import csv
+import re
 
 from django.contrib.auth.decorators import permission_required
 from django.http import HttpResponse
@@ -92,6 +93,11 @@ def export_report_to_csv(request, report_slug, current_tab=None):
         # For table reports
         writer.writerow([header["text"] for header in headers])
         for row in rows:
+            for column in row:
+                if str(column["text"]).startswith("<a"):
+                    match = re.search(r">(.*?)<", column["text"])
+                    if match:
+                        column["text"] = match.group(1)
             writer.writerow([column["text"] for column in row])
     else:
         writer.writerow(["Date", "Data"])


### PR DESCRIPTION
# Link a quota order number origin to the relevant geo area on the expiring quotas report
<!---
 * Include the JIRA ticket number, eg TP-123, to automatically link.
 * Use 50 characters maximum.
 * Do not end with a full-stop.
--->

## Why
<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Use as many lines as you like.
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions or deliberately ignored edge-cases.
--->
For easability of report usage, we are allowing users to have a follow-through journey to the relevant geo area of related origins. CSV export was also giving the whole link values for both quota order number and quota origins so have fixed that.
## What
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Explain like I'm 5.
 * Use pictures if you can.
--->
Simple update of logic so picks up if the row is a link and only grabs the value using regex. Also adding a new function that renders a link for quota order number origins.
<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
## Checklist
- Requires migrations?
- Requires dependency updates?
--->

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
