### PR TITLE
TP2000-1389 Restrict sqlite dump to published only

### DIFF
--- a/common/jinja2.py
+++ b/common/jinja2.py
@@ -11,6 +11,7 @@ from django.templatetags.static import static
 from django.urls import reverse
 from django.utils.safestring import mark_safe
 from django.utils.timezone import template_localtime
+from humanize import naturalsize
 from jinja2.utils import markupsafe
 from webpack_loader.contrib.jinja2ext import _render_bundle
 from webpack_loader.templatetags.webpack_loader import webpack_static
@@ -139,6 +140,8 @@ def environment(**kwargs):
             "get_messages": messages.get_messages,
             "get_current_workbasket": WorkBasket.current,
             "localtime": template_localtime,
+            "mark_safe": mark_safe,
+            "naturalsize": naturalsize,
             "pluralize": pluralize,
             "render_bundle": _render_bundle,
             "settings": settings,
@@ -147,7 +150,6 @@ def environment(**kwargs):
             "intcomma": intcomma,
             "url": reverse,
             "webpack_static": webpack_static,
-            "mark_safe": mark_safe,
         },
     )
 

--- a/common/jinja2/common/app_info.jinja
+++ b/common/jinja2/common/app_info.jinja
@@ -61,6 +61,12 @@
           {"text": LAST_TRANSACTION_TIME},
           {"text": "Last transaction change time"},
         ],
+        [
+          {"text": "LAST_PUBLISHED_TRANSACTION_ORDER"},
+          {"text": LAST_PUBLISHED_TRANSACTION_ORDER},
+          {"text": "Last published transaction order value"},
+        ],
+
       ] %}
 
       {{ govukTable({

--- a/common/jinja2/common/app_info.jinja
+++ b/common/jinja2/common/app_info.jinja
@@ -162,7 +162,7 @@
               "colspan": 4,
             }
           ]) or "" }}
-      {% endif %}
+      {% endif -%}
 
       {{ govukTable({
           "head": table_head,
@@ -170,5 +170,46 @@
       }) }}
     </div>
   </div>
+
+
+  {%- if request.user.is_superuser and SQLITE_DUMP_LIST %}
+  <div class="govuk-grid-row govuk-!-margin-bottom-6 info-section">
+    <div class="govuk-grid-column-full">
+      <h2 class="govuk-heading-m">Sqlite dumps (past {{ SQLITE_DUMP_DAYS }} days)</h2>
+
+      {%- set table_head = [
+        {"text": "File name"},
+        {"text": "Size"},
+        {"text": "Created date"},
+      ] %}
+
+      {%- set table_rows = [] %}
+      {%- for obj in SQLITE_DUMP_LIST %}
+        {%- if obj.file_size != None %}
+          {%- set file_size = naturalsize(obj.file_size) %}
+        {% else -%}
+          {%- set file_size = "Unknown" %}
+        {% endif -%}
+
+        {%- if obj.created_datetime %}
+          {%- set created_datetime = obj.created_datetime.strftime("%d %b %Y, %H:%M") %}
+        {%- else %}
+          {%-set created_datetime = "Unknown" %}
+        {% endif %}
+
+        {{ table_rows.append([
+          {"text": obj.file_name},
+          {"text": file_size},
+          {"text": created_datetime},
+        ]) or "" }}
+      {% endfor -%}
+
+      {{ govukTable({
+          "head": table_head,
+          "rows": table_rows
+      }) }}
+    </div>
+  </div>
+  {% endif -%}
 
 {% endblock %}

--- a/common/models/tracked_qs.py
+++ b/common/models/tracked_qs.py
@@ -148,8 +148,18 @@ class TrackedModelQuerySet(
         """
         return self.exclude(version_group=version_group)
 
+    def published(self):
+        """Return a queryset of TrackedModels that are associated with approved
+        Transactions and Workbaskets whose status is PUBLISHED."""
+        from workbaskets.validators import WorkflowStatus
+
+        return self.has_approved_state().filter(
+            transaction__workbasket__status=WorkflowStatus.PUBLISHED,
+        )
+
     def has_approved_state(self):
-        """Get objects which have been approved/sent-to-cds/published."""
+        """Get objects which have been approved, though not necessarily
+        "published" - see `published()` filter."""
         return self.filter(self.approved_query_filter())
 
     def annotate_record_codes(self) -> TrackedModelQuerySet:

--- a/common/models/tracked_qs.py
+++ b/common/models/tracked_qs.py
@@ -148,7 +148,7 @@ class TrackedModelQuerySet(
         """
         return self.exclude(version_group=version_group)
 
-    def published(self):
+    def published(self) -> TrackedModelQuerySet:
         """Return a queryset of TrackedModels that are associated with approved
         Transactions and Workbaskets whose status is PUBLISHED."""
         from workbaskets.validators import WorkflowStatus

--- a/common/models/transactions.py
+++ b/common/models/transactions.py
@@ -78,7 +78,7 @@ class TransactionQueryset(models.QuerySet):
             transaction__in=self,
         )
 
-    def published(self) -> "TransactionQueryset":
+    def published(self) -> TransactionQueryset:
         """Return a queryset of Transactions that have been both approved (are
         in the SEED_FILE or REVISION partitions) and are associated with
         Workbaskets whose status is PUBLISHED."""

--- a/common/models/transactions.py
+++ b/common/models/transactions.py
@@ -80,7 +80,7 @@ class TransactionQueryset(models.QuerySet):
 
     def published(self) -> "TransactionQueryset":
         """Return a queryset of Transactions that have been both approved (are
-        in the SEED_FILE or REVISION partitions) and are associated with a
+        in the SEED_FILE or REVISION partitions) and are associated with
         Workbaskets whose status is PUBLISHED."""
         return self.filter(
             workbasket__status=WorkflowStatus.PUBLISHED,

--- a/common/static/common/scss/_text.scss
+++ b/common/static/common/scss/_text.scss
@@ -19,3 +19,7 @@
 .right-arrow {
   font-size: 1rem;
 }
+
+.fixed-width {
+  font-family: monospace;
+}

--- a/common/static/common/scss/_text.scss
+++ b/common/static/common/scss/_text.scss
@@ -19,7 +19,3 @@
 .right-arrow {
   font-size: 1rem;
 }
-
-.fixed-width {
-  font-family: monospace;
-}

--- a/common/tests/factories.py
+++ b/common/tests/factories.py
@@ -176,6 +176,19 @@ class PublishedWorkBasketFactory(WorkBasketFactory):
     )
 
 
+class SimplePublishedWorkBasketFactory(WorkBasketFactory):
+    """SimplePublishedWorkBasketFactory is distinguished from
+    PublishedWorkBasketFactory by having no transactions, allowing Transaction
+    factories to add to the created workbasket without surplus, incidental
+    transactions."""
+
+    class Meta:
+        model = "workbaskets.WorkBasket"
+
+    approver = factory.SubFactory(UserFactory)
+    status = WorkflowStatus.PUBLISHED
+
+
 class SimpleQueuedWorkBasketFactory(WorkBasketFactory):
     class Meta:
         model = "workbaskets.WorkBasket"
@@ -210,6 +223,11 @@ class TransactionFactory(factory.django.DjangoModelFactory):
             workbasket=factory.SubFactory(PublishedWorkBasketFactory),
         )
 
+        single_published = factory.Trait(
+            partition=TransactionPartition.REVISION,
+            workbasket=factory.SubFactory(SimplePublishedWorkBasketFactory),
+        )
+
         seed = factory.Trait(
             partition=TransactionPartition.SEED_FILE,
         )
@@ -231,6 +249,10 @@ class SeedFileTransactionFactory(TransactionFactory):
 
 class PublishedTransactionFactory(TransactionFactory):
     published = True
+
+
+class SinglePublishedTransactionFactory(TransactionFactory):
+    single_published = True
 
 
 class ApprovedTransactionFactory(TransactionFactory):

--- a/common/tests/factories.py
+++ b/common/tests/factories.py
@@ -229,6 +229,10 @@ class SeedFileTransactionFactory(TransactionFactory):
     seed = True
 
 
+class PublishedTransactionFactory(TransactionFactory):
+    published = True
+
+
 class ApprovedTransactionFactory(TransactionFactory):
     approved = True
 

--- a/common/tests/factories.py
+++ b/common/tests/factories.py
@@ -141,6 +141,17 @@ class EditingWorkBasketFactory(WorkBasketFactory):
     )
 
 
+class ErroredWorkBasketFactory(WorkBasketFactory):
+    class Meta:
+        model = "workbaskets.WorkBasket"
+
+    status = WorkflowStatus.ERRORED
+    transaction = factory.RelatedFactory(
+        "common.tests.factories.UnapprovedTransactionFactory",
+        factory_related_name="workbasket",
+    )
+
+
 class QueuedWorkBasketFactory(WorkBasketFactory):
     class Meta:
         model = "workbaskets.WorkBasket"

--- a/common/tests/factories.py
+++ b/common/tests/factories.py
@@ -248,10 +248,6 @@ class SeedFileTransactionFactory(TransactionFactory):
 
 
 class PublishedTransactionFactory(TransactionFactory):
-    published = True
-
-
-class SinglePublishedTransactionFactory(TransactionFactory):
     single_published = True
 
 

--- a/common/tests/test_querysets.py
+++ b/common/tests/test_querysets.py
@@ -73,6 +73,7 @@ def test_published_transaction_queryset():
     Transactions that are approved and associated with a workbasket that has
     been published."""
 
+    errored_workbasket = factories.ErroredWorkBasketFactory()
     editing_workbasket = factories.EditingWorkBasketFactory()
     queued_workbasket = factories.QueuedWorkBasketFactory()
     published_workbasket = factories.PublishedWorkBasketFactory()
@@ -84,14 +85,20 @@ def test_published_transaction_queryset():
     assert set(published_tranx_ids) == set(
         published_workbasket.transactions.values_list("id", flat=True),
     )
+
     assert not (
         set(published_tranx_ids).intersection(
-            set(queued_workbasket.transactions.values_list("id", flat=True)),
+            set(errored_workbasket.transactions.values_list("id", flat=True)),
         )
     )
     assert not (
         set(published_tranx_ids).intersection(
             set(editing_workbasket.transactions.values_list("id", flat=True)),
+        )
+    )
+    assert not (
+        set(published_tranx_ids).intersection(
+            set(queued_workbasket.transactions.values_list("id", flat=True)),
         )
     )
 
@@ -101,6 +108,10 @@ def test_published_trackedmodels_queryset():
     TrackedModels that are associated with approved transactions and also
     associated with a workbasket that has been published."""
 
+    errored_workbasket = factories.ErroredWorkBasketFactory()
+    factories.TestModel1Factory(
+        transaction=errored_workbasket.transactions.first(),
+    )
     editing_workbasket = factories.EditingWorkBasketFactory()
     factories.TestModel1Factory(
         transaction=editing_workbasket.transactions.first(),
@@ -121,13 +132,19 @@ def test_published_trackedmodels_queryset():
     assert set(published_models_ids) == set(
         published_workbasket.tracked_models.values_list("id", flat=True),
     )
+
     assert not (
         set(published_models_ids).intersection(
-            set(queued_workbasket.tracked_models.values_list("id", flat=True)),
+            set(errored_workbasket.tracked_models.values_list("id", flat=True)),
         )
     )
     assert not (
         set(published_models_ids).intersection(
             set(editing_workbasket.tracked_models.values_list("id", flat=True)),
+        )
+    )
+    assert not (
+        set(published_models_ids).intersection(
+            set(queued_workbasket.tracked_models.values_list("id", flat=True)),
         )
     )

--- a/common/util.py
+++ b/common/util.py
@@ -580,7 +580,7 @@ def get_mime_type(file):
     return mime_type
 
 
-def as_date(date_or_datetime: Union(date, datetime)) -> date:
+def as_date(date_or_datetime: Union[date, datetime]) -> date:
     """Given an object of type datetime.date or datetime.datetime return the
     date portion as type datetime.date."""
     if type(date_or_datetime) is datetime:

--- a/common/views.py
+++ b/common/views.py
@@ -52,6 +52,7 @@ from common.models import TrackedModel
 from common.models import Transaction
 from common.pagination import build_pagination_list
 from common.validators import UpdateType
+from exporter.sqlite.util import sqlite_dumps
 from footnotes.models import Footnote
 from geo_areas.models import GeographicalArea
 from measures.models import Measure
@@ -441,6 +442,8 @@ class AppInfoView(
             data["LAST_PUBLISHED_TRANSACTION_ORDER"] = (
                 last_published_tranx.order if last_published_tranx else 0
             )
+            data["SQLITE_DUMP_DAYS"] = 30
+            data["SQLITE_DUMP_LIST"] = sqlite_dumps(days_past=30)
 
         return data
 

--- a/common/views.py
+++ b/common/views.py
@@ -437,6 +437,10 @@ class AppInfoView(
                 if last_transaction
                 else "No transactions"
             )
+            last_published_tranx = Transaction.objects.published().last()
+            data["LAST_PUBLISHED_TRANSACTION_ORDER"] = (
+                last_published_tranx.order if last_published_tranx else 0
+            )
 
         return data
 

--- a/exporter/sqlite/plan.py
+++ b/exporter/sqlite/plan.py
@@ -109,8 +109,8 @@ class Plan:
             queryset, output_column = add_column_to_queryset(column, queryset)
             output_columns.append(output_column)
 
-        if hasattr(queryset, "has_approved_state"):
-            queryset = queryset.has_approved_state()
+        if hasattr(queryset, "published"):
+            queryset = queryset.published()
 
         queryset = queryset.values_list(*output_columns).iterator()
         operation = (

--- a/exporter/sqlite/tasks.py
+++ b/exporter/sqlite/tasks.py
@@ -15,7 +15,7 @@ def get_output_filename():
 
     If no revisions are present the filename is prefixed with seed_.
     """
-    tx = Transaction.objects.approved().last()
+    tx = Transaction.objects.published().last()
     order = tx.order if tx else 0
     if tx.partition == TransactionPartition.REVISION:
         return f"{order:0>9}.db"

--- a/exporter/sqlite/tasks.py
+++ b/exporter/sqlite/tasks.py
@@ -9,6 +9,12 @@ from exporter.storages import SQLiteStorage
 logger = logging.getLogger(__name__)
 
 
+def normalised_order(order):
+    """Return a transaction's normalised order value - left-padded with zeroes
+    to a normalised width of nine digits."""
+    return f"{order:0>9}"
+
+
 def get_output_filename():
     """
     Generate output filename with transaction order field.
@@ -18,9 +24,9 @@ def get_output_filename():
     tx = Transaction.objects.published().last()
     order = tx.order if tx else 0
     if tx.partition == TransactionPartition.REVISION:
-        return f"{order:0>9}.db"
+        return f"{normalised_order(order)}.db"
 
-    return f"seed_{order:0>9}.db"
+    return f"seed_{normalised_order(order)}.db"
 
 
 @app.task

--- a/exporter/sqlite/util.py
+++ b/exporter/sqlite/util.py
@@ -1,0 +1,84 @@
+import logging
+from datetime import datetime
+from datetime import timedelta
+
+import boto3
+from django.conf import settings
+
+logger = logging.getLogger(__name__)
+
+
+def sqlite_dumps(
+    days_past: int = 30,
+    max_objects: int = 100,
+) -> list[dict[str, int, datetime]]:
+    """
+    Return a list of S3 object information for the most recent sqlite dumps from
+    S3. Information for each object is held in dictionary format:
+
+        {
+            "file_name": str,
+            "file_size": int,   # size in bytes, None if value is unavailable.
+            "created_datetime": datetime.datetime,
+        }
+
+    :param days_past: sets the maximum number of days of object history to
+    retrieve.
+
+    :param max_objects: sets the maximum number of objects to retrieve.
+    """
+
+    s3_client = boto3.client(
+        "s3",
+        aws_access_key_id=settings.SQLITE_S3_ACCESS_KEY_ID,
+        aws_secret_access_key=settings.SQLITE_S3_SECRET_ACCESS_KEY,
+        endpoint_url=settings.SQLITE_S3_ENDPOINT_URL,
+    )
+    paginator = s3_client.get_paginator("list_objects_v2")
+    page_iterator = paginator.paginate(
+        Bucket=settings.SQLITE_STORAGE_BUCKET_NAME,
+        Prefix=settings.SQLITE_STORAGE_DIRECTORY,
+        Delimiter="/",
+        PaginationConfig={"PageSize": max_objects},
+    )
+
+    start_day = (datetime.today() - timedelta(days=days_past)).strftime("%Y-%m-%d")
+    last_modified_filter = f"to_string(LastModified)>='\"{start_day} 00:00:00+00:00\"'"
+    filter_string = (
+        # GTE filter projection - https://jmespath.org/tutorial.html#filter-projections
+        f"Contents[?{last_modified_filter}]"
+        # Pipe to reverse builtin - https://jmespath.org/specification.html#reverse
+        " | reverse(sort_by(@, &to_string(LastModified)))"
+    )
+
+    try:
+        results = []
+        for obj in page_iterator.search(filter_string):
+            file_name = (
+                obj["Key"].split("/", 1)[1]
+                if "Key" in obj and isinstance(obj["Key"], str)
+                else "Unknown"
+            )
+
+            try:
+                file_size = int(obj["Size"]) if "Size" in obj else None
+            except ValueError:
+                file_size = None
+
+            created_datetime = (
+                obj["LastModified"]
+                if "LastModified" in obj and isinstance(obj["LastModified"], datetime)
+                else None
+            )
+
+            results.append(
+                {
+                    "file_name": file_name,
+                    "file_size": file_size,
+                    "created_datetime": created_datetime,
+                },
+            )
+        return results
+    except Exception as e:
+        logging.warn(f"Sqlite S3 query raised exception: {e}")
+        return []

--- a/exporter/tests/test_sqlite.py
+++ b/exporter/tests/test_sqlite.py
@@ -139,7 +139,7 @@ def test_export_task_does_not_reupload(sqlite_storage, s3_object_names, settings
     constantly uploading files and wasting bandwidth/money.
     """
     factories.SeedFileTransactionFactory.create(order="999")
-    transaction = factories.SinglePublishedTransactionFactory.create()
+    transaction = factories.PublishedTransactionFactory.create()
 
     expected_key = path.join(
         settings.SQLITE_STORAGE_DIRECTORY,
@@ -160,7 +160,7 @@ def test_export_task_does_not_reupload(sqlite_storage, s3_object_names, settings
 def test_export_task_uploads(sqlite_storage, s3_object_names, settings):
     """The export system should actually upload a file to S3."""
     factories.SeedFileTransactionFactory.create(order="999")
-    transaction = factories.SinglePublishedTransactionFactory.create()
+    transaction = factories.PublishedTransactionFactory.create()
 
     expected_key = path.join(
         settings.SQLITE_STORAGE_DIRECTORY,
@@ -185,7 +185,7 @@ def test_export_task_ignores_unpublished_and_unapproved_transactions(
     upload as draft data may be sensitive and unpublished, and shouldn't be
     included."""
     factories.SeedFileTransactionFactory.create(order="999")
-    transaction = factories.SinglePublishedTransactionFactory.create(order="123")
+    transaction = factories.PublishedTransactionFactory.create(order="123")
     factories.ApprovedTransactionFactory.create(order="124")
     factories.UnapprovedTransactionFactory.create(order="125")
 

--- a/exporter/tests/test_sqlite.py
+++ b/exporter/tests/test_sqlite.py
@@ -141,7 +141,7 @@ def test_export_task_does_not_reupload(sqlite_storage, s3_object_names, settings
     factories.SeedFileTransactionFactory.create(
         order="999",
     )
-    factories.ApprovedTransactionFactory.create(order="123")
+    factories.PublishedTransactionFactory.create(order="123")
     expected_key = path.join(
         settings.SQLITE_STORAGE_DIRECTORY,
         "000000123.db",
@@ -161,7 +161,7 @@ def test_export_task_does_not_reupload(sqlite_storage, s3_object_names, settings
 def test_export_task_uploads(sqlite_storage, s3_object_names, settings):
     """The export system should actually upload a file to S3."""
     factories.SeedFileTransactionFactory.create(order="999")
-    factories.ApprovedTransactionFactory.create(order="123")
+    factories.PublishedTransactionFactory.create(order="123")
     expected_key = path.join(settings.SQLITE_STORAGE_DIRECTORY, "000000123.db")
 
     with mock.patch("exporter.sqlite.tasks.SQLiteStorage", new=lambda: sqlite_storage):
@@ -173,7 +173,7 @@ def test_export_task_uploads(sqlite_storage, s3_object_names, settings):
     )
 
 
-def test_export_task_ignores_unapproved_transactions(
+def test_export_task_ignores_unpublished_and_unapproved_transactions(
     sqlite_storage,
     s3_object_names,
     settings,
@@ -182,8 +182,9 @@ def test_export_task_ignores_unapproved_transactions(
     upload as draft data may be sensitive and unpublished, and shouldn't be
     included."""
     factories.SeedFileTransactionFactory.create(order="999")
-    factories.ApprovedTransactionFactory.create(order="123")
-    factories.UnapprovedTransactionFactory.create(order="124")
+    factories.PublishedTransactionFactory.create(order="123")
+    factories.ApprovedTransactionFactory.create(order="124")
+    factories.UnapprovedTransactionFactory.create(order="125")
     expected_key = path.join(
         settings.SQLITE_STORAGE_DIRECTORY,
         "000000123.db",


### PR DESCRIPTION
# TP2000-1389 Restrict sqlite dump to published only
<!---
 * Include the JIRA ticket number, eg TP-123, to automatically link.
 * Use 50 characters maximum.
 * Do not end with a full-stop.
--->

## Why
<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Use as many lines as you like.
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions or deliberately ignored edge-cases.
--->

Approved transactions are used to determine whether the sqlite dump process should be run and also to create the data for those dumps. This is incorrect because approved transactions include queued, unpublished transactions. Only transactions that are approved **and** associated with a workbasket in PUBLISHED status should be used.

There is also poor visibility of the most recent sqlite dump files in S3. This makes it unnecessarily difficult to identify when problems occur with sqlite dump creation.

## What
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Explain like I'm 5.
 * Use pictures if you can.
--->

This PR:

- Adds a custom queryset filter `TrackedModelQuerySet.published()` to retrieve `TrackedModel` instances associated with approved Transactions and workbaskets that are have PUBLISHED status.
- Adds unit tests for the new `TrackedModelQuerySet.published()` filter.
- Extends unit test for `TransactionQueryset.published()` filter.
- Adds a list of the most recent (last 30 days) sqlite dump files associated with the service instance on the app-info page. Visibility of the list is restricted to those with superuser status - the same as for deployment information that is also displayed on the app-info page.
- Factors out functionality to normalise value representations of `Transaction.order`, which is used when creating a database dump name and also when testing.
- Updates unit tests that create and upload database dumps using published rather than approved transactions.
- Updates unit test on /app-info view to include mocked sqlite dump data and test that the sqlite dumps section is present.

![image](https://github.com/uktrade/tamato/assets/85895113/8aa8baed-6b60-4dd5-a65a-27054a7cc947)

<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
--->
## Checklist
- Requires migrations? No
- Requires dependency updates? No

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
