### PR TITLE
TP2000 1382 change workbasket id to tops number

### DIFF
--- a/common/jinja2/common/homepage.jinja
+++ b/common/jinja2/common/homepage.jinja
@@ -75,7 +75,7 @@
                   <a
                     href="{{ url("workbaskets:workbasket-ui-detail", kwargs={"pk": workbasket["id"]}) }}"
                     class="govuk-link"
-                  >Workbasket TOPS {{ workbasket["title"] }}</a>
+                  >{{ workbasket["description"] }}</a>
                   <span>
                     {% if workbasket["rule_violations_count"] %}
                       - {{ workbasket["assignment_type"] }}, rule violation{{ workbasket["rule_violations_count"]|pluralize }}

--- a/common/jinja2/common/homepage.jinja
+++ b/common/jinja2/common/homepage.jinja
@@ -75,7 +75,7 @@
                   <a
                     href="{{ url("workbaskets:workbasket-ui-detail", kwargs={"pk": workbasket["id"]}) }}"
                     class="govuk-link"
-                  >Workbasket ID {{ workbasket["id"] }}</a>
+                  >Workbasket TOPS {{ workbasket["title"] }}</a>
                   <span>
                     {% if workbasket["rule_violations_count"] %}
                       - {{ workbasket["assignment_type"] }}, rule violation{{ workbasket["rule_violations_count"]|pluralize }}

--- a/common/tests/test_views.py
+++ b/common/tests/test_views.py
@@ -264,13 +264,14 @@ def test_homepage_cards_contain_expected_links(superuser_client):
     ],
 )
 def test_homepage_card_currently_working_on(status, valid_user, valid_user_client):
-    workbasket = factories.WorkBasketFactory.create(status=status)
-    review_assignment = factories.UserAssignmentFactory.create(
+    test_reason = "test reason"
+    workbasket = factories.WorkBasketFactory.create(status=status, reason=test_reason)
+    factories.UserAssignmentFactory.create(
         user=valid_user,
         assignment_type=UserAssignment.AssignmentType.WORKBASKET_REVIEWER,
         task__workbasket=workbasket,
     )
-    rule_violation = TrackedModelCheckFactory.create(
+    TrackedModelCheckFactory.create(
         transaction_check__transaction=workbasket.new_transaction(),
         successful=False,
     )
@@ -281,7 +282,8 @@ def test_homepage_card_currently_working_on(status, valid_user, valid_user_clien
     assigned_workbasket = card.find_next("a")
     details = card.find_next("span")
 
-    assert f"Workbasket ID {workbasket.pk}" in assigned_workbasket.text
+    assert test_reason in assigned_workbasket.text
+    assert str(workbasket.pk) in assigned_workbasket.attrs["href"]
     assert "Reviewing" and "rule violation" in details.text
 
 

--- a/common/views.py
+++ b/common/views.py
@@ -95,7 +95,7 @@ class HomeView(LoginRequiredMixin, FormView):
             assigned_workbaskets.append(
                 {
                     "id": workbasket.id,
-                    "title": workbasket.title,
+                    "description": workbasket.reason,
                     "rule_violations_count": rule_violations_count,
                     "assignment_type": assignment_type,
                 },

--- a/common/views.py
+++ b/common/views.py
@@ -95,6 +95,7 @@ class HomeView(LoginRequiredMixin, FormView):
             assigned_workbaskets.append(
                 {
                     "id": workbasket.id,
+                    "title": workbasket.title,
                     "rule_violations_count": rule_violations_count,
                     "assignment_type": assignment_type,
                 },


### PR DESCRIPTION

TP2000-1382 Change workbasket id to tops number in the list of workbaskets assigned to the current user

The user does not immediately recognised the workbasket ID, and prefers to see the description.

![MicrosoftTeams-image](https://github.com/uktrade/tamato/assets/36708790/cbb3f19a-c320-4e30-b05b-fd0a713b58d3)




