### PR TITLE
TP2000-1322 Fixing incorrectly named celery task

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -81,7 +81,7 @@ services:
         - "ENV=${ENV:-prod}"
     volumes:
       - ./:/app/
-    command: ["celery", "-A" , "common.celery" ,"worker", "-O", "fair", "-l", "info", "-Q", "bulk-create", "--concurrency", "1"]
+    command: ["celery", "-A" , "common.celery" ,"worker", "-O", "fair", "-l", "info", "-Q", "importer", "--concurrency", "1"]
     env_file:
       - .env
       - settings/envs/docker.env


### PR DESCRIPTION
# TP2000-1322 Fixing incorrectly named celery task

## Why
PR [1196](https://github.com/uktrade/tamato/pull/1196) renamed the importer celery task by mistake.

## What
Correcting the importer celery task