### PR TITLE
TP2000-1298 Celery health check support

### DIFF
--- a/common/celery.py
+++ b/common/celery.py
@@ -2,6 +2,7 @@ import os
 
 from celery import Celery
 from celery.signals import setup_logging
+from dbt_copilot_python.celery_health_check import healthcheck
 from django.conf import settings
 
 # set the default Django settings module for the 'celery' program.
@@ -31,3 +32,6 @@ app.autodiscover_tasks()
 # this should be automactically configured via ^^ config_from_object
 # but it isn't so here it's configured here
 app.conf.task_routes = settings.CELERY_ROUTES
+
+# Setup and expose the DBT Celery healthcheck interface.
+app = healthcheck.setup(app)

--- a/docker-compose.pytest.yml
+++ b/docker-compose.pytest.yml
@@ -1,0 +1,35 @@
+# Containerised pytest:
+#   $ docker-compose --file docker-compose.pytest.yml up --build pytest
+
+version: "3"
+services:
+
+  # Container providing Postgresql instance to pytest.
+  pytest-db:
+    # With no persistent volume, it's possible to clear the database contents by
+    # simply stopping this service: docker-compose stop pytest-db.
+    image: "postgres:16"
+    environment:
+      POSTGRES_HOST_AUTH_METHOD: "trust"
+      POSTGRES_USER: postgres
+      POSTGRES_DB: tamato
+    ports:
+      # Map a port from the host to allow inspection via DB clients, e.g.:
+      # $ psql --host=127.0.0.1 --port=5430 --username=postgres --dbname=tamato
+      - "127.0.0.1:5430:5432"
+
+  # Runs all tamato unit tests.
+  pytest:
+    build:
+      context: .
+      dockerfile: Dockerfile.pytest
+    image: pytest
+    depends_on:
+      - pytest-db
+    environment:
+      DATABASE_URL: postgres://postgres@pytest-db/tamato
+      DJANGO_SETTINGS_MODULE: settings.test
+      ENV: test
+    command: sh -c "python manage.py migrate && pytest"
+    stdin_open: true
+    tty: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,6 +51,12 @@ services:
     tty: true
     depends_on:
       - celery-redis
+    healthcheck:
+      test: [ "CMD-SHELL", "python -m dbt_copilot_python.celery_health_check.healthcheck" ]
+      interval: 10s
+      timeout: 5s
+      retries: 2
+      start_period: 5s
 
   # Celery worker used to execute business rule checks on workbaskets.
   rule-check-celery:
@@ -69,6 +75,13 @@ services:
     tty: true
     depends_on:
       - celery-redis
+    healthcheck:
+      test: [ "CMD-SHELL", "python -m dbt_copilot_python.celery_health_check.healthcheck" ]
+      interval: 10s
+      timeout: 5s
+      retries: 2
+      start_period: 5s
+
 
   # Celery worker for bulk creating and editing of objects.
   bulk-create-celery:
@@ -87,6 +100,13 @@ services:
     tty: true
     depends_on:
       - celery-redis
+    healthcheck:
+      test: [ "CMD-SHELL", "python -m dbt_copilot_python.celery_health_check.healthcheck" ]
+      interval: 10s
+      timeout: 5s
+      retries: 2
+      start_period: 5s
+
 
   # Celery worker used to execute importer parser and objection creation.
   importer-celery:
@@ -103,6 +123,13 @@ services:
     restart: "${DOCKER_RESTART_POLICY:-unless-stopped}"
     depends_on:
       - celery-redis
+    healthcheck:
+      test: [ "CMD-SHELL", "python -m dbt_copilot_python.celery_health_check.healthcheck" ]
+      interval: 10s
+      timeout: 5s
+      retries: 2
+      start_period: 5s
+
 
   # Celery Beat process, used to execute scheduled, cron-like tasks.
   celery-beat:
@@ -165,34 +192,6 @@ services:
       - settings/envs/docker.env
     command: sh -c "python manage.py runserver 0.0.0.0:8000"
     restart: "${DOCKER_RESTART_POLICY:-unless-stopped}"
-    stdin_open: true
-    tty: true
-
-  pytest-db:
-    # With no persistent volume, it's possible to clear the database contents by
-    # simply stopping this service: docker-compose stop pytest-db.
-    image: "postgres:16"
-    environment:
-      POSTGRES_HOST_AUTH_METHOD: "trust"
-      POSTGRES_USER: postgres
-      POSTGRES_DB: tamato
-    ports:
-      # Map a port from the host to allow inspection via DB clients, e.g.:
-      # $ psql --host=127.0.0.1 --port=5430 --username=postgres --dbname=tamato
-      - "127.0.0.1:5430:5432"
-
-  pytest:
-    build:
-      context: .
-      dockerfile: Dockerfile.pytest
-    image: pytest
-    depends_on:
-      - pytest-db
-    environment:
-      DATABASE_URL: postgres://postgres@pytest-db/tamato
-      DJANGO_SETTINGS_MODULE: settings.test
-      ENV: test
-    command: sh -c "python manage.py migrate && pytest"
     stdin_open: true
     tty: true
 

--- a/requirements-dev-jupyter.txt
+++ b/requirements-dev-jupyter.txt
@@ -1,4 +1,6 @@
 -r requirements-dev.txt
 
-ipython
-jupyter
+ipython==8.18.1
+jupyter==1.0.0
+jupyter-nbextensions-configurator==0.6.3
+notebook==6.5.6


### PR DESCRIPTION
# TP2000-1298 Celery health check support
<!---
 * Include the JIRA ticket number, eg TP-123, to automatically link.
 * Use 50 characters maximum.
 * Do not end with a full-stop.
--->

## Why
<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Use as many lines as you like.
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions or deliberately ignored edge-cases.
--->

DBT Platform migration requires Celery worker health check support from host environments.

## What
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Explain like I'm 5.
 * Use pictures if you can.
--->

This PR:

- Exposes a health check interface with the help of DBT's Copilot library.
- Adds a `healthcheck` section to each Celery service, including test and timing details.

In addition to health check capabilities, the PR splits out docker-compose pytest support into its own `docker-compose.pytest.yml` file, allowing the web service to be easily started without also running unit tests.

<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
--->
## Checklist
- Requires migrations? No
- Requires dependency updates? Yes, if you rely upon the `requirements-dev-jupyter.txt` file for Jupyter support.

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
