### PR TITLE
Tp2000 1517 implement improved quota views for users

### DIFF
--- a/common/jinja2/layouts/detail.jinja
+++ b/common/jinja2/layouts/detail.jinja
@@ -12,6 +12,13 @@
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
+      {% if title_caption %}
+      {% block page_subtitle%}
+        <span class="govuk-caption-xl">
+          {{ title_caption }}
+        </span>
+      {% endblock %}
+      {% endif %}
       <h1 class="govuk-heading-xl">{{ page_title }}</h1>
     </div>
   </div>

--- a/quotas/jinja2/includes/quotas/actions.jinja
+++ b/quotas/jinja2/includes/quotas/actions.jinja
@@ -2,15 +2,7 @@
   <div class="app-related-items" role="complementary">
       <h2 class="govuk-heading-s" id="subsection-title">Actions</h2>
       <ul class="govuk-list govuk-!-font-size-16">
-            <li><a class="govuk-link" href="{{ url('quota_definition-ui-list', args=[object.sid]) }}">View and edit quota data</a></li>
-            <li><a class="govuk-link" href="{{ url('quota_definition-ui-create', args=[object.sid]) }}">Create definition period</a></li>
-            <br>
-            <li><a class="govuk-link" href="{{ url('sub_quota_definitions-ui-create') }}">Create quota associations</a></li>
-            <br>
-            <li><a class="govuk-link" href="{{ url('quota_suspension_or_blocking-ui-create', args=[object.sid]) }}">Create suspension or blocking period</a></li>
-            <br>
-            <li><a class="govuk-link" href="{{ measures_url }}">View all measures</a></li>
-            <br>
+          <strong class=govuk-heading-xs">Edit and delete quota</strong>
           {% set edit_url = object.get_url('edit') %}
           {% if edit_url %}
             <li><a class="govuk-link" href="{{ edit_url }}">Edit this {{object._meta.verbose_name}}</a></li>
@@ -19,8 +11,17 @@
           {% if delete_url %}
             <li><a class="govuk-link" href="{{ delete_url }}">Delete this {{object._meta.verbose_name}}</a></li>
           {% endif %}
-          <br><br>
-          <li><a class="govuk-link" href="{{ uk_tariff_url }}" target="_blank" noopener noreferrer>View this quota on the UK Integrated Online Tariff </a></li>
+          <br>
+          <strong class=govuk-heading-xs">Create quota data</strong>
+            <li><a class="govuk-link" href="{{ url('quota_definition-ui-create', args=[object.sid]) }}">Create definition period</a></li>
+            <li><a class="govuk-link" href="{{ url('sub_quota_definitions-ui-create') }}">Create quota associations</a></li>
+            <li><a class="govuk-link" href="{{ url('quota_suspension_or_blocking-ui-create', args=[object.sid]) }}">Create suspension or blocking period</a></li>
+          <br>
+          <strong class=govuk-heading-xs">View and edit quota data</strong>
+            <li><a class="govuk-link" href="{{ url('quota_definition-ui-list', args=[object.sid]) }}">View and edit quota data</a></li>
+            <li><a class="govuk-link" href="{{ measures_url }}">View all measures</a></li>
+            <li><a class="govuk-link" href="{{ uk_tariff_url }}" target="_blank" noopener noreferrer>View this quota on the UK Integrated Online Tariff </a></li>
+            
       </ul>
   </div>
 </div>

--- a/quotas/jinja2/includes/quotas/tabs/blocking_periods.jinja
+++ b/quotas/jinja2/includes/quotas/tabs/blocking_periods.jinja
@@ -1,6 +1,6 @@
 <div class="quota__blocking-periods govuk-grid-row">
     <div class="quota__blocking-periods__content govuk-grid-column-three-quarters">
-        <h2 class="govuk-heading-l">Details</h2>
+        <h2 class="govuk-heading-l">Blocking periods</h2>
         {% if blocking_period %}
             {{ govukSummaryList({
                 "rows": [

--- a/quotas/jinja2/includes/quotas/tabs/core_data.jinja
+++ b/quotas/jinja2/includes/quotas/tabs/core_data.jinja
@@ -8,11 +8,11 @@
 
 <div class="quota__core-data govuk-grid-row">
     <div class="quota__core-data__content govuk-grid-column-three-quarters">
-        <h2 class="govuk-heading-l">Details</h2>
+        <h2 class="govuk-heading-l">Order number details</h2>
         {{ govukSummaryList({
             "rows": [
             {
-                "key": {"text": "Order Number"},
+                "key": {"text": "Order number"},
                 "value": {"text": object.order_number},
                 "actions": {"items": []}
             },

--- a/quotas/jinja2/includes/quotas/tabs/definition_details.jinja
+++ b/quotas/jinja2/includes/quotas/tabs/definition_details.jinja
@@ -1,6 +1,6 @@
 <div class="quota__definition-details govuk-grid-row">
     <div class="quota__definition-details__content govuk-grid-column-three-quarters">
-        <h2 class="govuk-heading-l">Details</h2>
+        <h2 class="govuk-heading-l">Definition details</h2>
         {% if current_definition %}
             {{ govukSummaryList({
                 "rows": [

--- a/quotas/jinja2/includes/quotas/tabs/measures.jinja
+++ b/quotas/jinja2/includes/quotas/tabs/measures.jinja
@@ -24,7 +24,7 @@
 
 <div class="quota__measures govuk-grid-row">
     <div class="quota__measures__content govuk-grid-column-three-quarters">
-        <h2 class="govuk-heading-l">Details</h2>
+        <h2 class="govuk-heading-l">Measures</h2>
         {% if measures %}
         <p class="govuk-body">Showing currently active measures.</p>
         {{ govukTable({

--- a/quotas/jinja2/includes/quotas/tabs/sub_quotas.jinja
+++ b/quotas/jinja2/includes/quotas/tabs/sub_quotas.jinja
@@ -43,24 +43,26 @@
 <div class="quota__sub-quotas govuk-grid-row">
     <div class="quota__sub-quotas__content govuk-grid-column-three-quarters">
       <h2 class="govuk-heading-l">Quota associations</h2>
-        {% if sub_quota_associations %}
-        <h3>Sub-quotas</h3>
-        {% elif main_quota_associations %}
-        <h3>Main quota</h3>
-        {% else %}
-          <p class="govuk-body">No active main or sub-quotas.</p>
-        {% endif %}
-        {{
-          govukTable({
-            "head": [
-              {"text": "Order number"},
-              {"text": "Relationship type"},
-              {"text": "Co-efficient"},
-              {"text": "Actions"}
-            ],
-            "rows": table_rows
-          })
-        }}
+      {% if sub_quota_associations or main_quota_associations %}
+          {% if sub_quota_associations %}
+          <h3>Sub-quotas</h3>
+          {% elif main_quota_associations %}
+          <h3>Main quota</h3>
+          {{
+            govukTable({
+              "head": [
+                {"text": "Order number"},
+                {"text": "Relationship type"},
+                {"text": "Co-efficient"},
+                {"text": "Actions"}
+              ],
+              "rows": table_rows
+            })
+          }}
+          {% endif %}
+      {% else %}
+        <p class="govuk-body">No active main or sub-quotas.</p>
+      {% endif %}
         
     </div>
     {% include "includes/quotas/actions.jinja"%}

--- a/quotas/jinja2/includes/quotas/tabs/sub_quotas.jinja
+++ b/quotas/jinja2/includes/quotas/tabs/sub_quotas.jinja
@@ -44,10 +44,11 @@
     <div class="quota__sub-quotas__content govuk-grid-column-three-quarters">
       <h2 class="govuk-heading-l">Quota associations</h2>
       {% if sub_quota_associations or main_quota_associations %}
-          {% if sub_quota_associations %}
-          <h3>Sub-quotas</h3>
-          {% elif main_quota_associations %}
-          <h3>Main quota</h3>
+          {% if main_quota_associations %}
+            <h3>Main quota</h3>
+          {% elif sub_quota_associations %}
+            <h3>Sub-quotas</h3>
+          {% endif %}
           {{
             govukTable({
               "head": [
@@ -59,10 +60,9 @@
               "rows": table_rows
             })
           }}
-          {% endif %}
-      {% else %}
-        <p class="govuk-body">No active main or sub-quotas.</p>
-      {% endif %}
+    {% else %}
+      <p class="govuk-body">No active main or sub-quotas.</p>
+    {% endif %}
         
     </div>
     {% include "includes/quotas/actions.jinja"%}

--- a/quotas/jinja2/includes/quotas/tabs/sub_quotas.jinja
+++ b/quotas/jinja2/includes/quotas/tabs/sub_quotas.jinja
@@ -13,7 +13,7 @@
   {% endset %}
   {{ table_rows.append([
     {"html": sub_quota_link},
-    {"html": object.sub_quota_relation_type},
+    {"html": object.get_sub_quota_relation_type_display()},
     {"text": object.coefficient},
     {"text": actions_html }
   ]) or "" }}
@@ -34,7 +34,7 @@
 
   {{ table_rows.append([
     {"html": main_quota_link},
-    {"html": object.sub_quota_relation_type},
+    {"html": object.get_sub_quota_relation_type_display()},
     {"text": object.coefficient},
     {"text": actions_html }
   ]) or "" }}
@@ -45,31 +45,23 @@
       <h2 class="govuk-heading-l">Quota associations</h2>
         {% if sub_quota_associations %}
         <h3>Sub-quotas</h3>
-        {{ govukTable({
-            "head": [
-                {"text": "Sub-quota order number"},
-                {"text": "Relation type"},
-                {"text": "Co-efficient"},
-                {"text": "Actions"}
-            ],
-            "rows": table_rows
-            }) }}
         {% elif main_quota_associations %}
         <h3>Main quota</h3>
+        {% else %}
+          <p class="govuk-body">No active main or sub-quotas.</p>
+        {% endif %}
         {{
           govukTable({
             "head": [
-              {"text": "Main quota order number"},
-              {"text": "Relation type"},
+              {"text": "Order number"},
+              {"text": "Relationship type"},
               {"text": "Co-efficient"},
               {"text": "Actions"}
             ],
             "rows": table_rows
           })
         }}
-        {% else %}
-          <p class="govuk-body">No active main or sub-quotas.</p>
-        {% endif %}
+        
     </div>
     {% include "includes/quotas/actions.jinja"%}
 </div>

--- a/quotas/jinja2/includes/quotas/tabs/sub_quotas.jinja
+++ b/quotas/jinja2/includes/quotas/tabs/sub_quotas.jinja
@@ -1,5 +1,5 @@
 {% set table_rows = [] %}
-{% for quota_association in quota_associations %}
+{% for quota_association in sub_quota_associations %}
   {% set sub_quota_link %}
     <a class="govuk-link govuk-!-font-weight-bold"
       href="{{ url('quota-ui-detail', args=[quota_association.sub_quota.order_number.sid]) }}">
@@ -13,10 +13,25 @@
   ]) or "" }}
 {% endfor %}
 
+{% for quota_association in main_quota_associations %}
+  {% set main_quota_link %}
+    <a class="govuk-link govuk-!-font-weight-bold"
+      href="{{ url('quota-ui-detail', args=[quota_association.main_quota.order_number.sid]) }}">
+      {{ quota_association.main_quota.order_number }}
+    </a>
+  {% endset %}
+  {{ table_rows.append([
+    {"html": main_quota_link},
+    {"html": quota_association.sub_quota_relation_type},
+    {"text": quota_association.coefficient},
+  ]) or "" }}
+{% endfor %}
+
 <div class="quota__sub-quotas govuk-grid-row">
     <div class="quota__sub-quotas__content govuk-grid-column-three-quarters">
-        <h2 class="govuk-heading-l">Details</h2>
-        {% if quota_associations %}
+      <h2 class="govuk-heading-l">Quota associations</h2>
+        {% if sub_quota_associations %}
+        <h3>Sub-quotas</h3>
         {{ govukTable({
             "head": [
                 {"text": "Sub-quota order number"},
@@ -25,8 +40,20 @@
             ],
             "rows": table_rows
             }) }}
+        {% elif main_quota_associations %}
+        <h3>Main quota</h3>
+        {{
+          govukTable({
+            "head": [
+              {"text": "Main quota order number"},
+              {"text": "Relation type"},
+              {"text": "Co-efficient"},
+            ],
+            "rows": table_rows
+          })
+        }}
         {% else %}
-          <p class="govuk-body">No active sub-quotas.</p>
+          <p class="govuk-body">No active main or sub-quotas.</p>
         {% endif %}
     </div>
     {% include "includes/quotas/actions.jinja"%}

--- a/quotas/jinja2/includes/quotas/tabs/sub_quotas.jinja
+++ b/quotas/jinja2/includes/quotas/tabs/sub_quotas.jinja
@@ -6,10 +6,16 @@
       {{ quota_association.sub_quota.order_number }}
     </a>
   {% endset %}
+  {% set actions_html %}
+      <a class="govuk-link" href="{{ quota_association.sub_quota.version_at(request.user.current_workbasket.transactions.last()).get_association_edit_url() }}">Edit</a>
+      <br/>
+      <a class="govuk-link" href="{{ url('quota_association-ui-delete', args=[quota_association.pk]) }}">Delete</a>
+  {% endset %}
   {{ table_rows.append([
     {"html": sub_quota_link},
     {"html": quota_association.sub_quota_relation_type},
     {"text": quota_association.coefficient},
+    {"text": actions_html }
   ]) or "" }}
 {% endfor %}
 
@@ -20,10 +26,17 @@
       {{ quota_association.main_quota.order_number }}
     </a>
   {% endset %}
+  {% set actions_html %}
+      <a class="govuk-link" href="{{ quota_association.sub_quota.version_at(request.user.current_workbasket.transactions.last()).get_association_edit_url() }}">Edit</a>
+      <br/>
+      <a class="govuk-link" href="{{ url('quota_association-ui-delete', args=[quota_association.pk]) }}">Delete</a>
+  {% endset %}
+
   {{ table_rows.append([
     {"html": main_quota_link},
     {"html": quota_association.sub_quota_relation_type},
     {"text": quota_association.coefficient},
+    {"text": actions_html }
   ]) or "" }}
 {% endfor %}
 
@@ -37,6 +50,7 @@
                 {"text": "Sub-quota order number"},
                 {"text": "Relation type"},
                 {"text": "Co-efficient"},
+                {"text": "Actions"}
             ],
             "rows": table_rows
             }) }}
@@ -48,6 +62,7 @@
               {"text": "Main quota order number"},
               {"text": "Relation type"},
               {"text": "Co-efficient"},
+              {"text": "Actions"}
             ],
             "rows": table_rows
           })

--- a/quotas/jinja2/includes/quotas/tabs/sub_quotas.jinja
+++ b/quotas/jinja2/includes/quotas/tabs/sub_quotas.jinja
@@ -1,41 +1,41 @@
 {% set table_rows = [] %}
-{% for quota_association in sub_quota_associations %}
+{% for object in sub_quota_associations %}
   {% set sub_quota_link %}
     <a class="govuk-link govuk-!-font-weight-bold"
-      href="{{ url('quota-ui-detail', args=[quota_association.sub_quota.order_number.sid]) }}">
-      {{ quota_association.sub_quota.order_number }}
+      href="{{ url('quota-ui-detail', args=[object.sub_quota.order_number.sid]) }}">
+      {{ object.sub_quota.order_number }}
     </a>
   {% endset %}
   {% set actions_html %}
-      <a class="govuk-link" href="{{ quota_association.sub_quota.version_at(request.user.current_workbasket.transactions.last()).get_association_edit_url() }}">Edit</a>
+      <a class="govuk-link" href="{{ object.sub_quota.version_at(request.user.current_workbasket.transactions.last()).get_association_edit_url() }}">Edit</a>
       <br/>
-      <a class="govuk-link" href="{{ url('quota_association-ui-delete', args=[quota_association.pk]) }}">Delete</a>
+      <a class="govuk-link" href="{{ url('quota_association-ui-delete', args=[object.pk]) }}">Delete</a>
   {% endset %}
   {{ table_rows.append([
     {"html": sub_quota_link},
-    {"html": quota_association.sub_quota_relation_type},
-    {"text": quota_association.coefficient},
+    {"html": object.sub_quota_relation_type},
+    {"text": object.coefficient},
     {"text": actions_html }
   ]) or "" }}
 {% endfor %}
 
-{% for quota_association in main_quota_associations %}
+{% for object in main_quota_associations %}
   {% set main_quota_link %}
     <a class="govuk-link govuk-!-font-weight-bold"
-      href="{{ url('quota-ui-detail', args=[quota_association.main_quota.order_number.sid]) }}">
-      {{ quota_association.main_quota.order_number }}
+      href="{{ url('quota-ui-detail', args=[object.main_quota.order_number.sid]) }}">
+      {{ object.main_quota.order_number }}
     </a>
   {% endset %}
   {% set actions_html %}
-      <a class="govuk-link" href="{{ quota_association.sub_quota.version_at(request.user.current_workbasket.transactions.last()).get_association_edit_url() }}">Edit</a>
+      <a class="govuk-link" href="{{ object.sub_quota.version_at(request.user.current_workbasket.transactions.last()).get_association_edit_url() }}">Edit</a>
       <br/>
-      <a class="govuk-link" href="{{ url('quota_association-ui-delete', args=[quota_association.pk]) }}">Delete</a>
+      <a class="govuk-link" href="{{ url('quota_association-ui-delete', args=[object.pk]) }}">Delete</a>
   {% endset %}
 
   {{ table_rows.append([
     {"html": main_quota_link},
-    {"html": quota_association.sub_quota_relation_type},
-    {"text": quota_association.coefficient},
+    {"html": object.sub_quota_relation_type},
+    {"text": object.coefficient},
     {"text": actions_html }
   ]) or "" }}
 {% endfor %}

--- a/quotas/jinja2/includes/quotas/tabs/suspension_periods.jinja
+++ b/quotas/jinja2/includes/quotas/tabs/suspension_periods.jinja
@@ -1,6 +1,6 @@
 <div class="quota__suspension-periods govuk-grid-row">
     <div class="quota__suspension-periods__content govuk-grid-column-three-quarters">
-        <h2 class="govuk-heading-l">Details</h2>
+        <h2 class="govuk-heading-l">Suspension periods</h2>
         {% if suspension_period %}
             {{ govukSummaryList({
                 "rows": [

--- a/quotas/jinja2/quota-definitions/sub-quota-definitions-updates.jinja
+++ b/quotas/jinja2/quota-definitions/sub-quota-definitions-updates.jinja
@@ -3,9 +3,10 @@
 
 {% from "components/table/macro.njk" import govukTable %}
 
-{% set page_title = "Update sub-quota definition and association" %}
+{% set page_title = "Edit sub-quota definition and association" %}
 
 {% block content %}
+    <h1 class="govuk-heading-xl">{{ page_title }}</h1>
     <h2 class="govuk-heading">Main quota definition details</h2>
     {% set main_definition = view.get_main_definition() %}
     {% set table_rows = [] %}

--- a/quotas/jinja2/quotas/definitions.jinja
+++ b/quotas/jinja2/quotas/definitions.jinja
@@ -49,12 +49,13 @@
 {% endblock %}
 
 {% block content %}
-
-<span class="govuk-caption-xl">
-  {% block page_subtitle %}
-    {{ page_subtitle }}
-  {% endblock %}
-</span>
+{% if page_subtitle %}
+  <span class="govuk-caption-xl">
+    {% block page_subtitle %}
+      {{ page_subtitle }}
+    {% endblock %}
+  </span>
+{% endif %}
 <h1 class="govuk-heading-xl">{{ page_title }}</h1>
 
 

--- a/quotas/jinja2/quotas/definitions.jinja
+++ b/quotas/jinja2/quotas/definitions.jinja
@@ -17,9 +17,9 @@
       "selected": quota_type == None
     },
     {
-      "text": "Sub-quotas",
-      "href": url('quota_definition-ui-list-filter', kwargs={"sid": quota.sid, "quota_type": "sub_quotas"}),
-      "selected": quota_type == "sub_quotas",
+      "text": "Quota associations",
+      "href": url('quota_definition-ui-list-filter', kwargs={"sid": quota.sid, "quota_type": "quota_associations"}),
+      "selected": quota_type == "quota_associations",
     },
     {
       "text": "Blocking periods",
@@ -54,7 +54,7 @@
     {% include "quotas/tables/blocking_periods.jinja" %}
   {% elif quota_type == "suspension_periods" %}
     {% include "quotas/tables/suspension_periods.jinja" %}
-  {% elif quota_type == "sub_quotas" %}
+  {% elif quota_type == "quota_associations" %}
     {% include "quotas/tables/sub_quotas.jinja" %}
   {% else %}
     {% include "quotas/tables/definitions.jinja" %}

--- a/quotas/jinja2/quotas/definitions.jinja
+++ b/quotas/jinja2/quotas/definitions.jinja
@@ -10,6 +10,12 @@
 {% set page_title = "Quota ID: " ~ quota.order_number ~ " - Data" %}
 {% set find_edit_url = url("quota-ui-list") %}
 
+{% if sub_quotas %}
+  {% set page_subtitle = "Main quota" %}
+{% elif main_quotas %}
+  {% set page_subtitle = "Sub-quota" %}
+{% endif %}
+
 {% set links = [
     {
       "text": "Quota definition periods",
@@ -44,7 +50,13 @@
 
 {% block content %}
 
+<span class="govuk-caption-xl">
+  {% block page_subtitle %}
+    {{ page_subtitle }}
+  {% endblock %}
+</span>
 <h1 class="govuk-heading-xl">{{ page_title }}</h1>
+
 
 {{ fake_tabs(links) }}
 <div class="quota-definitions">

--- a/quotas/jinja2/quotas/detail.jinja
+++ b/quotas/jinja2/quotas/detail.jinja
@@ -2,7 +2,7 @@
 {% from "components/summary-list/macro.njk" import govukSummaryList %}
 {% from "components/table/macro.njk" import govukTable %}
 
-{% set page_title = "Quota ID: " ~ object.order_number %}
+{% set page_title = "Quota order number: " ~ object.order_number %}
 {% set find_edit_url = url("quota-ui-list") %}
 
 {% if sub_quota_associations %}

--- a/quotas/jinja2/quotas/detail.jinja
+++ b/quotas/jinja2/quotas/detail.jinja
@@ -30,8 +30,8 @@
         }
       },
       {
-        "label": "Sub-quotas",
-        "id": "sub-quotas",
+        "label": "Quota associations",
+        "id": "quotas-associations",
         "panel": {
           "html": sub_quotas_html
         }

--- a/quotas/jinja2/quotas/detail.jinja
+++ b/quotas/jinja2/quotas/detail.jinja
@@ -5,6 +5,12 @@
 {% set page_title = "Quota ID: " ~ object.order_number %}
 {% set find_edit_url = url("quota-ui-list") %}
 
+{% if sub_quota_associations %}
+  {% set title_caption = "Main quota" %}
+{% elif main_quota_associations %}
+  {% set title_caption = "Sub-quota" %}
+{% endif %}
+
 {% set core_data_tab_html %}{% include "includes/quotas/tabs/core_data.jinja" %}{% endset %}
 {% set definition_details_html %}{% include "includes/quotas/tabs/definition_details.jinja" %}{% endset %}
 {% set sub_quotas_html %}{% include "includes/quotas/tabs/sub_quotas.jinja" %}{% endset %}

--- a/quotas/jinja2/quotas/tables/definitions.jinja
+++ b/quotas/jinja2/quotas/tables/definitions.jinja
@@ -65,7 +65,7 @@
 {% endfor %}
 
 {% set sid %}
-  {{ create_sortable_anchor(request, "sid", "Quota definition sid", base_url) }}
+  {{ create_sortable_anchor(request, "sid", "Quota definition SID", base_url) }}
 {% endset %}
 
 {% set start_date %}

--- a/quotas/jinja2/quotas/tables/sub_quotas.jinja
+++ b/quotas/jinja2/quotas/tables/sub_quotas.jinja
@@ -1,8 +1,8 @@
 
-<h2 class="govuk-heading-l">Sub-quotas</h2>
-
+<h2 class="govuk-heading-l">Quota associations</h2>
 {% set table_rows = [] %}
 {% if sub_quotas %}
+<h3 class="govuk-heading-m">Sub-quotas</h3>
   {% for object in sub_quotas %}
     {% set definition_link -%}
       <a class="govuk-link" href="{{ url('quota-ui-detail', args=[object.sub_quota.order_number.sid]) }}#definition-details">{{ object.sub_quota.sid }}</a>
@@ -11,9 +11,9 @@
       <a class="govuk-link" href="{{ url('quota-ui-detail', args=[object.sub_quota.order_number.sid]) }}">{{ object.sub_quota.order_number.order_number }}</a>
     {% endset %}
     {% set actions_html %}
-      <a class="govuk-link" href="{{ object.sub_quota.version_at(request.user.current_workbasket.transactions.last()).get_association_edit_url() }}">Edit association</a>
+      <a class="govuk-link" href="{{ object.sub_quota.version_at(request.user.current_workbasket.transactions.last()).get_association_edit_url() }}">Edit</a>
       <br/>
-      <a class="govuk-link" href="{{ url('quota_association-ui-delete', args=[object.pk]) }}">Delete association</a>
+      <a class="govuk-link" href="{{ url('quota_association-ui-delete', args=[object.pk]) }}">Delete</a>
     {% endset %}
 
     {{ table_rows.append([
@@ -30,7 +30,46 @@
   {{ govukTable({
     "head": [
       {"text": "Quota definition SID"},
-      {"text": "Sub-quota order number"},
+      {"text": "Order number"},
+      {"text": "Start date"},
+      {"text": "End date"},
+      {"text": "Relationship type"},
+      {"text": "Coefficient"},
+      {"text": "Actions"},
+    ],
+    "rows": table_rows
+  }) }}
+{% elif main_quotas %}
+<h3 class="govuk-heading-m">Main quotas</h3>
+  {% for object in main_quotas %}
+    {% set definition_link -%}
+      <a class="govuk-link" href="{{ url('quota-ui-detail', args=[object.main_quota.order_number.sid]) }}#definition-details">{{ object.main_quota.sid }}</a>
+    {% endset %}
+    {% set main_quota_link -%}
+      <a class="govuk-link" href="{{ url('quota-ui-detail', args=[object.main_quota.order_number.sid]) }}">{{ object.main_quota.order_number.order_number }}</a>
+    {% endset %}
+    {% set actions_html %}
+      <a class="govuk-link" href="{{ object.main_quota.get_association_edit_url() }}">Edit</a>
+      <br/>
+      <a class="govuk-link" href="{{ url('quota_association-ui-delete', args=[object.pk]) }}">Delete</a>
+    {% endset %}
+    {{ definition_link }}
+    {{ main_quota_link }}
+    {{ object }}
+    {# {{ table_rows.append([
+      {"text": definition_link },
+      {"text": main_quota_link },
+      {"text": "{:%d %b %Y}".format(object.main_quota.version_at(request.user.current_workbasket.transactions.last()).valid_between.lower) },
+      {"text": "{:%d %b %Y}".format(object.main_quota.version_at(request.user.current_workbasket.transactions.last()).valid_between.upper) if object.main_quota.valid_between.upper else "-"},
+      {"text": object.get_sub_quota_relation_type_display() },
+      {"text": object.coefficient },
+      {"text": actions_html },
+    ]) or "" }} #}
+  {% endfor %}
+  {{ govukTable({
+    "head": [
+      {"text": "Quota definition SID"},
+      {"text": "Order number"},
       {"text": "Start date"},
       {"text": "End date"},
       {"text": "Relationship type"},
@@ -40,5 +79,5 @@
     "rows": table_rows
   }) }}
 {% else %}
-  <p class="govuk-body">There are no sub-quotas for this quota order number.</p>
+  <p class="govuk-body">There are no main or sub-quotas for this quota order number.</p>
 {% endif %}

--- a/quotas/jinja2/quotas/tables/sub_quotas.jinja
+++ b/quotas/jinja2/quotas/tables/sub_quotas.jinja
@@ -49,7 +49,7 @@
       <a class="govuk-link" href="{{ url('quota-ui-detail', args=[object.main_quota.order_number.sid]) }}">{{ object.main_quota.order_number.order_number }}</a>
     {% endset %}
     {% set actions_html %}
-      <a class="govuk-link" href="{{ object.main_quota.get_association_edit_url() }}">Edit</a>
+      <a class="govuk-link" href="{{ object.sub_quota.version_at(request.user.current_workbasket.transactions.last()).get_association_edit_url() }}">Edit</a>
       <br/>
       <a class="govuk-link" href="{{ url('quota_association-ui-delete', args=[object.pk]) }}">Delete</a>
     {% endset %}

--- a/quotas/jinja2/quotas/tables/sub_quotas.jinja
+++ b/quotas/jinja2/quotas/tables/sub_quotas.jinja
@@ -53,10 +53,7 @@
       <br/>
       <a class="govuk-link" href="{{ url('quota_association-ui-delete', args=[object.pk]) }}">Delete</a>
     {% endset %}
-    {{ definition_link }}
-    {{ main_quota_link }}
-    {{ object }}
-    {# {{ table_rows.append([
+    {{ table_rows.append([
       {"text": definition_link },
       {"text": main_quota_link },
       {"text": "{:%d %b %Y}".format(object.main_quota.version_at(request.user.current_workbasket.transactions.last()).valid_between.lower) },
@@ -64,7 +61,7 @@
       {"text": object.get_sub_quota_relation_type_display() },
       {"text": object.coefficient },
       {"text": actions_html },
-    ]) or "" }} #}
+    ]) or "" }}
   {% endfor %}
   {{ govukTable({
     "head": [

--- a/quotas/tests/test_views.py
+++ b/quotas/tests/test_views.py
@@ -2010,7 +2010,7 @@ def test_quota_definition_view(client_with_current_workbasket):
     response = client_with_current_workbasket.get(
         reverse(
             "quota_definition-ui-list-filter",
-            kwargs={"sid": main_quota.sid, "quota_type": "sub_quotas"},
+            kwargs={"sid": main_quota.sid, "quota_type": "quota_associations"},
         ),
     )
     assert response.status_code == 200

--- a/quotas/tests/test_views.py
+++ b/quotas/tests/test_views.py
@@ -680,6 +680,7 @@ def test_quota_detail_sub_quota_tab(
     valid_user_client,
     date_ranges,
     mock_quota_api_no_data,
+    session_request_with_workbasket,
 ):
     quota_order_number = factories.QuotaOrderNumberFactory()
     current_definition = factories.QuotaDefinitionFactory.create(

--- a/quotas/views.py
+++ b/quotas/views.py
@@ -241,9 +241,13 @@ class QuotaDetail(QuotaOrderNumberMixin, TrackedModelDetailView, SortingMixin):
         )
 
         context[
-            "quota_associations"
+            "sub_quota_associations"
         ] = QuotaAssociation.objects.latest_approved().filter(
             main_quota=current_definition,
+        )
+
+        context["main_quota_associations"] = QuotaAssociation.objects.current().filter(
+            sub_quota=current_definition,
         )
 
         context["blocking_period"] = (
@@ -314,6 +318,18 @@ class QuotaDefinitionList(SortingMixin, ListView):
             .order_by("sub_quota__sid")
         )
 
+    @property
+    def main_quotas(self):
+        main_quotas = QuotaAssociation.objects.all().filter(
+            sub_quota__order_number=self.quota,
+        )
+        # return main_quota
+        return main_quotas
+        # return (
+        #     QuotaAssociation.objects.current()
+        #     .get(sub_quota__order_number=self.quota)
+        # )
+
     @cached_property
     def quota_data(self):
         if not self.kwargs.get("quota_type"):
@@ -332,6 +348,7 @@ class QuotaDefinitionList(SortingMixin, ListView):
             blocking_periods=self.blocking_periods,
             suspension_periods=self.suspension_periods,
             sub_quotas=self.sub_quotas,
+            main_quotas=self.main_quotas,
             *args,
             **kwargs,
         )

--- a/quotas/views.py
+++ b/quotas/views.py
@@ -240,11 +240,11 @@ class QuotaDetail(QuotaOrderNumberMixin, TrackedModelDetailView, SortingMixin):
             f"{URLs.BASE_URL.value}quota_search?order_number={self.object.order_number}"
         )
 
-        context["sub_quota_associations"] = QuotaAssociation.objects.all().filter(
+        context["sub_quota_associations"] = QuotaAssociation.objects.current().filter(
             main_quota=current_definition,
         )
 
-        context["main_quota_associations"] = QuotaAssociation.objects.all().filter(
+        context["main_quota_associations"] = QuotaAssociation.objects.current().filter(
             sub_quota=current_definition,
         )
 
@@ -318,7 +318,7 @@ class QuotaDefinitionList(SortingMixin, ListView):
 
     @property
     def main_quotas(self):
-        main_quotas = QuotaAssociation.objects.all().filter(
+        main_quotas = QuotaAssociation.objects.current().filter(
             sub_quota__order_number=self.quota,
         )
         return main_quotas

--- a/quotas/views.py
+++ b/quotas/views.py
@@ -240,13 +240,11 @@ class QuotaDetail(QuotaOrderNumberMixin, TrackedModelDetailView, SortingMixin):
             f"{URLs.BASE_URL.value}quota_search?order_number={self.object.order_number}"
         )
 
-        context[
-            "sub_quota_associations"
-        ] = QuotaAssociation.objects.latest_approved().filter(
+        context["sub_quota_associations"] = QuotaAssociation.objects.all().filter(
             main_quota=current_definition,
         )
 
-        context["main_quota_associations"] = QuotaAssociation.objects.current().filter(
+        context["main_quota_associations"] = QuotaAssociation.objects.all().filter(
             sub_quota=current_definition,
         )
 
@@ -323,12 +321,7 @@ class QuotaDefinitionList(SortingMixin, ListView):
         main_quotas = QuotaAssociation.objects.all().filter(
             sub_quota__order_number=self.quota,
         )
-        # return main_quota
         return main_quotas
-        # return (
-        #     QuotaAssociation.objects.current()
-        #     .get(sub_quota__order_number=self.quota)
-        # )
 
     @cached_property
     def quota_data(self):


### PR DESCRIPTION
# TP2000-1517

## Why
Implement updates to the QuotaDetail and QuotaDefinitionList 

## What
- Adding a title caption based on the quotas' status as a main or sub-quota
- Displaying main and sub-quotas on relevant tabs
- Add an action column with Edit/Delete columns on the Quota data view
- Change tab title from `Sub-quotas` to `Quota associations`
- Further changes as requested by UR team as detailed on ticket 1517, including changes to Actions column as requested by @SteveCN7 


<img width="1205" alt="image" src="https://github.com/user-attachments/assets/d272afb9-abcb-4327-ab7b-3412653da44c">
<img width="1214" alt="image" src="https://github.com/user-attachments/assets/97356e5b-8f66-4557-b57d-2708c5530afc">
<img width="1195" alt="image" src="https://github.com/user-attachments/assets/aa895c7e-6376-4e84-906e-ea5ebcd52ad7">
<img width="1200" alt="image" src="https://github.com/user-attachments/assets/31ebf33f-06f7-40e8-89d3-9f62874413f6">
<img width="1202" alt="image" src="https://github.com/user-attachments/assets/89873195-04aa-4dbf-8110-85d4a06dd9d2">


