### PR TITLE
TP2000-1501 Fix comm code hierarchy bug

### DIFF
--- a/commodities/tests/test_views.py
+++ b/commodities/tests/test_views.py
@@ -719,3 +719,16 @@ def test_commodities_hierarchy_inactive_commodity(valid_user_client, date_ranges
         "This commodity has been end dated so no longer forms part of the hierarchy."
         in str(response.content)
     )
+
+
+def test_commodities_hierarchy_only_shows_current(valid_user_client, workbasket):
+    """Test that only current versions of a commodity are shown and no
+    duplicates."""
+    commodity1 = factories.GoodsNomenclatureFactory.create(item_id="8540111111")
+    factories.GoodsNomenclatureFactory.create(item_id="8540222222")
+    commodity1.new_version(workbasket=workbasket, update_type=UpdateType.UPDATE)
+    url = reverse("commodity-ui-detail-hierarchy", kwargs={"sid": commodity1.sid})
+    response = valid_user_client.get(url)
+    soup = BeautifulSoup(response.content.decode(response.charset), "html.parser")
+    commodities = [p.text[:10] for p in soup.find_all("p")]
+    assert len(commodities) == len(set(commodities))

--- a/commodities/views.py
+++ b/commodities/views.py
@@ -182,7 +182,9 @@ class CommodityHierarchy(CommodityDetail):
 
         if is_current:
             prefix = self.object.item_id[0:4]
-            commodities_collection = CommodityCollectionLoader(prefix=prefix).load()
+            commodities_collection = CommodityCollectionLoader(prefix=prefix).load(
+                current_only=True,
+            )
             active_commodities = [
                 commodity
                 for commodity in commodities_collection.commodities


### PR DESCRIPTION
# TP2000-1501 Fix comm code hierarchy bug
<!---
 * Include the JIRA ticket number, eg TP-123, to automatically link.
 * Use 50 characters maximum.
 * Do not end with a full-stop.
--->

## Why
<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Use as many lines as you like.
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions or deliberately ignored edge-cases.
--->

The commodity code hierarchy currently shows all versions of commodities. Therefore if one has multiple versions it will appear multiple times in the tree which is incorrect.

## What
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Explain like I'm 5.
 * Use pictures if you can.
--->

This PR:
- adds current_only so only current commodities are shown
- adds a test to account for this 


<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
## Checklist
- Requires migrations?
- Requires dependency updates?
--->

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
