### PR TITLE
TP2000-1562 Quota association view update

### DIFF
--- a/common/tests/test_models.py
+++ b/common/tests/test_models.py
@@ -409,7 +409,7 @@ def test_get_description_dates(description_factory, date_ranges):
 
 def test_trackedmodel_get_url(
     trackedmodel_factory,
-    valid_user_client,
+    client_with_current_workbasket,
     mock_quota_api_no_data,
 ):
     """Verify get_url() returns something sensible and doesn't crash."""
@@ -428,7 +428,7 @@ def test_trackedmodel_get_url(
     # Verify URL is not local
     assert not urlparse(url).netloc
 
-    response = valid_user_client.get(url)
+    response = client_with_current_workbasket.get(url)
     assert response.status_code == 200
 
 

--- a/quotas/jinja2/includes/quotas/tabs/sub_quotas.jinja
+++ b/quotas/jinja2/includes/quotas/tabs/sub_quotas.jinja
@@ -1,4 +1,12 @@
 {% set table_rows = [] %}
+{% set table_head = [
+                {"text": "Order number"},
+                {"text": "Relationship type"},
+                {"text": "Co-efficient"},
+              ] %}
+{% if sub_quota_associations %}
+  {{ table_head.append({"text": "Actions"}) or "" }}
+{% endif %}
 {% for object in sub_quota_associations %}
   {% set sub_quota_link %}
     <a class="govuk-link govuk-!-font-weight-bold"
@@ -36,7 +44,6 @@
     {"html": main_quota_link},
     {"html": object.get_sub_quota_relation_type_display()},
     {"text": object.coefficient},
-    {"text": actions_html }
   ]) or "" }}
 {% endfor %}
 
@@ -51,12 +58,7 @@
           {% endif %}
           {{
             govukTable({
-              "head": [
-                {"text": "Order number"},
-                {"text": "Relationship type"},
-                {"text": "Co-efficient"},
-                {"text": "Actions"}
-              ],
+              "head": table_head,
               "rows": table_rows
             })
           }}

--- a/quotas/jinja2/quotas/tables/sub_quotas.jinja
+++ b/quotas/jinja2/quotas/tables/sub_quotas.jinja
@@ -3,6 +3,7 @@
 {% set table_rows = [] %}
 {% if sub_quotas %}
 <h3 class="govuk-heading-m">Sub-quotas</h3>
+<p class="govuk-body">The following sub-quota definitions exist for definition periods on Quota {{ quota.order_number}}.</p>
   {% for object in sub_quotas %}
     {% set definition_link -%}
       <a class="govuk-link" href="{{ url('quota-ui-detail', args=[object.sub_quota.order_number.sid]) }}#definition-details">{{ object.sub_quota.sid }}</a>
@@ -11,7 +12,7 @@
       <a class="govuk-link" href="{{ url('quota-ui-detail', args=[object.sub_quota.order_number.sid]) }}">{{ object.sub_quota.order_number.order_number }}</a>
     {% endset %}
     {% set actions_html %}
-      <a class="govuk-link" href="{{ object.sub_quota.version_at(request.user.current_workbasket.transactions.last()).get_association_edit_url() }}">Edit</a>
+      <a class="govuk-link" href="{{ object.sub_quota.get_association_edit_url() }}">Edit</a>
       <br/>
       <a class="govuk-link" href="{{ url('quota_association-ui-delete', args=[object.pk]) }}">Delete</a>
     {% endset %}
@@ -41,17 +42,13 @@
   }) }}
 {% elif main_quotas %}
 <h3 class="govuk-heading-m">Main quotas</h3>
+<p class="govuk-body">Quota {{ quota.order_number }} has definition periods which are sub-quotas of the following quota definitions. To edit the associations, go to the main quota's data page.</p>
   {% for object in main_quotas %}
     {% set definition_link -%}
       <a class="govuk-link" href="{{ url('quota-ui-detail', args=[object.main_quota.order_number.sid]) }}#definition-details">{{ object.main_quota.sid }}</a>
     {% endset %}
     {% set main_quota_link -%}
       <a class="govuk-link" href="{{ url('quota-ui-detail', args=[object.main_quota.order_number.sid]) }}">{{ object.main_quota.order_number.order_number }}</a>
-    {% endset %}
-    {% set actions_html %}
-      <a class="govuk-link" href="{{ object.sub_quota.version_at(request.user.current_workbasket.transactions.last()).get_association_edit_url() }}">Edit</a>
-      <br/>
-      <a class="govuk-link" href="{{ url('quota_association-ui-delete', args=[object.pk]) }}">Delete</a>
     {% endset %}
     {{ table_rows.append([
       {"text": definition_link },
@@ -60,7 +57,6 @@
       {"text": "{:%d %b %Y}".format(object.main_quota.version_at(request.user.current_workbasket.transactions.last()).valid_between.upper) if object.main_quota.valid_between.upper else "-"},
       {"text": object.get_sub_quota_relation_type_display() },
       {"text": object.coefficient },
-      {"text": actions_html },
     ]) or "" }}
   {% endfor %}
   {{ govukTable({
@@ -71,7 +67,6 @@
       {"text": "End date"},
       {"text": "Relationship type"},
       {"text": "Coefficient"},
-      {"text": "Actions"},
     ],
     "rows": table_rows
   }) }}

--- a/quotas/views/definitions.py
+++ b/quotas/views/definitions.py
@@ -3,6 +3,7 @@ from django.db import transaction
 from django.db.models import Q
 from django.http import HttpResponseRedirect
 from django.urls import reverse
+from django.utils.decorators import method_decorator
 from django.utils.functional import cached_property
 from django.views.generic.list import ListView
 from rest_framework import permissions
@@ -23,6 +24,7 @@ from quotas.models import QuotaAssociation
 from quotas.models import QuotaBlocking
 from quotas.models import QuotaSuspension
 from workbaskets.models import WorkBasket
+from workbaskets.views.decorators import require_current_workbasket
 from workbaskets.views.generic import CreateTaricCreateView
 from workbaskets.views.generic import CreateTaricDeleteView
 from workbaskets.views.generic import CreateTaricUpdateView
@@ -36,6 +38,7 @@ class QuotaDefinitionViewset(viewsets.ReadOnlyModelViewSet):
     search_fields = ["sid", "order_number__order_number", "description"]
 
 
+@method_decorator(require_current_workbasket, name="dispatch")
 class QuotaDefinitionList(SortingMixin, ListView):
     template_name = "quotas/definitions.jinja"
     model = models.QuotaDefinition


### PR DESCRIPTION
# TP2000-1562 Quota association view update
<!---
 * Include the JIRA ticket number, eg TP-123, to automatically link.
 * Use 50 characters maximum.
 * Do not end with a full-stop.
--->

## Why
<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Use as many lines as you like.
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions or deliberately ignored edge-cases.
--->

There are some issues with the current quota association view:
- it errors if someone loads the page without a workbasket
- if a sole definition has been edited in the workbasket, it currently links to an update-edit form which errors - as while an update-edit would be appropriate for the definition this does not work for the unedited association
- there is an edit link for main quota associations which doesn't reflect where the link goes (currently to the edit page of whatever the most recently edited sub quota was)

## What
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Explain like I'm 5.
 * Use pictures if you can.
--->

This PR:
- adds require_workbasket_decorator to quota definition list view to catch and redirect anyone without a workbasket
- removes the actions column (thus edit link) for main quota associations since the form in question only handles sub quota association edits
- ensures the update (not update-edit) form is loaded if an association has not yet been edited to prevent errors

## Notes
- Whilst I could have kept the edit link for main quota associations and just linked to the edit form for whatever the sub-quota is of that relationship, this seemed overly complex and difficult to make clear to the user that that is what it would be doing.
- I've also added in some help text as the whole thing feels quite confusing to me. However, if you feel this help text actually confuses things more I'm happy to remove.


**Main quota with sub quota definitions**

<img width="1088" alt="image" src="https://github.com/user-attachments/assets/bc4876e4-bc51-46f4-86a1-ef06ff4df7aa">


**Sub quota with main quota definitions**

<img width="1094" alt="image" src="https://github.com/user-attachments/assets/49c9e029-27b0-4828-a834-147fc423fdf4">


<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
## Checklist
- Requires migrations?
- Requires dependency updates?
--->

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
