### PR TITLE
TP2000-1403  Fix missing quota origin associations

### DIFF
--- a/quotas/jinja2/includes/quotas/tabs/core_data.jinja
+++ b/quotas/jinja2/includes/quotas/tabs/core_data.jinja
@@ -1,7 +1,7 @@
 {% from "quota-origins/macros/origin_display.jinja" import origin_display %}
 
 {% set origins %}
-    {% for origin in object.quotaordernumberorigin_set.current().with_latest_geo_area_description() %}
+    {% for origin in object.get_current_origins().with_latest_geo_area_description() %}
         {{ origin_display(origin) }}
     {% endfor %}
 {% endset %}
@@ -18,7 +18,7 @@
             },
             {
                 "key": {"text": "Origins"},
-                "value": {"text": origins if object.quotaordernumberorigin_set.current().with_latest_geo_area_description() else "-"},
+                "value": {"text": origins if object.get_current_origins().with_latest_geo_area_description() else "-"},
                 "actions": {"items": []}
             },
             {

--- a/quotas/models.py
+++ b/quotas/models.py
@@ -112,6 +112,11 @@ class QuotaOrderNumber(TrackedModel, ValidityMixin):
 
         return sorted(descriptions)
 
+    def get_current_origins(self):
+        return QuotaOrderNumberOrigin.objects.filter(
+            order_number__sid=self.sid,
+        ).current()
+
     class Meta:
         verbose_name = "quota"
 

--- a/quotas/views.py
+++ b/quotas/views.py
@@ -311,17 +311,13 @@ class QuotaUpdateMixin(
             .order_by("description")
         )
         kwargs["existing_origins"] = (
-            self.object.quotaordernumberorigin_set.current().with_latest_geo_area_description()
+            self.object.get_current_origins().with_latest_geo_area_description()
         )
         return kwargs
 
     def update_origins(self, instance, form_origins):
-        existing_origin_pks = {
-            o.pk
-            for o in models.QuotaOrderNumberOrigin.objects.current().filter(
-                order_number__sid=instance.sid,
-            )
-        }
+        existing_origin_pks = {origin.pk for origin in instance.get_current_origins()}
+
         if form_origins:
             submitted_origin_pks = {o["pk"] for o in form_origins}
             deleted_origin_pks = existing_origin_pks.difference(submitted_origin_pks)


### PR DESCRIPTION
# TP2000-1403  Fix missing quota origin associations

## Why
An origin that should be associated to quota order number 058801 doesn't appear on the quota's detail view nor does it appear as an existing origin when editing the quota.

## What
- Changes the queryset to find current/existing origins using the order number SID not PK as a way to catch associations that may have been lost when a quota's version has changed