### PR TITLE
TP2000-1389 Add published() filter to TransactionQueryset

### DIFF
--- a/common/models/transactions.py
+++ b/common/models/transactions.py
@@ -14,6 +14,7 @@ from django_fsm import transition
 from common.models.mixins import TimestampedMixin
 from common.models.utils import lazy_string
 from common.renderers import counter_generator
+from workbaskets.validators import WorkflowStatus
 
 logger = getLogger(__name__)
 PREEMPTIVE_TRANSACTION_SEED = -100000
@@ -76,6 +77,14 @@ class TransactionQueryset(models.QuerySet):
         return self.model.tracked_models.rel.related_model.objects.filter(
             transaction__in=self,
         )
+
+    def published(self) -> "TransactionQueryset":
+        """Return a queryset of Transactions that have been both approved (are
+        in the SEED_FILE or REVISION partitions) and are associated with a
+        Workbaskets whose status is PUBLISHED."""
+        return self.filter(
+            workbasket__status=WorkflowStatus.PUBLISHED,
+        ).approved()
 
     def approved(self):
         """Currently approved Transactions are SEED_FILE and REVISION this can

--- a/common/tests/factories.py
+++ b/common/tests/factories.py
@@ -130,6 +130,17 @@ class WorkBasketFactory(factory.django.DjangoModelFactory):
     title = factory.Faker("sentence", nb_words=4)
 
 
+class EditingWorkBasketFactory(WorkBasketFactory):
+    class Meta:
+        model = "workbaskets.WorkBasket"
+
+    status = WorkflowStatus.EDITING
+    transaction = factory.RelatedFactory(
+        "common.tests.factories.UnapprovedTransactionFactory",
+        factory_related_name="workbasket",
+    )
+
+
 class QueuedWorkBasketFactory(WorkBasketFactory):
     class Meta:
         model = "workbaskets.WorkBasket"


### PR DESCRIPTION
# TP2000-1389 Add published() filter to TransactionQueryset
<!---
 * Include the JIRA ticket number, eg TP-123, to automatically link.
 * Use 50 characters maximum.
 * Do not end with a full-stop.
--->

## Why
<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Use as many lines as you like.
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions or deliberately ignored edge-cases.
--->

There is no direct capability to filter only published transactions - those that have been approved and are associated with a PUBLISHED workbasket. Having a filter to narrow down transactions to those that are published is required by TP2000-1389.

## What
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Explain like I'm 5.
 * Use pictures if you can.
--->

This PR provides part of the solution to fixing issue TP2000-1389, by allowing the sqlite dump process to check for "published" transactions. (Additional filtering capability is required on `TrackedModel`s to include only those that have been "published" when accumulating data for inclusion in the sqlite dump.)

Specifically, this PR:

- Adds a new `TransactionQueryset.published()` queryset filter.
- Adds a new `EditingWorkBasketFactory` factory.
- Unit tests the newly added filter.

<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
--->
## Checklist
- Requires migrations? No
- Requires dependency updates? No

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
