### PR TITLE
TP2000-1269 Resolve uncontrolled data used in path expression alert

### DIFF
--- a/common/util.py
+++ b/common/util.py
@@ -8,7 +8,9 @@ from datetime import datetime
 from datetime import timedelta
 from functools import lru_cache
 from functools import partial
+from pathlib import Path
 from platform import python_version_tuple
+from typing import IO
 from typing import Any
 from typing import Dict
 from typing import Optional
@@ -553,7 +555,7 @@ def check_docinfo(elementtree, forbid_dtd=False):
             raise DTDForbidden(docinfo.doctype, docinfo.system_url, docinfo.public_id)
 
 
-def parse_xml(source, forbid_dtd=True):
+def parse_xml(source: Union[str, Path, IO], forbid_dtd=True):
     parser = etree.XMLParser(resolve_entities=False)
     elementtree = etree.parse(source, parser)
     check_docinfo(elementtree, forbid_dtd=forbid_dtd)

--- a/importer/forms.py
+++ b/importer/forms.py
@@ -15,10 +15,11 @@ from django.core.files.base import ContentFile
 from django.core.files.uploadedfile import InMemoryUploadedFile
 from django.db import transaction
 from sentry_sdk import capture_exception
-from werkzeug.utils import secure_filename
 
 from common.util import get_mime_type
 from common.util import parse_xml
+from common.validators import validate_filename
+from common.validators import validate_filepath
 from importer.chunker import chunk_taric
 from importer.management.commands.run_import_batch import run_batch
 from importer.models import ImportBatch
@@ -74,13 +75,8 @@ class ImporterV2FormMixin:
         if mime_type not in ["text/xml", "application/xml"]:
             raise ValidationError("The selected file must be XML")
 
-        secure_file_name = secure_filename(uploaded_taric_file.name)
-        if uploaded_taric_file.name.replace(" ", "_") == secure_file_name:
-            uploaded_taric_file.name == secure_file_name
-        else:
-            raise ValidationError(
-                "File name must only include alphanumeric characters and special characters such as spaces, hyphens and underscores.",
-            )
+        validate_filename(uploaded_taric_file.name)
+        validate_filepath(uploaded_taric_file)
 
         try:
             xml_file = parse_xml(uploaded_taric_file)
@@ -154,13 +150,8 @@ class ImportFormMixin:
         if mime_type not in ["text/xml", "application/xml"]:
             raise ValidationError("The selected file must be XML")
 
-        secure_file_name = secure_filename(uploaded_taric_file.name)
-        if uploaded_taric_file.name.replace(" ", "_") == secure_file_name:
-            uploaded_taric_file.name == secure_file_name
-        else:
-            raise ValidationError(
-                "File name must only include alphanumeric characters and special characters such as spaces, hyphens and underscores.",
-            )
+        validate_filename(uploaded_taric_file.name)
+        validate_filepath(uploaded_taric_file)
 
         try:
             xml_file = parse_xml(uploaded_taric_file)

--- a/measures/tests/test_views.py
+++ b/measures/tests/test_views.py
@@ -216,13 +216,13 @@ def test_multiple_measure_delete_template(client, valid_user, user_workbasket):
     )
 
     # Get the measure ids that are being shown in the table in the template.
-    measure_ids_in_table = [e.text for e in soup.select("table tr td:first-child")]
+    measure_ids_in_table = {e.text for e in soup.select("table tr td:first-child")}
 
     # Get the sids for the measures we selected, as these are what are shown in the template.
-    selected_measures_ids = [str(measure.sid) for measure in selected_measures]
+    selected_measures_ids = {str(measure.sid) for measure in selected_measures}
 
     assert measure_ids_in_table == selected_measures_ids
-    assert set(measure_ids_in_table).difference([measure_4.sid, measure_5.sid])
+    assert measure_ids_in_table.difference([measure_4.sid, measure_5.sid])
 
     # 4th column is start date
     start_dates_in_table = {e.text for e in soup.select("table tr td:nth-child(4)")}


### PR DESCRIPTION
# TP2000-1269 Resolve uncontrolled data used in path expression alert

## Why
The filenames of TARIC files uploaded in the importer form could use some validation and sanitisation.

## What
- Adds two new functions, `validate_filename` and `validate_filepath`, that can be used to guard against malicious filenames and path traversal attacks
- Validates the filename of uploaded TARIC files
- Sanitises the name used to create an `ImportBatch` based on the uploaded TARIC file
