### PR TITLE
formatting

### DIFF
--- a/quotas/forms/__init__.py
+++ b/quotas/forms/__init__.py
@@ -1,0 +1,2 @@
+from .base import *
+from .wizards import *

--- a/quotas/forms/wizards.py
+++ b/quotas/forms/wizards.py
@@ -1,0 +1,309 @@
+from crispy_forms_gds.helper import FormHelper
+
+# from crispy_forms_gds.layout import Button
+from crispy_forms_gds.layout import HTML
+from crispy_forms_gds.layout import Div
+from crispy_forms_gds.layout import Field
+from crispy_forms_gds.layout import Layout
+from crispy_forms_gds.layout import Size
+from crispy_forms_gds.layout import Submit
+from django import forms
+from django.core.exceptions import ValidationError
+
+from common.fields import AutoCompleteField
+from common.forms import ValidityPeriodForm
+from measures.models import MeasurementUnit
+from quotas import models
+from quotas import validators
+from quotas.serializers import serialize_duplicate_data
+from workbaskets.forms import SelectableObjectsForm
+
+
+class DuplicateQuotaDefinitionPeriodStartForm(forms.Form):
+    pass
+
+
+class QuotaOrderNumbersSelectForm(forms.Form):
+    main_quota_order_number = AutoCompleteField(
+        label="Main quota order number",
+        queryset=models.QuotaOrderNumber.objects.all(),
+        required=True,
+    )
+    sub_quota_order_number = AutoCompleteField(
+        label="Sub-quota order number",
+        queryset=models.QuotaOrderNumber.objects.all(),
+        required=True,
+    )
+
+    def __init__(self, *args, **kwargs):
+        self.request = kwargs.pop("request", None)
+        super().__init__(*args, **kwargs)
+        self.init_layout(self.request)
+
+    def init_layout(self, request):
+        self.helper = FormHelper(self)
+        self.helper.label_size = Size.SMALL
+        self.helper.legend_size = Size.SMALL
+
+        self.helper.layout = Layout(
+            Div(
+                HTML(
+                    '<h2 class="govuk-heading">Enter main and sub-quota order numbers</h2>',
+                ),
+            ),
+            Div(
+                "main_quota_order_number",
+                Div(
+                    "sub_quota_order_number",
+                    css_class="govuk-inset-text",
+                ),
+            ),
+            Submit(
+                "submit",
+                "Continue",
+                data_module="govuk-button",
+                data_prevent_double_click="true",
+            ),
+        )
+
+
+class SelectSubQuotaDefinitionsForm(
+    SelectableObjectsForm,
+):
+    """Form to select the main quota definitions that are to be duplicated."""
+
+    def __init__(self, *args, **kwargs):
+        self.request = kwargs.pop("request", None)
+        super().__init__(*args, **kwargs)
+
+    def set_staged_definition_data(self, selected_definitions):
+        if (
+            self.prefix in ["select_definition_periods"]
+            and self.request.path != "/quotas/duplicate_quota_definitions/complete"
+        ):
+            staged_definition_data = []
+            for definition in selected_definitions:
+                staged_definition_data.append(
+                    {
+                        "main_definition": definition.pk,
+                        "sub_definition_staged_data": serialize_duplicate_data(
+                            definition,
+                        ),
+                    },
+                )
+            self.request.session["staged_definition_data"] = staged_definition_data
+
+    def clean(self):
+        cleaned_data = super().clean()
+        selected_definitions = {
+            key: value for key, value in cleaned_data.items() if value
+        }
+        definitions_pks = [
+            self.object_id_from_field_name(key) for key in selected_definitions
+        ]
+        if len(selected_definitions) < 1:
+            raise ValidationError("At least one quota definition must be selected")
+        selected_definitions = models.QuotaDefinition.objects.filter(
+            pk__in=definitions_pks,
+        ).current()
+        cleaned_data["selected_definitions"] = selected_definitions
+        self.set_staged_definition_data(selected_definitions)
+        return cleaned_data
+
+
+class SelectedDefinitionsForm(forms.Form):
+    def __init__(self, *args, **kwargs):
+        self.request = kwargs.pop("request")
+        super().__init__(*args, **kwargs)
+
+    def clean(self):
+        cleaned_data = super().clean()
+        cleaned_data["staged_definitions"] = self.request.session[
+            "staged_definition_data"
+        ]
+        for definition in cleaned_data["staged_definitions"]:
+            if not definition["sub_definition_staged_data"]["status"]:
+                raise forms.ValidationError(
+                    "Each definition period must have a specified relationship and co-efficient value",
+                )
+        return cleaned_data
+
+
+class BulkQuotaDefinitionCreateStartForm(forms.Form):
+    pass
+
+
+class BulkQuotaDefinitionCreateIntroductoryPeriod(forms.Form):
+    pass
+
+
+class QuotaDefinitionCreateForm(
+    ValidityPeriodForm,
+    forms.ModelForm,
+):
+    class Meta:
+        model = models.QuotaDefinition
+        fields = [
+            "valid_between",
+            "description",
+            "volume",
+            "initial_volume",
+            "measurement_unit",
+            "measurement_unit_qualifier",
+            "quota_critical_threshold",
+            "quota_critical",
+            "maximum_precision",
+        ]
+
+    description = forms.CharField(label="", widget=forms.Textarea(), required=False)
+    volume = forms.DecimalField(
+        label="Current volume",
+        widget=forms.TextInput(),
+        error_messages={
+            "invalid": "Volume must be a number",
+            "required": "Enter the volume",
+        },
+    )
+    initial_volume = forms.DecimalField(
+        widget=forms.TextInput(),
+        error_messages={
+            "invalid": "Initial volume must be a number",
+            "required": "Enter the initial volume",
+        },
+    )
+    measurement_unit = forms.ModelChoiceField(
+        queryset=MeasurementUnit.objects.current(),
+        error_messages={"required": "Select the measurement unit"},
+    )
+
+    quota_critical_threshold = forms.DecimalField(
+        label="Threshold",
+        help_text="The point at which this quota definition period becomes critical, as a percentage of the total volume.",
+        widget=forms.TextInput(),
+        error_messages={
+            "invalid": "Critical threshold must be a number",
+            "required": "Enter the critical threshold",
+        },
+    )
+    quota_critical = forms.TypedChoiceField(
+        label="Is the quota definition period in a critical state?",
+        help_text="This determines if a trader needs to pay securities when utilising the quota.",
+        coerce=lambda value: value == "True",
+        choices=((True, "Yes"), (False, "No")),
+        widget=forms.RadioSelect(),
+        error_messages={"required": "Critical state must be set"},
+    )
+    maximum_precision = forms.IntegerField(
+        widget=forms.HiddenInput(),
+    )
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.init_layout()
+        self.init_fields()
+
+    def clean(self):
+        validators.validate_quota_volume(self.cleaned_data)
+        return super().clean()
+
+    def init_fields(self):
+        # This is always set to 3 for current definitions
+        # see https://uktrade.github.io/tariff-data-manual/documentation/data-structures/quotas.html#the-quota-definition-table
+        self.fields["maximum_precision"].initial = 3
+
+        # Set these as the default values
+        self.fields["quota_critical"].initial = False
+        self.fields["quota_critical_threshold"].initial = 90
+
+        self.fields["measurement_unit"].queryset = self.fields[
+            "measurement_unit"
+        ].queryset.order_by("code")
+        self.fields["measurement_unit"].label_from_instance = (
+            lambda obj: f"{obj.code} - {obj.description}"
+        )
+
+        self.fields["measurement_unit_qualifier"].queryset = self.fields[
+            "measurement_unit_qualifier"
+        ].queryset.order_by("code")
+        self.fields["measurement_unit_qualifier"].label_from_instance = (
+            lambda obj: f"{obj.code} - {obj.description}"
+        )
+
+    def init_layout(self):
+        self.helper = FormHelper(self)
+        self.helper.label_size = Size.SMALL
+        self.helper.legend_size = Size.SMALL
+
+        self.helper.layout = Layout(
+            Div(
+                HTML(
+                    '<h3 class="govuk-heading">Definitions count</h3>',
+                ),
+            ),
+            HTML(
+                '<hr class="govuk-section-break govuk-section-break--s govuk-section-break--visible">',
+            ),
+            Div(
+                HTML(
+                    '<h3 class="govuk-heading">Description</h3>',
+                ),
+                HTML.p("Adding a description is optional."),
+                "description",
+                "order_number",
+            ),
+            HTML(
+                '<hr class="govuk-section-break govuk-section-break--s govuk-section-break--visible">',
+            ),
+            Div(
+                HTML(
+                    '<h3 class="govuk-heading">Validity period</h3>',
+                ),
+                "start_date",
+                "end_date",
+            ),
+            HTML(
+                '<hr class="govuk-section-break govuk-section-break--s govuk-section-break--visible">',
+            ),
+            Div(
+                HTML(
+                    '<h3 class="govuk-heading">Measurements</h3>',
+                ),
+                HTML.p("A measurement unit qualifier is not always required."),
+                Field("measurement_unit", css_class="govuk-!-width-full"),
+                Field("measurement_unit_qualifier", css_class="govuk-!-width-full"),
+            ),
+            HTML(
+                '<hr class="govuk-section-break govuk-section-break--s govuk-section-break--visible">',
+            ),
+            Div(
+                HTML(
+                    '<h3 class="govuk-heading">Volume</h3>',
+                ),
+                HTML.p(
+                    "The initial volume is the legal balance applied to the definition period.<br><br>The current volume is the starting balance for the quota.",
+                ),
+                "initial_volume",
+                "volume",
+                "maximum_precision",
+            ),
+            HTML(
+                '<hr class="govuk-section-break govuk-section-break--s govuk-section-break--visible">',
+            ),
+            Div(
+                HTML(
+                    '<h3 class="govuk-heading">Criticality</h3>',
+                ),
+                "quota_critical_threshold",
+                "quota_critical",
+            ),
+            Submit(
+                "submit",
+                "Save",
+                data_module="govuk-button",
+                data_prevent_double_click="true",
+            ),
+        )
+
+
+class BulkQuotaDefinitionCreateSummaryForm:
+    pass

--- a/quotas/jinja2/quota-definitions/bulk-create-definition-intro-period.jinja
+++ b/quotas/jinja2/quota-definitions/bulk-create-definition-intro-period.jinja
@@ -1,0 +1,4 @@
+{# 
+Displays if the option to include an intro period has been selected
+Duplicate of the current create definition period page.
+#}

--- a/quotas/jinja2/quota-definitions/bulk-create-definition-review.jinja
+++ b/quotas/jinja2/quota-definitions/bulk-create-definition-review.jinja
@@ -1,0 +1,5 @@
+{# 
+Summary page for each of the staged definition periods
+Similar display to the summary page for the duplicate definition periods
+should have a link to each of the staged definitions where data can be updated
+#}

--- a/quotas/jinja2/quota-definitions/bulk-create-definitions-create.jinja
+++ b/quotas/jinja2/quota-definitions/bulk-create-definitions-create.jinja
@@ -1,0 +1,6 @@
+{# 
+This will be an update of the current definition create template
+Should also include 
+a numerical input for the number of deffinition periods to be created
+an option collecing the date split for the different definition periods 
+ #}

--- a/quotas/jinja2/quota-definitions/bulk-create-definitions-start.jinja
+++ b/quotas/jinja2/quota-definitions/bulk-create-definitions-start.jinja
@@ -1,0 +1,4 @@
+{# 
+First step for bulk creating definition periods
+Collects whether there's an introductory period
+#}

--- a/quotas/jinja2/quota-definitions/bulk-create-step.jinja
+++ b/quotas/jinja2/quota-definitions/bulk-create-step.jinja
@@ -1,0 +1,28 @@
+{# TODO: This is identical to the sub-quota-duplicate-definitions-step.jinja 
+Investigate renaming the other one and using that here as well.
+#}
+
+{% extends "layouts/form.jinja" %}
+{% from "components/details/macro.njk" import govukDetails %}
+
+{% set page_title = step_metadata[wizard.steps.current].title %}
+
+{% block content %}
+    <div class="govuk-grid-uk">
+        <div class="govuk-grid-colum-two-thirds">
+            <span class="govuk-caption-l">{{ page_subtitle|default("")}}</span>
+            <h1 class="govuk-heading-xl">
+                {% block page_title_heading %}
+                    {{ page_title }}
+                {% endblock %}
+            </h1>
+            {% if step_metadata[wizard.steps.current].info %}
+                <p class="govuk-body">{{ step_metadata[wizard.steps.current].info }}</p>
+            {% endif %}
+            {% call django_form(action=view.get_step_url(wizard.steps.current)) %}
+                {{ wizard.management_form }}
+                {% block form %}{{ crispy(form) }}{% endblock %}
+            {% endcall %}
+        </div>
+    </div>
+{% endblock %}

--- a/quotas/tests/test_views.py
+++ b/quotas/tests/test_views.py
@@ -22,7 +22,7 @@ from common.views import TrackedModelDetailMixin
 from geo_areas.validators import AreaCode
 from quotas import models
 from quotas import validators
-from quotas.forms import QuotaSuspensionType
+from quotas.forms.base import QuotaSuspensionType
 from quotas.views import DuplicateDefinitionsWizard
 from quotas.views import QuotaList
 from quotas.wizard import QuotaDefinitionDuplicatorSessionStorage

--- a/quotas/views/__init__.py
+++ b/quotas/views/__init__.py
@@ -1,0 +1,2 @@
+from .base import *
+from .wizards import *

--- a/quotas/views/base.py
+++ b/quotas/views/base.py
@@ -1,6 +1,4 @@
-import datetime
 from datetime import date
-from decimal import Decimal
 from urllib.parse import urlencode
 
 from django.contrib import messages
@@ -8,15 +6,12 @@ from django.contrib.auth.mixins import PermissionRequiredMixin
 from django.db import transaction
 from django.db.models import Q
 from django.http import HttpResponseRedirect
-from django.shortcuts import redirect
 from django.urls import reverse
 from django.utils.decorators import method_decorator
 from django.utils.functional import cached_property
 from django.utils.safestring import mark_safe
 from django.views.generic import FormView
-from django.views.generic import TemplateView
 from django.views.generic.list import ListView
-from formtools.wizard.views import NamedUrlSessionWizardView
 from rest_framework import permissions
 from rest_framework import viewsets
 
@@ -24,12 +19,10 @@ from common.business_rules import UniqueIdentifyingFields
 from common.business_rules import UpdateValidity
 from common.forms import delete_form_for
 from common.serializers import AutoCompleteSerializer
-from common.serializers import serialize_date
 from common.tariffs_api import URLs
 from common.tariffs_api import get_quota_data
 from common.tariffs_api import get_quota_definitions_data
 from common.validators import UpdateType
-from common.views import BusinessRulesMixin
 from common.views import SortingMixin
 from common.views import TamatoListView
 from common.views import TrackedModelDetailMixin
@@ -49,8 +42,6 @@ from quotas.filters import QuotaFilter
 from quotas.models import QuotaAssociation
 from quotas.models import QuotaBlocking
 from quotas.models import QuotaSuspension
-from quotas.serializers import deserialize_definition_data
-from settings.common import DATE_FORMAT
 from workbaskets.models import WorkBasket
 from workbaskets.views.decorators import require_current_workbasket
 from workbaskets.views.generic import CreateTaricCreateView
@@ -825,258 +816,6 @@ class QuotaDefinitionConfirmDelete(
     TrackedModelDetailView,
 ):
     template_name = "quota-definitions/confirm-delete.jinja"
-
-
-@method_decorator(require_current_workbasket, name="dispatch")
-class DuplicateDefinitionsWizard(
-    PermissionRequiredMixin,
-    NamedUrlSessionWizardView,
-):
-    """
-    Multipart form wizard for duplicating QuotaDefinitionPeriods from a parent
-    QuotaOrderNumber to a child QuotaOrderNumber.
-
-    https://django-formtools.readthedocs.io/en/latest/wizard.html
-    """
-
-    storage_name = "quotas.wizard.QuotaDefinitionDuplicatorSessionStorage"
-    permission_required = ["common.add_trackedmodel"]
-
-    START = "start"
-    QUOTA_ORDER_NUMBERS = "quota_order_numbers"
-    SELECT_DEFINITION_PERIODS = "select_definition_periods"
-    SELECTED_DEFINITIONS = "selected_definition_periods"
-    COMPLETE = "complete"
-
-    form_list = [
-        (START, forms.DuplicateQuotaDefinitionPeriodStartForm),
-        (QUOTA_ORDER_NUMBERS, forms.QuotaOrderNumbersSelectForm),
-        (SELECT_DEFINITION_PERIODS, forms.SelectSubQuotaDefinitionsForm),
-        (SELECTED_DEFINITIONS, forms.SelectedDefinitionsForm),
-    ]
-
-    templates = {
-        START: "quota-definitions/sub-quota-duplicate-definitions-start.jinja",
-        QUOTA_ORDER_NUMBERS: "quota-definitions/sub-quota-definitions-select-order-numbers.jinja",
-        SELECT_DEFINITION_PERIODS: "quota-definitions/sub-quota-definitions-select-definition-period.jinja",
-        SELECTED_DEFINITIONS: "quota-definitions/sub-quota-definitions-selected.jinja",
-        COMPLETE: "quota-definitions/sub-quota-definitions-done.jinja",
-    }
-
-    step_metadata = {
-        START: {
-            "title": "Duplicate quota definitions",
-            "link_text": "Start",
-        },
-        QUOTA_ORDER_NUMBERS: {
-            "title": "Create associations",
-            "link_text": "Order numbers",
-        },
-        SELECT_DEFINITION_PERIODS: {
-            "title": "Select definition periods",
-            "link_text": "Definition periods",
-        },
-        SELECTED_DEFINITIONS: {
-            "title": "Provide updates and details for duplicated definitions",
-            "link_text": "Selected definitions",
-        },
-        COMPLETE: {"title": "Finished", "link_text": "Success"},
-    }
-
-    @property
-    def workbasket(self) -> WorkBasket:
-        return WorkBasket.current(self.request)
-
-    def get_context_data(self, form, **kwargs):
-        context = super().get_context_data(form=form, **kwargs)
-        context["step_metadata"] = self.step_metadata
-        return context
-
-    def get_template_names(self):
-        template = self.templates.get(
-            self.steps.current,
-            "quota-definitions/sub-quota-duplicate-definitions-step.jinja",
-        )
-        return template
-
-    def get_cleaned_data_for_step(self, step):
-        """
-        Returns cleaned data for a given `step`.
-
-        Note: This patched version of `super().get_cleaned_data_for_step` temporarily saves the cleaned_data
-        to provide quick retrieval should another call for it be made in the same request (as happens in
-        `get_form_kwargs()`) to avoid revalidating forms unnecessarily.
-        """
-        self.cleaned_data = getattr(self, "cleaned_data", {})
-        if step in self.cleaned_data:
-            return self.cleaned_data[step]
-
-        self.cleaned_data[step] = super().get_cleaned_data_for_step(step)
-        return self.cleaned_data[step]
-
-    def format_date(self, date_str):
-        """Parses and converts a date string from that used for storing data to
-        the one used in the TAP UI."""
-        if date_str:
-            date_object = datetime.datetime.strptime(date_str, "%Y-%m-%d").date()
-            return date_object.strftime(DATE_FORMAT)
-        return ""
-
-    def get_staged_definition_data(self):
-        return self.request.session["staged_definition_data"]
-
-    def get_main_definition(self, main_definition_pk):
-        return models.QuotaDefinition.objects.get(pk=main_definition_pk)
-
-    def get_form_kwargs(self, step):
-        kwargs = {}
-        if step == self.SELECT_DEFINITION_PERIODS:
-            main_quota_order_number_sid = self.get_cleaned_data_for_step(
-                self.QUOTA_ORDER_NUMBERS,
-            )["main_quota_order_number"].sid
-            main_quota_definitions = (
-                models.QuotaDefinition.objects.filter(
-                    order_number__sid=main_quota_order_number_sid,
-                )
-                .current()
-                .order_by("pk")
-            )
-            kwargs["request"] = self.request
-            kwargs["objects"] = main_quota_definitions
-
-        elif step == self.SELECTED_DEFINITIONS:
-            kwargs["request"] = self.request
-
-        return kwargs
-
-    def status_tag_generator(self, definition) -> dict:
-        """
-        Based on the status_tag_generator() for the Measure create Process
-        queue.
-
-        Returns a dict with text and a CSS class for a label for a duplicated
-        definition.
-        """
-        if definition["status"]:
-            return {
-                "text": "Edited",
-                "tag_class": "tamato-badge-light-green",
-            }
-        else:
-            return {
-                "text": "Unedited",
-                "tag_class": "tamato-badge-light-blue",
-            }
-
-    def done(self, form_list, **kwargs):
-        cleaned_data = self.get_all_cleaned_data()
-
-        with transaction.atomic():
-            for definition in cleaned_data["staged_definitions"]:
-                self.create_definition(definition)
-        sub_quota_view_url = reverse(
-            "quota_definition-ui-list",
-            kwargs={"sid": cleaned_data["main_quota_order_number"].sid},
-        )
-        sub_quota_view_query_string = "quota_type=sub_quotas&submit="
-        self.request.session["success_data"] = {
-            "main_quota": cleaned_data["main_quota_order_number"].order_number,
-            "sub_quota": cleaned_data["sub_quota_order_number"].order_number,
-            "definition_view_url": (
-                f"{sub_quota_view_url}?{sub_quota_view_query_string}"
-            ),
-        }
-
-        return redirect("sub_quota_definitions-ui-success")
-
-    def create_definition(self, definition):
-        staged_data = deserialize_definition_data(
-            self,
-            definition["sub_definition_staged_data"],
-        )
-        transaction = self.workbasket.new_transaction()
-        instance = models.QuotaDefinition.objects.create(
-            **staged_data,
-            transaction=transaction,
-        )
-        models.QuotaAssociation.objects.create(
-            main_quota=models.QuotaDefinition.objects.get(
-                pk=definition["main_definition"],
-            ),
-            sub_quota=instance,
-            coefficient=Decimal(
-                definition["sub_definition_staged_data"]["coefficient"],
-            ),
-            sub_quota_relation_type=definition["sub_definition_staged_data"][
-                "relationship_type"
-            ],
-            update_type=UpdateType.CREATE,
-            transaction=transaction,
-        )
-
-
-class QuotaDefinitionDuplicateUpdates(
-    FormView,
-    BusinessRulesMixin,
-):
-    """UI endpoint for any updates to duplicated definitions."""
-
-    template_name = "quota-definitions/sub-quota-definitions-updates.jinja"
-    form_class = forms.SubQuotaDefinitionsUpdatesForm
-    permission_required = "common.add_trackedmodel"
-
-    def get_form_kwargs(self):
-        kwargs = super().get_form_kwargs()
-        kwargs["pk"] = self.kwargs["pk"]
-        kwargs["request"] = self.request
-        return kwargs
-
-    def get_context_data(self, *args, **kwargs):
-        context = super().get_context_data(*args, **kwargs)
-        context["page_title"] = "Update definition and association details"
-        context["quota_order_number"] = self.kwargs["pk"]
-        return context
-
-    def get_main_definition(self):
-        return models.QuotaDefinition.objects.current().get(
-            trackedmodel_ptr_id=self.kwargs["pk"],
-        )
-
-    def form_valid(self, form):
-        main_definition = self.get_main_definition()
-        cleaned_data = form.cleaned_data
-        updated_serialized_data = {
-            "initial_volume": str(cleaned_data["initial_volume"]),
-            "volume": str(cleaned_data["volume"]),
-            "measurement_unit_code": cleaned_data["measurement_unit"].code,
-            "start_date": serialize_date(cleaned_data["valid_between"].lower),
-            "end_date": serialize_date(cleaned_data["valid_between"].upper),
-            "status": True,
-            "coefficient": str(cleaned_data["coefficient"]),
-            "relationship_type": cleaned_data["relationship_type"],
-        }
-        staged_definition_data = self.request.session["staged_definition_data"]
-        list(
-            filter(
-                lambda staged_definition_data: staged_definition_data["main_definition"]
-                == main_definition.pk,
-                staged_definition_data,
-            ),
-        )[0]["sub_definition_staged_data"] = updated_serialized_data
-
-        return redirect(reverse("sub_quota_definitions-ui-create"))
-
-
-class QuotaDefinitionDuplicatorSuccess(TemplateView):
-    template_name = "quota-definitions/sub-quota-definitions-done.jinja"
-
-    def get_context_data(self, **kwargs):
-        context = super().get_context_data(**kwargs)
-        success_data = self.request.session["success_data"]
-        context["main_quota"] = success_data["main_quota"]
-        context["sub_quota"] = success_data["sub_quota"]
-        context["definition_view_url"] = success_data["definition_view_url"]
-        return context
 
 
 @method_decorator(require_current_workbasket, name="dispatch")

--- a/quotas/views/wizards.py
+++ b/quotas/views/wizards.py
@@ -1,0 +1,273 @@
+import datetime
+from decimal import Decimal
+
+from django.contrib.auth.mixins import PermissionRequiredMixin
+from django.db import transaction
+from django.shortcuts import redirect
+from django.urls import reverse
+from django.utils.decorators import method_decorator
+from django.views.generic import FormView
+from django.views.generic import TemplateView
+from formtools.wizard.views import NamedUrlSessionWizardView
+
+from common.serializers import serialize_date
+from common.validators import UpdateType
+from common.views import BusinessRulesMixin
+from quotas import forms
+from quotas import models
+from quotas.serializers import deserialize_definition_data
+from settings.common import DATE_FORMAT
+from workbaskets.models import WorkBasket
+from workbaskets.views.decorators import require_current_workbasket
+
+
+@method_decorator(require_current_workbasket, name="dispatch")
+class DuplicateDefinitionsWizard(
+    PermissionRequiredMixin,
+    NamedUrlSessionWizardView,
+):
+    """
+    Multipart form wizard for duplicating QuotaDefinitionPeriods from a parent
+    QuotaOrderNumber to a child QuotaOrderNumber.
+
+    https://django-formtools.readthedocs.io/en/latest/wizard.html
+    """
+
+    storage_name = "quotas.wizard.QuotaDefinitionDuplicatorSessionStorage"
+    permission_required = ["common.add_trackedmodel"]
+
+    START = "start"
+    QUOTA_ORDER_NUMBERS = "quota_order_numbers"
+    SELECT_DEFINITION_PERIODS = "select_definition_periods"
+    SELECTED_DEFINITIONS = "selected_definition_periods"
+    COMPLETE = "complete"
+
+    form_list = [
+        (START, forms.DuplicateQuotaDefinitionPeriodStartForm),
+        (QUOTA_ORDER_NUMBERS, forms.QuotaOrderNumbersSelectForm),
+        (SELECT_DEFINITION_PERIODS, forms.SelectSubQuotaDefinitionsForm),
+        (SELECTED_DEFINITIONS, forms.SelectedDefinitionsForm),
+    ]
+
+    templates = {
+        START: "quota-definitions/sub-quota-duplicate-definitions-start.jinja",
+        QUOTA_ORDER_NUMBERS: "quota-definitions/sub-quota-definitions-select-order-numbers.jinja",
+        SELECT_DEFINITION_PERIODS: "quota-definitions/sub-quota-definitions-select-definition-period.jinja",
+        SELECTED_DEFINITIONS: "quota-definitions/sub-quota-definitions-selected.jinja",
+        COMPLETE: "quota-definitions/sub-quota-definitions-done.jinja",
+    }
+
+    step_metadata = {
+        START: {
+            "title": "Duplicate quota definitions",
+            "link_text": "Start",
+        },
+        QUOTA_ORDER_NUMBERS: {
+            "title": "Create associations",
+            "link_text": "Order numbers",
+        },
+        SELECT_DEFINITION_PERIODS: {
+            "title": "Select definition periods",
+            "link_text": "Definition periods",
+        },
+        SELECTED_DEFINITIONS: {
+            "title": "Provide updates and details for duplicated definitions",
+            "link_text": "Selected definitions",
+        },
+        COMPLETE: {"title": "Finished", "link_text": "Success"},
+    }
+
+    @property
+    def workbasket(self) -> WorkBasket:
+        return WorkBasket.current(self.request)
+
+    def get_context_data(self, form, **kwargs):
+        context = super().get_context_data(form=form, **kwargs)
+        context["step_metadata"] = self.step_metadata
+        return context
+
+    def get_template_names(self):
+        template = self.templates.get(
+            self.steps.current,
+            "quota-definitions/sub-quota-duplicate-definitions-step.jinja",
+        )
+        return template
+
+    def get_cleaned_data_for_step(self, step):
+        """
+        Returns cleaned data for a given `step`.
+
+        Note: This patched version of `super().get_cleaned_data_for_step` temporarily saves the cleaned_data
+        to provide quick retrieval should another call for it be made in the same request (as happens in
+        `get_form_kwargs()`) to avoid revalidating forms unnecessarily.
+        """
+        self.cleaned_data = getattr(self, "cleaned_data", {})
+        if step in self.cleaned_data:
+            return self.cleaned_data[step]
+
+        self.cleaned_data[step] = super().get_cleaned_data_for_step(step)
+        return self.cleaned_data[step]
+
+    def format_date(self, date_str):
+        """Parses and converts a date string from that used for storing data to
+        the one used in the TAP UI."""
+        if date_str:
+            date_object = datetime.datetime.strptime(date_str, "%Y-%m-%d").date()
+            return date_object.strftime(DATE_FORMAT)
+        return ""
+
+    def get_staged_definition_data(self):
+        return self.request.session["staged_definition_data"]
+
+    def get_main_definition(self, main_definition_pk):
+        return models.QuotaDefinition.objects.get(pk=main_definition_pk)
+
+    def get_form_kwargs(self, step):
+        kwargs = {}
+        if step == self.SELECT_DEFINITION_PERIODS:
+            main_quota_order_number_sid = self.get_cleaned_data_for_step(
+                self.QUOTA_ORDER_NUMBERS,
+            )["main_quota_order_number"].sid
+            main_quota_definitions = (
+                models.QuotaDefinition.objects.filter(
+                    order_number__sid=main_quota_order_number_sid,
+                )
+                .current()
+                .order_by("pk")
+            )
+            kwargs["request"] = self.request
+            kwargs["objects"] = main_quota_definitions
+
+        elif step == self.SELECTED_DEFINITIONS:
+            kwargs["request"] = self.request
+
+        return kwargs
+
+    def status_tag_generator(self, definition) -> dict:
+        """
+        Based on the status_tag_generator() for the Measure create Process
+        queue.
+
+        Returns a dict with text and a CSS class for a label for a duplicated
+        definition.
+        """
+        if definition["status"]:
+            return {
+                "text": "Edited",
+                "tag_class": "tamato-badge-light-green",
+            }
+        else:
+            return {
+                "text": "Unedited",
+                "tag_class": "tamato-badge-light-blue",
+            }
+
+    def done(self, form_list, **kwargs):
+        cleaned_data = self.get_all_cleaned_data()
+
+        with transaction.atomic():
+            for definition in cleaned_data["staged_definitions"]:
+                self.create_definition(definition)
+        sub_quota_view_url = reverse(
+            "quota_definition-ui-list",
+            kwargs={"sid": cleaned_data["main_quota_order_number"].sid},
+        )
+        sub_quota_view_query_string = "quota_type=sub_quotas&submit="
+        self.request.session["success_data"] = {
+            "main_quota": cleaned_data["main_quota_order_number"].order_number,
+            "sub_quota": cleaned_data["sub_quota_order_number"].order_number,
+            "definition_view_url": (
+                f"{sub_quota_view_url}?{sub_quota_view_query_string}"
+            ),
+        }
+
+        return redirect("sub_quota_definitions-ui-success")
+
+    def create_definition(self, definition):
+        staged_data = deserialize_definition_data(
+            self,
+            definition["sub_definition_staged_data"],
+        )
+        transaction = self.workbasket.new_transaction()
+        instance = models.QuotaDefinition.objects.create(
+            **staged_data,
+            transaction=transaction,
+        )
+        models.QuotaAssociation.objects.create(
+            main_quota=models.QuotaDefinition.objects.get(
+                pk=definition["main_definition"],
+            ),
+            sub_quota=instance,
+            coefficient=Decimal(
+                definition["sub_definition_staged_data"]["coefficient"],
+            ),
+            sub_quota_relation_type=definition["sub_definition_staged_data"][
+                "relationship_type"
+            ],
+            update_type=UpdateType.CREATE,
+            transaction=transaction,
+        )
+
+
+class QuotaDefinitionDuplicateUpdates(
+    FormView,
+    BusinessRulesMixin,
+):
+    """UI endpoint for any updates to duplicated definitions."""
+
+    template_name = "quota-definitions/sub-quota-definitions-updates.jinja"
+    form_class = forms.SubQuotaDefinitionsUpdatesForm
+    permission_required = "common.add_trackedmodel"
+
+    def get_form_kwargs(self):
+        kwargs = super().get_form_kwargs()
+        kwargs["pk"] = self.kwargs["pk"]
+        kwargs["request"] = self.request
+        return kwargs
+
+    def get_context_data(self, *args, **kwargs):
+        context = super().get_context_data(*args, **kwargs)
+        context["page_title"] = "Update definition and association details"
+        context["quota_order_number"] = self.kwargs["pk"]
+        return context
+
+    def get_main_definition(self):
+        return models.QuotaDefinition.objects.current().get(
+            trackedmodel_ptr_id=self.kwargs["pk"],
+        )
+
+    def form_valid(self, form):
+        main_definition = self.get_main_definition()
+        cleaned_data = form.cleaned_data
+        updated_serialized_data = {
+            "initial_volume": str(cleaned_data["initial_volume"]),
+            "volume": str(cleaned_data["volume"]),
+            "measurement_unit_code": cleaned_data["measurement_unit"].code,
+            "start_date": serialize_date(cleaned_data["valid_between"].lower),
+            "end_date": serialize_date(cleaned_data["valid_between"].upper),
+            "status": True,
+            "coefficient": str(cleaned_data["coefficient"]),
+            "relationship_type": cleaned_data["relationship_type"],
+        }
+        staged_definition_data = self.request.session["staged_definition_data"]
+        list(
+            filter(
+                lambda staged_definition_data: staged_definition_data["main_definition"]
+                == main_definition.pk,
+                staged_definition_data,
+            ),
+        )[0]["sub_definition_staged_data"] = updated_serialized_data
+
+        return redirect(reverse("sub_quota_definitions-ui-create"))
+
+
+class QuotaDefinitionDuplicatorSuccess(TemplateView):
+    template_name = "quota-definitions/sub-quota-definitions-done.jinja"
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        success_data = self.request.session["success_data"]
+        context["main_quota"] = success_data["main_quota"]
+        context["sub_quota"] = success_data["sub_quota"]
+        context["definition_view_url"] = success_data["definition_view_url"]
+        return context

--- a/server.py
+++ b/server.py
@@ -1,0 +1,16 @@
+import asyncio
+
+import tornado
+
+
+class MainHandler(tornado.web.RequestHandler):
+    def post(self):
+        self.write(self.request.body)
+
+
+async def main():
+    tornado.web.Application([(r"/", MainHandler)]).listen(8000)
+    await asyncio.Event().wait()
+
+
+asyncio.run(main())


### PR DESCRIPTION
# Refactor of quotas/views.py and forms.py

## Why
Both the views.py and forms.py files are getting large (>1,000 lines long)
These are only going to grow further as we add functionality. Reducing the size of the files makes them easier to comprehend.

## What
This PR separates out the forms and views which are used for the DuplicateDefinitionsWizard and BulkQuotaDefinitionCreate processes. Note that the BulkQuotaDefinitionCreate is a work in progress.
