### PR TITLE
Update importer V2 to handle issues raised from TGB24095 (multiple matches on GoodsNomenclatureDescription

### DIFF
--- a/taric_parsers/parsers/commodity_parser.py
+++ b/taric_parsers/parsers/commodity_parser.py
@@ -179,6 +179,7 @@ class GoodsNomenclatureDescriptionParserV2(Writable, BaseTaricParser):
     xml_object_tag = "goods.nomenclature.description"
 
     identity_fields = [
+        "sid",
         "described_goods_nomenclature__sid",
         "described_goods_nomenclature__item_id",
         "described_goods_nomenclature__suffix",


### PR DESCRIPTION
# TP2000-1353
 * Updates import key identity fields for GoodsNomenclatureDescriptionV2 for the importer so that it also matches on the SID which is actually the description periods SID but for matching this works. 

## Why
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Import failed for TGB24095 due to multiple object matches, the importer needs updating to better identify the correct record in this specific scenario. 

## What
 * Updates import key identity fields for GoodsNomenclatureDescriptionV2 for the importer so that it also matches on the SID which is actually the description periods SID but for matching this works. 

## Checklist
- Requires migrations? No 
- Requires dependency updates? No

Links to relevant material
See: [Jira](https://uktrade.atlassian.net/browse/TP2000-1353)
