### PR TITLE
TP2000-1443 Fix MultipleObjectsReturned error on Footnote measures tab

### DIFF
--- a/footnotes/views.py
+++ b/footnotes/views.py
@@ -209,7 +209,7 @@ class FootnoteDetailMeasures(SortingMixin, WithPaginationListMixin, ListView):
 
     @property
     def footnote(self):
-        return models.Footnote.objects.get(
+        return models.Footnote.objects.current().get(
             footnote_type__footnote_type_id=self.kwargs[
                 "footnote_type__footnote_type_id"
             ],


### PR DESCRIPTION
# TP2000-1443 Fix MultipleObjectsReturned error on Footnote measures tab

## Why
An uncaught `MultipleObjectsReturned` exception is raised on the measures tab of the footnote detail view if a footnote has multiple versions.

## What
- Chains `current()` to the queryset to get the latest version of the footnote
