### PR TITLE
TP2000-1498 Fix intermittent unit test failure

### DIFF
--- a/reference_documents/tests/test_preferential_quota_order_number_forms.py
+++ b/reference_documents/tests/test_preferential_quota_order_number_forms.py
@@ -148,7 +148,6 @@ class TestPreferentialQuotaOrderNumberCreateUpdateForm:
         assert "quota_order_number" in target.errors.keys()
 
     def test_clean_coefficient_no_main_order(self):
-        factories.PreferentialQuotaOrderNumberFactory()
         pref_quota_order_number = factories.PreferentialQuotaOrderNumberFactory()
 
         data = {


### PR DESCRIPTION
# TP2000-1498 Fix intermittent unit test failure

## Why
The unit test `test_clean_coefficient_no_main_order` in `reference_documents/tests/test_preferential_quota_order_number_forms.py` failed following a recent merge to master.

A `ReferenceDocument` object had attempted to be created with an `area_id` matching an existing `ReferenceDocument` object, raising an `IntegrityError`: `duplicate key value violates unique constraint "reference_documents_referencedocument_area_id_key". DETAIL:  Key (area_id)=(PX) already exists.`

In the test, the `ReferenceDocument` objects are created indirectly via ` PreferentialQuotaOrderNumberFactory()`'s sub-factories. `ReferenceDocument.area_id` is generated randomly from $26^2$ possible combinations.

## What
- Removes superfluous call to `PreferentialQuotaOrderNumberFactory()` in the test, removing the possibility of duplication
