### PR TITLE
TP2000-1402  Implement journey to create quota suspension or blocking periods

### DIFF
--- a/common/forms.py
+++ b/common/forms.py
@@ -356,27 +356,13 @@ class DescriptionForm(forms.ModelForm):
         fields = ("description", "validity_start")
 
 
-class ValidityPeriodForm(forms.ModelForm):
+class ValidityPeriodBaseForm(forms.Form):
     start_date = DateInputFieldFixed(label="Start date")
     end_date = DateInputFieldFixed(
         label="End date",
         required=False,
     )
     valid_between = GovukDateRangeField(required=False)
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
-        self.fields["end_date"].help_text = (
-            f"Leave empty if {get_model_indefinite_article(self.instance)} "
-            f"{self.instance._meta.verbose_name} is needed for an unlimited time."
-        )
-
-        if self.instance.valid_between:
-            if self.instance.valid_between.lower:
-                self.fields["start_date"].initial = self.instance.valid_between.lower
-            if self.instance.valid_between.upper:
-                self.fields["end_date"].initial = self.instance.valid_between.upper
 
     def clean_validity_period(
         self,
@@ -429,6 +415,22 @@ class ValidityPeriodForm(forms.ModelForm):
         cleaned_data = super().clean()
         self.clean_validity_period(cleaned_data)
         return cleaned_data
+
+
+class ValidityPeriodForm(ValidityPeriodBaseForm, forms.ModelForm):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self.fields["end_date"].help_text = (
+            f"Leave empty if {get_model_indefinite_article(self.instance)} "
+            f"{self.instance._meta.verbose_name} is needed for an unlimited time."
+        )
+
+        if self.instance.valid_between:
+            if self.instance.valid_between.lower:
+                self.fields["start_date"].initial = self.instance.valid_between.lower
+            if self.instance.valid_between.upper:
+                self.fields["end_date"].initial = self.instance.valid_between.upper
 
 
 class CreateDescriptionForm(DescriptionForm):

--- a/common/jinja2/layouts/confirm.jinja
+++ b/common/jinja2/layouts/confirm.jinja
@@ -19,16 +19,18 @@
       <h2 class="govuk-heading-m">Next steps</h2>
       <div>{% block main_button %}{% endblock%}</div>
       <div class="govuk-button-group">
-      {{ govukButton({
-        "text": "View workbasket summary",
-        "href": url("workbaskets:current-workbasket"),
-        "classes": "govuk-button"
-      }) }}
-      {{ govukButton({
-        "text": "View " ~ object._meta.verbose_name ~ ": " ~ object|string,
-        "href": object.get_url(),
-        "classes": "govuk-button--secondary"
-      }) }}
+        {% block button_group %}
+          {{ govukButton({
+            "text": "View workbasket summary",
+            "href": url("workbaskets:current-workbasket"),
+            "classes": "govuk-button"
+          }) }}
+          {{ govukButton({
+            "text": "View " ~ object._meta.verbose_name ~ ": " ~ object|string,
+            "href": object.get_url(),
+            "classes": "govuk-button--secondary"
+          }) }}
+        {% endblock %}
       </div>
       <ul class="govuk-list govuk-list-spaced">
         {% block actions %}

--- a/quotas/forms.py
+++ b/quotas/forms.py
@@ -26,6 +26,7 @@ from common.forms import delete_form_for
 from common.forms import formset_factory
 from common.forms import unprefix_formset_data
 from common.util import validity_range_contains_range
+from common.validators import SymbolValidator
 from common.validators import UpdateType
 from geo_areas.models import GeographicalArea
 from measures.models import MeasurementUnit
@@ -903,6 +904,7 @@ class QuotaSuspensionOrBlockingCreateForm(
 
     description = forms.CharField(
         label="Description",
+        validators=[SymbolValidator],
         widget=forms.Textarea(),
         required=False,
     )

--- a/quotas/forms.py
+++ b/quotas/forms.py
@@ -11,6 +11,8 @@ from crispy_forms_gds.layout import Submit
 from django import forms
 from django.core.exceptions import NON_FIELD_ERRORS
 from django.core.exceptions import ValidationError
+from django.db import transaction
+from django.db.models import TextChoices
 from django.template.loader import render_to_string
 from django.urls import reverse_lazy
 
@@ -18,10 +20,14 @@ from common.forms import BindNestedFormMixin
 from common.forms import FormSet
 from common.forms import FormSetField
 from common.forms import FormSetSubmitMixin
+from common.forms import RadioNested
+from common.forms import ValidityPeriodBaseForm
 from common.forms import ValidityPeriodForm
 from common.forms import delete_form_for
 from common.forms import formset_factory
 from common.forms import unprefix_formset_data
+from common.util import validity_range_contains_range
+from common.validators import UpdateType
 from geo_areas.models import GeographicalArea
 from measures.models import MeasurementUnit
 from quotas import models
@@ -852,3 +858,139 @@ class QuotaOriginExclusionsReactForm(forms.Form):
             .as_at_today_and_beyond()
             .order_by("description")
         )
+
+
+class QuotaSuspensionType(TextChoices):
+    SUSPENSION = "SUSPENSION", "Suspension period"
+    BLOCKING = "BLOCKING", "Blocking period"
+
+
+class BlockingPeriodTypeForm(forms.Form):
+    blocking_period_type = forms.ChoiceField(
+        help_text="Select a blocking period type.",
+        choices=validators.BlockingPeriodType.choices,
+        error_messages={
+            "required": "Select a blocking period type",
+        },
+    )
+
+
+class QuotaSuspensionOrBlockingCreateForm(
+    ValidityPeriodBaseForm,
+    BindNestedFormMixin,
+    forms.Form,
+):
+    quota_definition = forms.ModelChoiceField(
+        label="Quota definition SID",
+        empty_label="Select a quota definition SID",
+        queryset=models.QuotaDefinition.objects.all(),
+        error_messages={
+            "required": "Select a quota definition SID",
+        },
+    )
+
+    suspension_type = RadioNested(
+        label="Do you want to create a suspension or blocking period?",
+        help_text="Select one option.",
+        choices=QuotaSuspensionType.choices,
+        nested_forms={
+            QuotaSuspensionType.SUSPENSION.value: [],
+            QuotaSuspensionType.BLOCKING.value: [BlockingPeriodTypeForm],
+        },
+        error_messages={
+            "required": "Select if you want to create a suspension or blocking period",
+        },
+    )
+
+    description = forms.CharField(
+        label="Description",
+        widget=forms.Textarea(),
+        required=False,
+    )
+
+    def __init__(self, *args, **kwargs):
+        self.quota_order_number = kwargs.pop("quota_order_number")
+        super().__init__(*args, **kwargs)
+        self.bind_nested_forms(*args, **kwargs)
+        self.init_fields()
+        self.init_layout()
+
+    def init_fields(self):
+        self.fields["quota_definition"].queryset = (
+            models.QuotaDefinition.objects.current()
+            .as_at_today_and_beyond()
+            .filter(order_number=self.quota_order_number)
+            .order_by("-sid")
+        )
+        self.fields["quota_definition"].label_from_instance = (
+            lambda obj: f"{obj.sid} ({obj.valid_between.lower} - {obj.valid_between.upper})"
+        )
+
+    def init_layout(self):
+        cancel_url = reverse_lazy(
+            "quota-ui-detail",
+            kwargs={"sid": self.quota_order_number.sid},
+        )
+        self.helper = FormHelper(self)
+        self.helper.label_size = Size.SMALL
+        self.helper.legend_size = Size.SMALL
+        self.helper.layout = Layout(
+            "quota_definition",
+            "suspension_type",
+            Field.textarea("description", rows=5),
+            "start_date",
+            "end_date",
+            Div(
+                Submit(
+                    "submit",
+                    "Save",
+                    css_class="govuk-button--primary",
+                    data_module="govuk-button",
+                    data_prevent_double_click="true",
+                ),
+                HTML(
+                    f"<a class='govuk-button govuk-button--secondary' href={cancel_url}>Cancel</a>",
+                ),
+                css_class="govuk-button-group",
+            ),
+        )
+
+    def clean(self):
+        cleaned_data = super().clean()
+        definition_period = (
+            cleaned_data["quota_definition"].valid_between
+            if cleaned_data.get("quota_definition")
+            else None
+        )
+        validity_period = cleaned_data.get("valid_between")
+        if (
+            definition_period
+            and validity_period
+            and not validity_range_contains_range(definition_period, validity_period)
+        ):
+            raise ValidationError(
+                f"The start and end date must sit within the selected quota definition's start and end date ({definition_period.lower} - {definition_period.upper})",
+            )
+
+        return cleaned_data
+
+    @transaction.atomic
+    def save(self, workbasket):
+        if self.cleaned_data["suspension_type"] == QuotaSuspensionType.SUSPENSION:
+            object = models.QuotaSuspension.objects.create(
+                quota_definition=self.cleaned_data["quota_definition"],
+                description=self.cleaned_data["description"],
+                valid_between=self.cleaned_data["valid_between"],
+                update_type=UpdateType.CREATE,
+                transaction=workbasket.new_transaction(),
+            )
+        else:
+            object = models.QuotaBlocking.objects.create(
+                quota_definition=self.cleaned_data["quota_definition"],
+                blocking_period_type=self.cleaned_data["blocking_period_type"],
+                description=self.cleaned_data["description"],
+                valid_between=self.cleaned_data["valid_between"],
+                update_type=UpdateType.CREATE,
+                transaction=workbasket.new_transaction(),
+            )
+        return object

--- a/quotas/jinja2/includes/quotas/actions.jinja
+++ b/quotas/jinja2/includes/quotas/actions.jinja
@@ -5,6 +5,8 @@
             <li><a class="govuk-link" href="{{ url('quota_definition-ui-list', args=[object.sid]) }}">View definition periods</a></li>
             <li><a class="govuk-link" href="{{ url('quota_definition-ui-create', args=[object.sid]) }}">Create definition period</a></li>
             <br>
+            <li><a class="govuk-link" href="{{ url('quota_suspension_or_blocking-ui-create', args=[object.sid]) }}">Create suspension or blocking period</a></li>
+            <br>
             <li><a class="govuk-link" href="{{ measures_url }}">View all measures</a></li>
             <br>
           {% set edit_url = object.get_url('edit') %}

--- a/quotas/jinja2/quota-suspensions/confirm-create.jinja
+++ b/quotas/jinja2/quota-suspensions/confirm-create.jinja
@@ -2,6 +2,8 @@
 {% from "components/breadcrumbs.jinja" import breadcrumbs %}
 {% from "components/button/macro.njk" import govukButton %}
 
+{% set page_title = object_name ~ " created" %}
+
 {% block breadcrumb %}
   {{ breadcrumbs(request, [
     {"text": "Find and edit quotas", "href": url("quota-ui-list")},
@@ -21,25 +23,21 @@
   }) }}
 {% endblock %}
 
-{% block main_button %}
-  {{ govukButton({
-    "text": "Return to quota ID " ~ quota_order_number,
-    "href": quota_order_number.get_url(),
-    "classes": "govuk-button--primary",
-  }) }}
-{% endblock %}
-
 {% block button_group %}
   {{ govukButton({
     "text": "View workbasket summary",
     "href": url("workbaskets:current-workbasket"),
-    "classes": "govuk-button",
+    "classes": "govuk-button--primary",
   }) }}
   {{ govukButton({
-    "text": "View quota ID " ~ quota_order_number ~ " " ~ object_name|lower ~ "s",
-    "href": tab_url,
-    "classes": "govuk-button--secondary"
+    "text": "Return to quota ID " ~ quota_order_number,
+    "href": quota_order_number.get_url(),
+    "classes": "govuk-button--secondary",
   }) }}
 {% endblock %}
 
-{% block actions %}{% endblock %}
+{% block actions %}
+  <li>
+    <a class="govuk-link" href="{{ list_url }}">View quota ID {{ quota_order_number }} {{ object_name|lower }}s</a>
+  </li>
+{% endblock %}

--- a/quotas/jinja2/quota-suspensions/confirm-create.jinja
+++ b/quotas/jinja2/quota-suspensions/confirm-create.jinja
@@ -1,0 +1,45 @@
+{% extends "common/confirm_create.jinja" %}
+{% from "components/breadcrumbs.jinja" import breadcrumbs %}
+{% from "components/button/macro.njk" import govukButton %}
+
+{% block breadcrumb %}
+  {{ breadcrumbs(request, [
+    {"text": "Find and edit quotas", "href": url("quota-ui-list")},
+    {
+      "text": "Quota ID: " ~ quota_order_number,
+      "href": quota_order_number.get_url(),
+    },
+    {"text": page_title}
+  ])}}
+{% endblock %}
+
+{% block panel %}
+  {{ govukPanel({
+    "titleText": object_name ~ " SID " ~ object.sid,
+    "text": object_name ~ " SID " ~ object.sid ~ " has been created and added to workbasket ID " ~ request.user.current_workbasket.pk,
+    "classes": "govuk-!-margin-bottom-7",
+  }) }}
+{% endblock %}
+
+{% block main_button %}
+  {{ govukButton({
+    "text": "Return to quota ID " ~ quota_order_number,
+    "href": quota_order_number.get_url(),
+    "classes": "govuk-button--primary",
+  }) }}
+{% endblock %}
+
+{% block button_group %}
+  {{ govukButton({
+    "text": "View workbasket summary",
+    "href": url("workbaskets:current-workbasket"),
+    "classes": "govuk-button",
+  }) }}
+  {{ govukButton({
+    "text": "View quota ID " ~ quota_order_number ~ " " ~ object_name|lower ~ "s",
+    "href": tab_url,
+    "classes": "govuk-button--secondary"
+  }) }}
+{% endblock %}
+
+{% block actions %}{% endblock %}

--- a/quotas/jinja2/quota-suspensions/create.jinja
+++ b/quotas/jinja2/quota-suspensions/create.jinja
@@ -1,0 +1,12 @@
+{% extends "layouts/create.jinja" %}
+
+{% block breadcrumb %}
+  {{ breadcrumbs(request, [
+    {"text": "Find and edit quotas", "href": url("quota-ui-list")},
+    {
+        "text": "Quota ID: " ~ quota_order_number,
+        "href": url("quota-ui-detail", kwargs={"sid": quota_order_number.sid})
+    },
+    {"text": page_title}
+  ])}}
+{% endblock %}

--- a/quotas/urls.py
+++ b/quotas/urls.py
@@ -124,5 +124,20 @@ urlpatterns = [
         views.QuotaOrderNumberOriginConfirmUpdate.as_view(),
         name="quota_order_number_origin-ui-confirm-update",
     ),
+    path(
+        f"quotas/<sid>/blocking-or-suspension-periods/create/",
+        views.QuotaSuspensionOrBlockingCreate.as_view(),
+        name="quota_suspension_or_blocking-ui-create",
+    ),
+    path(
+        f"quotas/suspension-periods/<sid>/confirm-create/",
+        views.QuotaSuspensionConfirmCreate.as_view(),
+        name="quota_suspension-ui-confirm-create",
+    ),
+    path(
+        f"quotas/blocking-periods/<sid>/confirm-create/",
+        views.QuotaBlockingConfirmCreate.as_view(),
+        name="quota_blocking-ui-confirm-create",
+    ),
     path("api/", include(api_router.urls)),
 ]

--- a/quotas/views.py
+++ b/quotas/views.py
@@ -745,16 +745,17 @@ class QuotaSuspensionOrBlockingCreate(
         return super().form_valid(form)
 
     def get_success_url(self):
-        if isinstance(self.object, QuotaSuspension):
-            return reverse(
+        redirect_map = {
+            QuotaSuspension: reverse(
                 "quota_suspension-ui-confirm-create",
                 kwargs={"sid": self.object.sid},
-            )
-        else:
-            return reverse(
+            ),
+            QuotaBlocking: reverse(
                 "quota_blocking-ui-confirm-create",
                 kwargs={"sid": self.object.sid},
-            )
+            ),
+        }
+        return redirect_map.get(type(self.object))
 
 
 class QuotaSuspensionConfirmCreate(TrackedModelDetailView):

--- a/quotas/views.py
+++ b/quotas/views.py
@@ -2,10 +2,13 @@ from datetime import date
 from urllib.parse import urlencode
 
 from django.contrib import messages
+from django.contrib.auth.mixins import PermissionRequiredMixin
 from django.db import transaction
 from django.urls import reverse
+from django.utils.decorators import method_decorator
 from django.utils.functional import cached_property
 from django.utils.safestring import mark_safe
+from django.views.generic import FormView
 from django.views.generic.edit import FormMixin
 from django.views.generic.list import ListView
 from rest_framework import permissions
@@ -37,6 +40,7 @@ from quotas.models import QuotaAssociation
 from quotas.models import QuotaBlocking
 from quotas.models import QuotaSuspension
 from workbaskets.models import WorkBasket
+from workbaskets.views.decorators import require_current_workbasket
 from workbaskets.views.generic import CreateTaricCreateView
 from workbaskets.views.generic import CreateTaricDeleteView
 from workbaskets.views.generic import CreateTaricUpdateView
@@ -704,3 +708,86 @@ class QuotaDefinitionConfirmDelete(
     TrackedModelDetailView,
 ):
     template_name = "quota-definitions/confirm-delete.jinja"
+
+
+@method_decorator(require_current_workbasket, name="dispatch")
+class QuotaSuspensionOrBlockingCreate(
+    PermissionRequiredMixin,
+    FormView,
+):
+    """UI endpoint for creating a suspension period or a blocking period."""
+
+    template_name = "quota-suspensions/create.jinja"
+    form_class = forms.QuotaSuspensionOrBlockingCreateForm
+    permission_required = "common.add_trackedmodel"
+
+    @property
+    def quota_order_number(self):
+        return models.QuotaOrderNumber.objects.current().get(sid=self.kwargs["sid"])
+
+    @property
+    def workbasket(self):
+        return WorkBasket.current(self.request)
+
+    def get_form_kwargs(self):
+        kwargs = super().get_form_kwargs()
+        kwargs["quota_order_number"] = self.quota_order_number
+        return kwargs
+
+    def get_context_data(self, *args, **kwargs):
+        context = super().get_context_data(*args, **kwargs)
+        context["page_title"] = "Create a suspension or blocking period"
+        context["quota_order_number"] = self.quota_order_number
+        return context
+
+    def form_valid(self, form):
+        self.object = form.save(workbasket=self.workbasket)
+        return super().form_valid(form)
+
+    def get_success_url(self):
+        if isinstance(self.object, QuotaSuspension):
+            return reverse(
+                "quota_suspension-ui-confirm-create",
+                kwargs={"sid": self.object.sid},
+            )
+        else:
+            return reverse(
+                "quota_blocking-ui-confirm-create",
+                kwargs={"sid": self.object.sid},
+            )
+
+
+class QuotaSuspensionConfirmCreate(TrackedModelDetailView):
+    model = models.QuotaSuspension
+    template_name = "quota-suspensions/confirm-create.jinja"
+
+    def get_context_data(self, *args, **kwargs):
+        context = super().get_context_data(*args, **kwargs)
+        quota_order_number = self.object.quota_definition.order_number
+        context.update(
+            {
+                "page_title": "Suspension period created",
+                "quota_order_number": quota_order_number,
+                "object_name": "Suspension period",
+                "tab_url": f"{quota_order_number.get_url()}#suspension-periods",
+            },
+        )
+        return context
+
+
+class QuotaBlockingConfirmCreate(TrackedModelDetailView):
+    model = models.QuotaBlocking
+    template_name = "quota-suspensions/confirm-create.jinja"
+
+    def get_context_data(self, *args, **kwargs):
+        context = super().get_context_data(*args, **kwargs)
+        quota_order_number = self.object.quota_definition.order_number
+        context.update(
+            {
+                "page_title": "Blocking period created",
+                "quota_order_number": quota_order_number,
+                "object_name": "Blocking period",
+                "tab_url": f"{quota_order_number.get_url()}#blocking-periods",
+            },
+        )
+        return context

--- a/quotas/views.py
+++ b/quotas/views.py
@@ -765,12 +765,16 @@ class QuotaSuspensionConfirmCreate(TrackedModelDetailView):
     def get_context_data(self, *args, **kwargs):
         context = super().get_context_data(*args, **kwargs)
         quota_order_number = self.object.quota_definition.order_number
+        list_url = reverse(
+            "quota_definition-ui-list",
+            kwargs={"sid": quota_order_number.sid},
+        )
+        url_param = urlencode({"quota_type": "suspension_periods"})
         context.update(
             {
-                "page_title": "Suspension period created",
                 "quota_order_number": quota_order_number,
                 "object_name": "Suspension period",
-                "tab_url": f"{quota_order_number.get_url()}#suspension-periods",
+                "list_url": f"{list_url}?{url_param}",
             },
         )
         return context
@@ -783,12 +787,16 @@ class QuotaBlockingConfirmCreate(TrackedModelDetailView):
     def get_context_data(self, *args, **kwargs):
         context = super().get_context_data(*args, **kwargs)
         quota_order_number = self.object.quota_definition.order_number
+        list_url = reverse(
+            "quota_definition-ui-list",
+            kwargs={"sid": quota_order_number.sid},
+        )
+        url_param = urlencode({"quota_type": "blocking_periods"})
         context.update(
             {
-                "page_title": "Blocking period created",
                 "quota_order_number": quota_order_number,
                 "object_name": "Blocking period",
-                "tab_url": f"{quota_order_number.get_url()}#blocking-periods",
+                "list_url": f"{list_url}?{url_param}",
             },
         )
         return context

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ django-csp==3.6
 django-cte==1.3.1
 django-dotenv==1.4.2
 django-extensions==3.2.3
-django-fakeredis>=0.1.*
+django-fakeredis>=0.1.2
 django-filter==23.5
 django-formtools==2.3
 django-fsm==2.8.1


### PR DESCRIPTION
# TP2000-1402  Implement journey to create quota suspension or blocking periods

## Why
There is currently no way to create quota suspension or blocking periods in the UI.

## What
- Adds `QuotaSuspensionOrBlockingCreate` view & form
- Adds `QuotaSuspensionConfirmCreate` & `QuotaBlockingConfirmCreate` views
- Links to the create form on the actions menu on the quota detail view
- Adds view and form unit tests

### Screenshots
<img width="300" alt="Screenshot 2024-06-18 at 16 59 45" src="https://github.com/uktrade/tamato/assets/118175145/a297e7eb-b4a0-4c37-a217-941f561f8f17">

---

<img width="400" alt="Screenshot 2024-06-18 at 17 00 24" src="https://github.com/uktrade/tamato/assets/118175145/a6ea4477-7f71-47f6-9958-87113348284d">

---

<img width="400" alt="Screenshot 2024-06-20 at 13 52 23" src="https://github.com/uktrade/tamato/assets/118175145/28ae2e35-1082-4276-a004-ff4ea07b862e">

---

<img width="400" alt="Screenshot 2024-06-18 at 17 01 26" src="https://github.com/uktrade/tamato/assets/118175145/862afad8-97a8-466c-92fa-f1eaac8008e5">

---

<img width="400" alt="Screenshot 2024-06-18 at 17 02 03" src="https://github.com/uktrade/tamato/assets/118175145/6ca3eb29-b4e1-4a99-a14b-be80062b83c4">