### PR TITLE
TP2000-1384 Allow end dates to be removed when bulk editing measures

### DIFF
--- a/measures/forms.py
+++ b/measures/forms.py
@@ -1697,6 +1697,7 @@ class MeasureEndDateForm(forms.Form):
     end_date = DateInputFieldFixed(
         label="End date",
         help_text="For example, 27 3 2008",
+        required=False,
     )
 
     def __init__(self, *args, **kwargs):
@@ -1719,8 +1720,8 @@ class MeasureEndDateForm(forms.Form):
     def clean(self):
         cleaned_data = super().clean()
 
-        if "end_date" in cleaned_data:
-            end_date = cleaned_data["end_date"]
+        end_date = cleaned_data.get("end_date", None)
+        if end_date:
             for measure in self.selected_measures:
                 start_date = measure.valid_between.lower
                 if start_date > end_date:
@@ -1728,6 +1729,8 @@ class MeasureEndDateForm(forms.Form):
                         f"The end date cannot be before the start date: "
                         f"Start date {start_date:%d/%m/%Y} does not start before {end_date:%d/%m/%Y}",
                     )
+        else:
+            cleaned_data["end_date"] = None
 
         return cleaned_data
 

--- a/measures/forms.py
+++ b/measures/forms.py
@@ -1720,19 +1720,13 @@ class MeasureEndDateForm(forms.Form):
         cleaned_data = super().clean()
 
         if "end_date" in cleaned_data:
+            end_date = cleaned_data["end_date"]
             for measure in self.selected_measures:
-                year = int(cleaned_data["end_date"].year)
-                month = int(cleaned_data["end_date"].month)
-                day = int(cleaned_data["end_date"].day)
-
-                lower = measure.valid_between.lower
-                upper = datetime.date(year, month, day)
-                if lower > upper:
-                    formatted_lower = lower.strftime("%d/%m/%Y")
-                    formatted_upper = upper.strftime("%d/%m/%Y")
+                start_date = measure.valid_between.lower
+                if start_date > end_date:
                     raise ValidationError(
                         f"The end date cannot be before the start date: "
-                        f"Start date {formatted_lower} does not start before {formatted_upper}",
+                        f"Start date {start_date:%d/%m/%Y} does not start before {end_date:%d/%m/%Y}",
                     )
 
         return cleaned_data

--- a/measures/forms.py
+++ b/measures/forms.py
@@ -1765,20 +1765,13 @@ class MeasureStartDateForm(forms.Form):
         cleaned_data = super().clean()
 
         if "start_date" in cleaned_data:
+            start_date = cleaned_data["start_date"]
             for measure in self.selected_measures:
-                year = int(cleaned_data["start_date"].year)
-                month = int(cleaned_data["start_date"].month)
-                day = int(cleaned_data["start_date"].day)
-
-                upper = measure.valid_between.upper
-                lower = datetime.date(year, month, day)
-                # for an open-ended measure the end date can be None
-                if upper and lower > upper:
-                    formatted_lower = lower.strftime("%d/%m/%Y")
-                    formatted_upper = upper.strftime("%d/%m/%Y")
+                end_date = measure.valid_between.upper
+                if end_date and start_date > end_date:
                     raise ValidationError(
                         f"The start date cannot be after the end date: "
-                        f"Start date {formatted_lower} does not start before {formatted_upper}",
+                        f"Start date {start_date:%d/%m/%Y} does not start before {end_date:%d/%m/%Y}",
                     )
 
         return cleaned_data

--- a/measures/tests/test_forms.py
+++ b/measures/tests/test_forms.py
@@ -1398,6 +1398,18 @@ def test_measure_end_date_validation_fail():
     )
 
 
+def test_measure_end_date_form_no_end_date():
+    """Tests that `MeasureEndDateForm` allows an empty end date value and sets
+    the cleaned data value to `None`."""
+    selected_measures = factories.MeasureFactory.create_batch(3)
+    form = MeasureEndDateForm(
+        data={},
+        selected_measures=selected_measures,
+    )
+    assert form.is_valid()
+    assert form.cleaned_data["end_date"] == None
+
+
 def test_measure_forms_footnotes_valid():
     footnote = factories.FootnoteFactory.create()
     data = {

--- a/measures/tests/test_views.py
+++ b/measures/tests/test_views.py
@@ -3,6 +3,7 @@ import json
 import unittest
 from datetime import date
 from decimal import Decimal
+from functools import reduce
 from typing import OrderedDict
 from unittest.mock import PropertyMock
 from unittest.mock import patch
@@ -1927,7 +1928,7 @@ def test_multiple_measure_start_and_end_date_edit_functionality(
 
 
 @pytest.mark.parametrize(
-    "step,data",
+    "step, form_data, updated_attribute, expected_data",
     [
         (
             "start_date",
@@ -1937,6 +1938,8 @@ def test_multiple_measure_start_and_end_date_edit_functionality(
                 "start_date-start_date_1": "01",
                 "start_date-start_date_2": "2000",
             },
+            "valid_between.lower",
+            datetime.date(2000, 1, 1),
         ),
         (
             "end_date",
@@ -1946,12 +1949,27 @@ def test_multiple_measure_start_and_end_date_edit_functionality(
                 "end_date-end_date_1": "01",
                 "end_date-end_date_2": "2100",
             },
+            "valid_between.upper",
+            datetime.date(2100, 1, 1),
+        ),
+        (
+            "end_date",
+            {
+                "measure_edit_wizard-current_step": MeasureEditSteps.END_DATE,
+                "end_date-end_date_0": "",
+                "end_date-end_date_1": "",
+                "end_date-end_date_2": "",
+            },
+            "valid_between.upper",
+            None,
         ),
     ],
 )
 def test_multiple_measure_edit_single_form_functionality(
     step,
-    data,
+    form_data,
+    updated_attribute,
+    expected_data,
     valid_user_client,
     user_workbasket,
     mocked_diff_components,
@@ -1987,7 +2005,7 @@ def test_multiple_measure_edit_single_form_functionality(
             "next_step": step,
         },
         {
-            "data": data,
+            "data": form_data,
             "next_step": "complete",
         },
     ]
@@ -2017,6 +2035,7 @@ def test_multiple_measure_edit_single_form_functionality(
     assert valid_user_client.session["MULTIPLE_MEASURE_SELECTIONS"] == {}
     for measure in workbasket_measures:
         assert measure.update_type == UpdateType.UPDATE
+        assert reduce(getattr, updated_attribute.split("."), measure) == expected_data
 
 
 def test_multiple_measure_edit_only_regulation(

--- a/measures/views.py
+++ b/measures/views.py
@@ -620,14 +620,8 @@ class MeasureEditWizard(
         cleaned_data = self.get_all_cleaned_data()
         selected_measures = self.get_queryset()
         workbasket = WorkBasket.current(self.request)
-        new_start_date = None
+        new_start_date = cleaned_data.get("start_date", None)
         new_end_date = None
-        if cleaned_data.get("start_date"):
-            new_start_date = datetime.date(
-                cleaned_data["start_date"].year,
-                cleaned_data["start_date"].month,
-                cleaned_data["start_date"].day,
-            )
         if cleaned_data.get("end_date"):
             new_end_date = datetime.date(
                 cleaned_data["end_date"].year,

--- a/measures/views.py
+++ b/measures/views.py
@@ -1,4 +1,3 @@
-import datetime
 import json
 import logging
 from itertools import groupby
@@ -621,13 +620,7 @@ class MeasureEditWizard(
         selected_measures = self.get_queryset()
         workbasket = WorkBasket.current(self.request)
         new_start_date = cleaned_data.get("start_date", None)
-        new_end_date = None
-        if cleaned_data.get("end_date"):
-            new_end_date = datetime.date(
-                cleaned_data["end_date"].year,
-                cleaned_data["end_date"].month,
-                cleaned_data["end_date"].day,
-            )
+        new_end_date = cleaned_data.get("end_date", None)
         new_quota_order_number = cleaned_data.get("order_number", None)
         new_generating_regulation = cleaned_data.get("generating_regulation", None)
         new_duties = cleaned_data.get("duties", None)

--- a/measures/views.py
+++ b/measures/views.py
@@ -620,7 +620,7 @@ class MeasureEditWizard(
         selected_measures = self.get_queryset()
         workbasket = WorkBasket.current(self.request)
         new_start_date = cleaned_data.get("start_date", None)
-        new_end_date = cleaned_data.get("end_date", None)
+        new_end_date = cleaned_data.get("end_date", False)
         new_quota_order_number = cleaned_data.get("order_number", None)
         new_generating_regulation = cleaned_data.get("generating_regulation", None)
         new_duties = cleaned_data.get("duties", None)
@@ -638,7 +638,11 @@ class MeasureEditWizard(
                         if new_start_date
                         else measure.valid_between.lower
                     ),
-                    upper=new_end_date if new_end_date else measure.valid_between.upper,
+                    upper=(
+                        new_end_date
+                        if new_end_date is not False
+                        else measure.valid_between.upper
+                    ),
                 ),
                 order_number=(
                     new_quota_order_number


### PR DESCRIPTION
# TP2000-1384  Allow end dates to be removed when bulk editing measures

## Why
The measure end date form in the bulk measure editing journey requires an end date otherwise it raises a validation error, preventing end dates from being removed.

## What
- Refactors both `MeasureStartDateForm.clean()` and `MeasureEndDateForm.clean()` as the forms already normalise their respective field data to a datetime object

- Adds `required=False` to the `end_date` field on `MeasureEndDateForm` to allow empty values to be submitted

- Makes `MeasureEndDateForm` set its end date cleaned data to `None` if no end date was inputted

- Changes how `MeasureEditWizard.done()` gets the new start/end date for the edited measures
    - If end date key is in cleaned data, then use its value to set as the new end date (even if the value is `None` as that means the end date is intended to be removed)
    - If end date key is not in cleaned data, then the end date has not been updated and should default to the measure's current end date

- Updates unit tests

