### PR TITLE
TP2000-1444 Require a current workbasket on workbasket checks and violations views

### DIFF
--- a/workbaskets/views/ui.py
+++ b/workbaskets/views/ui.py
@@ -972,8 +972,9 @@ class WorkBasketTransactionOrderView(PermissionRequiredMixin, FormView):
         return self.workbasket_transactions().last()
 
 
+@method_decorator(require_current_workbasket, name="dispatch")
 class WorkBasketViolations(SortingMixin, WithPaginationListView):
-    """UI endpoint for viewing a specified workbasket's business rule
+    """UI endpoint for viewing the current workbasket's business rule
     violations."""
 
     model = TrackedModelCheck

--- a/workbaskets/views/ui.py
+++ b/workbaskets/views/ui.py
@@ -1182,6 +1182,7 @@ class WorkBasketCompare(WithCurrentWorkBasket, FormView):
         )
 
 
+@method_decorator(require_current_workbasket, name="dispatch")
 class WorkBasketChecksView(FormView):
     template_name = "workbaskets/checks.jinja"
     form_class = forms.SelectableObjectsForm


### PR DESCRIPTION
# TP2000-1444 Require a current workbasket on workbasket checks and violations views

## Why
Uncaught exceptions are raised and a generic server error page is displayed when attempting to access the workbasket checks view (`/workbaskets/current/checks/`) or workbasket violations view (`/workbaskets/current/violations/`) without a current workbasket.

## What
- Uses `require_current_workbasket` decorator on both `WorkBasketsChecksView` and `WorkBasketsViolations`, redirecting users without a current workbasket to the `NoActiveWorkbasket` view, where users are invited to create or select a new workbasket (like other views that require a current workbasket do)
