### PR TITLE
TP2000-1325 Fix failing migration unit tests in dev environment

### DIFF
--- a/Dockerfile.pytest
+++ b/Dockerfile.pytest
@@ -5,6 +5,7 @@
 FROM python:3.9-bookworm
 
 ARG TARGETPLATFORM
+ARG TARGETARCH
 RUN echo "Building for ${TARGETPLATFORM} platform..."
 
 ENV PYTHONUNBUFFERED=1
@@ -29,14 +30,22 @@ RUN apt-get update -qqy --fix-missing && \
 ###############
 # Download and setup Node.
 
-ENV NODE_VERION="v20.10.0"
-ENV NODE_NAME="node-${NODE_VERION}-linux-arm64"
+ENV NODE_VERSION="v20.10.0"
 
-RUN curl "https://nodejs.org/dist/${NODE_VERION}/${NODE_NAME}.tar.gz" -O
-RUN tar xzf "${NODE_NAME}.tar.gz"
-RUN ln -s "/${NODE_NAME}/bin/node" /usr/local/bin/node
-RUN ln -s "/${NODE_NAME}/bin/npm" /usr/local/bin/npm
-RUN ln -s "/${NODE_NAME}/bin/npx" /usr/local/bin/npx
+RUN if [ "$TARGETARCH" = "arm64" ]; then \
+        NODE_ARCH="linux-arm64"; \
+    elif [ "$TARGETARCH" = "amd64" ]; then \
+        NODE_ARCH="linux-x64"; \
+    else \
+        echo "Unsupported node binary package platform architecture: ${TARGETARCH}"; \
+        exit 1; \
+    fi \
+    && NODE_NAME="node-${NODE_VERSION}-${NODE_ARCH}" \
+    && curl "https://nodejs.org/dist/${NODE_VERSION}/${NODE_NAME}.tar.gz" -O \
+    && tar xzf "${NODE_NAME}.tar.gz" \
+    && ln -s "/${NODE_NAME}/bin/node" /usr/local/bin/node \
+    && ln -s "/${NODE_NAME}/bin/npm" /usr/local/bin/npm \
+    && ln -s "/${NODE_NAME}/bin/npx" /usr/local/bin/npx
 
 ###############
 # Install Node packages and Python packages.

--- a/common/tests/test_migrations.py
+++ b/common/tests/test_migrations.py
@@ -50,7 +50,7 @@ def test_missing_current_version_fix(migrator):
 
     kwargs = {
         "update_type": UpdateType.CREATE,
-        "transaction": transaction,
+        "transaction_id": transaction.id,
         "valid_between": TaricDateRange(date(2000, 1, 1), None),
         "code": "XXX",
         "description": "made up measurement unit",


### PR DESCRIPTION
# TP2000-1325 Fix failing migration unit tests in dev environment

## Why
The following commands fail when executed in a development environment:
1) `$ pytest common/tests/test_migrations.py::test_missing_current_version_fix`

2) `$ pytest common/tests/test_migrations.py::test_timestamp_migration`

3) `$ docker-compose --file docker-compose.pytest.yml up --build pytest`

## What
-  Passes the `ID` of the transaction as a foreign key value to create the measurement unit.

- Uses `DateTimeTZRange` to set the valid_between values of the tracked models to match the column's expected data type.
- Creates the factories in `test_timestamp_migration` using the current DB state based on the applied migration.

- Adds support for `amd64` node binary package in `Dockerfile.pytest`

## Screenshots of errors
<img width="800" alt="Screenshot 2024-04-29 at 16 28 41" src="https://github.com/uktrade/tamato/assets/118175145/94eca8ef-e3b3-4080-99ce-51ae623d51a1">

###

<img width="500" alt="Screenshot 2024-04-29 at 17 15 05" src="https://github.com/uktrade/tamato/assets/118175145/2455fc5f-bd75-4c06-8d76-1cfc1069ca1c">
