### PR TITLE
TP2000-1381 Celery logging config error pt2

### DIFF
--- a/settings/envs/docker.env
+++ b/settings/envs/docker.env
@@ -1,4 +1,9 @@
 CELERY_BROKER_URL=redis://celery-redis 
 CACHE_URL=redis://cache-redis  
 DATABASE_URL=postgres://postgres@db/tamato
+# S3_ENDPOINT_URL, if used, also requires S3_ACCESS_KEY_ID and
+# S3_SECRET_ACCESS_KEY env vars setting - usually from a .env file.
 S3_ENDPOINT_URL=http://s3:9000
+# SQLITE_S3_ENDPOINT_URL, if used, also requires SQLITE_S3_ACCESS_KEY_ID and
+# SQLITE_S3_SECRET_ACCESS_KEY env vars setting - usually from a .env file.
+SQLITE_S3_ENDPOINT_URL=http://s3:9000


### PR DESCRIPTION
# TP2000-1381 Celery logging config error pt2
<!---
 * Include the JIRA ticket number, eg TP-123, to automatically link.
 * Use 50 characters maximum.
 * Do not end with a full-stop.
--->

## Why
<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Use as many lines as you like.
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions or deliberately ignored edge-cases.
--->

The sqlite dump process executes Django commands in new processes. In doing so, environment variables are copied into the environment. One of the environment variables, CELERY_LOG_LEVEL, is incorrectly represented as a string integer "20" rather than its correct loglevel string value, "INFO".

## What
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Explain like I'm 5.
 * Use pictures if you can.
--->

This PR:

- Adds a utility function, `Runner.normalise_loglevel()` to normalise (correct) loglevel values.
- Adds a call to the newly introduced`Runner.normalise_loglevel()` for the `CELERY_LOG_LEVEL` env var.
- Adds a new env var to docker-specific env file along with docstrings.

<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
--->
## Checklist
- Requires migrations? No
- Requires dependency updates? No

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
