### PR TITLE
TP2000-1381 Celery logging config error pt.1

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,6 +1,6 @@
 web: scripts/web-worker-entrypoint.sh
 worker: celery -A common.celery worker -O fair -l info -Q standard
-beat: celery -A common.celery beat
+beat: celery -A common.celery beat -l info
 rule-check-worker: celery -A common.celery worker -O fair -l info -Q rule-check --concurrency 1
 importer-worker: celery -A common.celery worker -O fair -l info -Q importer
 bulk-create-worker: celery -A common.celery worker -O fair -l info -Q bulk-create --concurrency 1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -143,8 +143,6 @@ services:
     env_file:
       - .env
       - settings/envs/docker.env
-    environment:
-      SQLITE_EXPORT_CRONTAB: "05 19 * * *"
     restart: "${DOCKER_RESTART_POLICY:-unless-stopped}"
     stdin_open: true
     tty: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -143,6 +143,8 @@ services:
     env_file:
       - .env
       - settings/envs/docker.env
+    environment:
+      SQLITE_EXPORT_CRONTAB: "05 19 * * *"
     restart: "${DOCKER_RESTART_POLICY:-unless-stopped}"
     stdin_open: true
     tty: true

--- a/exporter/management/commands/dump_sqlite.py
+++ b/exporter/management/commands/dump_sqlite.py
@@ -5,7 +5,7 @@ from typing import Optional
 from django.core.management import BaseCommand
 from django.core.management.base import CommandParser
 
-from exporter.sqlite import tasks
+from exporter.sqlite.tasks import export_and_upload_sqlite
 
 logger = logging.getLogger(__name__)
 
@@ -24,7 +24,7 @@ class Command(BaseCommand):
     def handle(self, *args: Any, **options: Any) -> Optional[str]:
         logger.info(f"Triggering tariff database export to SQLite")
 
-        go = tasks.export_and_upload_sqlite
-        if not options["immediately"]:
-            go = go.delay()
-        go()
+        if options["immediately"]:
+            export_and_upload_sqlite()
+        else:
+            export_and_upload_sqlite.delay()


### PR DESCRIPTION
# TP2000-1381 Celery logging config error pt.1
<!---
 * Include the JIRA ticket number, eg TP-123, to automatically link.
 * Use 50 characters maximum.
 * Do not end with a full-stop.
--->

## Why
<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Use as many lines as you like.
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions or deliberately ignored edge-cases.
--->

`ValueError` log entries are created by the Celery Beat process. A component of Celery configuration is overriding the 'celery' logger's log level. This PR is a first attempt at helping with issue investigation.

## What
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Explain like I'm 5.
 * Use pictures if you can.
--->

This PR:

- Sets the log level of the Beat process to `info` via a command line flag, making the Beat process consistent with other Celery processes.
- Enables the Beat process `sqlite_export` schedule to be set from config rather than hard coded, allowing flexible configration when testing in different environments (including Docker).

<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
--->
## Checklist
- Requires migrations? No
- Requires dependency updates? No

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
