### PR TITLE
TP2000-1279 Upgrade to Python version 3.9

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,10 +109,9 @@ celerybeat.pid
 .env.*
 .venv
 env/
-venv/
+venv*/
 ENV/
 env.bak/
-venv.bak/
 docker-compose.override.yml
 settings/envs/docker.override.env
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 
 ############################################################
 
-FROM python:3.8-buster
+FROM python:3.10-bookworm
 
 LABEL maintainer="webops@digital.trade.gov.uk"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 
 ############################################################
 
-FROM python:3.10-bookworm
+FROM python:3.9-bookworm
 
 LABEL maintainer="webops@digital.trade.gov.uk"
 

--- a/Dockerfile.pytest
+++ b/Dockerfile.pytest
@@ -2,7 +2,7 @@
 ###############
 # Build on Python-based image using default target platform (TARGETPLATFORM).
 
-FROM python:3.10-bookworm
+FROM python:3.9-bookworm
 
 ARG TARGETPLATFORM
 RUN echo "Building for ${TARGETPLATFORM} platform..."

--- a/Dockerfile.pytest
+++ b/Dockerfile.pytest
@@ -2,7 +2,7 @@
 ###############
 # Build on Python-based image using default target platform (TARGETPLATFORM).
 
-FROM python:3.8
+FROM python:3.10-bookworm
 
 ARG TARGETPLATFORM
 RUN echo "Building for ${TARGETPLATFORM} platform..."
@@ -58,5 +58,3 @@ COPY . /app/
 
 RUN npm run build
 RUN python manage.py collectstatic --noinput
-
-CMD ["pytest"]

--- a/README.rst
+++ b/README.rst
@@ -17,7 +17,7 @@ Prerequisites
 
 The following dependencies are required to run this app:
 
-- Python_ 3.10.x
+- Python_ 3.9.x
 - Node.js_ 20.10.0 (LTS)
 - PostgreSQL_ 12
 - Redis_ 5.x
@@ -82,7 +82,7 @@ substituting your own python version as appropriate:
     $ pip uninstall psycopg2
     $ brew install postgresql
     $ export CPPFLAGS="-I/opt/homebrew/opt/openssl@1.1/include"
-    $ export LDFLAGS="-L/opt/homebrew/opt/openssl@1.1/lib -L${HOME}/.pyenv/versions/3.10/lib"
+    $ export LDFLAGS="-L/opt/homebrew/opt/openssl@1.1/lib -L${HOME}/.pyenv/versions/3.9/lib"
     $ arch -arm64 pip install psycopg2 --no-binary :all:
 
 Credit due to armenzg and his `answer here

--- a/README.rst
+++ b/README.rst
@@ -17,7 +17,7 @@ Prerequisites
 
 The following dependencies are required to run this app:
 
-- Python_ 3.8.x
+- Python_ 3.10.x
 - Node.js_ 20.10.0 (LTS)
 - PostgreSQL_ 12
 - Redis_ 5.x
@@ -82,7 +82,7 @@ substituting your own python version as appropriate:
     $ pip uninstall psycopg2
     $ brew install postgresql
     $ export CPPFLAGS="-I/opt/homebrew/opt/openssl@1.1/include"
-    $ export LDFLAGS="-L/opt/homebrew/opt/openssl@1.1/lib -L${HOME}/.pyenv/versions/3.8.10/lib"
+    $ export LDFLAGS="-L/opt/homebrew/opt/openssl@1.1/lib -L${HOME}/.pyenv/versions/3.10/lib"
     $ arch -arm64 pip install psycopg2 --no-binary :all:
 
 Credit due to armenzg and his `answer here

--- a/checks/tests/test_checkers.py
+++ b/checks/tests/test_checkers.py
@@ -60,10 +60,13 @@ def test_indirect_business_rule_validation():
         transaction=model.transaction,
     )
 
-    with add_business_rules(type(model), TestRule), add_business_rules(
-        factories.TestModelDescription1Factory._meta.model,
-        TestRule,
-        indirect=True,
+    with (
+        add_business_rules(type(model), TestRule),
+        add_business_rules(
+            factories.TestModelDescription1Factory._meta.model,
+            TestRule,
+            indirect=True,
+        ),
     ):
         checker_type = IndirectBusinessRuleChecker.of(TestRule)
 

--- a/common/tests/util.py
+++ b/common/tests/util.py
@@ -17,7 +17,7 @@ from unittest.mock import MagicMock
 from unittest.mock import patch
 
 import pytest
-from backports.zoneinfo import ZoneInfo
+from zoneinfo import ZoneInfo
 from dateutil.parser import parse as parse_date
 from dateutil.relativedelta import relativedelta
 from django import forms

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "tamato"
 version = "0.0.1"
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 license = {file = "LICENSE"}
 description = "UK Tariff Management Tool"
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "tamato"
 version = "0.0.1"
-requires-python = ">=3.10"
+requires-python = ">=3.9"
 license = {file = "LICENSE"}
 description = "UK Tariff Management Tool"
 authors = [

--- a/requirements.txt
+++ b/requirements.txt
@@ -71,7 +71,7 @@ sphinx-gherkindoc==3.6.2
 sqlite-s3vfs==0.0.35
 tabulate==0.9.0
 urllib3==1.26.18
-wrapt==1.12.1
+wrapt==1.16.0
 Werkzeug==3.0.1
 whitenoise==5.2.0
 xmldiff==2.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -71,7 +71,7 @@ sphinxcontrib.devhelp==1.0.2
 sphinxcontrib.htmlhelp==2.0.1
 sphinxcontrib-jquery==4.1
 sphinxcontrib-jsmath==1.0.0
-sphinxcontrib-qthelp==1.0.5
+sphinxcontrib-qthelp==1.0.3
 sphinxcontrib-serializinghtml==1.1.5
 Sphinx==4.2.0
 sphinx-gherkindoc==3.6.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -71,7 +71,7 @@ sphinx-gherkindoc==3.6.2
 sqlite-s3vfs==0.0.35
 tabulate==0.9.0
 urllib3==1.26.18
-wrapt==1.16.0
+wrapt==1.12.1
 Werkzeug==3.0.1
 whitenoise==5.2.0
 xmldiff==2.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -66,6 +66,7 @@ requests-oauthlib==1.3.0
 requests-mock==1.10.0
 responses==0.12.1
 sentry-sdk==0.20.2
+sphinxcontrib-applehelp==1.0.4
 Sphinx==4.2.0
 sphinx-gherkindoc==3.6.2
 sqlite-s3vfs==0.0.35

--- a/requirements.txt
+++ b/requirements.txt
@@ -69,6 +69,10 @@ sentry-sdk==0.20.2
 sphinxcontrib-applehelp==1.0.4
 sphinxcontrib.devhelp==1.0.2
 sphinxcontrib.htmlhelp==2.0.1
+sphinxcontrib-jquery==4.1
+sphinxcontrib-jsmath==1.0.0
+sphinxcontrib-qthelp==1.0.5
+sphinxcontrib-serializinghtml==1.1.5
 Sphinx==4.2.0
 sphinx-gherkindoc==3.6.2
 sqlite-s3vfs==0.0.35

--- a/requirements.txt
+++ b/requirements.txt
@@ -67,6 +67,7 @@ requests-mock==1.10.0
 responses==0.12.1
 sentry-sdk==0.20.2
 sphinxcontrib-applehelp==1.0.4
+sphinxcontrib.devhelp==1.0.2
 Sphinx==4.2.0
 sphinx-gherkindoc==3.6.2
 sqlite-s3vfs==0.0.35

--- a/requirements.txt
+++ b/requirements.txt
@@ -68,6 +68,7 @@ responses==0.12.1
 sentry-sdk==0.20.2
 sphinxcontrib-applehelp==1.0.4
 sphinxcontrib.devhelp==1.0.2
+sphinxcontrib.htmlhelp==2.0.1
 Sphinx==4.2.0
 sphinx-gherkindoc==3.6.2
 sqlite-s3vfs==0.0.35

--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.8.x
+python-3.10.x

--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.10.x
+python-3.9.x


### PR DESCRIPTION
# TP2000-1279 Upgrade to Python version 3.9
<!---
 * Include the JIRA ticket number, eg TP-123, to automatically link.
 * Use 50 characters maximum.
 * Do not end with a full-stop.
--->

## Why
<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Use as many lines as you like.
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions or deliberately ignored edge-cases.
--->

Platform migration requires a minimum of Python version 3.9.

## What
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Explain like I'm 5.
 * Use pictures if you can.
--->

This PR:
- Provides an initial, intermediate upgrade step unblocking other upgrade activities that require 3.9 or greater.
- Upgrades Python in Docker config files.
- Upgrades Python in Cloud Foundry config.
- Fixes module imports and requirements dependencies.
- Pins the set of Sphinxcontrib packages to the latest version requiring Sphinx versions less than version 5. This is because Sphinx does not pin its dependencies and Python version 3.9 or greater causes Sphinx's most recent dependencies to be used, which in turn pulls in Sphinx version 5. However, only one version of the dependent package govuk-tech-docs-sphinx-theme exists and it requires versions of Sphinx less than 5.

<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
--->
## Checklist
- Requires migrations? No
- Requires dependency updates? Yes

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
