### PR TITLE
TP2000-1324 Fix homepage card masonry layout

### DIFF
--- a/common/jinja2/common/homepage.jinja
+++ b/common/jinja2/common/homepage.jinja
@@ -16,9 +16,9 @@
     </div>
   {% endblock %}
 
-  <div id="homepage-articles" class="govuk-grid-row">
+  <div id="masonry-container" class="govuk-grid-row">
     {% if can_view_workbasket %}
-      <article class="homepage-card">
+      <article class="masonry-card">
         <h3 class="govuk-heading-m">What would you like to do?</h3>
         <p class="govuk-body">
           Create a new workbasket, edit an existing workbasket, package or search for workbaskets.
@@ -63,7 +63,7 @@
     {% endif %}
 
     {% if can_edit_workbasket %}
-      <article class="homepage-card">
+      <article class="masonry-card">
         <h3 class="govuk-heading-m">Currently working on</h3>
         {% if not assigned_workbaskets %}
           <p class="govuk-body">You are not currently assigned to a workbasket.</p>
@@ -93,7 +93,7 @@
     {% endif %}
 
     {% if can_import_taric %}
-      <article class="homepage-card">
+      <article class="masonry-card">
         <h3 class="govuk-heading-m">EU TARIC files</h3>
         <p class="govuk-body">
           <a href="{{ url('commodity_importer-ui-list') }}"
@@ -104,7 +104,7 @@
     {% endif %}
 
     {% if can_consume_packaging %}
-      <article class="homepage-card">
+      <article class="masonry-card">
         <h3 class="govuk-heading-m">Envelopes</h3>
         <p class="govuk-body">
           <a href="{{ url('publishing:envelope-queue-ui-list') }}"
@@ -115,7 +115,7 @@
     {% endif %}
 
     {% if can_view_processing_queues %}
-      <article class="homepage-card">
+      <article class="masonry-card">
         <h3 class="govuk-heading-m">Processing queues</h3>
         <p class="govuk-body">
           <a href="{{ url('measure-create-process-queue') }}"
@@ -128,7 +128,7 @@
       </article>
     {% endif %}
 
-    <article class="homepage-card">
+    <article class="masonry-card">
       <h3 class="govuk-heading-m">Resources</h3>
       <p class="govuk-body">
         We have a range of resources you can use with the Tariff Application Platform.
@@ -162,7 +162,7 @@
   <div class="govuk-grid-row">
     <h2 class="govuk-heading-l govuk-grid-column-full govuk-!-margin-bottom-3">How can we support you?</h2>
 
-    <article class="homepage-card">
+    <article class="masonry-card">
       <h3 class="govuk-heading-m">Get help</h3>
       <p class="govuk-body">
         Find documentation, guidance, training and updates in the
@@ -175,7 +175,7 @@
       </p>
     </article>
 
-    <article class="homepage-card govuk-!-padding-bottom-5">
+    <article class="masonry-card govuk-!-padding-bottom-5">
       <h3 class="govuk-heading-m">Get in touch</h3>
       <p class="govuk-body"><a class="govuk-link" href="mailto:9cf0f83c.trade.gov.uk@uk.teams.ms">Contact us</a> if you have a question or suggestion.</p>
     </article>

--- a/common/static/common/js/application.js
+++ b/common/static/common/js/application.js
@@ -23,6 +23,7 @@ import initOpenCloseAccordionSection from "./openCloseAccordion";
 import initTapDebounce from "./buttonDebounce";
 import { setupQuotaOriginFormset } from "./components/QuotaOriginFormset/index";
 import { setupWorkbasketUserAssignment } from "./components/WorkbasketUserAssignment/index";
+import { initMasonry } from "./masonry";
 
 showHideCheckboxes();
 // Initialise accessible-autocomplete components without a `name` attr in order
@@ -40,3 +41,4 @@ initOpenCloseAccordionSection();
 initTapDebounce();
 setupQuotaOriginFormset();
 setupWorkbasketUserAssignment();
+initMasonry();

--- a/common/static/common/js/masonry.js
+++ b/common/static/common/js/masonry.js
@@ -1,11 +1,11 @@
 let timeout = null;
 
 /**
- * Transforms the position of homepage cards in a masonry-layout fashion.
+ * Transforms the position of cards in a container in a masonry-layout fashion.
  */
 const masonryLayout = () => {
-  const container = document.getElementById("homepage-articles");
-  const cards = container.querySelectorAll(".homepage-card");
+  const container = document.getElementById("masonry-container");
+  const cards = container.querySelectorAll(".masonry-card");
 
   // The desired gap between all cards in the container.
   const margin = parseInt(window.getComputedStyle(cards[0]).margin) * 2;
@@ -49,10 +49,13 @@ const throttleMasonry = () => {
 };
 
 /**
- * Sets up masonry layout for homepage cards.
+ * Sets up masonry layout for pages with a container comprising of cards.
+ *
+ * The container element must have `masonry-container` as an ID attribute.
+ * And card elements must have `masonry-card` as a class attribute.
  */
 const initMasonry = () => {
-  const container = document.getElementById("homepage-articles");
+  const container = document.getElementById("masonry-container");
   if (container) {
     masonryLayout();
 

--- a/common/static/common/js/masonry.js
+++ b/common/static/common/js/masonry.js
@@ -1,0 +1,64 @@
+let timeout = null;
+
+/**
+ * Transforms the position of homepage cards in a masonry-layout fashion.
+ */
+const masonryLayout = () => {
+  const container = document.getElementById("homepage-articles");
+  const cards = container.querySelectorAll(".homepage-card");
+
+  // The desired gap between all cards in the container.
+  const margin = parseInt(window.getComputedStyle(cards[0]).margin) * 2;
+
+  const columns =
+    container.offsetWidth / cards[0].offsetWidth >= 2 ? [0, 0] : [0];
+  const columnWidth = container.offsetWidth / columns.length;
+
+  let containerHeight = container.offsetHeight;
+  container.style.position = "relative";
+  container.style.height = containerHeight + "px";
+
+  for (const card of cards) {
+    const shortestColHeight = Math.min(...columns);
+    const shortestColumn = columns.indexOf(shortestColHeight);
+
+    // Position below the card in the shortest column with respect to `margin`.
+    card.style.position = "absolute";
+    card.style.top = shortestColHeight + "px";
+    card.style.left = shortestColumn * columnWidth + "px";
+
+    columns[shortestColumn] += card.offsetHeight + margin;
+  }
+
+  // Adjust for space saved.
+  containerHeight -= containerHeight - Math.max(...columns);
+  container.style.height = containerHeight + "px";
+};
+
+/**
+ * Delays calls to `masonryLayout()` triggered by resize events to once every 200ms.
+ */
+const throttleMasonry = () => {
+  const delay = 200;
+  if (!timeout) {
+    timeout = setTimeout(() => {
+      masonryLayout();
+      timeout = null;
+    }, delay);
+  }
+};
+
+/**
+ * Sets up masonry layout for homepage cards.
+ */
+const initMasonry = () => {
+  const container = document.getElementById("homepage-articles");
+  if (container) {
+    masonryLayout();
+
+    // Ensure the layout remains responsive.
+    window.addEventListener("resize", throttleMasonry);
+  }
+};
+
+export { initMasonry };

--- a/common/static/common/scss/_components.scss
+++ b/common/static/common/scss/_components.scss
@@ -91,7 +91,7 @@
 
 }
 
-.homepage-card {
+.masonry-card {
   box-sizing: border-box;
   border: 1px solid $govuk-border-colour;
   padding: govuk-spacing(3) govuk-spacing(3) 0;
@@ -101,7 +101,7 @@
 }
 
 @media screen and (min-width: 1063px) {
-  .homepage-card {
+  .masonry-card {
     width: calc(50% - govuk-spacing(6));
   }
 }


### PR DESCRIPTION
# TP2000-1324 Fix homepage card masonry layout

## Why
Gaps in between cards on the homepage can appear inconsistently sized depending on which cards are conditionally displayed and whether the "Currently working on" card adjusts its height to fit content.

## What
- Uses JavaScript to adjust out-of-position cards in the masonry layout to ensure a consistent margin no matter the permutation or size of homepage cards.

## Screenshots
### Before
<img width="400" alt="Screenshot 2024-04-22 at 11 47 15" src="https://github.com/uktrade/tamato/assets/118175145/800b2585-07d1-4380-a12b-8092265d4d88"><img width="400" alt="Screenshot 2024-04-22 at 11 47 29" src="https://github.com/uktrade/tamato/assets/118175145/7776bec0-40be-4bc9-8f40-bfb8a9277cd9">

### After
<img width="400" alt="Screenshot 2024-04-22 at 11 48 28" src="https://github.com/uktrade/tamato/assets/118175145/79dce0ef-ade2-4345-9a6e-e1603ea14b2b"><img width="400" alt="Screenshot 2024-04-22 at 11 47 47" src="https://github.com/uktrade/tamato/assets/118175145/ae190380-2b68-42ea-b5cd-2832e7558931">


