### PR TITLE
bugfix

### DIFF
--- a/quotas/business_rules.py
+++ b/quotas/business_rules.py
@@ -380,7 +380,7 @@ class QA2(ValidityPeriodContained):
 
 
 def check_QA2_dict(sub_definition_valid_between, main_definition_valid_between):
-    """confirms data is compliant with QA2"""
+    """Confirms data is compliant with QA2."""
     return (
         sub_definition_valid_between.lower >= main_definition_valid_between.lower
     ) and (sub_definition_valid_between.upper <= main_definition_valid_between.upper)
@@ -421,10 +421,8 @@ def check_QA3_dict(
     sub_initial_volume,
     main_initial_volume,
 ):
-    """
-    Confirms data is compliant with QA3
-    See note above about changing the unit types.
-    """
+    """Confirms data is compliant with QA3 See note above about changing the
+    unit types."""
     return (
         main_definition_unit == sub_definition_unit
         and sub_definition_volume <= main_definition_volume
@@ -499,7 +497,7 @@ def check_QA5_equivalent_volumes(original_definition, volume=None):
         .order_by("volume")
         .distinct("volume")
         .count()
-        == 1
+        <= 1
     )
 
 
@@ -523,9 +521,11 @@ class QA6(BusinessRule):
 def check_QA6_dict(main_quota, new_relation_type, transaction=None):
     """
     Confirms the provided data is compliant with the above businsess rule.
-    The above test will be re-run so as to separate historic violations, which will require TAP to fix, from a user trying to introduce a new violation.
-    Because the business rule should have been checked and there should only be one type,
-    we can check the new type against any one of the old type
+
+    The above test will be re-run so as to separate historic violations, which
+    will require TAP to fix, from a user trying to introduce a new violation.
+    Because the business rule should have been checked and there should only be
+    one type, we can check the new type against any one of the old type
     """
     relation_type = (
         main_quota.sub_quota_associations.approved_up_to_transaction(

--- a/quotas/business_rules.py
+++ b/quotas/business_rules.py
@@ -381,9 +381,14 @@ class QA2(ValidityPeriodContained):
 
 def check_QA2_dict(sub_definition_valid_between, main_definition_valid_between):
     """Confirms data is compliant with QA2."""
-    return (
-        sub_definition_valid_between.lower >= main_definition_valid_between.lower
-    ) and (sub_definition_valid_between.upper <= main_definition_valid_between.upper)
+    if main_definition_valid_between.upper:
+        return (
+            sub_definition_valid_between.lower >= main_definition_valid_between.lower
+        ) and (
+            sub_definition_valid_between.upper <= main_definition_valid_between.upper
+        )
+    else:
+        return sub_definition_valid_between.lower >= main_definition_valid_between.lower
 
 
 class QA3(BusinessRule):

--- a/quotas/jinja2/quota-definitions/sub-quota-definitions-selected.jinja
+++ b/quotas/jinja2/quota-definitions/sub-quota-definitions-selected.jinja
@@ -15,11 +15,12 @@
         </span>
       {% endset %}
       {% set main_definition = view.get_main_definition(definition.main_definition)%}
-
+      {{main_definition.valid_between.lower}}
+      {{main_definition.measurement_unit.abbreviation}}
       {{ table_rows.append([
         {"text": main_definition.sid},
         {"text": "{:%d %b %Y}".format(main_definition.valid_between.lower) },
-        {"text": "{:%d %b %Y}".format(main_definition.valid_between.upper) },
+        {"text": "{:%d %b %Y}".format(main_definition.valid_between.upper) if main_definition.valid_between.upper else "-" },
         {"text": intcomma(main_definition.volume) },
         {"text": main_definition.measurement_unit.abbreviation },
         {"text": "-" },

--- a/quotas/jinja2/quota-definitions/sub-quota-definitions-selected.jinja
+++ b/quotas/jinja2/quota-definitions/sub-quota-definitions-selected.jinja
@@ -15,8 +15,7 @@
         </span>
       {% endset %}
       {% set main_definition = view.get_main_definition(definition.main_definition)%}
-      {{main_definition.valid_between.lower}}
-      {{main_definition.measurement_unit.abbreviation}}
+
       {{ table_rows.append([
         {"text": main_definition.sid},
         {"text": "{:%d %b %Y}".format(main_definition.valid_between.lower) },

--- a/quotas/jinja2/quota-definitions/sub-quota-definitions-updates.jinja
+++ b/quotas/jinja2/quota-definitions/sub-quota-definitions-updates.jinja
@@ -8,7 +8,7 @@
     {{ table_rows.append([
         {"html": main_definition.sid },
         {"html": "{:%d %b %Y}".format(main_definition.valid_between.lower) },
-        {"html": "{:%d %b %Y}".format(main_definition.valid_between.upper) },
+        {"html": "{:%d %b %Y}".format(main_definition.valid_between.upper) if main_definition.valid_between.upper else "-" },
         {"html": intcomma(main_definition.volume) },
         {"html": main_definition.measurement_unit.abbreviation},
     ]) or ""}}


### PR DESCRIPTION
# Bug fix on the QuotaDefinition duplicator

## Why
During use, the Tariff Managers discovered that there was an issue with the validation:
if a QuotaDefinition did not have any sub_quotas, it would fail `check_QA5_equivalent_volumes` as the volume value count would be 0 rather than 1. 
During testing of this, identified another issue whereby if the main quota definition was open ended, the select definition pages and edit definition pages would error, and `check_QA2_dict` would fail.

## What
Fixes the above problems by:
- allowing for null values in parent definition end dates
- checking that the volume values count in `check_QA5_equivalent_volumes` is `<=1` rather than `==1`