### PR TITLE
TP2000-1487: Create Subtask Form

### DIFF
--- a/tasks/forms.py
+++ b/tasks/forms.py
@@ -67,4 +67,14 @@ class TaskUpdateForm(TaskBaseForm):
     pass
 
 
+class SubTaskCreateForm(TaskBaseForm):
+    def save(self, parent_task, user, commit=True):
+        instance = super().save(commit=False)
+        instance.creator = user
+        instance.parent_task = parent_task
+        if commit:
+            instance.save()
+        return instance
+
+
 TaskDeleteForm = delete_form_for(Task)

--- a/tasks/tests/test_forms.py
+++ b/tasks/tests/test_forms.py
@@ -1,0 +1,22 @@
+from common.tests.factories import ProgressStateFactory
+from common.tests.factories import TaskFactory
+from tasks import forms
+from tasks.models import ProgressState
+
+
+def test_create_subtask_assigns_correct_parent_task(valid_user):
+    """Tests that SubtaskCreateForm assigns the correct parent on form.save."""
+    parent_task_instance = TaskFactory.create()
+    progress_state = ProgressStateFactory.create(
+        name=ProgressState.State.IN_PROGRESS,
+    )
+
+    subtask_form_data = {
+        "progress_state": progress_state.pk,
+        "title": "subtask test title",
+        "description": "subtask test description",
+    }
+    form = forms.SubTaskCreateForm(data=subtask_form_data)
+    new_subtask = form.save(parent_task_instance, user=valid_user)
+
+    assert new_subtask.parent_task.pk == parent_task_instance.pk

--- a/tasks/urls.py
+++ b/tasks/urls.py
@@ -26,6 +26,11 @@ ui_patterns = [
         views.TaskConfirmDeleteView.as_view(),
         name="task-ui-confirm-delete",
     ),
+    path(
+        "<int:pk>/sub-tasks/create",
+        views.SubTaskCreateView.as_view(),
+        name="subtask-ui-create",
+    ),
 ]
 
 urlpatterns = [


### PR DESCRIPTION
# TP2000-1487: Create Subtask Form
## Why
* As part of the task workflow work, we need to provide users with a way of creating subtasks that are linked to parent tasks.
* This is so users can break down their tasks into smaller tasks should they choose to do so. 

## What
* Created a URL for creating a subtask from a parent task.
* Added a view to serve this URL 
* Added a Create Subtask form which extends off of TaskBaseForm, that on save passes in a parent task and assigns to the created subtask

## Checklist
- Requires migrations? - NO
- Requires dependency updates? - NO

