### PR TITLE
TP2000-1268  Resolve XML external entity expansion alert

### DIFF
--- a/common/tests/test_util.py
+++ b/common/tests/test_util.py
@@ -306,7 +306,7 @@ def test_parse_xml_vulnerabilities(file_name):
         "test_files",
         file_name,
     )
-    with pytest.raises(XMLSyntaxError):
+    with pytest.raises((XMLSyntaxError, DTDForbidden)):
         util.parse_xml(file)
 
 
@@ -318,5 +318,5 @@ def test_xml_fromstring_vulnerabilities(file_name):
         file_name,
     )
     string = open(file).read()
-    with pytest.raises(XMLSyntaxError):
+    with pytest.raises((XMLSyntaxError, DTDForbidden)):
         util.xml_fromstring(string)

--- a/common/util.py
+++ b/common/util.py
@@ -554,14 +554,16 @@ def check_docinfo(elementtree, forbid_dtd=False):
 
 
 def parse_xml(source, forbid_dtd=True):
-    elementtree = etree.parse(source)
+    parser = etree.XMLParser(resolve_entities=False)
+    elementtree = etree.parse(source, parser)
     check_docinfo(elementtree, forbid_dtd=forbid_dtd)
 
     return elementtree
 
 
 def xml_fromstring(text, forbid_dtd=True):
-    rootelement = etree.fromstring(text)
+    parser = etree.XMLParser(resolve_entities=False)
+    rootelement = etree.fromstring(text, parser)
     elementtree = rootelement.getroottree()
     check_docinfo(elementtree, forbid_dtd=forbid_dtd)
 

--- a/importer/forms.py
+++ b/importer/forms.py
@@ -15,6 +15,7 @@ from django.core.files.base import ContentFile
 from django.core.files.uploadedfile import InMemoryUploadedFile
 from django.db import transaction
 from sentry_sdk import capture_exception
+from werkzeug.utils import secure_filename
 
 from common.util import get_mime_type
 from common.util import parse_xml
@@ -72,6 +73,14 @@ class ImporterV2FormMixin:
         mime_type = get_mime_type(uploaded_taric_file)
         if mime_type not in ["text/xml", "application/xml"]:
             raise ValidationError("The selected file must be XML")
+
+        secure_file_name = secure_filename(uploaded_taric_file.name)
+        if uploaded_taric_file.name.replace(" ", "_") == secure_file_name:
+            uploaded_taric_file.name == secure_file_name
+        else:
+            raise ValidationError(
+                "File name must only include alphanumeric characters and special characters such as spaces, hyphens and underscores.",
+            )
 
         try:
             xml_file = parse_xml(uploaded_taric_file)
@@ -144,6 +153,14 @@ class ImportFormMixin:
         mime_type = get_mime_type(uploaded_taric_file)
         if mime_type not in ["text/xml", "application/xml"]:
             raise ValidationError("The selected file must be XML")
+
+        secure_file_name = secure_filename(uploaded_taric_file.name)
+        if uploaded_taric_file.name.replace(" ", "_") == secure_file_name:
+            uploaded_taric_file.name == secure_file_name
+        else:
+            raise ValidationError(
+                "File name must only include alphanumeric characters and special characters such as spaces, hyphens and underscores.",
+            )
 
         try:
             xml_file = parse_xml(uploaded_taric_file)

--- a/requirements.txt
+++ b/requirements.txt
@@ -46,7 +46,7 @@ govuk-tech-docs-sphinx-theme==1.0.0
 gunicorn==22.0.0
 Jinja2==3.1.4
 lark==1.1.9
-lxml==4.9.1
+lxml==5.2.2
 markdown==3.6
 markdownify==0.12.1
 markupsafe==2.1.2


### PR DESCRIPTION
# TP2000-1268  Resolve XML external entity expansion alert

## Why
External entity expansion hasn't been disabled when calling `etree.parse()` within `parse_xml()`.

## What
- Bumps `lxml` to 5.2.2 (latest version), which no longer expands external entities by default as of version 5.0.0
- Explicitly disables entity expansion in `parse_xml()` and `xml_fromstring()`
- Uses `werkzeug.utils.secure_filename` to validate the file name of uploaded taric files to guard against path traversal
- Updates unit tests

## Screenshot
<img width="450" alt="Screenshot 2024-06-28 at 14 55 00" src="https://github.com/uktrade/tamato/assets/118175145/f23fa42b-69cb-420f-b303-03919c769a7f">

## Checklist
- Requires dependency updates? **Yes**

