### PR TITLE
TP2000-1495 Prevent CrownDependenciesEnvelope TransitionNotAllowed exception.

### DIFF
--- a/publishing/models/crown_dependencies_envelope.py
+++ b/publishing/models/crown_dependencies_envelope.py
@@ -144,7 +144,10 @@ class CrownDependenciesEnvelope(TimestampedMixin):
     @save_after
     @transition(
         field=publishing_state,
-        source=ApiPublishingState.CURRENTLY_PUBLISHING,
+        source=[
+            ApiPublishingState.CURRENTLY_PUBLISHING,
+            ApiPublishingState.FAILED_PUBLISHING,
+        ],
         target=ApiPublishingState.FAILED_PUBLISHING,
         custom={"label": "Publishing failed"},
     )


### PR DESCRIPTION
# TP2000-1495 Prevent CrownDependenciesEnvelope TransitionNotAllowed exception.

## Why
When a `CrownDependenciesEnvelope` fails to be published, its `publishing_state` is transitioned to `FAILED_PUBLISHING`. If that envelope fails to be published once more, a `TransitionNotAllowed` exception is raised. While this unhandled exception alone does not prevent an envelope from being published, it can obscure the real cause of the publishing failure.

## What
- Adds `FAILED_PUBLISHING` as a valid source state in the `publishing_failed()` transition method on the `CrownDependenciesEnvelope` model
- Adds a unit test for the transition methods
