### PR TITLE
Bugfix-QuotaDefinition duplicator transaction

### DIFF
--- a/quotas/tests/test_views.py
+++ b/quotas/tests/test_views.py
@@ -1,10 +1,10 @@
+from typing import OrderedDict
 from unittest import mock
 
 import pytest
 from bs4 import BeautifulSoup
 from django.contrib.humanize.templatetags.humanize import intcomma
 from django.urls import reverse
-from typing import OrderedDict
 
 from common.models.transactions import Transaction
 from common.models.utils import override_current_transaction
@@ -23,7 +23,8 @@ from geo_areas.validators import AreaCode
 from quotas import models
 from quotas import validators
 from quotas.forms import QuotaSuspensionType
-from quotas.views import DuplicateDefinitionsWizard, QuotaList
+from quotas.views import DuplicateDefinitionsWizard
+from quotas.views import QuotaList
 from quotas.wizard import QuotaDefinitionDuplicatorSessionStorage
 
 pytestmark = pytest.mark.django_db
@@ -1701,19 +1702,22 @@ def test_definition_duplicator_form_wizard_start(client_with_current_workbasket)
 
 @pytest.fixture
 def main_quota_order_number() -> models.QuotaOrderNumber:
-    """Provides a main quota order number for use across the fixtures and following tests"""
+    """Provides a main quota order number for use across the fixtures and
+    following tests."""
     return factories.QuotaOrderNumberFactory()
 
 
 @pytest.fixture
 def sub_quota_order_number() -> models.QuotaOrderNumber:
-    """Provides a sub-quota order number for use across the fixtures and following tests"""
+    """Provides a sub-quota order number for use across the fixtures and
+    following tests."""
     return factories.QuotaOrderNumberFactory()
 
 
 @pytest.fixture
 def quota_definition_1(main_quota_order_number, date_ranges) -> models.QuotaDefinition:
-    """Provides a definition, linked to the main_quota_order_number to be used across the following tests"""
+    """Provides a definition, linked to the main_quota_order_number to be used
+    across the following tests."""
     return factories.QuotaDefinitionFactory.create(
         order_number=main_quota_order_number,
         valid_between=date_ranges.normal,
@@ -1726,7 +1730,8 @@ def quota_definition_1(main_quota_order_number, date_ranges) -> models.QuotaDefi
 
 @pytest.fixture
 def quota_definition_2(main_quota_order_number, date_ranges) -> models.QuotaDefinition:
-    """Provides a definition, linked to the main_quota_order_number to be used across the following tests"""
+    """Provides a definition, linked to the main_quota_order_number to be used
+    across the following tests."""
     return factories.QuotaDefinitionFactory.create(
         order_number=main_quota_order_number,
         valid_between=date_ranges.normal,
@@ -1735,7 +1740,8 @@ def quota_definition_2(main_quota_order_number, date_ranges) -> models.QuotaDefi
 
 @pytest.fixture
 def quota_definition_3(main_quota_order_number, date_ranges) -> models.QuotaDefinition:
-    """Provides a definition, linked to the main_quota_order_number to be used across the following tests"""
+    """Provides a definition, linked to the main_quota_order_number to be used
+    across the following tests."""
     return factories.QuotaDefinitionFactory.create(
         order_number=main_quota_order_number,
         valid_between=date_ranges.normal,
@@ -1744,9 +1750,11 @@ def quota_definition_3(main_quota_order_number, date_ranges) -> models.QuotaDefi
 
 @pytest.fixture
 def wizard(requests_mock, session_request):
-    """Provides an instance of the form wizard for use across the following tests"""
+    """Provides an instance of the form wizard for use across the following
+    tests."""
     storage = QuotaDefinitionDuplicatorSessionStorage(
-        request=session_request, prefix=""
+        request=session_request,
+        prefix="",
     )
     return DuplicateDefinitionsWizard(
         request=requests_mock,
@@ -1755,7 +1763,9 @@ def wizard(requests_mock, session_request):
 
 
 def test_duplicate_definition_wizard_get_cleaned_data_for_step(
-    session_request, main_quota_order_number, sub_quota_order_number
+    session_request,
+    main_quota_order_number,
+    sub_quota_order_number,
 ):
 
     order_number_data = {
@@ -1764,7 +1774,8 @@ def test_duplicate_definition_wizard_get_cleaned_data_for_step(
         "quota_order_numbers-sub_quota_order_number": [sub_quota_order_number.pk],
     }
     storage = QuotaDefinitionDuplicatorSessionStorage(
-        request=session_request, prefix=""
+        request=session_request,
+        prefix="",
     )
 
     storage.set_step_data("quota_order_numbers", order_number_data)
@@ -1809,7 +1820,8 @@ def test_duplicate_definition_wizard_get_form_kwargs(
     }
 
     storage = QuotaDefinitionDuplicatorSessionStorage(
-        request=session_request, prefix=""
+        request=session_request,
+        prefix="",
     )
 
     storage.set_step_data("quota_order_numbers", quota_order_numbers_data)
@@ -1832,20 +1844,24 @@ def test_duplicate_definition_wizard_get_form_kwargs(
                     quota_definition_1.sid,
                     quota_definition_2.sid,
                     quota_definition_3.sid,
-                ]
+                ],
             )
             assert set(kwargs["objects"]) == set(definitions)
         if step == "selected_definition_periods":
             assert kwargs["request"].session
 
 
+# @unittest.mock.patch("workbaskets.models.WorkBasket.current")
 def test_definition_duplicator_creates_definition_and_association(
-    quota_definition_1, main_quota_order_number, sub_quota_order_number, session_request
+    quota_definition_1,
+    main_quota_order_number,
+    sub_quota_order_number,
+    session_request,
+    # mock_request,
+    # client_with_current_workbasket
 ):
-    """
-    Pass data to the Duplicator Wizard and verify that the created definition
-    contains the expected data.
-    """
+    """Pass data to the Duplicator Wizard and verify that the created definition
+    contains the expected data."""
     staged_definition_data = [
         {
             "main_definition": quota_definition_1.pk,
@@ -1859,7 +1875,7 @@ def test_definition_duplicator_creates_definition_and_association(
                 "coefficient": 1,
                 "relationship_type": "NM",
             },
-        }
+        },
     ]
     session_request.session["staged_definition_data"] = staged_definition_data
     order_number_data = {
@@ -1868,12 +1884,15 @@ def test_definition_duplicator_creates_definition_and_association(
         "quota_order_numbers-sub_quota_order_number": [sub_quota_order_number.pk],
     }
     storage = QuotaDefinitionDuplicatorSessionStorage(
-        request=session_request, prefix=""
+        request=session_request,
+        prefix="",
     )
 
     storage.set_step_data("quota_order_numbers", order_number_data)
     storage._set_current_step("quota_order_numbers")
+    # assert 0
     wizard = DuplicateDefinitionsWizard(
+        # workbasket=sessio,
         request=session_request,
         storage=storage,
         initial_dict={"quota_order_numbers": {}},
@@ -1943,3 +1962,66 @@ def test_format_date(wizard):
     date_str = "2021-01-01"
     formatted_date = wizard.format_date(date_str)
     assert formatted_date == "01 Jan 2021"
+
+
+# def test_definition_duplicator_creates_with_new_workbasket(
+#     quota_definition_1, main_quota_order_number, sub_quota_order_number, session_request
+# ):
+#     """
+#     Pass data to the Duplicator Wizard and verify that the created definition
+#     contains the expected data.
+#     """
+#     staged_definition_data = [
+#         {
+#             "main_definition": quota_definition_1.pk,
+#             "sub_definition_staged_data": {
+#                 "initial_volume": str(quota_definition_1.initial_volume),
+#                 "volume": str(quota_definition_1.volume),
+#                 "measurement_unit_code": quota_definition_1.measurement_unit.code,
+#                 "start_date": serialize_date(quota_definition_1.valid_between.lower),
+#                 "end_date": serialize_date(quota_definition_1.valid_between.upper),
+#                 "status": True,
+#                 "coefficient": 1,
+#                 "relationship_type": "NM",
+#             },
+#         }
+#     ]
+#     session_request.session["staged_definition_data"] = staged_definition_data
+#     order_number_data = {
+#         "duplicate_definitions_wizard-current_step": "quota_order_numbers",
+#         "quota_order_numbers-main_quota_order_number": [main_quota_order_number.pk],
+#         "quota_order_numbers-sub_quota_order_number": [sub_quota_order_number.pk],
+#     }
+#     storage = QuotaDefinitionDuplicatorSessionStorage(
+#         request=session_request, prefix=""
+#     )
+
+#     storage.set_step_data("quota_order_numbers", order_number_data)
+#     storage._set_current_step("quota_order_numbers")
+#     wizard = DuplicateDefinitionsWizard(
+#         request=session_request,
+#         storage=storage,
+#         initial_dict={"quota_order_numbers": {}},
+#         instance_dict={"quota_order_numbers": None},
+#     )
+#     wizard.form_list = OrderedDict(wizard.form_list)
+
+#     association_table_before = models.QuotaAssociation.objects.all()
+#     assert len(association_table_before) == 0
+#     for definition in session_request.session["staged_definition_data"]:
+#         wizard.create_definition(definition)
+
+#     definition_objects = models.QuotaDefinition.objects.all()
+
+#     # assert that the values of the definitions match
+#     assert definition_objects[0].volume == definition_objects[1].volume
+#     assert (
+#         definition_objects[0].measurement_unit == definition_objects[1].measurement_unit
+#     )
+#     assert definition_objects[0].valid_between == definition_objects[1].valid_between
+
+#     assert len(definition_objects) == 2
+#     # assert that the association is created
+#     association_table_after = models.QuotaAssociation.objects.all()
+#     assert association_table_after[0].main_quota == quota_definition_1
+#     assert association_table_after[0].sub_quota in definition_objects

--- a/quotas/tests/test_views.py
+++ b/quotas/tests/test_views.py
@@ -1854,7 +1854,7 @@ def test_definition_duplicator_creates_definition_and_association(
     quota_definition_1,
     main_quota_order_number,
     sub_quota_order_number,
-    session_request,
+    session_request_with_workbasket,
 ):
     """Pass data to the Duplicator Wizard and verify that the created definition
     contains the expected data."""
@@ -1874,22 +1874,23 @@ def test_definition_duplicator_creates_definition_and_association(
             },
         },
     ]
-    session_request.session["staged_definition_data"] = staged_definition_data
-    session_request.workbasket = factories.WorkBasketFactory.create()
+    session_request_with_workbasket.session["staged_definition_data"] = (
+        staged_definition_data
+    )
     order_number_data = {
         "duplicate_definitions_wizard-current_step": "quota_order_numbers",
         "quota_order_numbers-main_quota_order_number": [main_quota_order_number.pk],
         "quota_order_numbers-sub_quota_order_number": [sub_quota_order_number.pk],
     }
     storage = QuotaDefinitionDuplicatorSessionStorage(
-        request=session_request,
+        request=session_request_with_workbasket,
         prefix="",
     )
 
     storage.set_step_data("quota_order_numbers", order_number_data)
     storage._set_current_step("quota_order_numbers")
     wizard = DuplicateDefinitionsWizard(
-        request=session_request,
+        request=session_request_with_workbasket,
         storage=storage,
         initial_dict={"quota_order_numbers": {}},
         instance_dict={"quota_order_numbers": None},
@@ -1899,7 +1900,7 @@ def test_definition_duplicator_creates_definition_and_association(
     association_table_before = models.QuotaAssociation.objects.all()
     # assert 0
     assert len(association_table_before) == 0
-    for definition in session_request.session["staged_definition_data"]:
+    for definition in session_request_with_workbasket.session["staged_definition_data"]:
         wizard.create_definition(definition)
 
     definition_objects = models.QuotaDefinition.objects.all()

--- a/quotas/tests/test_views.py
+++ b/quotas/tests/test_views.py
@@ -1,4 +1,5 @@
 from typing import OrderedDict
+from unittest import mock
 
 import pytest
 from bs4 import BeautifulSoup

--- a/quotas/views.py
+++ b/quotas/views.py
@@ -741,6 +741,7 @@ class QuotaDefinitionConfirmDelete(
     template_name = "quota-definitions/confirm-delete.jinja"
 
 
+@method_decorator(require_current_workbasket, name="dispatch")
 class DuplicateDefinitionsWizard(
     PermissionRequiredMixin,
     NamedUrlSessionWizardView,
@@ -797,7 +798,7 @@ class DuplicateDefinitionsWizard(
     }
 
     @property
-    def workbasket(self):
+    def workbasket(self) -> WorkBasket:
         return WorkBasket.current(self.request)
 
     def get_context_data(self, form, **kwargs):
@@ -907,12 +908,10 @@ class DuplicateDefinitionsWizard(
             self,
             definition["sub_definition_staged_data"],
         )
-        # instance = models.QuotaDefinition.objects.create(
-        #     **staged_data, transaction=WorkBasket.get_current_transaction(self.request)
-        # )
+        transaction = self.workbasket.new_transaction()
         instance = models.QuotaDefinition.objects.create(
             **staged_data,
-            transaction=self.workbasket.new_transaction(),
+            transaction=transaction,
         )
         models.QuotaAssociation.objects.create(
             main_quota=models.QuotaDefinition.objects.get(
@@ -926,7 +925,7 @@ class DuplicateDefinitionsWizard(
                 "relationship_type"
             ],
             update_type=UpdateType.CREATE,
-            transaction=instance.transaction,
+            transaction=transaction,
         )
 
 

--- a/quotas/views.py
+++ b/quotas/views.py
@@ -914,25 +914,19 @@ class DuplicateDefinitionsWizard(
             **staged_data,
             transaction=self.workbasket.new_transaction(),
         )
-        association_data = {
-            "main_quota": models.QuotaDefinition.objects.get(
+        models.QuotaAssociation.objects.create(
+            main_quota=models.QuotaDefinition.objects.get(
                 pk=definition["main_definition"],
             ),
-            "sub_quota": instance,
-            "coefficient": Decimal(
+            sub_quota=instance,
+            coefficient=Decimal(
                 definition["sub_definition_staged_data"]["coefficient"],
             ),
-            "sub_quota_relation_type": definition["sub_definition_staged_data"][
+            sub_quota_relation_type=definition["sub_definition_staged_data"][
                 "relationship_type"
             ],
-            "update_type": UpdateType.CREATE,
-        }
-        self.create_definition_association(association_data)
-
-    def create_definition_association(self, association_data):
-        models.QuotaAssociation.objects.create(
-            **association_data,
-            transaction=self.workbasket.new_transaction(),
+            update_type=UpdateType.CREATE,
+            transaction=instance.transaction,
         )
 
 

--- a/quotas/views.py
+++ b/quotas/views.py
@@ -2,16 +2,17 @@ import datetime
 from datetime import date
 from decimal import Decimal
 from urllib.parse import urlencode
+
 from django.contrib import messages
 from django.contrib.auth.mixins import PermissionRequiredMixin
 from django.db import transaction
 from django.shortcuts import redirect
-from django.views.generic import TemplateView
 from django.urls import reverse
 from django.utils.decorators import method_decorator
 from django.utils.functional import cached_property
 from django.utils.safestring import mark_safe
 from django.views.generic import FormView
+from django.views.generic import TemplateView
 from django.views.generic.edit import FormMixin
 from django.views.generic.list import ListView
 from formtools.wizard.views import NamedUrlSessionWizardView
@@ -21,12 +22,14 @@ from rest_framework import viewsets
 from common.business_rules import UniqueIdentifyingFields
 from common.business_rules import UpdateValidity
 from common.forms import delete_form_for
-from common.serializers import AutoCompleteSerializer, serialize_date
+from common.serializers import AutoCompleteSerializer
+from common.serializers import serialize_date
 from common.tariffs_api import URLs
 from common.tariffs_api import get_quota_data
 from common.tariffs_api import get_quota_definitions_data
 from common.validators import UpdateType
-from common.views import BusinessRulesMixin, SortingMixin
+from common.views import BusinessRulesMixin
+from common.views import SortingMixin
 from common.views import TamatoListView
 from common.views import TrackedModelDetailMixin
 from common.views import TrackedModelDetailView
@@ -743,8 +746,8 @@ class DuplicateDefinitionsWizard(
     NamedUrlSessionWizardView,
 ):
     """
-    Multipart form wizard for duplicating QuotaDefinitionPeriods from a parent QuotaOrderNumber
-    to a child QuotaOrderNumber.
+    Multipart form wizard for duplicating QuotaDefinitionPeriods from a parent
+    QuotaOrderNumber to a child QuotaOrderNumber.
 
     https://django-formtools.readthedocs.io/en/latest/wizard.html
     """
@@ -793,6 +796,10 @@ class DuplicateDefinitionsWizard(
         COMPLETE: {"title": "Finished", "link_text": "Success"},
     }
 
+    @property
+    def workbasket(self):
+        return WorkBasket.current(self.request)
+
     def get_context_data(self, form, **kwargs):
         context = super().get_context_data(form=form, **kwargs)
         context["step_metadata"] = self.step_metadata
@@ -821,8 +828,8 @@ class DuplicateDefinitionsWizard(
         return self.cleaned_data[step]
 
     def format_date(self, date_str):
-        """Parses and converts a date string from that used for storing data
-        to the one used in the TAP UI."""
+        """Parses and converts a date string from that used for storing data to
+        the one used in the TAP UI."""
         if date_str:
             date_object = datetime.datetime.strptime(date_str, "%Y-%m-%d").date()
             return date_object.strftime(DATE_FORMAT)
@@ -838,7 +845,7 @@ class DuplicateDefinitionsWizard(
         kwargs = {}
         if step == self.SELECT_DEFINITION_PERIODS:
             main_quota_order_number_sid = self.get_cleaned_data_for_step(
-                self.QUOTA_ORDER_NUMBERS
+                self.QUOTA_ORDER_NUMBERS,
             )["main_quota_order_number"].sid
             main_quota_definitions = (
                 models.QuotaDefinition.objects.filter(
@@ -859,6 +866,7 @@ class DuplicateDefinitionsWizard(
         """
         Based on the status_tag_generator() for the Measure create Process
         queue.
+
         Returns a dict with text and a CSS class for a label for a duplicated
         definition.
         """
@@ -896,18 +904,23 @@ class DuplicateDefinitionsWizard(
 
     def create_definition(self, definition):
         staged_data = deserialize_definition_data(
-            self, definition["sub_definition_staged_data"]
+            self,
+            definition["sub_definition_staged_data"],
         )
+        # instance = models.QuotaDefinition.objects.create(
+        #     **staged_data, transaction=WorkBasket.get_current_transaction(self.request)
+        # )
         instance = models.QuotaDefinition.objects.create(
-            **staged_data, transaction=WorkBasket.get_current_transaction(self.request)
+            **staged_data,
+            transaction=self.workbasket.new_transaction(),
         )
         association_data = {
             "main_quota": models.QuotaDefinition.objects.get(
-                pk=definition["main_definition"]
+                pk=definition["main_definition"],
             ),
             "sub_quota": instance,
             "coefficient": Decimal(
-                definition["sub_definition_staged_data"]["coefficient"]
+                definition["sub_definition_staged_data"]["coefficient"],
             ),
             "sub_quota_relation_type": definition["sub_definition_staged_data"][
                 "relationship_type"
@@ -919,7 +932,7 @@ class DuplicateDefinitionsWizard(
     def create_definition_association(self, association_data):
         models.QuotaAssociation.objects.create(
             **association_data,
-            transaction=WorkBasket.get_current_transaction(self.request),
+            transaction=self.workbasket.new_transaction(),
         )
 
 
@@ -927,7 +940,7 @@ class QuotaDefinitionDuplicateUpdates(
     FormView,
     BusinessRulesMixin,
 ):
-    """UI endpoint for any updates to duplicated definitions"""
+    """UI endpoint for any updates to duplicated definitions."""
 
     template_name = "quota-definitions/sub-quota-definitions-updates.jinja"
     form_class = forms.SubQuotaDefinitionsUpdatesForm
@@ -947,7 +960,7 @@ class QuotaDefinitionDuplicateUpdates(
 
     def get_main_definition(self):
         return models.QuotaDefinition.objects.current().get(
-            trackedmodel_ptr_id=self.kwargs["pk"]
+            trackedmodel_ptr_id=self.kwargs["pk"],
         )
 
     def form_valid(self, form):
@@ -969,7 +982,7 @@ class QuotaDefinitionDuplicateUpdates(
                 lambda staged_definition_data: staged_definition_data["main_definition"]
                 == main_definition.pk,
                 staged_definition_data,
-            )
+            ),
         )[0]["sub_definition_staged_data"] = updated_serialized_data
 
         return redirect(reverse("sub_quota_definitions-ui-create"))


### PR DESCRIPTION
# Bug Fix

## Why
Resolves an issue where, if a user duplicates a QuotaDefinition in a fresh workbasket, it will be associated with the last transaction, rather than creating a new transaction.

## What
Adds a `workbasket` property to the `QuotaDefinitionDuplicatorWizard`
Assigns the transaction for `models.QuotaDefinition.objects.create()` and `models.QuotaAssociation.objects.create()` as `self.workbasket.new_transaction`
Refactors the QuotaAssociation creation to take place within the `create_definition()` function.
