### PR TITLE
TP2000-1515 Deleting definition deletes association too

### DIFF
--- a/quotas/business_rules.py
+++ b/quotas/business_rules.py
@@ -540,12 +540,12 @@ def check_QA6_dict(main_quota, new_relation_type, transaction=None):
         .order_by("sub_quota_relation_type")
         .distinct()
     )
-    if relation_type.count() > 1:
-        return False
+    if relation_type.count() == 0:
+        return True
     elif relation_type.count() == 1:
         return relation_type[0]["sub_quota_relation_type"] == new_relation_type
     else:
-        return True
+        return False
 
 
 class SameMainAndSubQuota(BusinessRule):

--- a/quotas/business_rules.py
+++ b/quotas/business_rules.py
@@ -525,7 +525,7 @@ class QA6(BusinessRule):
 
 def check_QA6_dict(main_quota, new_relation_type, transaction=None):
     """
-    Confirms the provided data is compliant with the above businsess rule.
+    Confirms the provided data is compliant with the above business rule.
 
     The above test will be re-run so as to separate historic violations, which
     will require TAP to fix, from a user trying to introduce a new violation.
@@ -544,6 +544,8 @@ def check_QA6_dict(main_quota, new_relation_type, transaction=None):
         return False
     elif relation_type.count() == 1:
         return relation_type[0]["sub_quota_relation_type"] == new_relation_type
+    else:
+        return True
 
 
 class SameMainAndSubQuota(BusinessRule):

--- a/quotas/forms.py
+++ b/quotas/forms.py
@@ -1386,7 +1386,7 @@ class SubQuotaDefinitionAssociationUpdateForm(SubQuotaDefinitionsUpdatesForm):
             self.fields["measurement_unit"].disabled = True
 
 
-class QuotaAssociationEdit(forms.ModelForm):
+class QuotaAssociationUpdateForm(forms.ModelForm):
     class Meta:
         model = models.QuotaAssociation
         fields = [

--- a/quotas/tests/test_forms.py
+++ b/quotas/tests/test_forms.py
@@ -943,7 +943,7 @@ def test_quota_association_edit_form_valid():
         "main_quota": association.main_quota,
         "sub_quota": association.sub_quota,
     }
-    form = forms.QuotaAssociationEdit(data=data, instance=association)
+    form = forms.QuotaAssociationUpdateForm(data=data, instance=association)
 
     assert form.is_valid()
 
@@ -961,7 +961,7 @@ def test_quota_association_edit_form_invalid():
         "main_quota": association.main_quota,
         "sub_quota": association.sub_quota,
     }
-    form = forms.QuotaAssociationEdit(data=data, instance=association)
+    form = forms.QuotaAssociationUpdateForm(data=data, instance=association)
     assert (
         "Select a valid choice. Equivalent is not one of the available choices."
         in form.errors["sub_quota_relation_type"]

--- a/quotas/tests/test_views.py
+++ b/quotas/tests/test_views.py
@@ -973,7 +973,7 @@ def test_delete_quota_definition_deletes_associations(
     client_with_current_workbasket,
     date_ranges,
 ):
-    """Test that when a quota definition is deleted that all link associations
+    """Test that when a quota definition is deleted that all linked associations
     are deleted too."""
     main_quota = factories.QuotaDefinitionFactory.create(
         sid=1,

--- a/quotas/views.py
+++ b/quotas/views.py
@@ -770,7 +770,12 @@ class QuotaDefinitionDelete(
             association_form = forms.QuotaAssociationUpdateForm(
                 instance=association,
             )
-            super().get_result_object(association_form)
+            association_form.instance.new_version(
+                workbasket=self.workbasket,
+                update_type=self.update_type,
+                transaction=definition_instance.transaction,
+            )
+
         return definition_instance
 
     def form_valid(self, form):


### PR DESCRIPTION
# TP2000-1515 Deleting definition deletes association too
<!---
 * Include the JIRA ticket number, eg TP-123, to automatically link.
 * Use 50 characters maximum.
 * Do not end with a full-stop.
--->

## Why
<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Use as many lines as you like.
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions or deliberately ignored edge-cases.
--->

If a definition period for either the main or sub quota in an association is deleted, then the association object must also be deleted in that same transaction.

## What
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Explain like I'm 5.
 * Use pictures if you can.
--->

This PR:
- updates the definition delete view to also delete any linked associations in the same transaction
- adds a test
- updates QA6 so it doesn't fail when an association gets deleted as there aren't any left

<img width="726" alt="image" src="https://github.com/user-attachments/assets/6a2e16b8-87b5-40aa-8756-bd0313b3468d">


<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
## Checklist
- Requires migrations?
- Requires dependency updates?
--->

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
