### PR TITLE
TP2000-1477 Edit capability for suspension periods

### DIFF
--- a/common/forms.py
+++ b/common/forms.py
@@ -7,6 +7,7 @@ from typing import Type
 
 from crispy_forms_gds.fields import DateInputField
 from crispy_forms_gds.helper import FormHelper
+from crispy_forms_gds.layout import HTML
 from crispy_forms_gds.layout import Div
 from crispy_forms_gds.layout import Field
 from crispy_forms_gds.layout import Layout
@@ -458,12 +459,18 @@ class DeleteForm(forms.ModelForm):
         self.helper.label_size = Size.SMALL
         self.helper.legend_size = Size.SMALL
         self.helper.layout = Layout(
-            Submit(
-                "submit",
-                "Delete",
-                css_class="govuk-button--warning",
-                data_module="govuk-button",
-                data_prevent_double_click="true",
+            Div(
+                Submit(
+                    "submit",
+                    "Delete",
+                    css_class="govuk-button--warning",
+                    data_module="govuk-button",
+                    data_prevent_double_click="true",
+                ),
+                HTML(
+                    f"<a class='govuk-button govuk-button--secondary' href={self.instance.get_url()}>Cancel</a>",
+                ),
+                css_class="govuk-button-group",
             ),
         )
 

--- a/common/jinja2/common/delete.jinja
+++ b/common/jinja2/common/delete.jinja
@@ -22,10 +22,4 @@
   {% call django_form(action=object.get_url("delete")) %}
     {{ crispy(form) }}
   {% endcall %}
-
-  {{ govukButton({
-    "text": "Cancel",
-    "href": object.get_url(),
-    "classes": "govuk-button--secondary"
-  }) }}
 {% endblock %}

--- a/quotas/forms.py
+++ b/quotas/forms.py
@@ -1008,15 +1008,13 @@ class QuotaSuspensionUpdateForm(ValidityPeriodForm, forms.ModelForm):
     )
 
     def __init__(self, *args, **kwargs):
-        sid = kwargs.pop("sid")
         super().__init__(*args, **kwargs)
-        self.quota_suspension = models.QuotaSuspension.objects.current().get(sid=sid)
         self.init_layout()
 
     def init_layout(self):
         cancel_url = reverse_lazy(
             "quota-ui-detail",
-            kwargs={"sid": self.quota_suspension.quota_definition.order_number.sid},
+            kwargs={"sid": self.instance.quota_definition.order_number.sid},
         )
         self.helper = FormHelper(self)
         self.helper.label_size = Size.SMALL
@@ -1042,7 +1040,7 @@ class QuotaSuspensionUpdateForm(ValidityPeriodForm, forms.ModelForm):
 
     def clean(self):
         cleaned_data = super().clean()
-        definition_period = self.quota_suspension.quota_definition.valid_between
+        definition_period = self.instance.quota_definition.valid_between
         validity_period = cleaned_data.get("valid_between")
         if (
             definition_period

--- a/quotas/forms.py
+++ b/quotas/forms.py
@@ -1003,7 +1003,6 @@ class QuotaSuspensionUpdateForm(ValidityPeriodForm, forms.ModelForm):
 
     description = forms.CharField(
         label="Description",
-        validators=[SymbolValidator],
         widget=forms.Textarea(),
         required=False,
     )
@@ -1062,6 +1061,9 @@ class QuotaSuspensionUpdateForm(ValidityPeriodForm, forms.ModelForm):
             "valid_between",
             "description",
         ]
+
+
+QuotaSuspensionDeleteForm = delete_form_for(models.QuotaSuspension)
 
 
 class DuplicateQuotaDefinitionPeriodStartForm(forms.Form):

--- a/quotas/jinja2/quota-suspensions/confirm-delete.jinja
+++ b/quotas/jinja2/quota-suspensions/confirm-delete.jinja
@@ -1,0 +1,41 @@
+{% extends "layouts/confirm.jinja" %}
+{% from "components/breadcrumbs.jinja" import breadcrumbs %}
+
+{% set page_title = "Quota suspension deleted" %}
+
+{% block breadcrumb %}
+  {{ breadcrumbs(request, [
+      {"text": "Find and edit quotas", "href": url("quota-ui-list")},
+      {"text": object._meta.verbose_name|capitalize ~ ": " ~ object|string, "href": object.get_url()},
+      {"text": "Quota ID: " ~ object.order_number ~ " - Data", "href": url("quota_definition-ui-list", args=[object.sid])},
+      {"text": page_title}
+    ])
+  }}
+{% endblock %}
+
+{% set messages %}
+  {% for message in get_messages(request) %}
+    {{ message }}
+  {% endfor %}
+{% endset  %}
+
+{% block panel %}
+  {{ govukPanel({
+    "titleText": messages,
+    "text": "This change has been added to your workbasket",
+    "classes": "govuk-!-margin-bottom-7"
+  }) }}
+{% endblock %}
+
+{% block main_button %}
+{{ govukButton({
+  "text": "View other suspension periods for this quota order number",
+  "href": url('quota_definition-ui-list-filter', kwargs={'sid': object.sid, 'quota_type': "suspension_periods"}),
+  "classes": "govuk-button--primary"
+}) }}
+{% endblock%}
+
+
+{% block actions %}
+<li><a href="{{ object.get_url('list') }}">Find and edit quotas</a></li>
+{% endblock %}

--- a/quotas/jinja2/quota-suspensions/confirm-delete.jinja
+++ b/quotas/jinja2/quota-suspensions/confirm-delete.jinja
@@ -6,22 +6,17 @@
 {% block breadcrumb %}
   {{ breadcrumbs(request, [
       {"text": "Find and edit quotas", "href": url("quota-ui-list")},
-      {"text": object._meta.verbose_name|capitalize ~ ": " ~ object|string, "href": object.get_url()},
-      {"text": "Quota ID: " ~ object.order_number ~ " - Data", "href": url("quota_definition-ui-list", args=[object.sid])},
+      {"text": "Quota " ~ object.quota_definition.order_number|string, "href": object.quota_definition.order_number.get_url()},
+      {"text": "Quota ID: " ~ object.quota_definition.order_number ~ " - Data", "href": url("quota_definition-ui-list", args=[object.quota_definition.order_number.sid])},
+      {"text": "Suspension periods", "href": url('quota_definition-ui-list-filter', kwargs={'sid': object.quota_definition.order_number.sid, 'quota_type': "suspension_periods"})},
       {"text": page_title}
     ])
   }}
 {% endblock %}
 
-{% set messages %}
-  {% for message in get_messages(request) %}
-    {{ message }}
-  {% endfor %}
-{% endset  %}
-
 {% block panel %}
   {{ govukPanel({
-    "titleText": messages,
+    "titleText": "Quota suspension period " ~ object.sid ~ " has been deleted",
     "text": "This change has been added to your workbasket",
     "classes": "govuk-!-margin-bottom-7"
   }) }}
@@ -30,12 +25,25 @@
 {% block main_button %}
 {{ govukButton({
   "text": "View other suspension periods for this quota order number",
-  "href": url('quota_definition-ui-list-filter', kwargs={'sid': object.sid, 'quota_type': "suspension_periods"}),
+  "href": url('quota_definition-ui-list-filter', kwargs={'sid': object.quota_definition.order_number.sid, 'quota_type': "suspension_periods"}),
   "classes": "govuk-button--secondary"
 }) }}
 {% endblock%}
 
 
+{% block button_group %}
+          {{ govukButton({
+            "text": "View workbasket summary",
+            "href": url("workbaskets:current-workbasket"),
+            "classes": "govuk-button"
+          }) }}
+          {{ govukButton({
+            "text": "View quota order number: " ~ object.quota_definition.order_number|string,
+            "href": object.quota_definition.order_number.get_url(),
+            "classes": "govuk-button--secondary"
+          }) }}
+{% endblock %}
+
 {% block actions %}
-<li><a href="{{ object.get_url('list') }}">Find and edit quotas</a></li>
+<li><a href="{{ object.quota_definition.order_number.get_url('list') }}">Find and edit quotas</a></li>
 {% endblock %}

--- a/quotas/jinja2/quota-suspensions/confirm-delete.jinja
+++ b/quotas/jinja2/quota-suspensions/confirm-delete.jinja
@@ -31,7 +31,7 @@
 {{ govukButton({
   "text": "View other suspension periods for this quota order number",
   "href": url('quota_definition-ui-list-filter', kwargs={'sid': object.sid, 'quota_type': "suspension_periods"}),
-  "classes": "govuk-button--primary"
+  "classes": "govuk-button--secondary"
 }) }}
 {% endblock%}
 

--- a/quotas/jinja2/quota-suspensions/confirm-update.jinja
+++ b/quotas/jinja2/quota-suspensions/confirm-update.jinja
@@ -6,6 +6,7 @@
       {"text": "Find and edit quotas", "href": url("quota-ui-list")},
       {"text": object.quota_definition.order_number._meta.verbose_name|capitalize ~ ": " ~ object.quota_definition.order_number|string, "href": object.quota_definition.order_number.get_url()},
       {"text": "Quota ID: " ~ object.quota_definition.order_number.order_number ~ " - Data", "href": url("quota_definition-ui-list", args=[object.quota_definition.order_number.sid])},
+      {"text": "Suspension periods", "href": url('quota_definition-ui-list-filter', kwargs={'sid': object.quota_definition.order_number.sid, 'quota_type': "suspension_periods"})},
       {"text": page_title}
     ])
   }}

--- a/quotas/jinja2/quota-suspensions/confirm-update.jinja
+++ b/quotas/jinja2/quota-suspensions/confirm-update.jinja
@@ -1,0 +1,25 @@
+{% extends "common/confirm_update.jinja" %}
+{% from "components/breadcrumbs.jinja" import breadcrumbs %}
+
+{% block breadcrumb %}
+  {{ breadcrumbs(request, [
+      {"text": "Find and edit quotas", "href": url("quota-ui-list")},
+      {"text": object.quota_definition.order_number._meta.verbose_name|capitalize ~ ": " ~ object.quota_definition.order_number|string, "href": object.quota_definition.order_number.get_url()},
+      {"text": "Quota ID: " ~ object.quota_definition.order_number.order_number ~ " - Data", "href": url("quota_definition-ui-list", args=[object.quota_definition.order_number.sid])},
+      {"text": page_title}
+    ])
+  }}
+{% endblock %}
+
+{% block main_button %}
+{{ govukButton({
+  "text": "View other definition periods for this quota order number",
+  "href": url('quota_definition-ui-list', kwargs={'sid': object.quota_definition.order_number.sid}),
+  "classes": "govuk-button--primary"
+}) }}
+{% endblock%}
+
+{% block actions %}
+<li><a class="govuk-link" href="{{ object.quota_definition.order_number.get_url() }}">View this definition's quota order number</a></li>
+<li><a href="{{ object.quota_definition.order_number.get_url('list') }}">Find and edit quotas</a></li>
+{% endblock %}

--- a/quotas/jinja2/quota-suspensions/confirm-update.jinja
+++ b/quotas/jinja2/quota-suspensions/confirm-update.jinja
@@ -13,13 +13,12 @@
 
 {% block main_button %}
 {{ govukButton({
-  "text": "View other definition periods for this quota order number",
-  "href": url('quota_definition-ui-list', kwargs={'sid': object.quota_definition.order_number.sid}),
-  "classes": "govuk-button--primary"
+  "text": "View other suspension periods for this quota order number",
+  "href": url('quota_definition-ui-list-filter', kwargs={'sid': object.quota_definition.order_number.sid, 'quota_type': "suspension_periods"}),
+  "classes": "govuk-button--secondary"
 }) }}
 {% endblock%}
 
 {% block actions %}
-<li><a class="govuk-link" href="{{ object.quota_definition.order_number.get_url() }}">View this definition's quota order number</a></li>
 <li><a href="{{ object.quota_definition.order_number.get_url('list') }}">Find and edit quotas</a></li>
 {% endblock %}

--- a/quotas/jinja2/quota-suspensions/delete.jinja
+++ b/quotas/jinja2/quota-suspensions/delete.jinja
@@ -1,0 +1,12 @@
+{% extends "common/delete.jinja" %}
+
+
+{% block breadcrumb %}
+  {{ breadcrumbs(request, [
+      {"text": "Find and edit quotas", "href": url("quota-ui-list")},
+      {"text": object.quota_definition.order_number._meta.verbose_name|capitalize ~ " " ~ object.quota_definition.order_number|string, "href": object.quota_definition.order_number.get_url()},
+      {"text": object.quota_definition.order_number._meta.verbose_name|capitalize ~ " " ~ object.quota_definition.order_number|string ~ ": Data" , "href": url('quota_definition-ui-list', args=[object.quota_definition.order_number.sid])},
+      {"text": page_title}
+    ])
+  }}
+{% endblock %}

--- a/quotas/jinja2/quota-suspensions/delete.jinja
+++ b/quotas/jinja2/quota-suspensions/delete.jinja
@@ -6,6 +6,7 @@
       {"text": "Find and edit quotas", "href": url("quota-ui-list")},
       {"text": object.quota_definition.order_number._meta.verbose_name|capitalize ~ " " ~ object.quota_definition.order_number|string, "href": object.quota_definition.order_number.get_url()},
       {"text": object.quota_definition.order_number._meta.verbose_name|capitalize ~ " " ~ object.quota_definition.order_number|string ~ ": Data" , "href": url('quota_definition-ui-list', args=[object.quota_definition.order_number.sid])},
+      {"text": "Suspension periods", "href": url('quota_definition-ui-list-filter', kwargs={'sid': object.quota_definition.order_number.sid, 'quota_type': "suspension_periods"})},
       {"text": page_title}
     ])
   }}

--- a/quotas/jinja2/quota-suspensions/edit.jinja
+++ b/quotas/jinja2/quota-suspensions/edit.jinja
@@ -1,0 +1,13 @@
+{% extends "common/edit.jinja" %}
+
+{% set page_title = "Edit quota suspension details" %} 
+
+{% block breadcrumb %}
+  {{ breadcrumbs(request, [
+      {"text": "Find and edit quotas", "href": url("quota-ui-list")},
+      {"text": object.quota_definition.order_number._meta.verbose_name|capitalize ~ " " ~ object.quota_definition.order_number|string, "href": object.quota_definition.order_number.get_url()},
+      {"text": object.quota_definition.order_number._meta.verbose_name|capitalize ~ " " ~ object.quota_definition.order_number|string ~ ": Data" , "href": url('quota_definition-ui-list', args=[object.quota_definition.order_number.sid])},
+      {"text": page_title}
+    ])
+  }}
+{% endblock %}

--- a/quotas/jinja2/quota-suspensions/edit.jinja
+++ b/quotas/jinja2/quota-suspensions/edit.jinja
@@ -7,6 +7,7 @@
       {"text": "Find and edit quotas", "href": url("quota-ui-list")},
       {"text": object.quota_definition.order_number._meta.verbose_name|capitalize ~ " " ~ object.quota_definition.order_number|string, "href": object.quota_definition.order_number.get_url()},
       {"text": object.quota_definition.order_number._meta.verbose_name|capitalize ~ " " ~ object.quota_definition.order_number|string ~ ": Data" , "href": url('quota_definition-ui-list', args=[object.quota_definition.order_number.sid])},
+      {"text": "Suspension periods", "href": url('quota_definition-ui-list-filter', kwargs={'sid': object.quota_definition.order_number.sid, 'quota_type': "suspension_periods"})},
       {"text": page_title}
     ])
   }}

--- a/quotas/jinja2/quotas/tables/suspension_periods.jinja
+++ b/quotas/jinja2/quotas/tables/suspension_periods.jinja
@@ -1,4 +1,3 @@
-
 <h2 class="govuk-heading-l">Suspension periods</h2>
 
 {% set table_rows = [] %}
@@ -8,20 +7,25 @@
     {% set definition_link -%}
       <a class="govuk-link" href="{{ url('quota-ui-detail', args=[object.quota_definition.order_number.sid]) }}#definition-details">{{ object.quota_definition.sid }}</a>
     {% endset %}
+    {% set edit_url  %}
+         <a class="govuk-link" href="{{ object.get_url('edit') }}">Edit</a>
+    {% endset %}
       {{ table_rows.append([
         {"text": definition_link },
         {"text": "{:%d %b %Y}".format(object.valid_between.lower) },
         {"text": "{:%d %b %Y}".format(object.valid_between.upper) if object.valid_between.upper else "-"},
         {"text": object.description },
+        {"html": edit_url},
       ]) or "" }}
     {% endfor %}
 
   {{ govukTable({
     "head": [
-      {"text": "Quota definition sid"},
+      {"text": "Quota definition SID"},
       {"text": "Start date"},
       {"text": "End date"},
       {"text": "Description", "classes": "govuk-!-width-one-half"},
+      {"text": "Actions",},
     ],
     "rows": table_rows
   }) }}

--- a/quotas/jinja2/quotas/tables/suspension_periods.jinja
+++ b/quotas/jinja2/quotas/tables/suspension_periods.jinja
@@ -7,15 +7,16 @@
     {% set definition_link -%}
       <a class="govuk-link" href="{{ url('quota-ui-detail', args=[object.quota_definition.order_number.sid]) }}#definition-details">{{ object.quota_definition.sid }}</a>
     {% endset %}
-    {% set edit_url  %}
-         <a class="govuk-link" href="{{ object.get_url('edit') }}">Edit</a>
+    {% set actions  %}
+         <a class="govuk-link" href="{{ object.get_url('edit') }}">Edit</a><br>
+         <a class="govuk-link" href="{{ object.get_url('delete') }}">Delete</a>
     {% endset %}
       {{ table_rows.append([
         {"text": definition_link },
         {"text": "{:%d %b %Y}".format(object.valid_between.lower) },
         {"text": "{:%d %b %Y}".format(object.valid_between.upper) if object.valid_between.upper else "-"},
         {"text": object.description },
-        {"html": edit_url},
+        {"html": actions},
       ]) or "" }}
     {% endfor %}
 

--- a/quotas/models.py
+++ b/quotas/models.py
@@ -480,6 +480,9 @@ class QuotaSuspension(TrackedModel, ValidityMixin):
 
     business_rules = (business_rules.QSP2, UniqueIdentifyingFields, UpdateValidity)
 
+    def __str__(self):
+        return f"{self.sid}"
+
 
 class QuotaBlocking(TrackedModel, ValidityMixin):
     """Defines a blocking period for a (sub-)quota."""

--- a/quotas/models.py
+++ b/quotas/models.py
@@ -483,7 +483,7 @@ class QuotaSuspension(TrackedModel, ValidityMixin):
     def get_url(self, action: str = "detail") -> Optional[str]:
         """Overrides the parent get_url as there is no detail view for
         QuotaSuspensions for it to default to."""
-        url = super().get_url()
+        url = super().get_url(action=action)
         if not url:
             url = self.quota_definition.get_url()
 

--- a/quotas/models.py
+++ b/quotas/models.py
@@ -480,6 +480,15 @@ class QuotaSuspension(TrackedModel, ValidityMixin):
 
     business_rules = (business_rules.QSP2, UniqueIdentifyingFields, UpdateValidity)
 
+    def get_url(self, action: str = "detail") -> Optional[str]:
+        """Overrides the parent get_url as there is no detail view for
+        QuotaSuspensions for it to default to."""
+        url = super().get_url()
+        if not url:
+            url = self.quota_definition.get_url()
+
+        return url
+
     def __str__(self):
         return f"{self.sid}"
 

--- a/quotas/models.py
+++ b/quotas/models.py
@@ -485,7 +485,13 @@ class QuotaSuspension(TrackedModel, ValidityMixin):
         QuotaSuspensions for it to default to."""
         url = super().get_url(action=action)
         if not url:
-            url = self.quota_definition.get_url()
+            url = reverse(
+                "quota_definition-ui-list-filter",
+                kwargs={
+                    "sid": self.quota_definition.order_number.sid,
+                    "quota_type": "suspension_periods",
+                },
+            )
 
         return url
 

--- a/quotas/tests/test_forms.py
+++ b/quotas/tests/test_forms.py
@@ -949,7 +949,7 @@ def test_quota_association_edit_form_valid():
 
 
 def test_quota_association_edit_form_invalid():
-    "Test that the quota association edit form is invalid when data is passed in."
+    "Test that the quota association edit form is invalid when invalid data is passed in."
     association = factories.QuotaAssociationFactory.create(
         coefficient=1.67,
         sub_quota_relation_type="EQ",
@@ -968,3 +968,55 @@ def test_quota_association_edit_form_invalid():
     )
     assert "Enter a number." in form.errors["coefficient"]
     assert not form.is_valid()
+
+
+def test_quota_suspension_update_form_valid(date_ranges):
+    "Test that the quota suspension update form is valid when correct data is passed in"
+    suspension = factories.QuotaSuspensionFactory.create(
+        valid_between=date_ranges.normal,
+    )
+    current_validity = suspension.valid_between
+    data = {
+        "start_date_0": current_validity.lower.day + 1,
+        "start_date_1": current_validity.lower.month + 1,
+        "start_date_2": current_validity.lower.year + 1,
+        "end_date_0": current_validity.upper.day - 1,
+        "end_date_1": current_validity.upper.month - 1,
+        "end_date_2": current_validity.upper.year + -1,
+        "description": "New description",
+    }
+    with override_current_transaction(Transaction.objects.last()):
+        form = forms.QuotaSuspensionUpdateForm(
+            data=data,
+            instance=suspension,
+            sid=suspension.sid,
+        )
+        assert form.is_valid()
+
+
+def test_quota_suspension_update_form_invalid(date_ranges):
+    "Test that the quota suspension update form is invalid when the validity period does not span the validity of the definition"
+    definition = factories.QuotaDefinitionFactory.create(
+        valid_between=date_ranges.normal,
+    )
+    suspension = factories.QuotaSuspensionFactory.create(
+        quota_definition=definition,
+        valid_between=date_ranges.normal,
+    )
+    data = {
+        "start_date_0": date_ranges.earlier.lower.day,
+        "start_date_1": date_ranges.earlier.lower.month,
+        "start_date_2": date_ranges.earlier.lower.year,
+    }
+
+    with override_current_transaction(Transaction.objects.last()):
+        form = forms.QuotaSuspensionUpdateForm(
+            data=data,
+            instance=suspension,
+            sid=suspension.sid,
+        )
+        assert not form.is_valid()
+        assert (
+            f"The start and end date must sit within the selected quota definition's start and end date ({definition.valid_between.lower} - {definition.valid_between.upper})"
+            in form.errors["__all__"]
+        )

--- a/quotas/tests/test_forms.py
+++ b/quotas/tests/test_forms.py
@@ -978,11 +978,11 @@ def test_quota_suspension_update_form_valid(date_ranges):
     current_validity = suspension.valid_between
     data = {
         "start_date_0": current_validity.lower.day + 1,
-        "start_date_1": current_validity.lower.month + 1,
-        "start_date_2": current_validity.lower.year + 1,
-        "end_date_0": current_validity.upper.day - 1,
-        "end_date_1": current_validity.upper.month - 1,
-        "end_date_2": current_validity.upper.year + -1,
+        "start_date_1": current_validity.lower.month,
+        "start_date_2": current_validity.lower.year,
+        "end_date_0": "",
+        "end_date_1": "",
+        "end_date_2": "",
         "description": "New description",
     }
     with override_current_transaction(Transaction.objects.last()):

--- a/quotas/tests/test_forms.py
+++ b/quotas/tests/test_forms.py
@@ -989,7 +989,6 @@ def test_quota_suspension_update_form_valid(date_ranges):
         form = forms.QuotaSuspensionUpdateForm(
             data=data,
             instance=suspension,
-            sid=suspension.sid,
         )
         assert form.is_valid()
 
@@ -1013,7 +1012,6 @@ def test_quota_suspension_update_form_invalid(date_ranges):
         form = forms.QuotaSuspensionUpdateForm(
             data=data,
             instance=suspension,
-            sid=suspension.sid,
         )
         assert not form.is_valid()
         assert (

--- a/quotas/tests/test_views.py
+++ b/quotas/tests/test_views.py
@@ -2502,7 +2502,7 @@ def test_quota_suspension_edit(client_with_current_workbasket):
     assert response.status_code == 302
     assert response.url == reverse(
         "quota_suspension-ui-confirm-update",
-        kwargs={"sid": suspension.quota_definition.order_number.sid},
+        kwargs={"sid": suspension.sid},
     )
 
     updated_suspension = models.QuotaSuspension.objects.approved_up_to_transaction(

--- a/quotas/tests/test_views.py
+++ b/quotas/tests/test_views.py
@@ -2039,7 +2039,7 @@ def test_quota_definition_view(client_with_current_workbasket):
     )
     assert response.status_code == 200
     soup = BeautifulSoup(response.content.decode(response.charset), "html.parser")
-    description_cell_text = soup.select("tbody tr:first-child td:last-child")[0].text
+    description_cell_text = soup.select("tbody tr:first-child td")[-2].text
     assert description_cell_text == suspension.description
 
 

--- a/quotas/tests/test_views.py
+++ b/quotas/tests/test_views.py
@@ -2487,7 +2487,7 @@ def test_quota_suspension_edit(client_with_current_workbasket):
     suspension = factories.QuotaSuspensionFactory.create()
     current_validity = suspension.valid_between
     data = {
-        "start_date_0": current_validity.lower.day + 1,
+        "start_date_0": current_validity.lower.day,
         "start_date_1": current_validity.lower.month,
         "start_date_2": current_validity.lower.year,
         "end_date_0": current_validity.upper.day,

--- a/quotas/urls.py
+++ b/quotas/urls.py
@@ -206,6 +206,16 @@ urlpatterns = [
         name="quota_suspension-ui-confirm-update",
     ),
     path(
+        f"quotas/suspension-periods/<sid>/delete/",
+        views.QuotaSuspensionDelete.as_view(),
+        name="quota_suspension-ui-delete",
+    ),
+    path(
+        f"quotas/suspension-periods/<sid>/confirm-delete/",
+        views.QuotaSuspensionConfirmDelete.as_view(),
+        name="quota_suspension-ui-confirm-delete",
+    ),
+    path(
         f"quota_definitions/quota-association/<pk>/delete/",
         views.QuotaAssociationDelete.as_view(),
         name="quota_association-ui-delete",

--- a/quotas/urls.py
+++ b/quotas/urls.py
@@ -186,6 +186,26 @@ urlpatterns = [
         name="quota_blocking-ui-confirm-create",
     ),
     path(
+        f"quotas/suspension-periods/<sid>/edit/",
+        views.QuotaSuspensionUpdate.as_view(),
+        name="quota_suspension-ui-edit",
+    ),
+    path(
+        f"quotas/suspension-periods/<sid>/edit-create/",
+        views.QuotaSuspensionEditCreate.as_view(),
+        name="quota_suspension-ui-edit-create",
+    ),
+    path(
+        f"quotas/suspension-periods/<sid>/edit-update/",
+        views.QuotaSuspensionEditUpdate.as_view(),
+        name="quota_suspension-ui-edit-update",
+    ),
+    path(
+        f"quotas/suspension-periods/<sid>/confirm-update/",
+        views.QuotaSuspensionConfirmUpdate.as_view(),
+        name="quota_suspension-ui-confirm-update",
+    ),
+    path(
         f"quota_definitions/quota-association/<pk>/delete/",
         views.QuotaAssociationDelete.as_view(),
         name="quota_association-ui-delete",

--- a/quotas/views.py
+++ b/quotas/views.py
@@ -1157,6 +1157,50 @@ class QuotaBlockingConfirmCreate(TrackedModelDetailView):
         return context
 
 
+class QuotaSuspensionUpdateMixin(TrackedModelDetailMixin):
+    model = QuotaSuspension
+    template_name = "quota-suspensions/edit.jinja"
+    form_class = forms.QuotaSuspensionUpdateForm
+    permission_required = ["common.change_trackedmodel"]
+
+    def get_form_kwargs(self):
+        kwargs = super().get_form_kwargs()
+        kwargs["sid"] = self.kwargs["sid"]
+        return kwargs
+
+    def get_success_url(self):
+        return reverse(
+            "quota_suspension-ui-confirm-update",
+            kwargs={"sid": self.object.sid},
+        )
+
+
+class QuotaSuspensionUpdate(
+    QuotaSuspensionUpdateMixin,
+    CreateTaricUpdateView,
+):
+    pass
+
+
+class QuotaSuspensionEditCreate(
+    QuotaSuspensionUpdateMixin,
+    EditTaricView,
+):
+    pass
+
+
+class QuotaSuspensionEditUpdate(
+    QuotaSuspensionUpdateMixin,
+    EditTaricView,
+):
+    pass
+
+
+class QuotaSuspensionConfirmUpdate(TrackedModelDetailView):
+    model = models.QuotaSuspension
+    template_name = "quota-suspensions/confirm-update.jinja"
+
+
 class SubQuotaDefinitionAssociationMixin:
     template_name = "quota-definitions/sub-quota-definitions-updates.jinja"
     form_class = forms.SubQuotaDefinitionAssociationUpdateForm

--- a/quotas/views.py
+++ b/quotas/views.py
@@ -1213,11 +1213,23 @@ class QuotaSuspensionDelete(TrackedModelDetailMixin, CreateTaricDeleteView):
 
 
 class QuotaSuspensionConfirmDelete(TrackedModelDetailView):
-    model = models.QuotaSuspension
+    model = QuotaSuspension
     template_name = "quota-suspensions/confirm-delete.jinja"
 
+    @property
+    def deleted_suspension(self):
+        return QuotaSuspension.objects.filter(sid=self.kwargs["sid"]).last()
+
     def get_queryset(self):
-        return QuotaSuspension.objects.filter(update_type=UpdateType.DELETE)
+        """
+        Returns a queryset with one single version of the suspension in
+        question.
+
+        Done this way so the sid can be rendered on the confirm delete page and
+        generic tests don't fail which try to load the page without having
+        deleted anything.
+        """
+        return QuotaSuspension.objects.filter(pk=self.deleted_suspension)
 
 
 class SubQuotaDefinitionAssociationMixin:

--- a/quotas/views.py
+++ b/quotas/views.py
@@ -1167,11 +1167,6 @@ class QuotaSuspensionUpdateMixin(TrackedModelDetailMixin):
     form_class = forms.QuotaSuspensionUpdateForm
     permission_required = ["common.change_trackedmodel"]
 
-    def get_form_kwargs(self):
-        kwargs = super().get_form_kwargs()
-        kwargs["sid"] = self.kwargs["sid"]
-        return kwargs
-
     def get_success_url(self):
         return reverse(
             "quota_suspension-ui-confirm-update",
@@ -1210,23 +1205,19 @@ class QuotaSuspensionDelete(TrackedModelDetailMixin, CreateTaricDeleteView):
     model = models.QuotaSuspension
     template_name = "quota-suspensions/delete.jinja"
 
-    def form_valid(self, form):
-        messages.success(
-            self.request,
-            f"Quota suspension period {self.object.sid} has been deleted",
-        )
-        return super().form_valid(form)
-
     def get_success_url(self):
         return reverse(
             "quota_suspension-ui-confirm-delete",
-            kwargs={"sid": self.object.quota_definition.order_number.sid},
+            kwargs={"sid": self.object},
         )
 
 
 class QuotaSuspensionConfirmDelete(TrackedModelDetailView):
-    model = models.QuotaOrderNumber
+    model = models.QuotaSuspension
     template_name = "quota-suspensions/confirm-delete.jinja"
+
+    def get_queryset(self):
+        return QuotaSuspension.objects.filter(update_type=UpdateType.DELETE)
 
 
 class SubQuotaDefinitionAssociationMixin:

--- a/quotas/views.py
+++ b/quotas/views.py
@@ -304,7 +304,11 @@ class QuotaDefinitionList(SortingMixin, ListView):
 
     @property
     def suspension_periods(self):
-        return QuotaSuspension.objects.filter(quota_definition__order_number=self.quota)
+        return (
+            QuotaSuspension.objects.current()
+            .filter(quota_definition__order_number=self.quota)
+            .order_by("quota_definition__sid")
+        )
 
     @property
     def sub_quotas(self):

--- a/quotas/views.py
+++ b/quotas/views.py
@@ -1208,7 +1208,7 @@ class QuotaSuspensionDelete(TrackedModelDetailMixin, CreateTaricDeleteView):
     def get_success_url(self):
         return reverse(
             "quota_suspension-ui-confirm-delete",
-            kwargs={"sid": self.object},
+            kwargs={"sid": self.object.sid},
         )
 
 

--- a/quotas/views.py
+++ b/quotas/views.py
@@ -1201,6 +1201,30 @@ class QuotaSuspensionConfirmUpdate(TrackedModelDetailView):
     template_name = "quota-suspensions/confirm-update.jinja"
 
 
+class QuotaSuspensionDelete(TrackedModelDetailMixin, CreateTaricDeleteView):
+    form_class = forms.QuotaSuspensionDeleteForm
+    model = models.QuotaSuspension
+    template_name = "quota-suspensions/delete.jinja"
+
+    def form_valid(self, form):
+        messages.success(
+            self.request,
+            f"Quota suspension period {self.object.sid} has been deleted",
+        )
+        return super().form_valid(form)
+
+    def get_success_url(self):
+        return reverse(
+            "quota_suspension-ui-confirm-delete",
+            kwargs={"sid": self.object.quota_definition.order_number.sid},
+        )
+
+
+class QuotaSuspensionConfirmDelete(TrackedModelDetailView):
+    model = models.QuotaOrderNumber
+    template_name = "quota-suspensions/confirm-delete.jinja"
+
+
 class SubQuotaDefinitionAssociationMixin:
     template_name = "quota-definitions/sub-quota-definitions-updates.jinja"
     form_class = forms.SubQuotaDefinitionAssociationUpdateForm


### PR DESCRIPTION
# TP2000-1477 Edit capability for suspension periods
<!---
 * Include the JIRA ticket number, eg TP-123, to automatically link.
 * Use 50 characters maximum.
 * Do not end with a full-stop.
--->

## Why
<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Use as many lines as you like.
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions or deliberately ignored edge-cases.
--->

- Users can create a suspension periods for quotas, but they can’t edit existing periods. This allows editing so that it can be done by the user and not data engineers.

## What
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Explain like I'm 5.
 * Use pictures if you can.
--->

This PR:
- implements edit capability for quota suspension periods including the update, edit-update and edit-create journeys
- implements the ability to delete quota suspension periods
- adds form and view tests
- moves _Cancel_ button from generic delete from from template to form so it can be inline with the delete button

<img width="1071" alt="image" src="https://github.com/user-attachments/assets/ea68d858-e352-4a82-8b1c-713a2264cd78">

---

<img width="781" alt="image" src="https://github.com/user-attachments/assets/93c810a6-6c0f-406d-adc2-d598d31fed0a">

---

<img width="627" alt="image" src="https://github.com/user-attachments/assets/6c72991c-4b68-4d1f-b5d5-a9f5eae09659">

---

<img width="747" alt="image" src="https://github.com/user-attachments/assets/eed1d102-dc20-42d0-8ed2-ab3609056d5c">



<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
## Checklist
- Requires migrations?
- Requires dependency updates?
--->

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
