### PR TITLE
TP2000-1270  Resolve URL redirection from remote source alerts

### DIFF
--- a/measures/views.py
+++ b/measures/views.py
@@ -388,7 +388,7 @@ class MeasureList(
             self.session_store.add_items(selected_objects)
 
             params = urlencode(self.request.GET)
-            url = f"{reverse('measure-ui-list')}?{params}"
+            url = reverse("measure-ui-list") + "?" + params
         else:
             url = reverse("measure-ui-list")
 

--- a/publishing/views.py
+++ b/publishing/views.py
@@ -174,20 +174,19 @@ class EnvelopeQueueView(
         return data
 
     def post(self, request, *args, **kwargs):
-        """Manage POST requests, including download, accept and reject
-        envelopes."""
+        """
+        Manage POST requests that signal the start of envelope processing.
 
-        post = request.POST
+        Valid and invalid POST requests alike redisplay the envelope queue view.
+        """
 
-        if post.get("process_envelope"):
-            url = self._process_envelope(request, post.get("process_envelope"))
-        else:
-            # Handle invalid post content by redisplaying the page.
-            url = request.build_absolute_uri()
+        envelope_pk = request.POST.get("process_envelope")
+        if envelope_pk:
+            self._process_envelope(envelope_pk)
 
-        return redirect(url)
+        return redirect(reverse("publishing:envelope-queue-ui-list"))
 
-    def _process_envelope(self, request, pk):
+    def _process_envelope(self, pk):
         if not OperationalStatus.is_queue_paused():
             packaged_work_basket = PackagedWorkBasket.objects.get(pk=pk)
             try:
@@ -195,7 +194,6 @@ class EnvelopeQueueView(
             except TransitionNotAllowed:
                 # No error page right now, just reshow the list view.
                 pass
-        return request.build_absolute_uri()
 
 
 class DownloadEnvelopeMixin:

--- a/publishing/views.py
+++ b/publishing/views.py
@@ -41,7 +41,7 @@ class PackagedWorkbasketQueueView(
 
     model = PackagedWorkBasket
     permission_required = "publishing.manage_packaging_queue"
-    redirect_url = reverse_lazy("publishing:packaged-workbasket-queue-ui-list")
+    view_url = reverse_lazy("publishing:packaged-workbasket-queue-ui-list")
 
     def get_template_names(self):
         return ["publishing/packaged_workbasket_queue.jinja"]
@@ -80,7 +80,7 @@ class PackagedWorkbasketQueueView(
             url = self._remove_from_queue(post.get("remove_from_queue"))
         else:
             # Handle invalid post content by redisplaying the page.
-            url = self.redirect_url
+            url = self.view_url
 
         return redirect(url)
 
@@ -88,11 +88,11 @@ class PackagedWorkbasketQueueView(
 
     def _pause_queue(self, request):
         OperationalStatus.pause_queue(user=request.user)
-        return self.redirect_url
+        return self.view_url
 
     def _unpause_queue(self, request):
         OperationalStatus.unpause_queue(user=request.user)
-        return self.redirect_url
+        return self.view_url
 
     def _promote_position(self, pk):
         try:
@@ -104,7 +104,7 @@ class PackagedWorkbasketQueueView(
         ):
             # Nothing to do in the case of these exceptions.
             pass
-        return self.redirect_url
+        return self.view_url
 
     def _demote_position(self, pk):
         try:
@@ -116,7 +116,7 @@ class PackagedWorkbasketQueueView(
         ):
             # Nothing to do in the case of these exceptions.
             pass
-        return self.redirect_url
+        return self.view_url
 
     def _promote_to_top_position(self, pk):
         try:
@@ -128,7 +128,7 @@ class PackagedWorkbasketQueueView(
         ):
             # Nothing to do in the case of these exceptions.
             pass
-        return self.redirect_url
+        return self.view_url
 
     def _remove_from_queue(self, pk):
         try:
@@ -144,7 +144,7 @@ class PackagedWorkbasketQueueView(
             TransitionNotAllowed,
         ):
             # Nothing to do in the case of these exceptions.
-            return self.redirect_url
+            return self.view_url
 
 
 class EnvelopeQueueView(

--- a/publishing/views.py
+++ b/publishing/views.py
@@ -41,6 +41,7 @@ class PackagedWorkbasketQueueView(
 
     model = PackagedWorkBasket
     permission_required = "publishing.manage_packaging_queue"
+    redirect_url = reverse_lazy("publishing:packaged-workbasket-queue-ui-list")
 
     def get_template_names(self):
         return ["publishing/packaged_workbasket_queue.jinja"]
@@ -70,19 +71,16 @@ class PackagedWorkbasketQueueView(
         elif post.get("unpause_queue"):
             url = self._unpause_queue(request)
         elif post.get("promote_position"):
-            url = self._promote_position(request, post.get("promote_position"))
+            url = self._promote_position(post.get("promote_position"))
         elif post.get("demote_position"):
-            url = self._demote_position(request, post.get("demote_position"))
+            url = self._demote_position(post.get("demote_position"))
         elif post.get("promote_to_top_position"):
-            url = self._promote_to_top_position(
-                request,
-                post.get("promote_to_top_position"),
-            )
+            url = self._promote_to_top_position(post.get("promote_to_top_position"))
         elif post.get("remove_from_queue"):
-            url = self._remove_from_queue(request, post.get("remove_from_queue"))
+            url = self._remove_from_queue(post.get("remove_from_queue"))
         else:
             # Handle invalid post content by redisplaying the page.
-            url = request.build_absolute_uri()
+            url = self.redirect_url
 
         return redirect(url)
 
@@ -90,13 +88,13 @@ class PackagedWorkbasketQueueView(
 
     def _pause_queue(self, request):
         OperationalStatus.pause_queue(user=request.user)
-        return request.build_absolute_uri()
+        return self.redirect_url
 
     def _unpause_queue(self, request):
         OperationalStatus.unpause_queue(user=request.user)
-        return request.build_absolute_uri()
+        return self.redirect_url
 
-    def _promote_position(self, request, pk):
+    def _promote_position(self, pk):
         try:
             packaged_work_basket = PackagedWorkBasket.objects.get(pk=pk)
             packaged_work_basket.promote_position()
@@ -106,9 +104,9 @@ class PackagedWorkbasketQueueView(
         ):
             # Nothing to do in the case of these exceptions.
             pass
-        return request.build_absolute_uri()
+        return self.redirect_url
 
-    def _demote_position(self, request, pk):
+    def _demote_position(self, pk):
         try:
             packaged_work_basket = PackagedWorkBasket.objects.get(pk=pk)
             packaged_work_basket.demote_position()
@@ -118,9 +116,9 @@ class PackagedWorkbasketQueueView(
         ):
             # Nothing to do in the case of these exceptions.
             pass
-        return request.build_absolute_uri()
+        return self.redirect_url
 
-    def _promote_to_top_position(self, request, pk):
+    def _promote_to_top_position(self, pk):
         try:
             packaged_work_basket = PackagedWorkBasket.objects.get(pk=pk)
             packaged_work_basket.promote_to_top_position()
@@ -130,9 +128,9 @@ class PackagedWorkbasketQueueView(
         ):
             # Nothing to do in the case of these exceptions.
             pass
-        return request.build_absolute_uri()
+        return self.redirect_url
 
-    def _remove_from_queue(self, request, pk):
+    def _remove_from_queue(self, pk):
         try:
             packaged_work_basket = PackagedWorkBasket.objects.get(pk=pk)
             packaged_work_basket.abandon()
@@ -146,7 +144,7 @@ class PackagedWorkbasketQueueView(
             TransitionNotAllowed,
         ):
             # Nothing to do in the case of these exceptions.
-            return request.build_absolute_uri()
+            return self.redirect_url
 
 
 class EnvelopeQueueView(


### PR DESCRIPTION
# TP2000-1270  Resolve URL redirection from remote source alerts

## Why
Some redirect URLs may incorporate unvalidated user input.

## What
- Uses string concatenation instead of f-string formatting to form the redirect URL in `MeasureList.form_valid()` to compensate for false positive alert (see comment in [UrlRedirectCustomizations.qll](https://github.com/github/codeql/blob/main/python/ql/lib/semmle/python/security/dataflow/UrlRedirectCustomizations.qll#L103))


- Replaces `request.build_absolute_uri()` with functionally equivalent calls to `reverse(viewname)` in both `EnvelopeQueueView` and `PackagedWorkbasketQueueView`


