### PR TITLE
Tp2000 1516 delete quota association

### DIFF
--- a/quotas/jinja2/quota-associations/confirm-delete.jinja
+++ b/quotas/jinja2/quota-associations/confirm-delete.jinja
@@ -1,0 +1,43 @@
+{% extends "layouts/confirm.jinja" %}
+{% from "components/breadcrumbs.jinja" import breadcrumbs %}
+
+{% set page_title = "Delete quota definition" %}
+
+      {# {"text": "Quota ID: " ~ object.order_number ~ " - Data", "href": url("quota_definition-ui-list", args=[object.sid])}, #}
+      {# {"text": object._meta.verbose_name|capitalize ~ ": " ~ object|string, "href": object.get_url()}, #}
+{% block breadcrumb %}
+  {{ breadcrumbs(request, [
+      {"text": "Find and edit quotas", "href": url("quota-ui-list")},
+      {"test": "get sub or main quota order number for this"}
+      {"text": page_title}
+    ])
+  }}
+{% endblock %}
+
+{% set messages %}
+  {% for message in get_messages(request) %}
+    {{ message }}
+  {% endfor %}
+{% endset  %}
+
+{% block panel %}
+  {{ govukPanel({
+    "titleText": messages,
+    "text": "This change has been added to your workbasket",
+    "classes": "govuk-!-margin-bottom-7"
+  }) }}
+{% endblock %}
+
+{# {% block main_button %}
+{{ govukButton({
+  "text": "View other definition periods for this quota order number",
+  "href": url('quota_definition-ui-list', kwargs={'sid': object.sid}),
+  "classes": "govuk-button--primary"
+}) }}
+{% endblock%}
+
+
+{% block actions %}
+<li><a class="govuk-link" href="{{ object.get_url() }}">View this definition's quota order number</a></li>
+<li><a href="{{ object.get_url('list') }}">Find and edit quotas</a></li>
+{% endblock %} #}

--- a/quotas/jinja2/quota-associations/confirm-delete.jinja
+++ b/quotas/jinja2/quota-associations/confirm-delete.jinja
@@ -3,17 +3,6 @@
 
 {% set page_title = "Delete quota definition" %}
 
-      {# {"text": "Quota ID: " ~ object.order_number ~ " - Data", "href": url("quota_definition-ui-list", args=[object.sid])}, #}
-      {# {"text": object._meta.verbose_name|capitalize ~ ": " ~ object|string, "href": object.get_url()}, #}
-{% block breadcrumb %}
-  {{ breadcrumbs(request, [
-      {"text": "Find and edit quotas", "href": url("quota-ui-list")},
-      {"test": "get sub or main quota order number for this"}
-      {"text": page_title}
-    ])
-  }}
-{% endblock %}
-
 {% set messages %}
   {% for message in get_messages(request) %}
     {{ message }}
@@ -27,17 +16,3 @@
     "classes": "govuk-!-margin-bottom-7"
   }) }}
 {% endblock %}
-
-{# {% block main_button %}
-{{ govukButton({
-  "text": "View other definition periods for this quota order number",
-  "href": url('quota_definition-ui-list', kwargs={'sid': object.sid}),
-  "classes": "govuk-button--primary"
-}) }}
-{% endblock%}
-
-
-{% block actions %}
-<li><a class="govuk-link" href="{{ object.get_url() }}">View this definition's quota order number</a></li>
-<li><a href="{{ object.get_url('list') }}">Find and edit quotas</a></li>
-{% endblock %} #}

--- a/quotas/jinja2/quota-associations/delete.jinja
+++ b/quotas/jinja2/quota-associations/delete.jinja
@@ -1,14 +1,15 @@
-{% extends "common/delete.jinja" %}
+{% extends "layouts/form.jinja" %}
+{% from "components/breadcrumbs.jinja" import breadcrumbs %}
+{% from "components/warning-text/macro.njk" import govukWarningText %}
+{% from "components/button/macro.njk" import govukButton %}
 
-      {# {"text": object.order_number._meta.verbose_name|capitalize ~ " " ~ object.order_number|string, "href": object.order_number.get_url()},
-      {"text": object.order_number._meta.verbose_name|capitalize ~ " " ~ object.order_number|string ~ ": Data" , "href": url('quota_definition-ui-list', args=[object.order_number.sid])}, #}
+{% set page_title = "Delete " ~ object._meta.verbose_name ~ " between main quota " ~ object.main_quota ~ " and sub-quota " ~ object.sub_quota %}
 
-{# TODO: Copy form block from template, override action. Pass in delete url for quota-associtiona- delete #}
 {% block breadcrumb %}
   {{ breadcrumbs(request, [
-      {"text": "Find and edit quotas", "href": url("quota-ui-list")},
-      {"text": object },
-      {"text": page_title}
+      {"text": "Find and edit quotas", "href": url("quota-ui-list") },
+      {"text": object._meta.verbose_name|capitalize ~ ": " ~ object.pk, "href": object.get_url()},
+      {"text": page_title }
     ])
   }}
 {% endblock %}

--- a/quotas/jinja2/quota-associations/delete.jinja
+++ b/quotas/jinja2/quota-associations/delete.jinja
@@ -1,0 +1,29 @@
+{% extends "common/delete.jinja" %}
+
+      {# {"text": object.order_number._meta.verbose_name|capitalize ~ " " ~ object.order_number|string, "href": object.order_number.get_url()},
+      {"text": object.order_number._meta.verbose_name|capitalize ~ " " ~ object.order_number|string ~ ": Data" , "href": url('quota_definition-ui-list', args=[object.order_number.sid])}, #}
+
+{# TODO: Copy form block from template, override action. Pass in delete url for quota-associtiona- delete #}
+{% block breadcrumb %}
+  {{ breadcrumbs(request, [
+      {"text": "Find and edit quotas", "href": url("quota-ui-list")},
+      {"text": object },
+      {"text": page_title}
+    ])
+  }}
+{% endblock %}
+
+{% block form %}
+  {{ govukWarningText({
+    "text": "Are you sure you want to delete this " ~ object._meta.verbose_name ~ "?"
+  }) }}
+  {% call django_form(action="") %}
+    {{ crispy(form) }}
+  {% endcall %}
+
+  {{ govukButton({
+    "text": "Cancel",
+    "href": object.get_url(),
+    "classes": "govuk-button--secondary"
+  }) }}
+{% endblock %}

--- a/quotas/jinja2/quotas/tables/sub_quotas.jinja
+++ b/quotas/jinja2/quotas/tables/sub_quotas.jinja
@@ -2,7 +2,6 @@
 <h2 class="govuk-heading-l">Sub-quotas</h2>
 
 {% set table_rows = [] %}
-{# <a class="govuk-link" href="{{ url('quota_association-ui-delete', kwargs={'main_quota__sid': object.main_quota.sid, 'sub_quota__sid': object.sub_quota.sid}) }}">Delete</a> #}
 {% if sub_quotas %}
   {% for object in sub_quotas %}
     {% set definition_link -%}
@@ -29,11 +28,11 @@
 
   {{ govukTable({
     "head": [
-      {"text": "Quota definition sid"},
+      {"text": "Quota definition SID"},
       {"text": "Sub-quota order number"},
       {"text": "Start date"},
       {"text": "End date"},
-      {"text": "Relation type"},
+      {"text": "Relationship type"},
       {"text": "Coefficient"},
       {"text": "Actions"},
     ],

--- a/quotas/jinja2/quotas/tables/sub_quotas.jinja
+++ b/quotas/jinja2/quotas/tables/sub_quotas.jinja
@@ -2,7 +2,7 @@
 <h2 class="govuk-heading-l">Sub-quotas</h2>
 
 {% set table_rows = [] %}
-
+{# <a class="govuk-link" href="{{ url('quota_association-ui-delete', kwargs={'main_quota__sid': object.main_quota.sid, 'sub_quota__sid': object.sub_quota.sid}) }}">Delete</a> #}
 {% if sub_quotas %}
   {% for object in sub_quotas %}
     {% set definition_link -%}
@@ -13,7 +13,7 @@
     {% endset %}
     {% set actions_html %}
       <a class="govuk-link" href="{{ object.sub_quota.version_at(request.user.current_workbasket.transactions.last()).get_association_edit_url() }}">Edit</a>
-      <a class="govuk-link" href="{{ url('quota_association-ui-delete', kwargs={'sid':object.sub_quota.sid}) }}">Delete</a>
+      <a class="govuk-link" href="{{ url('quota_association-ui-delete', args=[object.pk]) }}">Delete</a>
     {% endset %}
 
     {{ table_rows.append([

--- a/quotas/jinja2/quotas/tables/sub_quotas.jinja
+++ b/quotas/jinja2/quotas/tables/sub_quotas.jinja
@@ -11,8 +11,9 @@
       <a class="govuk-link" href="{{ url('quota-ui-detail', args=[object.sub_quota.order_number.sid]) }}">{{ object.sub_quota.order_number.order_number }}</a>
     {% endset %}
     {% set actions_html %}
-      <a class="govuk-link" href="{{ object.sub_quota.version_at(request.user.current_workbasket.transactions.last()).get_association_edit_url() }}">Edit</a>
-      <a class="govuk-link" href="{{ url('quota_association-ui-delete', args=[object.pk]) }}">Delete</a>
+      <a class="govuk-link" href="{{ object.sub_quota.version_at(request.user.current_workbasket.transactions.last()).get_association_edit_url() }}">Edit association</a>
+      <br/>
+      <a class="govuk-link" href="{{ url('quota_association-ui-delete', args=[object.pk]) }}">Delete association</a>
     {% endset %}
 
     {{ table_rows.append([

--- a/quotas/jinja2/quotas/tables/sub_quotas.jinja
+++ b/quotas/jinja2/quotas/tables/sub_quotas.jinja
@@ -11,9 +11,11 @@
     {% set sub_quota_link -%}
       <a class="govuk-link" href="{{ url('quota-ui-detail', args=[object.sub_quota.order_number.sid]) }}">{{ object.sub_quota.order_number.order_number }}</a>
     {% endset %}
-    {% set edit_link -%}
+    {% set actions_html %}
       <a class="govuk-link" href="{{ object.sub_quota.version_at(request.user.current_workbasket.transactions.last()).get_association_edit_url() }}">Edit</a>
+      <a class="govuk-link" href="{{ url('quota_association-ui-delete', kwargs={'sid':object.sub_quota.sid}) }}">Delete</a>
     {% endset %}
+
     {{ table_rows.append([
       {"text": definition_link },
       {"text": sub_quota_link },
@@ -21,7 +23,7 @@
       {"text": "{:%d %b %Y}".format(object.sub_quota.version_at(request.user.current_workbasket.transactions.last()).valid_between.upper) if object.sub_quota.valid_between.upper else "-"},
       {"text": object.get_sub_quota_relation_type_display() },
       {"text": object.coefficient },
-      {"text": edit_link },
+      {"text": actions_html },
     ]) or "" }}
   {% endfor %}
 

--- a/quotas/urls.py
+++ b/quotas/urls.py
@@ -43,6 +43,11 @@ api_router.register(
 ui_patterns = get_ui_paths(views, "<sid:sid>")
 
 urlpatterns = [
+    path(
+        f"quotas/<sid>/quota-associations/confirm-delete/",
+        views.QuotaAssociationConfirmDelete.as_view(),
+        name="quota_association-ui-confirm-delete",
+    ),
     path("quotas/", include(ui_patterns)),
     path(
         f"quotas/create/",
@@ -186,14 +191,9 @@ urlpatterns = [
         name="quota_blocking-ui-confirm-create",
     ),
     path(
-        f"quotas/quota-association/<sid>/delete/",
+        f"quotas/quota-association/<pk>/delete/",
         views.QuotaAssociationDelete.as_view(),
         name="quota_association-ui-delete",
-    ),
-    path(
-        f"quotas/quota-association/<sid>/confirm-delete/",
-        views.QuotaAssociationConfirmDelete.as_view(),
-        name="quota_association-ui-confirm-delete",
     ),
     path("api/", include(api_router.urls)),
 ]

--- a/quotas/urls.py
+++ b/quotas/urls.py
@@ -186,12 +186,12 @@ urlpatterns = [
         name="quota_blocking-ui-confirm-create",
     ),
     path(
-        f"quotas/quota-association/<pk>/delete/",
+        f"quota_definitions/quota-association/<pk>/delete/",
         views.QuotaAssociationDelete.as_view(),
         name="quota_association-ui-delete",
     ),
     path(
-        f"quotas/<sid>/quota-associations/confirm-delete/",
+        f"quota_definitions/<sid>/quota-associations/confirm-delete/",
         views.QuotaAssociationConfirmDelete.as_view(),
         name="quota_association-ui-confirm-delete",
     ),

--- a/quotas/urls.py
+++ b/quotas/urls.py
@@ -43,11 +43,6 @@ api_router.register(
 ui_patterns = get_ui_paths(views, "<sid:sid>")
 
 urlpatterns = [
-    path(
-        f"quotas/<sid>/quota-associations/confirm-delete/",
-        views.QuotaAssociationConfirmDelete.as_view(),
-        name="quota_association-ui-confirm-delete",
-    ),
     path("quotas/", include(ui_patterns)),
     path(
         f"quotas/create/",
@@ -194,6 +189,11 @@ urlpatterns = [
         f"quotas/quota-association/<pk>/delete/",
         views.QuotaAssociationDelete.as_view(),
         name="quota_association-ui-delete",
+    ),
+    path(
+        f"quotas/<sid>/quota-associations/confirm-delete/",
+        views.QuotaAssociationConfirmDelete.as_view(),
+        name="quota_association-ui-confirm-delete",
     ),
     path("api/", include(api_router.urls)),
 ]

--- a/quotas/urls.py
+++ b/quotas/urls.py
@@ -188,6 +188,11 @@ urlpatterns = [
     path(
         f"quotas/quota-association/<sid>/delete/",
         views.QuotaAssociationDelete.as_view(),
+        name="quota_association-ui-delete",
+    ),
+    path(
+        f"quotas/quota-association/<sid>/confirm-delete/",
+        views.QuotaAssociationConfirmDelete.as_view(),
         name="quota_association-ui-confirm-delete",
     ),
     path("api/", include(api_router.urls)),

--- a/quotas/urls.py
+++ b/quotas/urls.py
@@ -185,5 +185,10 @@ urlpatterns = [
         views.QuotaBlockingConfirmCreate.as_view(),
         name="quota_blocking-ui-confirm-create",
     ),
+    path(
+        f"quotas/quota-association/<sid>/delete/",
+        views.QuotaAssociationDelete.as_view(),
+        name="quota_association-ui-confirm-delete",
+    ),
     path("api/", include(api_router.urls)),
 ]

--- a/quotas/views.py
+++ b/quotas/views.py
@@ -121,6 +121,14 @@ class QuotaOrderNumberMixin:
         return models.QuotaOrderNumber.objects.approved_up_to_transaction(tx)
 
 
+# class QuotaAssociationMixin:
+#     model = models.QuotaAssociation
+
+# def get_queryset(self):
+#     tx = WorkBasket.get_current_transaction(self.request)
+#     return models.QuotaAssociation.objects.approved_up_to_transaction(tx)
+
+
 class QuotaCreate(QuotaOrderNumberMixin, CreateTaricCreateView):
     form_class = forms.QuotaOrderNumberCreateForm
     template_name = "layouts/create.jinja"
@@ -1291,28 +1299,50 @@ class SubQuotaConfirmUpdate(TrackedModelDetailView):
 
 
 class QuotaAssociationDelete(
-    QuotaDefinitionUpdateMixin,
+    SubQuotaDefinitionAssociationMixin,
     CreateTaricDeleteView,
 ):
     form_class = delete_form_for(models.QuotaAssociation)
     template_name = "quota-associations/delete.jinja"
+    model = models.QuotaAssociation
 
     def form_valid(self, form):
         messages.success(
             self.request,
-            f"Quota association {self.object.sid} has been deleted",
+            f"Quota association {self.object.pk} has been deleted",
         )
         return super().form_valid(form)
 
     def get_success_url(self):
         return reverse(
             "quota_association-ui-confirm-delete",
-            kwargs={"sid": self.object.order_number.sid},
+            kwargs={"sid": self.object.pk},
         )
 
 
+# lass QuotaDefinitionDelete(
+#     QuotaDefinitionUpdateMixin,
+#     CreateTaricDeleteView,
+# ):
+#     form_class = delete_form_for(models.QuotaDefinition)
+#     template_name = "quota-definitions/delete.jinja"
+
+#     def form_valid(self, form):
+#         messages.success(
+#             self.request,
+#             f"Quota definition period {self.object.sid} has been deleted",
+#         )
+#         return super().form_valid(form)
+
+#     def get_success_url(self):
+#         return reverse(
+#             "quota_definition-ui-confirm-delete",
+#             kwargs={"sid": self.object.order_number.sid},
+#         )
+
+
 class QuotaAssociationConfirmDelete(
-    QuotaOrderNumberMixin,
     TrackedModelDetailView,
+    SubQuotaDefinitionAssociationMixin,
 ):
     template_name = "quota-associations/confirm-delete.jinja"

--- a/quotas/views.py
+++ b/quotas/views.py
@@ -1353,19 +1353,18 @@ class QuotaAssociationDelete(
         print("b" * 30, "get_success_url fires")
         return reverse(
             "quota_association-ui-confirm-delete",
+            kwargs={"sid": self.object.main_quota.order_number.sid},
         )
 
 
 class QuotaAssociationConfirmDelete(
     TrackedModelDetailView,
-    # QuotaAssociationUpdateMixin,
 ):
     template_name = "quota-associations/confirm-delete.jinja"
-    model = models.QuotaAssociation
+    model = models.QuotaOrderNumber
     print("d" * 30, "confirm_delete fires")
 
     def get_queryset(self):
         # super().get_queryset()
         print("e" * 30, "confirm_delete get_queryset fires")
-        qs = models.QuotaAssociation.objects.current()
-        return qs
+        return models.QuotaOrderNumber.objects.all()

--- a/quotas/views.py
+++ b/quotas/views.py
@@ -121,14 +121,6 @@ class QuotaOrderNumberMixin:
         return models.QuotaOrderNumber.objects.approved_up_to_transaction(tx)
 
 
-# class QuotaAssociationMixin:
-#     model = models.QuotaAssociation
-
-# def get_queryset(self):
-#     tx = WorkBasket.get_current_transaction(self.request)
-#     return models.QuotaAssociation.objects.approved_up_to_transaction(tx)
-
-
 class QuotaCreate(QuotaOrderNumberMixin, CreateTaricCreateView):
     form_class = forms.QuotaOrderNumberCreateForm
     template_name = "layouts/create.jinja"
@@ -1313,9 +1305,7 @@ class QuotaAssociationDelete(
         return super().form_valid(form)
 
     def get_queryset(self):
-        tx = WorkBasket.get_current_transaction(self.request)
-        qs = models.QuotaAssociation.objects.approved_up_to_transaction(tx)
-        return qs
+        return models.QuotaAssociation.objects.current()
 
     def get_success_url(self):
         return reverse(
@@ -1329,9 +1319,3 @@ class QuotaAssociationConfirmDelete(
 ):
     template_name = "quota-associations/confirm-delete.jinja"
     model = models.QuotaDefinition
-
-    def get_queryset(self):
-
-        return models.QuotaDefinition.objects.filter(
-            sid=self.kwargs["sid"],
-        )

--- a/quotas/views.py
+++ b/quotas/views.py
@@ -1288,3 +1288,31 @@ class SubQuotaConfirmUpdate(TrackedModelDetailView):
                 ),
             )
         return super().dispatch(request, *args, **kwargs)
+
+
+class QuotaAssociationDelete(
+    QuotaDefinitionUpdateMixin,
+    CreateTaricDeleteView,
+):
+    form_class = delete_form_for(models.QuotaAssociation)
+    template_name = "quota-associations/delete.jinja"
+
+    def form_valid(self, form):
+        messages.success(
+            self.request,
+            f"Quota association {self.object.sid} has been deleted",
+        )
+        return super().form_valid(form)
+
+    def get_success_url(self):
+        return reverse(
+            "quota_association-ui-confirm-delete",
+            kwargs={"sid": self.object.order_number.sid},
+        )
+
+
+class QuotaAssociationConfirmDelete(
+    QuotaOrderNumberMixin,
+    TrackedModelDetailView,
+):
+    template_name = "quota-associations/confirm-delete.jinja"


### PR DESCRIPTION
# TP-2000 1516 Delete Quota Association

## Why
There is a requirement for TMs to be able to delete a QuotaAssociation between two QuotaDefinitions while maintaining the QuotaDefinitions

## What
This PR follows the standard Delete journey, enabling a TM to delete a QuotaAssociation object without deleting either the main or sub-quota definition:
- Adding a Delete link in the Sub-quotas view (image 1 below)
- Following the standard delete journey (images 2 & 3)
- Adding tests
There are some minor copy changes as requested by Ash/Rachel during an initial review:
- On the Quota Data/sub-quotas page: changing table headings from `Quota definition sid` to `Quota definition SID` and `Relation type` to `Relationship type`

Note: on the confirm delete page, we currently link back to the sub-quota definition. Once this ticket is in production, should our users request it, we can either change this to direct the user back to the main quota definition, or add a button so the user can return to either main or sub-quota definition.
An association can be created from either main or sub-quota definition.

<img width="1211" alt="image" src="https://github.com/user-attachments/assets/9afeebba-d8b9-436d-bd6c-45a951415a35">
<img width="1137" alt="image" src="https://github.com/user-attachments/assets/3fb6b4b0-65a7-4458-ab62-b216775c8cd7">
<img width="817" alt="image" src="https://github.com/user-attachments/assets/db197be4-e898-4b7d-92fc-aba7e5be616f">

