### PR TITLE
TP2000-1474 Amend view definition periods

### DIFF
--- a/quotas/forms.py
+++ b/quotas/forms.py
@@ -66,38 +66,6 @@ class QuotaFilterForm(forms.Form):
 QuotaDeleteForm = delete_form_for(models.QuotaOrderNumber)
 
 
-class QuotaDefinitionFilterForm(forms.Form):
-    quota_type = forms.MultipleChoiceField(
-        label="View by",
-        choices=[
-            ("sub_quotas", "Sub-quotas"),
-            ("blocking_periods", "Blocking periods"),
-            ("suspension_periods", "Suspension periods"),
-        ],
-        widget=forms.RadioSelect(),
-    )
-
-    def __init__(self, *args, **kwargs):
-        quota_type_initial = kwargs.pop("form_initial")
-        object_sid = kwargs.pop("object_sid")
-        super().__init__(*args, **kwargs)
-        self.fields["quota_type"].initial = quota_type_initial
-        self.helper = FormHelper()
-
-        clear_url = reverse_lazy(
-            "quota_definition-ui-list",
-            kwargs={"sid": object_sid},
-        )
-
-        self.helper.layout = Layout(
-            Field.radios("quota_type", label_size=Size.SMALL),
-            Button("submit", "Apply"),
-            HTML(
-                f'<a class="govuk-button govuk-button--secondary" href="{clear_url}">Restore defaults</a>',
-            ),
-        )
-
-
 class QuotaOriginExclusionsForm(forms.Form):
     exclusion = forms.ModelChoiceField(
         label="",

--- a/quotas/jinja2/includes/quotas/actions.jinja
+++ b/quotas/jinja2/includes/quotas/actions.jinja
@@ -2,7 +2,7 @@
   <div class="app-related-items" role="complementary">
       <h2 class="govuk-heading-s" id="subsection-title">Actions</h2>
       <ul class="govuk-list govuk-!-font-size-16">
-            <li><a class="govuk-link" href="{{ url('quota_definition-ui-list', args=[object.sid]) }}">View definition periods</a></li>
+            <li><a class="govuk-link" href="{{ url('quota_definition-ui-list', args=[object.sid]) }}">View and edit definition periods</a></li>
             <li><a class="govuk-link" href="{{ url('quota_definition-ui-create', args=[object.sid]) }}">Create definition period</a></li>
             <br>
             <li><a class="govuk-link" href="{{ url('quota_suspension_or_blocking-ui-create', args=[object.sid]) }}">Create suspension or blocking period</a></li>

--- a/quotas/jinja2/includes/quotas/actions.jinja
+++ b/quotas/jinja2/includes/quotas/actions.jinja
@@ -2,7 +2,7 @@
   <div class="app-related-items" role="complementary">
       <h2 class="govuk-heading-s" id="subsection-title">Actions</h2>
       <ul class="govuk-list govuk-!-font-size-16">
-            <li><a class="govuk-link" href="{{ url('quota_definition-ui-list', args=[object.sid]) }}">View and edit definition periods</a></li>
+            <li><a class="govuk-link" href="{{ url('quota_definition-ui-list', args=[object.sid]) }}">View and edit quota data</a></li>
             <li><a class="govuk-link" href="{{ url('quota_definition-ui-create', args=[object.sid]) }}">Create definition period</a></li>
             <br>
             <li><a class="govuk-link" href="{{ url('sub_quota_definitions-ui-create') }}">Create quota associations</a></li>

--- a/quotas/jinja2/quotas/definitions.jinja
+++ b/quotas/jinja2/quotas/definitions.jinja
@@ -17,7 +17,7 @@
       "selected": quota_type == None
     },
     {
-      "text": "Sub-quota definition periods",
+      "text": "Sub-quotas",
       "href": url('quota_definition-ui-list-filter', kwargs={"sid": quota.sid, "quota_type": "sub_quotas"}),
       "selected": quota_type == "sub_quotas",
     },

--- a/quotas/jinja2/quotas/definitions.jinja
+++ b/quotas/jinja2/quotas/definitions.jinja
@@ -5,9 +5,34 @@
 {% from "components/details/macro.njk" import govukDetails %}
 {% from "components/summary-list/macro.njk" import govukSummaryList %}
 {% from "components/create_sortable_anchor.jinja" import create_sortable_anchor %}
+{% from "macros/fake_tabs.jinja" import fake_tabs %}
 
 {% set page_title = "Quota ID: " ~ quota.order_number ~ " - Data" %}
 {% set find_edit_url = url("quota-ui-list") %}
+
+{% set links = [
+    {
+      "text": "Quota definitions",
+      "href": url('quota_definition-ui-list', kwargs={"sid": quota.sid}),
+      "selected": quota_type == None
+    },
+    {
+      "text": "Sub-quotas",
+      "href": url('quota_definition-ui-list-filter', kwargs={"sid": quota.sid, "quota_type": "sub_quotas"}),
+      "selected": quota_type == "sub_quotas",
+    },
+    {
+      "text": "Blocking periods",
+      "href": url('quota_definition-ui-list-filter', kwargs={"sid": quota.sid, "quota_type": "blocking_periods"}),
+      "selected": quota_type == "blocking_periods"
+    },
+    {
+      "text": "Suspension periods",
+      "href": url('quota_definition-ui-list-filter', kwargs={"sid": quota.sid, "quota_type": "suspension_periods"}),
+      "selected": quota_type == "suspension_periods"
+    }
+  ]
+%}
 
 {% block breadcrumb %}
   {{ breadcrumbs(request, [
@@ -21,20 +46,10 @@
 
 <h1 class="govuk-heading-xl">{{ page_title }}</h1>
 
-  {% set filters_html -%}
-    <form action="">
-      {{ crispy(form) }}
-    </form>
-  {% endset %}
-
-  {{ govukDetails({
-      "summaryText": "Customise table",
-      "html": filters_html
-  }) }}
-
+{{ fake_tabs(links) }}
 <div class="quota-definitions">
   {% set base_url = url('quota_definition-ui-list', args=[quota.sid] ) %}
-
+  <div class="govuk-tabs__panel">
   {% if quota_type == "blocking_periods" %}
     {% include "quotas/tables/blocking_periods.jinja" %}
   {% elif quota_type == "suspension_periods" %}
@@ -44,6 +59,6 @@
   {% else %}
     {% include "quotas/tables/definitions.jinja" %}
   {% endif %}
-
+  </div>
 </div>
 {% endblock %}

--- a/quotas/jinja2/quotas/definitions.jinja
+++ b/quotas/jinja2/quotas/definitions.jinja
@@ -12,12 +12,12 @@
 
 {% set links = [
     {
-      "text": "Quota definitions",
+      "text": "Quota definition periods",
       "href": url('quota_definition-ui-list', kwargs={"sid": quota.sid}),
       "selected": quota_type == None
     },
     {
-      "text": "Sub-quotas",
+      "text": "Sub-quota definition periods",
       "href": url('quota_definition-ui-list-filter', kwargs={"sid": quota.sid, "quota_type": "sub_quotas"}),
       "selected": quota_type == "sub_quotas",
     },
@@ -61,4 +61,6 @@
   {% endif %}
   </div>
 </div>
+<br>
+<a href="{{ url('quota-ui-detail', kwargs={"sid": quota.sid}) }}" class="govuk-button govuk-button--secondary" >Back to quota ID</a>
 {% endblock %}

--- a/quotas/jinja2/quotas/tables/definitions.jinja
+++ b/quotas/jinja2/quotas/tables/definitions.jinja
@@ -1,5 +1,5 @@
 
-<h2 class="govuk-heading-l">Quota definitions</h2>
+<h2 class="govuk-heading-l">Quota definition periods</h2>
 
 {% set table_rows = [] %}
 

--- a/quotas/jinja2/quotas/tables/sub_quotas.jinja
+++ b/quotas/jinja2/quotas/tables/sub_quotas.jinja
@@ -1,5 +1,5 @@
 
-<h2 class="govuk-heading-l">Sub quota definition periods</h2>
+<h2 class="govuk-heading-l">Sub-quotas</h2>
 
 {% set table_rows = [] %}
 

--- a/quotas/jinja2/quotas/tables/sub_quotas.jinja
+++ b/quotas/jinja2/quotas/tables/sub_quotas.jinja
@@ -1,5 +1,5 @@
 
-<h2 class="govuk-heading-l">Sub quotas</h2>
+<h2 class="govuk-heading-l">Sub quota definition periods</h2>
 
 {% set table_rows = [] %}
 

--- a/quotas/tests/test_views.py
+++ b/quotas/tests/test_views.py
@@ -1,10 +1,10 @@
+from typing import OrderedDict
 from unittest import mock
 
 import pytest
 from bs4 import BeautifulSoup
 from django.contrib.humanize.templatetags.humanize import intcomma
 from django.urls import reverse
-from typing import OrderedDict
 
 from common.models.transactions import Transaction
 from common.models.utils import override_current_transaction
@@ -23,7 +23,8 @@ from geo_areas.validators import AreaCode
 from quotas import models
 from quotas import validators
 from quotas.forms import QuotaSuspensionType
-from quotas.views import DuplicateDefinitionsWizard, QuotaList
+from quotas.views import DuplicateDefinitionsWizard
+from quotas.views import QuotaList
 from quotas.wizard import QuotaDefinitionDuplicatorSessionStorage
 
 pytestmark = pytest.mark.django_db
@@ -1759,7 +1760,7 @@ def test_quota_definition_view(valid_user_client):
     description_cell_text = soup.select("tbody tr:first-child td:last-child")[0].text
     assert description_cell_text == suspension.description
 
-    
+
 def test_definition_duplicator_form_wizard_start(client_with_current_workbasket):
     url = reverse("sub_quota_definitions-ui-create", kwargs={"step": "start"})
     response = client_with_current_workbasket.get(url)
@@ -1768,19 +1769,22 @@ def test_definition_duplicator_form_wizard_start(client_with_current_workbasket)
 
 @pytest.fixture
 def main_quota_order_number() -> models.QuotaOrderNumber:
-    """Provides a main quota order number for use across the fixtures and following tests"""
+    """Provides a main quota order number for use across the fixtures and
+    following tests."""
     return factories.QuotaOrderNumberFactory()
 
 
 @pytest.fixture
 def sub_quota_order_number() -> models.QuotaOrderNumber:
-    """Provides a sub-quota order number for use across the fixtures and following tests"""
+    """Provides a sub-quota order number for use across the fixtures and
+    following tests."""
     return factories.QuotaOrderNumberFactory()
 
 
 @pytest.fixture
 def quota_definition_1(main_quota_order_number, date_ranges) -> models.QuotaDefinition:
-    """Provides a definition, linked to the main_quota_order_number to be used across the following tests"""
+    """Provides a definition, linked to the main_quota_order_number to be used
+    across the following tests."""
     return factories.QuotaDefinitionFactory.create(
         order_number=main_quota_order_number,
         valid_between=date_ranges.normal,
@@ -1793,7 +1797,8 @@ def quota_definition_1(main_quota_order_number, date_ranges) -> models.QuotaDefi
 
 @pytest.fixture
 def quota_definition_2(main_quota_order_number, date_ranges) -> models.QuotaDefinition:
-    """Provides a definition, linked to the main_quota_order_number to be used across the following tests"""
+    """Provides a definition, linked to the main_quota_order_number to be used
+    across the following tests."""
     return factories.QuotaDefinitionFactory.create(
         order_number=main_quota_order_number,
         valid_between=date_ranges.normal,
@@ -1802,7 +1807,8 @@ def quota_definition_2(main_quota_order_number, date_ranges) -> models.QuotaDefi
 
 @pytest.fixture
 def quota_definition_3(main_quota_order_number, date_ranges) -> models.QuotaDefinition:
-    """Provides a definition, linked to the main_quota_order_number to be used across the following tests"""
+    """Provides a definition, linked to the main_quota_order_number to be used
+    across the following tests."""
     return factories.QuotaDefinitionFactory.create(
         order_number=main_quota_order_number,
         valid_between=date_ranges.normal,
@@ -1811,9 +1817,11 @@ def quota_definition_3(main_quota_order_number, date_ranges) -> models.QuotaDefi
 
 @pytest.fixture
 def wizard(requests_mock, session_request):
-    """Provides an instance of the form wizard for use across the following tests"""
+    """Provides an instance of the form wizard for use across the following
+    tests."""
     storage = QuotaDefinitionDuplicatorSessionStorage(
-        request=session_request, prefix=""
+        request=session_request,
+        prefix="",
     )
     return DuplicateDefinitionsWizard(
         request=requests_mock,
@@ -1822,7 +1830,9 @@ def wizard(requests_mock, session_request):
 
 
 def test_duplicate_definition_wizard_get_cleaned_data_for_step(
-    session_request, main_quota_order_number, sub_quota_order_number
+    session_request,
+    main_quota_order_number,
+    sub_quota_order_number,
 ):
 
     order_number_data = {
@@ -1831,7 +1841,8 @@ def test_duplicate_definition_wizard_get_cleaned_data_for_step(
         "quota_order_numbers-sub_quota_order_number": [sub_quota_order_number.pk],
     }
     storage = QuotaDefinitionDuplicatorSessionStorage(
-        request=session_request, prefix=""
+        request=session_request,
+        prefix="",
     )
 
     storage.set_step_data("quota_order_numbers", order_number_data)
@@ -1876,7 +1887,8 @@ def test_duplicate_definition_wizard_get_form_kwargs(
     }
 
     storage = QuotaDefinitionDuplicatorSessionStorage(
-        request=session_request, prefix=""
+        request=session_request,
+        prefix="",
     )
 
     storage.set_step_data("quota_order_numbers", quota_order_numbers_data)
@@ -1899,7 +1911,7 @@ def test_duplicate_definition_wizard_get_form_kwargs(
                     quota_definition_1.sid,
                     quota_definition_2.sid,
                     quota_definition_3.sid,
-                ]
+                ],
             )
             assert set(kwargs["objects"]) == set(definitions)
         if step == "selected_definition_periods":
@@ -1907,12 +1919,13 @@ def test_duplicate_definition_wizard_get_form_kwargs(
 
 
 def test_definition_duplicator_creates_definition_and_association(
-    quota_definition_1, main_quota_order_number, sub_quota_order_number, session_request
+    quota_definition_1,
+    main_quota_order_number,
+    sub_quota_order_number,
+    session_request,
 ):
-    """
-    Pass data to the Duplicator Wizard and verify that the created definition
-    contains the expected data.
-    """
+    """Pass data to the Duplicator Wizard and verify that the created definition
+    contains the expected data."""
     staged_definition_data = [
         {
             "main_definition": quota_definition_1.pk,
@@ -1926,7 +1939,7 @@ def test_definition_duplicator_creates_definition_and_association(
                 "coefficient": 1,
                 "relationship_type": "NM",
             },
-        }
+        },
     ]
     session_request.session["staged_definition_data"] = staged_definition_data
     order_number_data = {
@@ -1935,7 +1948,8 @@ def test_definition_duplicator_creates_definition_and_association(
         "quota_order_numbers-sub_quota_order_number": [sub_quota_order_number.pk],
     }
     storage = QuotaDefinitionDuplicatorSessionStorage(
-        request=session_request, prefix=""
+        request=session_request,
+        prefix="",
     )
 
     storage.set_step_data("quota_order_numbers", order_number_data)

--- a/quotas/tests/test_views.py
+++ b/quotas/tests/test_views.py
@@ -1688,3 +1688,70 @@ def test_quota_blocking_confirm_create_view(valid_user_client):
     assert f"Blocking period SID {blocking.sid} has been created" in str(
         response.content,
     )
+
+
+def test_quota_definition_view(valid_user_client):
+    """Test all 4 of the quota definition tabs load and display the correct
+    objects."""
+    main_quota_definition = factories.QuotaDefinitionFactory.create(sid=123)
+    sub_quota_definition = factories.QuotaDefinitionFactory.create(sid=234)
+    main_quota = main_quota_definition.order_number
+    association = factories.QuotaAssociationFactory.create(
+        main_quota=main_quota_definition,
+        sub_quota=sub_quota_definition,
+    )
+    blocking = factories.QuotaBlockingFactory.create(
+        quota_definition=main_quota_definition,
+        description="Blocking period description",
+    )
+    suspension = factories.QuotaSuspensionFactory.create(
+        quota_definition=main_quota_definition,
+        description="Suspension period description",
+    )
+
+    # Definition period tab
+    response = valid_user_client.get(
+        reverse("quota_definition-ui-list", kwargs={"sid": main_quota.sid}),
+    )
+    assert response.status_code == 200
+    soup = BeautifulSoup(response.content.decode(response.charset), "html.parser")
+    sid_cell_text = soup.select(
+        "tbody tr:first-child td:first-child details summary span",
+    )[0].text.strip()
+    assert int(sid_cell_text) == main_quota_definition.sid
+
+    # Sub quotas tab
+    response = valid_user_client.get(
+        reverse(
+            "quota_definition-ui-list-filter",
+            kwargs={"sid": main_quota.sid, "quota_type": "sub_quotas"},
+        ),
+    )
+    assert response.status_code == 200
+    soup = BeautifulSoup(response.content.decode(response.charset), "html.parser")
+    sid_cell_text = soup.select("tbody tr:first-child td:first-child a")[0].text.strip()
+    assert int(sid_cell_text) == sub_quota_definition.sid
+
+    # Blocking periods tab
+    response = valid_user_client.get(
+        reverse(
+            "quota_definition-ui-list-filter",
+            kwargs={"sid": main_quota.sid, "quota_type": "blocking_periods"},
+        ),
+    )
+    assert response.status_code == 200
+    soup = BeautifulSoup(response.content.decode(response.charset), "html.parser")
+    description_cell_text = soup.select("tbody tr:first-child td:last-child")[0].text
+    assert description_cell_text == blocking.description
+
+    # Suspension period tab
+    response = valid_user_client.get(
+        reverse(
+            "quota_definition-ui-list-filter",
+            kwargs={"sid": main_quota.sid, "quota_type": "suspension_periods"},
+        ),
+    )
+    assert response.status_code == 200
+    soup = BeautifulSoup(response.content.decode(response.charset), "html.parser")
+    description_cell_text = soup.select("tbody tr:first-child td:last-child")[0].text
+    assert description_cell_text == suspension.description

--- a/quotas/urls.py
+++ b/quotas/urls.py
@@ -60,6 +60,11 @@ urlpatterns = [
         name="quota_definition-ui-list",
     ),
     path(
+        f"quotas/<sid>/quota_definitions/<quota_type>",
+        views.QuotaDefinitionList.as_view(),
+        name="quota_definition-ui-list-filter",
+    ),
+    path(
         f"quotas/<sid>/quota_definitions/create/",
         views.QuotaDefinitionCreate.as_view(),
         name="quota_definition-ui-create",

--- a/quotas/views.py
+++ b/quotas/views.py
@@ -9,7 +9,6 @@ from django.utils.decorators import method_decorator
 from django.utils.functional import cached_property
 from django.utils.safestring import mark_safe
 from django.views.generic import FormView
-from django.views.generic.edit import FormMixin
 from django.views.generic.list import ListView
 from rest_framework import permissions
 from rest_framework import viewsets
@@ -201,17 +200,10 @@ class QuotaDetail(QuotaOrderNumberMixin, TrackedModelDetailView, SortingMixin):
         return context
 
 
-class QuotaDefinitionList(FormMixin, SortingMixin, ListView):
+class QuotaDefinitionList(SortingMixin, ListView):
     template_name = "quotas/definitions.jinja"
     model = models.QuotaDefinition
     sort_by_fields = ["sid", "valid_between"]
-    form_class = forms.QuotaDefinitionFilterForm
-
-    def get_form_kwargs(self):
-        kwargs = super().get_form_kwargs()
-        kwargs["object_sid"] = self.quota.sid
-        kwargs["form_initial"] = self.quota_type
-        return kwargs
 
     def get_queryset(self):
         queryset = (
@@ -244,7 +236,7 @@ class QuotaDefinitionList(FormMixin, SortingMixin, ListView):
 
     @cached_property
     def quota_data(self):
-        if not self.quota_type:
+        if not self.kwargs.get("quota_type"):
             return get_quota_definitions_data(self.quota.order_number, self.object_list)
         return None
 
@@ -252,27 +244,14 @@ class QuotaDefinitionList(FormMixin, SortingMixin, ListView):
     def quota(self):
         return models.QuotaOrderNumber.objects.current().get(sid=self.kwargs["sid"])
 
-    @property
-    def quota_type(self):
-        return (
-            self.request.GET.get("quota_type")
-            if self.request.GET.get("quota_type")
-            in ["sub_quotas", "blocking_periods", "suspension_periods"]
-            else None
-        )
-
     def get_context_data(self, *args, **kwargs):
         return super().get_context_data(
             quota=self.quota,
-            quota_type=self.quota_type,
+            quota_type=self.kwargs.get("quota_type"),
             quota_data=self.quota_data,
             blocking_periods=self.blocking_periods,
             suspension_periods=self.suspension_periods,
             sub_quotas=self.sub_quotas,
-            form_url=reverse(
-                "quota_definition-ui-list",
-                kwargs={"sid": self.quota.sid},
-            ),
             *args,
             **kwargs,
         )


### PR DESCRIPTION
# TP2000-1474 Amend view definition periods
<!---
 * Include the JIRA ticket number, eg TP-123, to automatically link.
 * Use 50 characters maximum.
 * Do not end with a full-stop.
--->

## Why
<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Use as many lines as you like.
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions or deliberately ignored edge-cases.
--->

Currently the View Definition Periods view allows a user to view definition periods by default. If a user wants to view associations, blocking and suspension periods, they need to select the option via a radio button in a hidden menu. This is a legacy practice from a previous iteration of TAP. Instead we should show the various options as tabs.

## What
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Explain like I'm 5.
 * Use pictures if you can.
--->

This PR:
- replaces the old radio button form on the view definitions page with tabs
- adds a test 

<img width="1233" alt="image" src="https://github.com/user-attachments/assets/b773cb19-5dd3-464e-a3e3-b56ea29f865e">

<img width="1226" alt="image" src="https://github.com/user-attachments/assets/93405e88-9b5d-464d-8a56-0e6274a5a44e">


<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
## Checklist
- Requires migrations?
- Requires dependency updates?
--->

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
