### PR TITLE
TP2000-1378  Add option to new duty sentence parser to limit parsing to simple duties

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1735,7 +1735,6 @@ def lark_duty_sentence_parser(
     measurement_units,
     unit_qualifiers,
 ) -> LarkDutySentenceParser:
-
     return LarkDutySentenceParser(
         duty_expressions=duty_expressions_list,
         monetary_units=monetary_units_list,
@@ -1756,7 +1755,7 @@ def simple_lark_duty_sentence_parser(
     """Returns a duty sentence parser instance that parses ad valorem and
     specific duties only (i.e no compound duties)."""
     return LarkDutySentenceParser(
-        full_grammar=False,
+        compound_duties=False,
         duty_expressions=duty_expressions_list,
         monetary_units=monetary_units_list,
         measurements=measurements,

--- a/conftest.py
+++ b/conftest.py
@@ -1735,7 +1735,28 @@ def lark_duty_sentence_parser(
     measurement_units,
     unit_qualifiers,
 ) -> LarkDutySentenceParser:
+
     return LarkDutySentenceParser(
+        duty_expressions=duty_expressions_list,
+        monetary_units=monetary_units_list,
+        measurements=measurements,
+        measurement_units=measurement_units,
+        measurement_unit_qualifiers=unit_qualifiers,
+    )
+
+
+@pytest.fixture
+def simple_lark_duty_sentence_parser(
+    duty_expressions_list,
+    monetary_units_list,
+    measurements,
+    measurement_units,
+    unit_qualifiers,
+) -> LarkDutySentenceParser:
+    """Returns a duty sentence parser instance that parses ad valorem and
+    specific duties only (i.e no compound duties)."""
+    return LarkDutySentenceParser(
+        full_grammar=False,
         duty_expressions=duty_expressions_list,
         monetary_units=monetary_units_list,
         measurements=measurements,

--- a/measures/duty_sentence_parser.py
+++ b/measures/duty_sentence_parser.py
@@ -171,6 +171,40 @@ class DutySentenceParser:
             measurement_unit_qualifiers=measurement_unit_qualifiers,
         )
 
+    @property
+    def example_errors(self):
+        """Returns a mapping of example duty sentence syntax errors that may be
+        matched against the current parsing error to provide more user-friendly
+        error reporting."""
+        mapping = {
+            InvalidDutyExpression: [
+                "10% + Blah duty (reduced)",
+                "5.5% + ABCDE + Some other fake duty expression",
+                "10%&@#^&",
+                "ABC",
+                "@(*&$#)",
+            ],
+            DutyAmountRequired: [
+                "+",
+            ],
+            InvalidMonetaryUnit: [
+                "10% + 100 ABC / 100 kg",
+                "100 DEF",
+                "5.5% + 100 XYZ + AC (reduced)",
+            ],
+            InvalidMeasurementUnit: [
+                "10% + 100 GBP / 100 abc",
+                "100 GBP / foobar measurement",
+                "5.5% + 100 EUR / foobar",
+            ],
+            InvalidMeasurementUnitQualififer: [
+                "10% + 100 GBP / 100 kg / ABC",
+                "100 GBP / 100 kg / XYZ foo bar",
+                "5.5% + 100 EUR / % vol / foo bar",
+            ],
+        }
+        return mapping
+
     def parse(self, duty_sentence):
         try:
             return self.parser.parse(duty_sentence)
@@ -178,33 +212,7 @@ class DutySentenceParser:
         except UnexpectedInput as u:
             exc_class = u.match_examples(
                 self.parser.parse,
-                {
-                    InvalidDutyExpression: [
-                        "10% + Blah duty (reduced)",
-                        "5.5% + ABCDE + Some other fake duty expression",
-                        "10%&@#^&",
-                        "ABC",
-                        "@(*&$#)",
-                    ],
-                    DutyAmountRequired: [
-                        "+",
-                    ],
-                    InvalidMonetaryUnit: [
-                        "10% + 100 ABC / 100 kg",
-                        "100 DEF",
-                        "5.5% + 100 XYZ + AC (reduced)",
-                    ],
-                    InvalidMeasurementUnit: [
-                        "10% + 100 GBP / 100 abc",
-                        "100 GBP / foobar measurement",
-                        "5.5% + 100 EUR / foobar",
-                    ],
-                    InvalidMeasurementUnitQualififer: [
-                        "10% + 100 GBP / 100 kg / ABC",
-                        "100 GBP / 100 kg / XYZ foo bar",
-                        "5.5% + 100 EUR / % vol / foo bar",
-                    ],
-                },
+                self.example_errors,
                 use_accepts=True,
             )
             if not exc_class:

--- a/measures/forms.py
+++ b/measures/forms.py
@@ -369,7 +369,7 @@ class MeasureConditionsFormMixin(forms.ModelForm):
 
         if price:
             date = measure_start_date or datetime.datetime.now()
-            parser = LarkDutySentenceParser(full_grammar=False, date=date)
+            parser = LarkDutySentenceParser(compound_duties=False, date=date)
             try:
                 components = parser.transform(price)
                 cleaned_data["duty_amount"] = components[0].get("duty_amount")

--- a/measures/jinja2/includes/measures/macros/duty_amount.jinja
+++ b/measures/jinja2/includes/measures/macros/duty_amount.jinja
@@ -4,9 +4,10 @@
     {{ obj.duty_amount }}
     {%- if obj.monetary_unit %}
         <abbr title="{{ obj.monetary_unit.description }}">{{ obj.monetary_unit.code }}</abbr>
-    {%- elif obj.condition_measurement %}
-        {{ measurement(obj.condition_measurement) }}
     {%- else -%}
         %
+    {%- endif -%}
+    {%- if obj.condition_measurement %}
+        / {{ measurement(obj.condition_measurement) }}
     {%- endif -%}
 {%- endmacro %}

--- a/measures/tests/test_forms.py
+++ b/measures/tests/test_forms.py
@@ -978,10 +978,13 @@ def test_measure_forms_conditions_wizard_valid_duty(date_ranges, duty_sentence_p
 @pytest.mark.parametrize(
     "reference_price, message",
     [
-        ("invalid duty", "Enter a valid reference price or quantity."),
+        (
+            "invalid duty",
+            "No matching duty expression found at character 1. \n\nCheck the validity period of the duty expression and that you are using the correct prefix. ",
+        ),
         (
             "3.5 % + 11 GBP / 100 kg",
-            "A MeasureCondition cannot be created with a compound reference price (e.g. 3.5% + 11 GBP / 100 kg)",
+            "A compound duty expression was found at character 7. \n\nCheck that you are entering a single duty amount or a duty amount together with a measurement unit (and measurement unit qualifier if required). ",
         ),
     ],
 )
@@ -1014,10 +1017,13 @@ def test_measure_forms_conditions_invalid_duty(
 @pytest.mark.parametrize(
     "reference_price, message",
     [
-        ("invalid duty", "Enter a valid reference price or quantity."),
+        (
+            "invalid duty",
+            "No matching duty expression found at character 1. \n\nCheck the validity period of the duty expression and that you are using the correct prefix. ",
+        ),
         (
             "3.5 % + 11 GBP / 100 kg",
-            "A MeasureCondition cannot be created with a compound reference price (e.g. 3.5% + 11 GBP / 100 kg)",
+            "A compound duty expression was found at character 7. \n\nCheck that you are entering a single duty amount or a duty amount together with a measurement unit (and measurement unit qualifier if required). ",
         ),
     ],
 )

--- a/measures/tests/test_lark_parser.py
+++ b/measures/tests/test_lark_parser.py
@@ -282,7 +282,7 @@ def test_duty_syntax_errors(sentence, exp_error_class, lark_duty_sentence_parser
     ],
 )
 def test_compound_duty_not_permitted_error(sentence, simple_lark_duty_sentence_parser):
-    """Tests that a parser not using the complete duty sentence grammar raises a
+    """Tests that a parser with `compound_duties` set to `False` raises a
     `CompoundDutyNotPermitted` exception when parsing a compound duty."""
     with pytest.raises(CompoundDutyNotPermitted):
         simple_lark_duty_sentence_parser.parse(sentence)

--- a/measures/tests/test_lark_parser.py
+++ b/measures/tests/test_lark_parser.py
@@ -6,6 +6,7 @@ import pytest
 from django.core.exceptions import ValidationError
 from lark import Token
 
+from measures.duty_sentence_parser import CompoundDutyNotPermitted
 from measures.duty_sentence_parser import DutyAmountRequired
 from measures.duty_sentence_parser import DutySentenceParser
 from measures.duty_sentence_parser import InvalidDutyExpression
@@ -271,6 +272,20 @@ def test_only_permitted_measurements_allowed(lark_duty_sentence_parser):
 def test_duty_syntax_errors(sentence, exp_error_class, lark_duty_sentence_parser):
     with pytest.raises(exp_error_class):
         lark_duty_sentence_parser.parse(sentence)
+
+
+@pytest.mark.parametrize(
+    "sentence",
+    [
+        "1% + 2 GBP / m3",
+        "1% + AC (reduced)",
+    ],
+)
+def test_compound_duty_not_permitted_error(sentence, simple_lark_duty_sentence_parser):
+    """Tests that a parser not using the complete duty sentence grammar raises a
+    `CompoundDutyNotPermitted` exception when parsing a compound duty."""
+    with pytest.raises(CompoundDutyNotPermitted):
+        simple_lark_duty_sentence_parser.parse(sentence)
 
 
 @pytest.mark.parametrize(

--- a/measures/tests/test_views.py
+++ b/measures/tests/test_views.py
@@ -976,9 +976,10 @@ def test_measure_update_invalid_conditions_only(
         in errors
     )
     assert (
-        "A MeasureCondition cannot be created with a compound reference price (e.g. 3.5% + 11 GBP / 100 kg)"
-        in errors
-    )
+        "A compound duty expression was found at character 6. \n\n"
+        "Check that you are entering a single duty amount "
+        "or a duty amount together with a measurement unit (and measurement unit qualifier if required). "
+    ) in errors
     assert (
         "For each condition you must complete either ‘reference price or quantity’ or ‘certificate, licence or document’."
         in errors


### PR DESCRIPTION
# TP2000-1378  Add option to new duty sentence parser to limit parsing to simple duties

## Why
The measure conditions form doesn't currently take full advantage of the new duty sentence parser because the 
the reference price field doesn't permit compound duties and the parser cannot be limited to simple duties.

## What
- Adds `compound_duties: bool` attribute/param to duty sentence parser, which determines the start symbol of the grammar used by the parser instance so that parsing can be limited to ad valorem and specific duties only (if required)
- Hooks up new duty sentence parser in `MeasureConditionsFormMixin.conditions_clean()` to parse and validate duties inputted in the reference price field of the measure conditions form
- Fixes the display of condition duties both on the measure review view and on the measure detail view conditions tab to measurement units
- Updates unit tests  

---

Before | After
------  | ------
<img width="400" alt="Screenshot 2024-06-12 at 15 45 55" src="https://github.com/uktrade/tamato/assets/118175145/bae83984-dc28-4776-b5af-fe378acfc607">|<img width="400" alt="Screenshot 2024-06-12 at 16 50 26" src="https://github.com/uktrade/tamato/assets/118175145/885218cb-7649-45be-b6cf-be7d743f039a">
&nbsp; | <img width="400" alt="Screenshot 2024-06-12 at 15 39 54" src="https://github.com/uktrade/tamato/assets/118175145/32241fd1-b611-4366-81a8-b67373cd650b">
Missing measurement unit (and measurement unit qualifier) | <img width="400" alt="Screenshot 2024-06-12 at 15 48 17" src="https://github.com/uktrade/tamato/assets/118175145/225d2071-669d-4521-bcba-078ba707c341">
<img width="400" alt="Screenshot 2024-06-12 at 16 09 55" src="https://github.com/uktrade/tamato/assets/118175145/dae91651-3d08-4fa1-a9c9-d548f693a7ef"> | <img width="400" alt="Screenshot 2024-06-12 at 15 54 35" src="https://github.com/uktrade/tamato/assets/118175145/6e94b757-3cb4-4e76-8b75-214830c73059">
