### PR TITLE
Revert "Celery log level always be DEBUG"

### DIFF
--- a/settings/common.py
+++ b/settings/common.py
@@ -753,7 +753,7 @@ LOGGING = {
         },
         "celery": {
             "handlers": ["celery"],
-            "level": "DEBUG",
+            "level": os.environ.get("CELERY_LOG_LEVEL", "DEBUG"),
             "propagate": False,
         },
     },


### PR DESCRIPTION
Reverts uktrade/tamato#1232

Testing if this commit was responsible for the Celery error stopping or if it was simply a redeployment that fixed it.