### PR TITLE
TP2000-1465 Have commodity hierarchy only show active comm codes

### DIFF
--- a/commodities/jinja2/includes/commodities/tabs/hierarchy.jinja
+++ b/commodities/jinja2/includes/commodities/tabs/hierarchy.jinja
@@ -10,6 +10,9 @@
 
 <h2 class="govuk-heading-l">Commodity hierarchy</h2>
 
+{% if not current %}
+<p>This commodity has been end dated so no longer forms part of the hierarchy.</p>
+{% else %}
 {% if snapshot.commodities|length == 1 %}
   {{ leaf_commodity(snapshot.commodities[0]) }}
 {% else %}
@@ -45,4 +48,5 @@
 
 {% endif %}
 
+{% endif %}
 {% endblock %}

--- a/commodities/jinja2/includes/commodities/tabs/hierarchy.jinja
+++ b/commodities/jinja2/includes/commodities/tabs/hierarchy.jinja
@@ -10,43 +10,42 @@
 
 <h2 class="govuk-heading-l">Commodity hierarchy</h2>
 
-{% if not current %}
-<p>This commodity has been end dated so no longer forms part of the hierarchy.</p>
-{% else %}
-{% if snapshot.commodities|length == 1 %}
+{% if not is_current %}
+  <p>This commodity has been end dated so no longer forms part of the hierarchy.</p>
+
+{% elif snapshot.commodities|length == 1 %}
   {{ leaf_commodity(snapshot.commodities[0]) }}
+
 {% else %}
+  {% for comm in snapshot.commodities %}
 
-{% for comm in snapshot.commodities %}
+    {% if loop.nextitem and loop.nextitem.indent > comm.indent %}
+    <details class="govuk-details" data-code="{{comm.item_id}}-{{comm.suffix}}"{% if comm in snapshot.ancestors[this_commodity] %}open=""{% endif %}>
+    <summary class="govuk-details__summary">
+      <span class="govuk-details__summary-text {% if comm == this_commodity %}govuk-!-font-weight-bold{% endif %}">
+        {{ comm.code }} - {{ comm.description }} ({{ comm.suffix }})
+      </span>
+    </summary>
 
-  {% if loop.nextitem and loop.nextitem.indent > comm.indent %}
-  <details class="govuk-details" data-code="{{comm.item_id}}-{{comm.suffix}}"{% if comm in snapshot.ancestors[this_commodity] %}open=""{% endif %}>
-  <summary class="govuk-details__summary">
-    <span class="govuk-details__summary-text {% if comm == this_commodity %}govuk-!-font-weight-bold{% endif %}">
-      {{ comm.code }} - {{ comm.description }} ({{ comm.suffix }})
-    </span>
-  </summary>
+    <a class="govuk-link govuk-!-font-size-16" href="{{ url('commodity-ui-detail', args=[comm.sid]) }}">View commodity<span class="govuk-visually-hidden">{{ comm.code }}</span></a>
 
-  <a class="govuk-link govuk-!-font-size-16" href="{{ url('commodity-ui-detail', args=[comm.sid]) }}">View commodity<span class="govuk-visually-hidden">{{ comm.code }}</span></a>
+    {% elif not loop.nextitem or loop.nextitem.indent <= comm.indent %}
+      {{ leaf_commodity(comm) }}
 
-  {% elif not loop.nextitem or loop.nextitem.indent <= comm.indent %}
-    {{ leaf_commodity(comm) }}
+      {% if not loop.nextitem %}
+        {% for i in range(comm.indent) %}
+          </details>
+        {% endfor %}
+      {% else %}
+        {% for i in range(comm.indent - loop.nextitem.indent) %}
+          </details>
+        {% endfor %}
+      {% endif %}
 
-    {% if not loop.nextitem %}
-      {% for i in range(comm.indent) %}
-        </details>
-      {% endfor %}
-    {% else %}
-      {% for i in range(comm.indent - loop.nextitem.indent) %}
-        </details>
-      {% endfor %}
     {% endif %}
 
-  {% endif %}
-
-{% endfor %}
+  {% endfor %}
 
 {% endif %}
 
-{% endif %}
 {% endblock %}

--- a/commodities/tests/test_views.py
+++ b/commodities/tests/test_views.py
@@ -664,13 +664,24 @@ def test_commodity_measures_vat_excise_get_related(
     assert cells[4].text == "—"
 
 
-def test_commodities_hierarchy_inactive_commodity(valid_user_client, date_ranges):
-    """Test that a commodity and related commodity appear in the hierarchy but a
-    related end dated commodity does not."""
+def test_commodities_hierarchy_active_commodity(valid_user_client, date_ranges):
+    """Test that a commodity its related commodity appear in the hierarchy."""
     commodity1 = factories.GoodsNomenclatureFactory.create(item_id="8540111111")
     commodity2 = factories.GoodsNomenclatureFactory.create(item_id="8540222222")
-    commodity3 = factories.GoodsNomenclatureFactory.create(
-        item_id="8540333333",
+
+    url = reverse("commodity-ui-detail-hierarchy", kwargs={"sid": commodity1.sid})
+    response = valid_user_client.get(url)
+
+    assert commodity1.item_id in str(response.content)
+    assert commodity2.item_id in str(response.content)
+
+
+def test_commodities_hierarchy_inactive_commodity(valid_user_client, date_ranges):
+    """Test that an inactive commodity does not have a hierarchy and does not
+    appear in other commodities' hierarchies."""
+    commodity1 = factories.GoodsNomenclatureFactory.create(item_id="8540111111")
+    commodity2 = factories.GoodsNomenclatureFactory.create(
+        item_id="8540222222",
         valid_between=date_ranges.earlier,
     )
 
@@ -678,11 +689,10 @@ def test_commodities_hierarchy_inactive_commodity(valid_user_client, date_ranges
     response = valid_user_client.get(url)
 
     assert commodity1.item_id in str(response.content)
-    assert commodity2.item_id in str(response.content)
-    assert commodity3.item_id not in str(response.content)
+    assert commodity2.item_id not in str(response.content)
 
-    # Assert the tree does not show for the end dated commodity code
-    url = reverse("commodity-ui-detail-hierarchy", kwargs={"sid": commodity3.sid})
+    # Assert the end dated commodity does not display a hierarchy
+    url = reverse("commodity-ui-detail-hierarchy", kwargs={"sid": commodity2.sid})
     response = valid_user_client.get(url)
     assert (
         "This commodity has been end dated so no longer forms part of the hierarchy."

--- a/commodities/tests/test_views.py
+++ b/commodities/tests/test_views.py
@@ -665,7 +665,8 @@ def test_commodity_measures_vat_excise_get_related(
 
 
 def test_commodities_hierarchy_active_commodity(valid_user_client, date_ranges):
-    """Test that a commodity its related commodity appear in the hierarchy."""
+    """Test that a commodity and one of its related commodities appear in the
+    hierarchy."""
     commodity1 = factories.GoodsNomenclatureFactory.create(item_id="8540111111")
     commodity2 = factories.GoodsNomenclatureFactory.create(item_id="8540222222")
 
@@ -674,6 +675,10 @@ def test_commodities_hierarchy_active_commodity(valid_user_client, date_ranges):
 
     assert commodity1.item_id in str(response.content)
     assert commodity2.item_id in str(response.content)
+    assert not (
+        "This commodity has been end dated so no longer forms part of the hierarchy."
+        in str(response.content)
+    )
 
 
 def test_commodities_hierarchy_inactive_commodity(valid_user_client, date_ranges):

--- a/commodities/views.py
+++ b/commodities/views.py
@@ -177,10 +177,10 @@ class CommodityHierarchy(CommodityDetail):
         context["selected_tab"] = "hierarchy"
 
         end_date = context["commodity"].valid_between.upper
-        current = end_date is None or end_date > date.today()
-        context["current"] = current
+        is_current = end_date is None or end_date > date.today()
+        context["is_current"] = is_current
 
-        if current:
+        if is_current:
             prefix = self.object.item_id[0:4]
             commodities_collection = CommodityCollectionLoader(prefix=prefix).load()
             active_commodities = [


### PR DESCRIPTION
# TP2000-1465 Have commodity hierarchy only show active comm codes
<!---
 * Include the JIRA ticket number, eg TP-123, to automatically link.
 * Use 50 characters maximum.
 * Do not end with a full-stop.
--->

## Why
<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Use as many lines as you like.
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions or deliberately ignored edge-cases.
--->

The commodity code hierarchy tree in the Commodity Codes view, currently shows commodity codes that are no longer active (have been end dated)

TAP should only show “live” or Commodity Codes that either:

- Don’t have an end date or,
- Have an end date greater than todays date.

## What
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Explain like I'm 5.
 * Use pictures if you can.
--->

Commodity code hierarchy has been corrected to:
- not include end dated commodities
- not display at all if you're viewing it for an end dated commodity

<img width="1206" alt="image" src="https://github.com/user-attachments/assets/7fdaac00-40db-4a9c-8195-398d33c844ce">


<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
## Checklist
- Requires migrations?
- Requires dependency updates?
--->

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
