### PR TITLE
TP2000-1379 Redisplay measure conditions form data on validation error

### DIFF
--- a/common/jinja2/components/measure_condition_action_code/template.jinja
+++ b/common/jinja2/components/measure_condition_action_code/template.jinja
@@ -1,5 +1,4 @@
 <div id="div_id_{{ field.html_name }}" class="govuk-form-group {% if field.errors %} govuk-form-group--error{% endif %}">
-    {% set selected_action = field.initial | int %}
     <label for="id_{{ field.html_name }}" class="govuk-label">
         Action code
     </label>
@@ -12,6 +11,7 @@
         </p>
         {% endfor %}
     {% endif %}
+    {% set selected_action = field.data|int or field.initial|int %}
     <select name="{{ field.html_name }}" class="govuk-select" id="id_{{ field.html_name }}"> 
         <option value="">-- Please select an action code --</option>
         {% for action in form.fields.action.queryset %}

--- a/common/jinja2/components/measure_condition_code/template.jinja
+++ b/common/jinja2/components/measure_condition_code/template.jinja
@@ -11,7 +11,7 @@
         </p>
         {% endfor %}
     {% endif %}
-    {% set selected_code = field.initial | int %}
+    {% set selected_code = field.data|int or field.initial|int %}
     <select name="{{ field.html_name }}" class="govuk-select" id="id_{{ field.html_name }}">
         <option value="">-- Please select a condition code --</option>
         {% for condition in form.fields.condition_code.queryset %}

--- a/common/jinja2/components/measure_condition_component_duty/template.jinja
+++ b/common/jinja2/components/measure_condition_component_duty/template.jinja
@@ -1,7 +1,5 @@
 <div class="govuk-radios__conditional" id="div_id_{{ field.html_name }}">
-    
     <div class="govuk-form-group {% if field.errors %}govuk-form-group--error{% endif %}">
-    
         <label class="govuk-label" for="id_{{ field.html_name}}">Duty</label>
         <div id="condition-duty-hint" class="govuk-hint">
             If this condition should apply a different duty, enter it here.
@@ -16,7 +14,8 @@
                 </p>
                 {% endfor %}
             {% endif %}
-            <input class="govuk-input" id="id_{{ field.html_name }}" name="{{ field.html_name }}" type="text" spellcheck="false" value="{{ field.initial if field.initial else ""}}">
+            {% set duty = field.data or field.initial or "" %}
+            <input class="govuk-input" id="id_{{ field.html_name }}" name="{{ field.html_name }}" type="text" spellcheck="false" value="{{ duty }}">
         </div>
     </div>  
 </div>


### PR DESCRIPTION
# TP2000-1379 Redisplay measure conditions form data on validation error

## Why
If the measure conditions form in the measure creation journey contains validation errors, an empty form, cleared of all previously submitted data, is redisplayed to the user making it so all form data has to be re-inputted.

## What
- Adds a conditional expression to display the form field's submitted data if it exists (otherwise fallback to the field's initial value which may be an empty value) to the templates used to display the form's fields.

## Before
<img width="500" alt="Screenshot 2024-05-24 at 16 49 00" src="https://github.com/uktrade/tamato/assets/118175145/9be181ca-71b0-40d7-ad93-885dd0ac5baf">

## After
<img width="500" alt="Screenshot 2024-05-24 at 16 48 25" src="https://github.com/uktrade/tamato/assets/118175145/5fad90e4-592b-4838-9a57-7184c8ee3f75">


