### PR TITLE
TP2000-1352: Add react origins form to quota create page

### DIFF
--- a/common/jinja2/layouts/create.jinja
+++ b/common/jinja2/layouts/create.jinja
@@ -1,11 +1,7 @@
 {% extends 'layouts/form.jinja' %}
 
 {% block form %}
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-      {% call django_form() %}
-        {{ crispy(form) }}
-      {% endcall %}
-    </div>
-  </div>
+  {% call django_form() %}
+    {{ crispy(form) }}
+  {% endcall %}
 {% endblock %}

--- a/common/static/common/js/components/QuotaOriginFormset/index.js
+++ b/common/static/common/js/components/QuotaOriginFormset/index.js
@@ -13,7 +13,6 @@ function QuotaOriginFormset({
   groupsWithMembers,
   errors,
 }) {
-  const [origins, setOrigins] = useState([...data]);
   const emptyOrigin = {
     id: "",
     pk: "",
@@ -26,6 +25,10 @@ function QuotaOriginFormset({
     end_date_1: "",
     end_date_2: "",
   };
+  if (data.length == 0) {
+    data.push(emptyOrigin);
+  }
+  const [origins, setOrigins] = useState([...data]);
 
   const addEmptyOrigin = (e) => {
     e.preventDefault();

--- a/common/static/common/js/components/QuotaOriginFormset/tests/__snapshots__/index.test.js.snap
+++ b/common/static/common/js/components/QuotaOriginFormset/tests/__snapshots__/index.test.js.snap
@@ -4,6 +4,239 @@ exports[`QuotaOriginFormset renders empty formset when no initial data 1`] = `
 <div
   aria-live="polite"
 >
+  <div>
+    <h3
+      className="govuk-heading-m"
+    >
+      Origin 
+      1
+    </h3>
+    <input
+      name="origins-0-pk"
+      type="hidden"
+      value=""
+    />
+    <div
+      className="govuk-form-group"
+    >
+      <div
+        className="src__StyledContainer-sc-1l2t4xv-0 kSOVkC"
+      >
+        <span
+          className="src__LabelText-sc-1lbxenh-0 jZJbVy"
+        >
+          <legend
+            className="legend__StyledLegend-sc-12rap65-0 deblVS"
+            size="S"
+          >
+            Start date
+          </legend>
+        </span>
+        <div
+          className="input__StyledList-sc-una33r-1 UBJjX"
+        >
+          <label
+            className="src__Label-sc-iqzvxn-0 input__StyledLabel-sc-una33r-0 eTSPOL bXvZdL"
+            error={false}
+            year={false}
+          >
+            <span
+              className="src__LabelText-sc-1lbxenh-0 jZJbVy"
+            >
+              Day
+            </span>
+            <input
+              className="src__Input-sc-1ch9crp-0 esEbTY"
+              defaultValue=""
+              error={false}
+              name="origins-0-start_date_0"
+              onBlur={[Function]}
+              onChange={[Function]}
+              onFocus={[Function]}
+              type="text"
+            />
+          </label>
+          <label
+            className="src__Label-sc-iqzvxn-0 input__StyledLabel-sc-una33r-0 eTSPOL bXvZdL"
+            error={false}
+            year={false}
+          >
+            <span
+              className="src__LabelText-sc-1lbxenh-0 jZJbVy"
+            >
+              Month
+            </span>
+            <input
+              className="src__Input-sc-1ch9crp-0 esEbTY"
+              defaultValue=""
+              error={false}
+              name="origins-0-start_date_1"
+              onBlur={[Function]}
+              onChange={[Function]}
+              onFocus={[Function]}
+              type="text"
+            />
+          </label>
+          <label
+            className="src__Label-sc-iqzvxn-0 input__StyledLabel-sc-una33r-0 eTSPOL kjRNx"
+            error={false}
+            year={true}
+          >
+            <span
+              className="src__LabelText-sc-1lbxenh-0 jZJbVy"
+            >
+              Year
+            </span>
+            <input
+              className="src__Input-sc-1ch9crp-0 esEbTY"
+              defaultValue=""
+              error={false}
+              name="origins-0-start_date_2"
+              onBlur={[Function]}
+              onChange={[Function]}
+              onFocus={[Function]}
+              type="text"
+            />
+          </label>
+        </div>
+      </div>
+    </div>
+    <div
+      className="govuk-form-group"
+    >
+      <div
+        className="src__StyledContainer-sc-1l2t4xv-0 kSOVkC"
+      >
+        <span
+          className="src__LabelText-sc-1lbxenh-0 jZJbVy"
+        >
+          <legend
+            className="legend__StyledLegend-sc-12rap65-0 deblVS"
+            size="S"
+          >
+            End date
+          </legend>
+        </span>
+        <span
+          className="src__HintText-sc-tq1z5r-0 hIpBPn"
+        >
+          Leave empty if a quota order number origin is needed for an unlimited time
+        </span>
+        <div
+          className="input__StyledList-sc-una33r-1 UBJjX"
+        >
+          <label
+            className="src__Label-sc-iqzvxn-0 input__StyledLabel-sc-una33r-0 eTSPOL bXvZdL"
+            error={false}
+            year={false}
+          >
+            <span
+              className="src__LabelText-sc-1lbxenh-0 jZJbVy"
+            >
+              Day
+            </span>
+            <input
+              className="src__Input-sc-1ch9crp-0 esEbTY"
+              defaultValue=""
+              error={false}
+              name="origins-0-end_date_0"
+              onBlur={[Function]}
+              onChange={[Function]}
+              onFocus={[Function]}
+              type="text"
+            />
+          </label>
+          <label
+            className="src__Label-sc-iqzvxn-0 input__StyledLabel-sc-una33r-0 eTSPOL bXvZdL"
+            error={false}
+            year={false}
+          >
+            <span
+              className="src__LabelText-sc-1lbxenh-0 jZJbVy"
+            >
+              Month
+            </span>
+            <input
+              className="src__Input-sc-1ch9crp-0 esEbTY"
+              defaultValue=""
+              error={false}
+              name="origins-0-end_date_1"
+              onBlur={[Function]}
+              onChange={[Function]}
+              onFocus={[Function]}
+              type="text"
+            />
+          </label>
+          <label
+            className="src__Label-sc-iqzvxn-0 input__StyledLabel-sc-una33r-0 eTSPOL kjRNx"
+            error={false}
+            year={true}
+          >
+            <span
+              className="src__LabelText-sc-1lbxenh-0 jZJbVy"
+            >
+              Year
+            </span>
+            <input
+              className="src__Input-sc-1ch9crp-0 esEbTY"
+              defaultValue=""
+              error={false}
+              name="origins-0-end_date_2"
+              onBlur={[Function]}
+              onChange={[Function]}
+              onFocus={[Function]}
+              type="text"
+            />
+          </label>
+        </div>
+      </div>
+    </div>
+    <div
+      className="govuk-form-group"
+    >
+      <legend
+        className="legend__StyledLegend-sc-12rap65-0 deblVS"
+        size="S"
+      >
+        Geographical area
+      </legend>
+      <label
+        className="src__Label-sc-iqzvxn-0 eTSPOL"
+        defaultValue=""
+        error={false}
+      >
+        <span
+          className="src__LabelText-sc-1lbxenh-0 jZJbVy"
+        />
+        <select
+          className="src__StyledSelect-sc-sgud4a-0 lmpfTQ"
+          defaultValue=""
+          error={false}
+          name="origins-0-geographical_area"
+          onChange={[Function]}
+        >
+          <option
+            value={1}
+          />
+          <option
+            value={2}
+          />
+          <option
+            value={3}
+          />
+          <option
+            value={4}
+          />
+          <option
+            value={5}
+          />
+        </select>
+      </label>
+    </div>
+    <hr
+      className="govuk-!-margin-top-3"
+    />
+  </div>
   <button
     className="govuk-button govuk-button--secondary"
     onClick={[Function]}

--- a/common/static/common/js/components/QuotaOriginFormset/tests/index.test.js
+++ b/common/static/common/js/components/QuotaOriginFormset/tests/index.test.js
@@ -150,7 +150,8 @@ describe("QuotaOriginFormset", () => {
     // add an empty origin
     fireEvent.click(screen.getByText("Add another origin"));
     expect(screen.getByText("Origin 1")).toBeInTheDocument();
-    expect(screen.queryByText("Origin 2")).not.toBeInTheDocument();
+    expect(screen.queryByText("Origin 2")).toBeInTheDocument();
+    expect(screen.queryByText("Origin 3")).not.toBeInTheDocument();
   });
 
   it("should remove origin form when delete button is clicked", () => {

--- a/quotas/forms.py
+++ b/quotas/forms.py
@@ -51,7 +51,7 @@ START_DATE_HELP_TEXT = "If possible, avoid putting a start date in the past as t
 ORDER_NUMBER_HELP_TEXT = "The order number must begin with 05 and be 6 digits long. Licensed quotas must begin 054 and safeguards must begin 058"
 
 
-class QuotaOriginsReactMixin:
+class QuotaOriginsReactMixin(ExtraErrorFormMixin):
     """Custom cleaning and validation for QuotaUpdateForm and
     QuotaOrderNumberCreateForm."""
 
@@ -167,7 +167,6 @@ QuotaOriginExclusionsFormSet = formset_factory(
 
 class QuotaUpdateForm(
     QuotaOriginsReactMixin,
-    ExtraErrorFormMixin,
     ValidityPeriodForm,
     forms.ModelForm,
 ):

--- a/quotas/forms.py
+++ b/quotas/forms.py
@@ -365,6 +365,17 @@ class QuotaOrderNumberCreateForm(
     def init_fields(self):
         self.fields["start_date"].help_text = START_DATE_HELP_TEXT
 
+    def get_origins_initial(self):
+        # if we just submitted the form, overwrite initial with submitted data
+        # this prevents newly added origin data being cleared if the form does not pass validation
+        initial = []
+        if self.data.get("submit"):
+            initial = unprefix_formset_data(
+                QUOTA_ORIGINS_FORMSET_PREFIX,
+                self.data.copy(),
+            )
+        return initial
+
     def init_layout(self, request):
         self.helper = FormHelper(self)
         self.helper.label_size = Size.SMALL
@@ -378,6 +389,7 @@ class QuotaOrderNumberCreateForm(
                 "geo_area_options": self.geo_area_options,
                 "groups_with_members": self.groups_with_members,
                 "exclusions_options": self.exclusions_options,
+                "origins_initial": self.get_origins_initial(),
                 "errors": self.errors,
             },
         )

--- a/quotas/jinja2/includes/quotas/quota-create-origins.jinja
+++ b/quotas/jinja2/includes/quotas/quota-create-origins.jinja
@@ -1,0 +1,30 @@
+<div id="quota_origins"></div>
+
+<script nonce="{{ request.csp_nonce }}">
+  {# data used by react form component: common/static/common/js/components/QuotaOriginFormset/index.js #}
+  const originsData = [];
+  const originsErrors = {
+    {% for k, errorlist in errors.as_data().items() %}
+      "{{ k }}": "{% for errors in errorlist %}{% for error in errors %}{{ error|safe }}{% if not loop.last %}\n{% endif %}{% endfor %}{% endfor %}",
+    {% endfor %}
+  };
+  const groupsWithMembers = {{groups_with_members|safe}};
+  const geoAreasOptions = [
+    {"label": "", "value": ""},
+    {% for geo_area in geo_area_options %}
+    {
+      "label": "{{ geo_area.area_id  ~ " - " ~ geo_area.description }}",
+      "value": {{ geo_area.pk }},
+    },
+    {% endfor %}
+  ]
+  const exclusionsOptions = [
+    {"label": "", "value": ""},
+    {% for geo_area in exclusions_options %}
+    {
+      "label": "{{ geo_area.area_id  ~ " - " ~ geo_area.description }}",
+      "value": {{ geo_area.pk }},
+    },
+    {% endfor %}
+  ]
+</script>

--- a/quotas/jinja2/includes/quotas/quota-create-origins.jinja
+++ b/quotas/jinja2/includes/quotas/quota-create-origins.jinja
@@ -2,7 +2,7 @@
 
 <script nonce="{{ request.csp_nonce }}">
   {# data used by react form component: common/static/common/js/components/QuotaOriginFormset/index.js #}
-  const originsData = [];
+  const originsData = {{origins_initial|safe}};
   const originsErrors = {
     {% for k, errorlist in errors.as_data().items() %}
       "{{ k }}": "{% for errors in errorlist %}{% for error in errors %}{{ error|safe }}{% if not loop.last %}\n{% endif %}{% endfor %}{% endfor %}",

--- a/quotas/tests/test_forms.py
+++ b/quotas/tests/test_forms.py
@@ -12,10 +12,11 @@ from common.util import TaricDateRange
 from common.validators import UpdateType
 from geo_areas.models import GeographicalArea
 from geo_areas.validators import AreaCode
-from quotas import models
 from quotas import forms
+from quotas import models
 from quotas import validators
-from quotas.models import QuotaBlocking, QuotaDefinition
+from quotas.models import QuotaBlocking
+from quotas.models import QuotaDefinition
 from quotas.models import QuotaSuspension
 from quotas.serializers import serialize_duplicate_data
 
@@ -353,6 +354,52 @@ def test_quota_update_add_extra_error(
         assert "There is a problem" in form.errors["some_field"]
 
 
+def test_quota_create_form_extra_errors(session_request_with_workbasket):
+    geo_group = factories.GeoGroupFactory.create()
+    area_1 = factories.GeographicalMembershipFactory.create(geo_group=geo_group).member
+    area_2 = factories.GeographicalMembershipFactory.create(geo_group=geo_group).member
+    area_3 = factories.GeographicalMembershipFactory.create(geo_group=geo_group).member
+    non_member = factories.GeographicalAreaFactory.create()
+
+    data = {
+        "order_number": "054000",
+        "mechanism": validators.AdministrationMechanism.LICENSED.value,
+        "category": validators.QuotaCategory.WTO.value,
+        "start_date_0": 1,
+        "start_date_1": 1,
+        "start_date_2": 2000,
+        "origins-0-geographical_area": geo_group.pk,
+        "origins-0-start_date_0": 1,
+        "origins-0-start_date_1": 1,
+        "origins-0-start_date_2": 2000,
+        "origins-0-end_date_0": 1,
+        "origins-0-end_date_1": 1,
+        # invalid end date
+        "origins-0-end_date_2": 1999,
+        "origins-0-exclusions-0-geographical_area": area_1.pk,
+        # invalid exclusion
+        "origins-0-exclusions-1-geographical_area": "foo",
+        "submit": "Save",
+    }
+
+    with override_current_transaction(non_member.transaction):
+        form = forms.QuotaOrderNumberCreateForm(
+            data=data,
+            request=session_request_with_workbasket,
+            initial={},
+            geo_area_options=[],
+            exclusions_options=[],
+            groups_with_members=[],
+        )
+        assert not form.is_valid()
+        assert form.errors["origins-0-exclusions-0-geographical_area"] == [
+            "Select a valid choice. That choice is not one of the available choices.",
+        ]
+        assert form.errors["origins-0-end_date"] == [
+            "The end date must be the same as or after the start date.",
+        ]
+
+
 def test_quota_update_add_extra_error_type_error(session_request_with_workbasket):
     quota = factories.QuotaOrderNumberFactory.create()
     data = {
@@ -495,13 +542,15 @@ def test_quota_suspension_or_blockling_create_form_save(
 
 @pytest.fixture
 def main_quota_order_number() -> models.QuotaOrderNumber:
-    """Provides a main quota order number for use across the fixtures and following tests"""
+    """Provides a main quota order number for use across the fixtures and
+    following tests."""
     return factories.QuotaOrderNumberFactory()
 
 
 @pytest.fixture
 def quota_definition_1(main_quota_order_number, date_ranges) -> QuotaDefinition:
-    """Provides a definition, linked to the main_quota_order_number to be used across the following tests"""
+    """Provides a definition, linked to the main_quota_order_number to be used
+    across the following tests."""
     return factories.QuotaDefinitionFactory.create(
         order_number=main_quota_order_number,
         valid_between=date_ranges.normal,
@@ -513,11 +562,13 @@ def quota_definition_1(main_quota_order_number, date_ranges) -> QuotaDefinition:
 
 
 def test_select_sub_quota_form_set_staged_definition_data(
-    quota_definition_1, session_request
+    quota_definition_1,
+    session_request,
 ):
     session_request.path = ""
     form = forms.SelectSubQuotaDefinitionsForm(
-        request=session_request, prefix="select_definition_periods"
+        request=session_request,
+        prefix="select_definition_periods",
     )
     quotas = models.QuotaDefinition.objects.all()
     with override_current_transaction(Transaction.objects.last()):
@@ -536,13 +587,15 @@ pass the previous rule check. More extensive testing is in test_business_rules.p
 
 
 def test_quota_duplicator_form_clean_QA2(
-    date_ranges, session_request, quota_definition_1
+    date_ranges,
+    session_request,
+    quota_definition_1,
 ):
     staged_definition_data = [
         {
             "main_definition": quota_definition_1.pk,
             "sub_definition_staged_data": serialize_duplicate_data(quota_definition_1),
-        }
+        },
     ]
     session_request.session["staged_definition_data"] = staged_definition_data
 
@@ -573,7 +626,7 @@ def test_quota_duplicator_form_clean_QA3(session_request, quota_definition_1):
         {
             "main_definition": quota_definition_1.pk,
             "sub_definition_staged_data": serialize_duplicate_data(quota_definition_1),
-        }
+        },
     ]
 
     data = {
@@ -607,7 +660,7 @@ def test_quota_duplicator_form_clean_QA4(session_request, quota_definition_1):
         {
             "main_definition": quota_definition_1.pk,
             "sub_definition_staged_data": serialize_duplicate_data(quota_definition_1),
-        }
+        },
     ]
 
     data = {
@@ -642,7 +695,7 @@ def test_quota_duplicator_form_clean_QA5_nm(session_request, quota_definition_1)
         {
             "main_definition": quota_definition_1.pk,
             "sub_definition_staged_data": serialize_duplicate_data(quota_definition_1),
-        }
+        },
     ]
 
     data = {
@@ -678,7 +731,7 @@ def test_quota_duplicator_form_clean_QA5_eq(session_request, quota_definition_1)
         {
             "main_definition": quota_definition_1.pk,
             "sub_definition_staged_data": serialize_duplicate_data(quota_definition_1),
-        }
+        },
     ]
 
     data = {

--- a/quotas/tests/test_views.py
+++ b/quotas/tests/test_views.py
@@ -956,6 +956,76 @@ def test_delete_quota_definition(client_with_current_workbasket, date_ranges):
     )
 
 
+def test_quota_create_with_origins(
+    client_with_current_workbasket,
+    date_ranges,
+):
+    # make a geo group with 3 member countries
+    country1 = factories.CountryFactory.create()
+    country2 = factories.CountryFactory.create()
+    country3 = factories.CountryFactory.create()
+    geo_group = factories.GeoGroupFactory.create()
+    membership1 = factories.GeographicalMembershipFactory.create(
+        member=country1,
+        geo_group=geo_group,
+    )
+    membership2 = factories.GeographicalMembershipFactory.create(
+        member=country2,
+        geo_group=geo_group,
+    )
+    membership3 = factories.GeographicalMembershipFactory.create(
+        member=country3,
+        geo_group=geo_group,
+    )
+
+    data = {
+        "order_number": "054000",
+        "mechanism": validators.AdministrationMechanism.LICENSED.value,
+        "category": validators.QuotaCategory.WTO.value,
+        "start_date_0": date_ranges.big_no_end.lower.day,
+        "start_date_1": date_ranges.big_no_end.lower.month,
+        "start_date_2": date_ranges.big_no_end.lower.year,
+        "end_date_0": "",
+        "end_date_1": "",
+        "end_date_2": "",
+        "origins-0-pk": "",
+        "origins-0-start_date_0": date_ranges.big_no_end.lower.day,
+        "origins-0-start_date_1": date_ranges.big_no_end.lower.month,
+        "origins-0-start_date_2": date_ranges.big_no_end.lower.year,
+        "origins-0-end_date_0": "",
+        "origins-0-end_date_1": "",
+        "origins-0-end_date_2": "",
+        "origins-0-geographical_area": geo_group.pk,
+        "origins-0-exclusions-0-pk": "",
+        "origins-0-exclusions-0-geographical_area": membership1.member.pk,
+        "submit": "Save",
+    }
+    url = reverse("quota-ui-create")
+    response = client_with_current_workbasket.post(url, data)
+
+    tx = Transaction.objects.last()
+    new_quota = models.QuotaOrderNumber.objects.approved_up_to_transaction(tx).last()
+
+    assert response.status_code == 302
+    assert response.url == reverse(
+        "quota-ui-confirm-create",
+        kwargs={"sid": new_quota.sid},
+    )
+
+    assert new_quota.origins.approved_up_to_transaction(tx).count() == 1
+    new_origin = new_quota.quotaordernumberorigin_set.approved_up_to_transaction(
+        tx,
+    ).first()
+    assert {
+        e.excluded_geographical_area.sid
+        for e in new_origin.quotaordernumberoriginexclusion_set.approved_up_to_transaction(
+            tx,
+        )
+    } == {
+        membership1.member.sid,
+    }
+
+
 def test_quota_create_origin(
     client_with_current_workbasket,
     approved_transaction,
@@ -1243,17 +1313,39 @@ def test_create_new_quota_definition_business_rule_violation(
 
 
 @pytest.mark.django_db
-def test_quota_order_number_create_200(
+def test_get_200_quota_order_number_create(
     client_with_current_workbasket,
+    geo_group1,
+    geo_group2,
 ):
     response = client_with_current_workbasket.get(reverse("quota-ui-create"))
+    assert response.status_code == 200
 
+
+def test_get_200_quota_edit(client_with_current_workbasket):
+    quota = factories.QuotaOrderNumberFactory.create()
+    response = client_with_current_workbasket.get(
+        reverse("quota-ui-edit", kwargs={"sid": quota.sid}),
+    )
+    assert response.status_code == 200
+
+
+def test_get_200_quota_origins_edit(client_with_current_workbasket):
+    quota = factories.QuotaOrderNumberFactory.create()
+    origin = quota.quotaordernumberorigin_set.approved_up_to_transaction(
+        quota.transaction,
+    ).first()
+    response = client_with_current_workbasket.get(
+        reverse("quota_order_number_origin-ui-edit", kwargs={"sid": origin.sid}),
+    )
     assert response.status_code == 200
 
 
 @pytest.mark.django_db
 def test_quota_order_number_create_errors_required(
     client_with_current_workbasket,
+    geo_group1,
+    geo_group2,
 ):
     form_data = {
         "submit": "Save",
@@ -1308,6 +1400,8 @@ def test_quota_order_number_create_validation(
     exp_error,
     client_with_current_workbasket,
     date_ranges,
+    geo_group1,
+    geo_group2,
 ):
     form_data = {
         "start_date_0": date_ranges.normal.lower.day,
@@ -1336,6 +1430,8 @@ def test_quota_order_number_create_validation(
 def test_quota_order_number_create_success(
     client_with_current_workbasket,
     date_ranges,
+    geo_group1,
+    geo_group2,
 ):
     form_data = {
         "start_date_0": date_ranges.normal.lower.day,
@@ -1362,6 +1458,59 @@ def test_quota_order_number_create_success(
     soup = BeautifulSoup(response2.content.decode(response2.charset), "html.parser")
 
     assert soup.find("h1").text.strip() == f"Quota: {quota.order_number}"
+
+
+def test_quota_update_existing_origins_no_submitted_origins(
+    client_with_current_workbasket,
+    date_ranges,
+):
+    quota = factories.QuotaOrderNumberFactory.create(
+        category=0,
+        valid_between=date_ranges.big_no_end,
+    )
+    factories.QuotaOrderNumberOriginFactory.create(order_number=quota)
+    new_origin = factories.QuotaOrderNumberOriginFactory.create(order_number=quota)
+    tx = new_origin.transaction
+    (
+        origin1,
+        origin2,
+        origin3,
+    ) = quota.quotaordernumberorigin_set.approved_up_to_transaction(tx)
+
+    # sanity check
+    assert quota.quotaordernumberorigin_set.count() == 3
+
+    data = {
+        "start_date_0": quota.valid_between.lower.day,
+        "start_date_1": quota.valid_between.lower.month,
+        "start_date_2": quota.valid_between.lower.year,
+        "end_date_0": "",
+        "end_date_1": "",
+        "end_date_2": "",
+        "category": "1",  # update category
+        "submit": "Save",
+    }
+    url = reverse("quota-ui-edit", kwargs={"sid": quota.sid})
+    response = client_with_current_workbasket.post(url, data)
+
+    assert response.status_code == 302
+    assert response.url == reverse("quota-ui-confirm-update", kwargs={"sid": quota.sid})
+
+    tx = Transaction.objects.last()
+    updated_quota = (
+        models.QuotaOrderNumber.objects.approved_up_to_transaction(tx)
+        .filter(sid=quota.sid)
+        .first()
+    )
+    assert updated_quota.category == 1
+    assert updated_quota.valid_between == quota.valid_between
+
+    assert updated_quota.origins.approved_up_to_transaction(tx).count() == 3
+    assert {o.sid for o in updated_quota.origins.approved_up_to_transaction(tx)} == {
+        origin1.geographical_area.sid,
+        origin2.geographical_area.sid,
+        origin3.geographical_area.sid,
+    }
 
 
 def test_quota_update_existing_origins(client_with_current_workbasket, date_ranges):
@@ -1441,6 +1590,76 @@ def test_quota_update_existing_origins(client_with_current_workbasket, date_rang
         geo_area1.sid,
         geo_area2.sid,
         origin1.geographical_area.sid,
+    }
+
+
+def test_quota_update_existing_origin_exclusion_new_version(
+    client_with_current_workbasket,
+    date_ranges,
+):
+    # make a geo group with a member country
+    country1 = factories.CountryFactory.create()
+    geo_group = factories.GeoGroupFactory.create()
+    membership1 = factories.GeographicalMembershipFactory.create(
+        member=country1,
+        geo_group=geo_group,
+    )
+
+    exclusion = factories.QuotaOrderNumberOriginExclusionFactory.create(
+        excluded_geographical_area=membership1.member,
+    )
+    origin = exclusion.origin
+    quota = origin.order_number
+
+    # sanity check
+    assert quota.quotaordernumberorigin_set.count() == 1
+
+    data = {
+        "start_date_0": date_ranges.big_no_end.lower.day,
+        "start_date_1": date_ranges.big_no_end.lower.month,
+        "start_date_2": date_ranges.big_no_end.lower.year,
+        "end_date_0": "",
+        "end_date_1": "",
+        "end_date_2": "",
+        "category": "1",  # update category
+        # leave origin and exclusion data the same
+        "origins-0-pk": origin.pk,
+        "origins-0-start_date_0": date_ranges.big_no_end.lower.day,
+        "origins-0-start_date_1": date_ranges.big_no_end.lower.month,
+        "origins-0-start_date_2": date_ranges.big_no_end.lower.year,
+        "origins-0-end_date_0": "",
+        "origins-0-end_date_1": "",
+        "origins-0-end_date_2": "",
+        "origins-0-geographical_area": geo_group.pk,
+        "origins-0-exclusions-0-pk": exclusion.pk,
+        "origins-0-exclusions-0-geographical_area": membership1.member.pk,
+        "submit": "Save",
+    }
+    url = reverse("quota-ui-edit", kwargs={"sid": quota.sid})
+    response = client_with_current_workbasket.post(url, data)
+
+    assert response.status_code == 302
+    assert response.url == reverse("quota-ui-confirm-update", kwargs={"sid": quota.sid})
+
+    tx = Transaction.objects.last()
+
+    updated_quota = (
+        models.QuotaOrderNumber.objects.approved_up_to_transaction(tx)
+        .filter(sid=quota.sid)
+        .first()
+    )
+
+    assert updated_quota.origins.approved_up_to_transaction(tx).count() == 1
+    updated_origin = (
+        updated_quota.quotaordernumberorigin_set.approved_up_to_transaction(tx).first()
+    )
+    assert {
+        e.excluded_geographical_area.sid
+        for e in updated_origin.quotaordernumberoriginexclusion_set.approved_up_to_transaction(
+            tx,
+        )
+    } == {
+        membership1.member.sid,
     }
 
 


### PR DESCRIPTION
# TP2000-1352: Add react origins form to quota create page
<!---
 * Include the JIRA ticket number, eg TP-123, to automatically link.
 * Use 50 characters maximum.
 * Do not end with a full-stop.
--->

## Why
<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Use as many lines as you like.
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions or deliberately ignored edge-cases.
--->
* Fixes a workbasket transaction error caused by trying to update a quota and origins after creating a quota and origins in different transactions
* Brings the create form in line with the edit form

## What
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Explain like I'm 5.
 * Use pictures if you can.
--->
* Reuses the react quota origins and exclusions form used on the quota edit page and adds it to the quota create page as well
* More tests to improve coverage

<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
## Checklist
- Requires migrations?
- Requires dependency updates?
--->

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
