### PR TITLE
TP2000-1338 Prevent maintenance mode UndefinedError exception

### DIFF
--- a/common/jinja2/common/maintenance.jinja
+++ b/common/jinja2/common/maintenance.jinja
@@ -1,13 +1,12 @@
-{% extends "layouts/layout.jinja" %}
+{% extends "layouts/_generic.jinja" %}
 
+{% set service_name = "Tariff Application Platform" %}
+{% set phase_banner_tag = "Alpha" %}
 {% set page_title = "Sorry, the service is unavailable" %}
 
-{% set workbasket_html %}{% endset %}
-{% set logout_login_link %}{% endset %}
-{% set can_view_workbasket %}{% endset %}
-{% set can_import_taric %}{% endset %}
-{% set can_manage_packaging %}{% endset %}
-{% set can_consume_packaging %}{% endset %}
+{% block pageTitle %}
+  {{ page_title }} | {{ service_name }}
+{% endblock %}
 
 {% block header %}
   <header class="govuk-header" role="banner" data-module="govuk-header">
@@ -22,8 +21,6 @@
     </div>
   </header>
 {% endblock %}
-
-{% block breadcrumb %}{% endblock %}
 
 {% block content %}
 <div class="govuk-width-container">

--- a/common/tests/test_views.py
+++ b/common/tests/test_views.py
@@ -182,6 +182,15 @@ def test_accessibility_statement_view_returns_200(valid_user_client):
 @override_settings(MAINTENANCE_MODE=True)
 @modify_settings(
     MIDDLEWARE={
+        "remove": [
+            "authbroker_client.middleware.ProtectAllViewsMiddleware",
+            "django.contrib.admin",
+            "django.contrib.sessions.middleware.SessionMiddleware",
+            "django.contrib.auth.middleware.AuthenticationMiddleware",
+            "django.contrib.messages.middleware.MessageMiddleware",
+            "common.models.utils.TransactionMiddleware",
+            "common.models.utils.ValidateUserWorkBasketMiddleware",
+        ],
         "append": "common.middleware.MaintenanceModeMiddleware",
     },
 )
@@ -189,6 +198,9 @@ def test_user_redirect_during_maintenance_mode(valid_user_client):
     response = valid_user_client.get(reverse("home"))
     assert response.status_code == 302
     assert response.url == reverse("maintenance")
+
+    response = valid_user_client.get(response.url)
+    assert response.status_code == 200
 
 
 def test_maintenance_mode_page_content(valid_user_client):


### PR DESCRIPTION
# TP2000-1338 Prevent maintenance mode UndefinedError exception

## Why
The recent activation of maintenance mode raised an unhandled `UndefinedError ('WSGIRequest object' has no attribute 'user')` that prevented the custom maintenance mode page from being displayed.

## What
- Extends `_generic.jinja` instead of `layout.jinja` to ensure `maintenance.jinja` no longer inherits references that rely upon accessing the user attribute of a request object (which has been removed in maintenance mode).
- Updates the maintenance mode unit test to provide coverage for this scenario.

