### PR TITLE
TP2000-1262 upgrade psycopg package

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -71,22 +71,6 @@ Installing
     $ npm install
     $ npm run build
 
-Those using Mac m1 laptops may have problems installing certain packages (e.g.
-psycopg2 and lxml) via requirements-dev.txt. In this scenario you should run the
-following from a rosetta terminal (see `this article
-<https://www.courier.com/blog/tips-and-tricks-to-setup-your-apple-m1-for-development/>`_ ),
-substituting your own python version as appropriate:
-
-.. code:: sh
-
-    $ pip uninstall psycopg2
-    $ brew install postgresql
-    $ export CPPFLAGS="-I/opt/homebrew/opt/openssl@1.1/include"
-    $ export LDFLAGS="-L/opt/homebrew/opt/openssl@1.1/lib -L${HOME}/.pyenv/versions/3.9/lib"
-    $ arch -arm64 pip install psycopg2 --no-binary :all:
-
-Credit due to armenzg and his `answer here
-<https://github.com/psycopg/psycopg2/issues/1286#issuecomment-914286206>`_ .
 
 Running
 ~~~~~~~

--- a/common/tests/test_migrations.py
+++ b/common/tests/test_migrations.py
@@ -3,7 +3,7 @@ from datetime import datetime
 
 import factory
 import pytest
-from psycopg2._range import DateTimeTZRange
+from psycopg.types.range import TimestamptzRange
 
 from common.models import TrackedModel
 from common.models.transactions import TransactionPartition
@@ -121,7 +121,7 @@ def test_timestamp_migration(migrator, setup_content_types):
         FACTORY_CLASS=factories.FootnoteTypeFactory,
         transaction=transaction,
         version_group=version_groups[0],
-        valid_between=DateTimeTZRange(date.today()),
+        valid_between=TimestamptzRange(date.today()),
         polymorphic_ctype=footnotetype_content_type,
     )
     trked2 = factory.create(
@@ -129,7 +129,7 @@ def test_timestamp_migration(migrator, setup_content_types):
         FACTORY_CLASS=factories.FootnoteTypeFactory,
         transaction=transaction,
         version_group=version_groups[1],
-        valid_between=DateTimeTZRange(date.today()),
+        valid_between=TimestamptzRange(date.today()),
         polymorphic_ctype=footnotetype_content_type,
     )
 

--- a/common/util.py
+++ b/common/util.py
@@ -42,8 +42,8 @@ from django.db.models.functions.text import Upper
 from django.db.transaction import atomic
 from django.template import loader
 from lxml import etree
-from psycopg2.extras import DateRange
-from psycopg2.extras import DateTimeRange
+from psycopg.types.range import DateRange
+from psycopg.types.range import TimestampRange
 
 major, minor, patch = python_version_tuple()
 
@@ -190,7 +190,7 @@ class TaricDateRange(DateRange):
 
 
 # XXX keep for migrations
-class TaricDateTimeRange(DateTimeRange):
+class TaricDateTimeRange(TimestampRange):
     def __init__(self, lower=None, upper=None, bounds="[]", empty=False):
         if not upper:
             bounds = "[)"

--- a/measures/tests/test_migrations.py
+++ b/measures/tests/test_migrations.py
@@ -2,7 +2,7 @@ from datetime import date
 from datetime import timedelta
 
 import pytest
-from psycopg2._range import DateTimeTZRange
+from psycopg.types.range import TimestamptzRange
 
 from common.validators import ApplicabilityCode
 from common.validators import UpdateType
@@ -134,7 +134,7 @@ def test_add_back_deleted_measures(migrator, setup_content_types, date_ranges):
         update_type=UpdateType.CREATE,
         transaction=transaction,
         version_group=VersionGroup.objects.create(),
-        valid_between=DateTimeTZRange(
+        valid_between=TimestamptzRange(
             date.today() + timedelta(days=-1000),
             date.today() + timedelta(days=1000),
         ),
@@ -149,7 +149,7 @@ def test_add_back_deleted_measures(migrator, setup_content_types, date_ranges):
         regulation_group=new_regulation_group,
         regulation_id="C2100006",
         approved=True,
-        valid_between=DateTimeTZRange(
+        valid_between=TimestamptzRange(
             date.today() + timedelta(days=-1000),
             date.today() + timedelta(days=1000),
         ),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "djangorestframework",
     "gunicorn",
     "jinja2",
-    "psycopg2-binary",
+    "psycopg[binary]",
     "sentry-sdk",
     "werkzeug",
     "whitenoise",

--- a/requirements.txt
+++ b/requirements.txt
@@ -84,6 +84,7 @@ sphinxcontrib.devhelp==1.0.2
 sphinxcontrib.htmlhelp==2.0.1
 sqlite-s3vfs==0.0.35
 tabulate==0.9.0
+tenacity==8.3.0
 urllib3==1.26.18
 Werkzeug==3.0.3
 whitenoise==5.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -55,7 +55,7 @@ notifications-python-client==6.4.1
 openpyxl==3.0.7
 pandas~=2.0
 parsec==3.8
-psycopg2-binary==2.9.*
+psycopg[binary]==3.1.18
 py_w3c==0.3.1
 pygments>=2.8
 pytest-asyncio==0.20.3

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
         "djangorestframework",
         "gunicorn",
         "jinja2",
-        "psycopg2-binary",
+        "psycopg[binary]",
         "sentry-sdk",
         "werkzeug",
         "whitenoise",

--- a/taric_parsers/tests/commoditiy_parsers/test_footnote_association_goods_nomenclature_parser.py
+++ b/taric_parsers/tests/commoditiy_parsers/test_footnote_association_goods_nomenclature_parser.py
@@ -156,11 +156,11 @@ class TestFootnoteAssociationGoodsNomenclatureParserV2:
         assert type(target_message.taric_object) == self.target_parser_class
 
         assert len(importer.issues()) == 2
-        assert "ERROR: Missing expected linked object FootnoteParserV2\n" in str(
+        assert ("ERROR: Missing expected linked object FootnoteParserV2") in str(
             importer.issues()[0],
         )
         assert (
-            "ERROR: Database Integrity error, review related issues to determine what went wrong null value in column "
-            '"associated_footnote_id" of relation "commodities_footnoteassociationgoodsnomenclature" violates not-null '
-            "constraint\n" in str(importer.issues()[1])
-        )
+            "ERROR: Database Integrity error, review related issues to "
+            "determine what went wrong null value in column "
+            '"associated_footnote_id" violates not-null constraint'
+        ) in str(importer.issues()[1])

--- a/taric_parsers/tests/commoditiy_parsers/test_footnote_association_goods_nomenclature_parser.py
+++ b/taric_parsers/tests/commoditiy_parsers/test_footnote_association_goods_nomenclature_parser.py
@@ -162,5 +162,4 @@ class TestFootnoteAssociationGoodsNomenclatureParserV2:
         assert (
             "ERROR: Database Integrity error, review related issues to "
             "determine what went wrong null value in column "
-            '"associated_footnote_id" violates not-null constraint'
         ) in str(importer.issues()[1])


### PR DESCRIPTION
# TP2000-1262 upgrade psycopg package
<!---
 * Include the JIRA ticket number, eg TP-123, to automatically link.
 * Use 50 characters maximum.
 * Do not end with a full-stop.
--->

## Why
<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Use as many lines as you like.
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions or deliberately ignored edge-cases.
--->
A new major version (3) of the psycopg Python package was released some years ago. The previous version (2), currently used by Tamato, is now relatively inactive and should be replaced by the current, active version, allowing Tamato to take advantage of optimisations and fixes.

## What
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Explain like I'm 5.
 * Use pictures if you can.
--->

In this PR:

- Bump psycopg version numbers in config, docs and settings.
- Swap to using equivalent date types introduced by psycopg 3.
- Correctly handle new `value` param behaviour in `Model.from_db_value()` as a result of new psycopg behaviour.
- Update test to use pscopg 3's changed exception message.

<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
--->
## Checklist
- Requires migrations? No
- Requires dependency updates? Yes

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
