### PR TITLE
TP2000-1458: Limit erga omnes exclusions to erga omnes group members

### DIFF
--- a/common/static/common/js/components/GeoAreaForm/ErgaOmnesForm.js
+++ b/common/static/common/js/components/GeoAreaForm/ErgaOmnesForm.js
@@ -9,7 +9,7 @@ function ErgaOmnesForm({
   data,
   errors,
   ergaOmnesExclusionsInitial,
-  exclusionsOptions,
+  ergaOmnesExclusions,
 }) {
   if (renderCondition) {
     return (
@@ -24,7 +24,7 @@ function ErgaOmnesForm({
           <Select
             className="react-select-container"
             classNamePrefix="react-select"
-            options={exclusionsOptions}
+            options={ergaOmnesExclusions}
             defaultValue={ergaOmnesExclusionsInitial}
             value={data.ergaOmnesExclusions}
             onChange={(value) => updateForm("ergaOmnesExclusions", value)}
@@ -58,7 +58,7 @@ ErgaOmnesForm.propTypes = {
   }).isRequired,
   errors: PropTypes.objectOf(PropTypes.string).isRequired,
   ergaOmnesExclusionsInitial: PropTypes.arrayOf(PropTypes.number),
-  exclusionsOptions: PropTypes.arrayOf(
+  ergaOmnesExclusions: PropTypes.arrayOf(
     PropTypes.shape({
       label: PropTypes.string.isRequired,
       value: PropTypes.oneOfType([PropTypes.oneOf([""]), PropTypes.number]),

--- a/common/static/common/js/components/GeoAreaForm/GeoAreaField.js
+++ b/common/static/common/js/components/GeoAreaForm/GeoAreaField.js
@@ -10,6 +10,7 @@ function GeoAreaField({
   errors,
   updateForm,
   data,
+  ergaOmnesExclusions,
   exclusionsOptions,
   groupsOptions,
   countryRegionsOptions,
@@ -73,7 +74,7 @@ function GeoAreaField({
           data={data}
           errors={errors}
           ergaOmnesExclusionsInitial={ergaOmnesExclusionsInitial}
-          exclusionsOptions={exclusionsOptions}
+          ergaOmnesExclusions={ergaOmnesExclusions}
         />
         <div className="govuk-radios__item">
           <input
@@ -157,6 +158,12 @@ GeoAreaField.propTypes = {
     geoGroupExclusions: PropTypes.arrayOf(PropTypes.number),
     countryRegions: PropTypes.arrayOf(PropTypes.number),
   }).isRequired,
+  ergaOmnesExclusions: PropTypes.arrayOf(
+    PropTypes.shape({
+      label: PropTypes.string.isRequired,
+      value: PropTypes.oneOfType([PropTypes.oneOf([""]), PropTypes.number]),
+    }),
+  ).isRequired,
   exclusionsOptions: PropTypes.arrayOf(
     PropTypes.shape({
       label: PropTypes.string.isRequired,

--- a/common/static/common/js/components/GeoAreaForm/index.js
+++ b/common/static/common/js/components/GeoAreaForm/index.js
@@ -11,7 +11,7 @@ function GeoAreaForm({
   errors,
   csrfToken,
   helpText,
-  exclusionsOptions,
+  ergaOmnesExclusions,
   groupsOptions,
   countryRegionsOptions,
   groupsWithMembers,
@@ -51,7 +51,8 @@ function GeoAreaForm({
             errors={errors}
             data={data}
             updateForm={updateForm}
-            exclusionsOptions={exclusionsOptions}
+            ergaOmnesExclusions={ergaOmnesExclusions}
+            exclusionsOptions={countryRegionsOptions}
             groupsOptions={groupsOptions}
             countryRegionsOptions={countryRegionsOptions}
             groupsWithMembers={groupsWithMembers}
@@ -118,14 +119,14 @@ function init() {
   if (!container) return;
   const root = createRoot(container);
   /* eslint-disable */
-  // initial, geoAreaErrors, exclusionsOptions, groupsOptions, countryRegionsOptions, groupsWithMembers come from template measures/jinja2/includes/measures/geo_area_script.jinja and MeasureGeographicalAreaForm.init_layout
+  // initial, geoAreaErrors, ergaOmnesExclusions, groupsOptions, countryRegionsOptions, groupsWithMembers come from template measures/jinja2/includes/measures/geo_area_script.jinja and MeasureGeographicalAreaForm.init_layout
   root.render(
     <GeoAreaForm
       initial={initial}
       errors={geoAreaErrors}
       csrfToken={csrfToken}
       helpText={helpText}
-      exclusionsOptions={exclusionsOptions}
+      ergaOmnesExclusions={ergaOmnesExclusions}
       groupsOptions={groupsOptions}
       countryRegionsOptions={countryRegionsOptions}
       groupsWithMembers={groupsWithMembers}
@@ -152,6 +153,12 @@ GeoAreaForm.propTypes = {
   errors: PropTypes.objectOf(PropTypes.string).isRequired,
   csrfToken: PropTypes.string.isRequired,
   helpText: PropTypes.string.isRequired,
+  ergaOmnesExclusions: PropTypes.arrayOf(
+    PropTypes.shape({
+      label: PropTypes.string.isRequired,
+      value: PropTypes.number.isRequired,
+    }),
+  ).isRequired,
   exclusionsOptions: PropTypes.arrayOf(
     PropTypes.shape({
       label: PropTypes.string.isRequired,

--- a/common/static/common/js/components/GeoAreaForm/tests/index.test.js
+++ b/common/static/common/js/components/GeoAreaForm/tests/index.test.js
@@ -28,10 +28,6 @@ const mockCountryRegionsOptions = [
     value: 3,
   },
   {
-    label: "Jersey",
-    value: 4,
-  },
-  {
     label: "Germany",
     value: 5,
   },
@@ -44,25 +40,26 @@ const mockCountryRegionsOptions = [
     value: 7,
   },
   {
-    label: "Guernsey",
-    value: 8,
-  },
-  {
     label: "Sweden",
     value: 9,
   },
+  {
+    label: "Jersey",
+    value: 4,
+  },
+  {
+    label: "Guernsey",
+    value: 8,
+  },
 ];
+
+const mockErgaOmnesExclusions = mockCountryRegionsOptions.slice(0, 6);
 
 const mockGroupsWithMembers = {
   11: [5, 6, 9],
   12: [3, 7],
   13: [4, 8],
 };
-
-const mockExclusionsOptions = [
-  ...mockGroupsOptions,
-  ...mockCountryRegionsOptions,
-];
 
 const mockCsrfToken = "123456789";
 const mockErrors = {};
@@ -84,7 +81,8 @@ describe("GeoAreaField", () => {
         errors={mockErrors}
         csrfToken={mockCsrfToken}
         helpText={helpText}
-        exclusionsOptions={mockExclusionsOptions}
+        ergaOmnesExclusions={mockErgaOmnesExclusions}
+        exclusionsOptions={mockCountryRegionsOptions}
         groupsOptions={mockGroupsOptions}
         countryRegionsOptions={mockCountryRegionsOptions}
         groupsWithMembers={mockGroupsWithMembers}
@@ -110,7 +108,8 @@ describe("GeoAreaField", () => {
         errors={mockErrors}
         csrfToken={mockCsrfToken}
         helpText={helpText}
-        exclusionsOptions={mockExclusionsOptions}
+        ergaOmnesExclusions={mockErgaOmnesExclusions}
+        exclusionsOptions={mockCountryRegionsOptions}
         groupsOptions={mockGroupsOptions}
         countryRegionsOptions={mockCountryRegionsOptions}
         groupsWithMembers={mockGroupsWithMembers}
@@ -137,7 +136,8 @@ describe("GeoAreaField", () => {
         errors={mockErrors}
         csrfToken={mockCsrfToken}
         helpText={helpText}
-        exclusionsOptions={mockExclusionsOptions}
+        ergaOmnesExclusions={mockErgaOmnesExclusions}
+        exclusionsOptions={mockCountryRegionsOptions}
         groupsOptions={mockGroupsOptions}
         countryRegionsOptions={mockCountryRegionsOptions}
         groupsWithMembers={mockGroupsWithMembers}
@@ -188,7 +188,8 @@ describe("GeoAreaField", () => {
         errors={mockErrors}
         csrfToken={mockCsrfToken}
         helpText={helpText}
-        exclusionsOptions={mockExclusionsOptions}
+        ergaOmnesExclusions={mockErgaOmnesExclusions}
+        exclusionsOptions={mockCountryRegionsOptions}
         groupsOptions={mockGroupsOptions}
         countryRegionsOptions={mockCountryRegionsOptions}
         groupsWithMembers={mockGroupsWithMembers}

--- a/measures/jinja2/includes/measures/geo_area_script.jinja
+++ b/measures/jinja2/includes/measures/geo_area_script.jinja
@@ -8,9 +8,9 @@
     {% endfor %}
   };
   const initial = {{initial|safe}};
-  const exclusionsOptions = [
+  const ergaOmnesExclusions = [
     {"label": "", "value": ""},
-    {% for geo_area in exclusions_options %}
+    {% for geo_area in erga_omnes_exclusions %}
     {
       "label": "{{ geo_area.area_id  ~ " - " ~ geo_area.description }}",
       "value": {{ geo_area.pk }},

--- a/measures/views/wizard.py
+++ b/measures/views/wizard.py
@@ -624,7 +624,14 @@ class MeasureCreateWizard(
             .as_at_today_and_beyond()
             .order_by("description")
         )
-        exclusions_options = all_geo_areas
+        erga_omnes = GeographicalArea.objects.erga_omnes().first()
+        erga_omnes_exclusions_pks = [
+            membership.member.pk
+            for membership in GeographicalMembership.objects.filter(
+                geo_group__pk=erga_omnes.pk,
+            ).prefetch_related("geo_group", "member")
+        ]
+        erga_omnes_exclusions = all_geo_areas.filter(pk__in=erga_omnes_exclusions_pks)
         groups_options = all_geo_areas.filter(area_code=AreaCode.GROUP)
         country_regions_options = all_geo_areas.exclude(
             area_code=AreaCode.GROUP,
@@ -678,7 +685,7 @@ class MeasureCreateWizard(
                 "request": self.request,
                 "initial": react_initial,
                 "groups_with_members": groups_with_members,
-                "exclusions_options": exclusions_options,
+                "erga_omnes_exclusions": erga_omnes_exclusions,
                 "groups_options": groups_options,
                 "country_regions_options": country_regions_options,
                 "errors": form.errors,

--- a/measures/views/wizard.py
+++ b/measures/views/wizard.py
@@ -629,7 +629,7 @@ class MeasureCreateWizard(
             membership.member.pk
             for membership in GeographicalMembership.objects.filter(
                 geo_group__pk=erga_omnes.pk,
-            ).prefetch_related("geo_group", "member")
+            ).prefetch_related("member")
         ]
         erga_omnes_exclusions = all_geo_areas.filter(pk__in=erga_omnes_exclusions_pks)
         groups_options = all_geo_areas.filter(area_code=AreaCode.GROUP)


### PR DESCRIPTION
# TP2000-1458: Limit erga omnes exclusions to erga omnes group members
<!---
 * Include the JIRA ticket number, eg TP-123, to automatically link.
 * Use 50 characters maximum.
 * Do not end with a full-stop.
--->

## Why
<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Use as many lines as you like.
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions or deliberately ignored edge-cases.
--->
* Jersey and Guernsey are not part of the erga omnes geo area group. This prevents users from selecting them as exclusions and causing an error

## What
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Explain like I'm 5.
 * Use pictures if you can.
--->
* Passes the list of erga omnes members to the react component as a new prop to populate the select options

<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
## Checklist
- Requires migrations?
- Requires dependency updates?
--->

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
