### PR TITLE
TP2000-1434 Prevent packaging queue race conditions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ repos:
     hooks:
       - id: add-trailing-comma
   - repo: https://github.com/myint/autoflake.git
-    rev: v2.2.1
+    rev: v2.3.1
     hooks:
       - id: autoflake
         args: [
@@ -13,7 +13,7 @@ repos:
             "--remove-unused-variable",
           ]
   - repo: https://github.com/pycqa/isort
-    rev: 5.12.0
+    rev: 5.13.2
     hooks:
       - id: isort
         args: [--force-single-line-imports]
@@ -28,7 +28,7 @@ repos:
             "--pre-summary-newline",
           ]
   - repo: https://github.com/psf/black
-    rev: 24.3.0
+    rev: 24.4.2
     hooks:
       - id: black
   - repo: https://github.com/ikamensh/flynt/
@@ -36,7 +36,7 @@ repos:
     hooks:
       - id: flynt
   - repo: https://github.com/uktrade/pii-secret-check-hooks
-    rev: 0.0.0.35
+    rev: 0.0.0.36
     hooks:
     -   id: pii_secret_filename
         files: ''

--- a/common/util.py
+++ b/common/util.py
@@ -439,7 +439,7 @@ class TableLock:
                         if isinstance(model, str):
                             model = apps.get_model(model)
                         cursor.execute(
-                            f"LOCK TABLE {model._meta.db_table} in {lock} MODE",
+                            f"LOCK TABLE {model._meta.db_table} IN {lock} MODE",
                         )
 
                     return wrapped(*args, **kwargs)

--- a/publishing/jinja2/includes/envelope-queue.jinja
+++ b/publishing/jinja2/includes/envelope-queue.jinja
@@ -30,6 +30,7 @@
         class="govuk-link fake-link process-envelope"
         name="process_envelope"
         value="{{ obj.pk }}"
+        data-prevent-double-click="true"
       >
         Start processing <span class="right-arrow">&#9654;</span>
       </button>

--- a/publishing/jinja2/includes/packaged-workbasket-queue.jinja
+++ b/publishing/jinja2/includes/packaged-workbasket-queue.jinja
@@ -6,6 +6,7 @@
     class="govuk-link fake-link"
     name="promote_position"
     value="{{ obj.pk }}"
+    data-prevent-double-click="true"
   >
     <img
       class="icon"
@@ -21,6 +22,7 @@
     class="govuk-link fake-link"
     name="demote_position"
     value="{{ obj.pk }}"
+    data-prevent-double-click="true"
   >
     <img
       class="icon"
@@ -106,6 +108,7 @@
         class="govuk-link fake-link"
         name="demote_position"
         value="{{ obj.pk }}"
+        data-prevent-double-click="true"
       >
         Move down
       </button>
@@ -115,6 +118,7 @@
         class="govuk-link fake-link"
         name="promote_to_top_position"
         value="{{ obj.pk }}"
+        data-prevent-double-click="true"
       >
         Move to top
       </button>
@@ -128,6 +132,7 @@
         class="govuk-link fake-link"
         name="remove_from_queue"
         value="{{ obj.pk }}"
+        data-prevent-double-click="true"
       >
         Remove
       </button>

--- a/publishing/models/packaged_workbasket.py
+++ b/publishing/models/packaged_workbasket.py
@@ -125,7 +125,7 @@ class PackagedWorkBasketInvalidQueueOperation(Exception):
 
 class PackagedWorkBasketManager(Manager):
     @atomic
-    @TableLock.acquire_lock("publishing.PackagedWorkBasket", lock="EXCLUSIVE")
+    @TableLock.acquire_lock("publishing.PackagedWorkBasket", lock=TableLock.EXCLUSIVE)
     def create(self, workbasket: WorkBasket, **kwargs):
         """Create a new instance, associating with workbasket."""
         if workbasket.status in WorkflowStatus.unchecked_statuses():

--- a/publishing/models/packaged_workbasket.py
+++ b/publishing/models/packaged_workbasket.py
@@ -669,7 +669,7 @@ class PackagedWorkBasket(TimestampedMixin):
         """Promote the instance to the top position of the package processing
         queue so that it occupies position 1."""
 
-        if self.position == 1:
+        if self.position <= 1:
             return self
 
         position = self.position
@@ -680,6 +680,7 @@ class PackagedWorkBasket(TimestampedMixin):
 
         self.position = 1
         self.save()
+        self.refresh_from_db()
 
         return self
 
@@ -689,8 +690,8 @@ class PackagedWorkBasket(TimestampedMixin):
         """Promote the instance by one position up the package processing
         queue."""
 
-        if self.position == 1:
-            return
+        if self.position <= 1:
+            return self
 
         obj_to_swap = PackagedWorkBasket.objects.select_for_update(nowait=True).get(
             position=self.position - 1,
@@ -711,8 +712,8 @@ class PackagedWorkBasket(TimestampedMixin):
         """Demote the instance by one position down the package processing
         queue."""
 
-        if self.position == PackagedWorkBasket.objects.max_position():
-            return
+        if self.position in {0, PackagedWorkBasket.objects.max_position()}:
+            return self
 
         obj_to_swap = PackagedWorkBasket.objects.select_for_update(nowait=True).get(
             position=self.position + 1,

--- a/publishing/models/packaged_workbasket.py
+++ b/publishing/models/packaged_workbasket.py
@@ -621,7 +621,9 @@ class PackagedWorkBasket(TimestampedMixin):
                 "because it is not at position 1.",
             )
 
-        PackagedWorkBasket.objects.filter(position__gt=0).update(
+        PackagedWorkBasket.objects.select_for_update(nowait=True).filter(
+            position__gt=0,
+        ).update(
             position=F("position") - 1,
         )
         self.refresh_from_db()
@@ -648,7 +650,9 @@ class PackagedWorkBasket(TimestampedMixin):
         self.position = 0
         self.save()
 
-        PackagedWorkBasket.objects.filter(position__gt=current_position).update(
+        PackagedWorkBasket.objects.select_for_update(nowait=True).filter(
+            position__gt=current_position,
+        ).update(
             position=F("position") - 1,
         )
         self.refresh_from_db()
@@ -666,7 +670,7 @@ class PackagedWorkBasket(TimestampedMixin):
 
         position = self.position
 
-        PackagedWorkBasket.objects.filter(
+        PackagedWorkBasket.objects.select_for_update(nowait=True).filter(
             Q(position__gte=1) & Q(position__lt=position),
         ).update(position=F("position") + 1)
 
@@ -684,7 +688,9 @@ class PackagedWorkBasket(TimestampedMixin):
         if self.position == 1:
             return
 
-        obj_to_swap = PackagedWorkBasket.objects.get(position=self.position - 1)
+        obj_to_swap = PackagedWorkBasket.objects.select_for_update(nowait=True).get(
+            position=self.position - 1,
+        )
         obj_to_swap.position += 1
         self.position -= 1
         PackagedWorkBasket.objects.bulk_update(
@@ -704,7 +710,9 @@ class PackagedWorkBasket(TimestampedMixin):
         if self.position == PackagedWorkBasket.objects.max_position():
             return
 
-        obj_to_swap = PackagedWorkBasket.objects.get(position=self.position + 1)
+        obj_to_swap = PackagedWorkBasket.objects.select_for_update(nowait=True).get(
+            position=self.position + 1,
+        )
         obj_to_swap.position -= 1
         self.position += 1
         PackagedWorkBasket.objects.bulk_update(

--- a/publishing/models/packaged_workbasket.py
+++ b/publishing/models/packaged_workbasket.py
@@ -142,15 +142,19 @@ class PackagedWorkBasketManager(Manager):
                 f"{packaged_work_baskets}.",
             )
 
-        position = (
-            PackagedWorkBasket.objects.aggregate(
-                out=Coalesce(
-                    Max("position"),
-                    Value(0),
-                ),
-            )["out"]
-            + 1
-        )
+        packaged_workbaskets = PackagedWorkBasket.objects.select_for_update().all()
+        if packaged_workbaskets:
+            position = (
+                packaged_workbaskets.aggregate(
+                    out=Coalesce(
+                        Max("position"),
+                        Value(0),
+                    ),
+                )["out"]
+                + 1
+            )
+        else:
+            position = 1
 
         new_obj = super().create(workbasket=workbasket, position=position, **kwargs)
 

--- a/publishing/views.py
+++ b/publishing/views.py
@@ -95,12 +95,9 @@ class PackagedWorkbasketQueueView(
         OperationalStatus.unpause_queue(user=request.user)
         return self.view_url
 
-    @atomic
     def _promote_position(self, pk):
         try:
-            packaged_work_basket = PackagedWorkBasket.objects.select_for_update(
-                nowait=True,
-            ).get(pk=pk)
+            packaged_work_basket = PackagedWorkBasket.objects.get(pk=pk)
             packaged_work_basket.promote_position()
         except (
             PackagedWorkBasket.DoesNotExist,
@@ -111,12 +108,9 @@ class PackagedWorkbasketQueueView(
             pass
         return self.view_url
 
-    @atomic
     def _demote_position(self, pk):
         try:
-            packaged_work_basket = PackagedWorkBasket.objects.select_for_update(
-                nowait=True,
-            ).get(pk=pk)
+            packaged_work_basket = PackagedWorkBasket.objects.get(pk=pk)
             packaged_work_basket.demote_position()
         except (
             PackagedWorkBasket.DoesNotExist,
@@ -127,12 +121,9 @@ class PackagedWorkbasketQueueView(
             pass
         return self.view_url
 
-    @atomic
     def _promote_to_top_position(self, pk):
         try:
-            packaged_work_basket = PackagedWorkBasket.objects.select_for_update(
-                nowait=True,
-            ).get(pk=pk)
+            packaged_work_basket = PackagedWorkBasket.objects.get(pk=pk)
             packaged_work_basket.promote_to_top_position()
         except (
             PackagedWorkBasket.DoesNotExist,
@@ -143,12 +134,9 @@ class PackagedWorkbasketQueueView(
             pass
         return self.view_url
 
-    @atomic
     def _remove_from_queue(self, pk):
         try:
-            packaged_work_basket = PackagedWorkBasket.objects.select_for_update(
-                nowait=True,
-            ).get(pk=pk)
+            packaged_work_basket = PackagedWorkBasket.objects.get(pk=pk)
             packaged_work_basket.abandon()
             return reverse(
                 "workbaskets:workbasket-ui-changes",
@@ -201,12 +189,9 @@ class EnvelopeQueueView(
 
         return redirect(reverse("publishing:envelope-queue-ui-list"))
 
-    @atomic
     def _process_envelope(self, pk):
         if not OperationalStatus.is_queue_paused():
-            packaged_work_basket = PackagedWorkBasket.objects.select_for_update(
-                nowait=True,
-            ).get(pk=pk)
+            packaged_work_basket = PackagedWorkBasket.objects.get(pk=pk)
             try:
                 packaged_work_basket.begin_processing()
             except (TransitionNotAllowed, OperationalError):


### PR DESCRIPTION
# TP2000-1434 Prevent packaging queue race conditions

## Why
A race condition can occur during concurrent requests to create/promote/demote/process packaged workbaskets, resulting in duplicate or non-contiguous queue positions that stop the queue from functioning.

## What
- Uses [select_for_update()](https://docs.djangoproject.com/en/4.2/ref/models/querysets/#select-for-update) queryset operation to lock affected packaged workbasket rows while queue position are being updated

    - Makes queue position update queries non-blocking (`nowait=True`), catching the raised exception if a conflicting lock is already acquired

- Returns early without updating queue positions if the selected packaged workbasket is no longer a queue member (position=0)
- Prevents accidental double-clicking of buttons in the packaging queue

## Examples
<details><summary>Shared queue positions after creating packaged workbaskets</summary>
<p>

https://github.com/user-attachments/assets/c495ba82-b076-43b7-aaa3-3aea3744fc85

</p>
</details> 

<details><summary>Shared queue positions after repositioning packaged workbaskets</summary>
<p>

https://github.com/user-attachments/assets/81e4f827-a165-454b-aa2f-791f1bd6f03c

</p>
</details> 

<details><summary>Invalid and inconsistent positions and processing states after processing a packaged workbasket while repositioning others</summary>
<p>

https://github.com/user-attachments/assets/a053895b-d3d7-4425-bfca-8554fc227609

</p>
</details>

<details><summary>Invalid and inconsistent positions and processing states after repositioning a since-removed packaged workbasket</summary>
<p>

https://github.com/user-attachments/assets/dcbd9e11-b2d5-4656-b2de-03bf6bc87c4b

</p>
</details>

