### PR TITLE
TP2000-1545  Add task template reordering capability to workflow template detail view

### DIFF
--- a/tasks/jinja2/tasks/includes/task_queue.jinja
+++ b/tasks/jinja2/tasks/includes/task_queue.jinja
@@ -1,0 +1,81 @@
+{% from "components/table/macro.njk" import govukTable %}
+{% from "tasks/macros/item_actions.jinja" import move_item %}
+
+{%- set table_rows = [] -%}
+
+{%- for obj in object_list %}
+  {%- set up_down_cell_content %}
+    {% if loop.index == 1 %}
+      {{ move_item(obj, "demote", use_icon=True) }}
+    {% elif loop.index == 2 %}
+      {{ move_item(obj, "promote", use_icon=True) }}
+      <br>
+      {% if 2 < object_list | length %}
+        {{ move_item(obj, "demote", use_icon=True) }}
+      {% endif %}
+    {% elif loop.index == object_list | length %}
+      {{ move_item(obj, "promote", use_icon=True) }}
+    {% else %}
+      {{ move_item(obj, "promote", use_icon=True) }}
+      <br>
+      {{ move_item(obj, "demote", use_icon=True) }}
+    {% endif %}
+  {% endset -%}
+
+  {%- set title_cell_content %}
+    <a href="#TODO" class="govuk-link">{{ obj.title }}</a>
+  {% endset -%}
+
+  {%- set description_cell_content %}
+    <span>{{ obj.description|truncate(50) }}</span>
+  {% endset -%}
+
+  {%- set order_cell_content %}
+    {% if loop.index == 1%}
+      {{ move_item(obj, "demote_to_last") }}
+    {% elif loop.index == object_list | length %}
+      {{ move_item(obj, "promote_to_first") }}
+    {% else %}
+      {{ move_item(obj, "promote_to_first") }}
+      <br>
+      {{ move_item(obj, "demote_to_last") }}
+    {% endif %}
+  {% endset -%}
+
+  {%- set remove_cell_content %}
+    <button
+      class="govuk-link fake-link"
+      name="remove_item"
+      value="{{ obj.pk }}"
+      data-prevent-double-click="true"
+    >
+      Remove
+    </button>
+  {% endset -%}
+
+  {{ table_rows.append([
+    {"html": up_down_cell_content},
+    {"text": loop.index},
+    {"html": title_cell_content},
+    {"html": description_cell_content},
+    {"html": order_cell_content},
+    {"html": remove_cell_content},
+  ]) or "" }}
+
+{% endfor -%}
+
+<form method="post">
+    <input type="hidden" name="csrfmiddlewaretoken" value="{{ csrf_token }}">
+
+  {{ govukTable({
+    "head": [
+      {"text": ""},
+      {"text": "Position"},
+      {"text": "Title"},
+      {"text": "Description"},
+      {"text": "Order"},
+      {"text": "Remove"},
+    ],
+    "rows": table_rows,
+  }) }}
+</form>

--- a/tasks/jinja2/tasks/includes/task_queue.jinja
+++ b/tasks/jinja2/tasks/includes/task_queue.jinja
@@ -1,24 +1,24 @@
 {% from "components/table/macro.njk" import govukTable %}
-{% from "tasks/macros/item_actions.jinja" import move_item %}
+{% from "tasks/macros/item_actions.jinja" import render_item_button %}
 
 {%- set table_rows = [] -%}
 
 {%- for obj in object_list %}
   {%- set up_down_cell_content %}
     {% if loop.index == 1 %}
-      {{ move_item(obj, "demote", use_icon=True) }}
+      {{ render_item_button(obj, "demote", use_icon=True) }}
     {% elif loop.index == 2 %}
-      {{ move_item(obj, "promote", use_icon=True) }}
+      {{ render_item_button(obj, "promote", use_icon=True) }}
       <br>
       {% if 2 < object_list | length %}
-        {{ move_item(obj, "demote", use_icon=True) }}
+        {{ render_item_button(obj, "demote", use_icon=True) }}
       {% endif %}
     {% elif loop.index == object_list | length %}
-      {{ move_item(obj, "promote", use_icon=True) }}
+      {{ render_item_button(obj, "promote", use_icon=True) }}
     {% else %}
-      {{ move_item(obj, "promote", use_icon=True) }}
+      {{ render_item_button(obj, "promote", use_icon=True) }}
       <br>
-      {{ move_item(obj, "demote", use_icon=True) }}
+      {{ render_item_button(obj, "demote", use_icon=True) }}
     {% endif %}
   {% endset -%}
 
@@ -32,25 +32,18 @@
 
   {%- set order_cell_content %}
     {% if loop.index == 1%}
-      {{ move_item(obj, "demote_to_last") }}
+      {{ render_item_button(obj, "demote_to_last") }}
     {% elif loop.index == object_list | length %}
-      {{ move_item(obj, "promote_to_first") }}
+      {{ render_item_button(obj, "promote_to_first") }}
     {% else %}
-      {{ move_item(obj, "promote_to_first") }}
+      {{ render_item_button(obj, "promote_to_first") }}
       <br>
-      {{ move_item(obj, "demote_to_last") }}
+      {{ render_item_button(obj, "demote_to_last") }}
     {% endif %}
   {% endset -%}
 
   {%- set remove_cell_content %}
-    <button
-      class="govuk-link fake-link"
-      name="remove_item"
-      value="{{ obj.pk }}"
-      data-prevent-double-click="true"
-    >
-      Remove
-    </button>
+    TODO
   {% endset -%}
 
   {{ table_rows.append([

--- a/tasks/jinja2/tasks/macros/item_actions.jinja
+++ b/tasks/jinja2/tasks/macros/item_actions.jinja
@@ -1,6 +1,6 @@
-{% macro render_reorder_actions(item, max_position) %}
-  <div class="task-list__reorder-actions">
-    {% if not item.position == 1 %}
+{% macro render_reorder_item_actions(item, item_count) %}
+  <div class="task-list__reorder-item-actions">
+    {% if item.position != 1 %}
       <button name="promote_item"
         value="{{ item.pk }}"
         class="govuk-link fake-link govuk-!-padding-right-2"
@@ -9,7 +9,7 @@
       >Move up <span aria-hidden="true">&#9206;</span></button>
     {% endif %}
 
-    {% if not item.position == max_position %}
+    {% if item.position != item_count %}
       <button name="demote_item"
         value="{{ item.pk }}"
         class="govuk-link fake-link"

--- a/tasks/jinja2/tasks/macros/item_actions.jinja
+++ b/tasks/jinja2/tasks/macros/item_actions.jinja
@@ -1,21 +1,29 @@
-{% macro render_reorder_item_actions(item, item_count) %}
-  <div class="task-list__reorder-item-actions">
-    {% if item.position != 1 %}
-      <button name="promote_item"
-        value="{{ item.pk }}"
-        class="govuk-link fake-link govuk-!-padding-right-2"
-        data-module="govuk-button"
-        data-prevent-double-click="true"
-      >Move up <span aria-hidden="true">&#9206;</span></button>
-    {% endif %}
+{% macro move_item(obj, action, use_icon=False) %}
+  {% set action_text = {
+    "promote": "Move up",
+    "demote": "Move down",
+    "promote_to_first": "Move to first",
+    "demote_to_last": "Move to last",
+  }[action] %}
 
-    {% if item.position != item_count %}
-      <button name="demote_item"
-        value="{{ item.pk }}"
-        class="govuk-link fake-link"
-        data-module="govuk-button"
-        data-prevent-double-click="true"
-      >Move down <span aria-hidden="true">&#9207;</span></button>
-    {% endif %}
-  </div>
+  {% set icon_src = {
+    "promote": "/common/images/chevron-up.svg",
+    "demote": "/common/images/chevron-down.svg",
+  }[action] %}
+
+  <button name="{{ action }}"
+    value="{{ obj.pk }}"
+    class="govuk-link fake-link govuk-!-padding-right-2"
+    data-module="govuk-button"
+    data-prevent-double-click="true"
+  >
+    {% if use_icon and action != "promote_to_first" and action != "promote_to_last" %}
+      <img class="icon"
+        src="{{ static(icon_src) }}"
+        alt="{{ action_text}} icon"
+      >
+    {% else %}
+      {{ action_text }}
+    {% endif%}
+  </button>
 {% endmacro %}

--- a/tasks/jinja2/tasks/macros/item_actions.jinja
+++ b/tasks/jinja2/tasks/macros/item_actions.jinja
@@ -1,4 +1,4 @@
-{% macro move_item(obj, action, use_icon=False) %}
+{% macro render_item_button(obj, action, use_icon=False) %}
   {% set action_text = {
     "promote": "Move up",
     "demote": "Move down",
@@ -17,7 +17,7 @@
     data-module="govuk-button"
     data-prevent-double-click="true"
   >
-    {% if use_icon and action != "promote_to_first" and action != "promote_to_last" %}
+    {% if use_icon and icon_src %}
       <img class="icon"
         src="{{ static(icon_src) }}"
         alt="{{ action_text}} icon"

--- a/tasks/jinja2/tasks/macros/reorder_actions.jinja
+++ b/tasks/jinja2/tasks/macros/reorder_actions.jinja
@@ -1,0 +1,21 @@
+{% macro render_reorder_actions(item, max_position) %}
+  <div class="task-list__reorder-actions">
+    {% if not item.position == 1 %}
+      <button name="promote_item"
+        value="{{ item.pk }}"
+        class="govuk-link fake-link govuk-!-padding-right-2"
+        data-module="govuk-button"
+        data-prevent-double-click="true"
+      >Move up <span aria-hidden="true">&#9206;</span></button>
+    {% endif %}
+
+    {% if not item.position == max_position %}
+      <button name="demote_item"
+        value="{{ item.pk }}"
+        class="govuk-link fake-link"
+        data-module="govuk-button"
+        data-prevent-double-click="true"
+      >Move down <span aria-hidden="true">&#9207;</span></button>
+    {% endif %}
+  </div>
+{% endmacro %}

--- a/tasks/jinja2/tasks/workflows/template_detail.jinja
+++ b/tasks/jinja2/tasks/workflows/template_detail.jinja
@@ -1,9 +1,9 @@
 {% extends "layouts/layout.jinja" %}
 {% from "components/breadcrumbs.jinja" import breadcrumbs %}
 {% from "components/button/macro.njk" import govukButton %}
-{% from "tasks/macros/item_actions.jinja" import render_reorder_item_actions %}
 
 {% set page_title = "Workflow template: " ~ object.title %}
+{% set list_include = "tasks/includes/task_queue.jinja" %}
 
 {% set edit_url = "#TODO" %}
 
@@ -33,6 +33,7 @@
       <dd class="govuk-summary-list__value">
         {{ object.pk }}
       </dd>
+      <dd class="govuk-summary-list__actions"></dd>
     </div>
 
     <div class="govuk-summary-list__row">
@@ -62,42 +63,26 @@
 
   <h2 class="govuk-heading-m">Task templates</h2>
 
-  {% if not task_template_items %}
-    <p class="govuk-body">There are currently no task templates for this workflow template.</p>
-  {% else %}
-    <form method="post">
-      <input type="hidden" name="csrfmiddlewaretoken" value="{{ csrf_token }}">
-      <ol class="govuk-task-list">
-        {% set max_position = task_template_items.count() %}
-        {% for task_template_item in task_template_items %}
-          <li class="govuk-task-list__item govuk-task-list__item--with-link">
-            <div class="govuk-task-list__name-and-hint">
-              <a class="govuk-link govuk-task-list__link" href="#TODO">
-                {{- task_template_item.task_template.title -}}
-              </a>
-              {% if task_template_item.task_template.description %}
-                <div class="govuk-task-list__hint">
-                  {{ task_template_item.task_template.description|truncate(50) }}
-                </div>
-              {% endif %}
-            </div>
-            {{ render_reorder_item_actions(task_template_item, max_position) }}
-          </li>
-        {% endfor %}
-      </ol>
-    </form>
-  {% endif %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+      {% if object_list %}
+        {% include list_include %}
+      {% else %}
+        <p class="govuk-body">There are no task templates for this workflow template.</p>
+      {% endif %}
+    </div>
+  </div>
 
-<div class="govuk-button-group govuk-!-margin-top-6">
-  {{ govukButton({
-    "text": "Delete workflow template",
-    "href": "#TODO",
-    "classes": "govuk-button--warning"
-  }) }}
-  {{ govukButton({
-    "text": "Find and view workflow templates",
-    "href": "#TODO",
-    "classes": "govuk-button--secondary"
-  }) }}
-</div>
+  <div class="govuk-button-group govuk-!-margin-top-6">
+    {{ govukButton({
+      "text": "Delete workflow template",
+      "href": "#TODO",
+      "classes": "govuk-button--warning"
+    }) }}
+    {{ govukButton({
+      "text": "Find and view workflow templates",
+      "href": "#TODO",
+      "classes": "govuk-button--secondary"
+    }) }}
+  </div>
 {% endblock %}

--- a/tasks/jinja2/tasks/workflows/template_detail.jinja
+++ b/tasks/jinja2/tasks/workflows/template_detail.jinja
@@ -1,6 +1,7 @@
 {% extends "layouts/layout.jinja" %}
 {% from "components/breadcrumbs.jinja" import breadcrumbs %}
 {% from "components/button/macro.njk" import govukButton %}
+{% from "tasks/macros/reorder_actions.jinja" import render_reorder_actions %}
 
 {% set page_title = "Workflow template: " ~ object.title %}
 
@@ -64,22 +65,27 @@
   {% if not task_template_items %}
     <p class="govuk-body">There are currently no task templates for this workflow template.</p>
   {% else %}
-    <ol class="govuk-task-list">
-      {% for task_template_item in task_template_items -%}
-        <li class="govuk-task-list__item govuk-task-list__item--with-link">
-          <div class="govuk-task-list__name-and-hint">
-            <a class="govuk-link govuk-task-list__link" href="#TODO">
-              {{- task_template_item.task_template.title -}}
-            </a>
-            {% if task_template_item.task_template.description -%}
-              <div class="govuk-task-list__hint">
-                {{ task_template_item.task_template.description|truncate(50) }}
-              </div>
-            {% endif %}
-          </div>
-        </li>
-      {% endfor %}
-    </ol>
+    <form method="post">
+      <input type="hidden" name="csrfmiddlewaretoken" value="{{ csrf_token }}">
+      <ol class="govuk-task-list">
+        {% set max_position = task_template_items.count() %}
+        {% for task_template_item in task_template_items %}
+          <li class="govuk-task-list__item govuk-task-list__item--with-link">
+            <div class="govuk-task-list__name-and-hint">
+              <a class="govuk-link govuk-task-list__link" href="#TODO">
+                {{- task_template_item.task_template.title -}}
+              </a>
+              {% if task_template_item.task_template.description %}
+                <div class="govuk-task-list__hint">
+                  {{ task_template_item.task_template.description|truncate(50) }}
+                </div>
+              {% endif %}
+            </div>
+            {{ render_reorder_actions(task_template_item, max_position) }}
+          </li>
+        {% endfor %}
+      </ol>
+    </form>
   {% endif %}
 
 <div class="govuk-button-group govuk-!-margin-top-6">

--- a/tasks/jinja2/tasks/workflows/template_detail.jinja
+++ b/tasks/jinja2/tasks/workflows/template_detail.jinja
@@ -1,7 +1,7 @@
 {% extends "layouts/layout.jinja" %}
 {% from "components/breadcrumbs.jinja" import breadcrumbs %}
 {% from "components/button/macro.njk" import govukButton %}
-{% from "tasks/macros/reorder_actions.jinja" import render_reorder_actions %}
+{% from "tasks/macros/item_actions.jinja" import render_reorder_item_actions %}
 
 {% set page_title = "Workflow template: " ~ object.title %}
 
@@ -81,7 +81,7 @@
                 </div>
               {% endif %}
             </div>
-            {{ render_reorder_actions(task_template_item, max_position) }}
+            {{ render_reorder_item_actions(task_template_item, max_position) }}
           </li>
         {% endfor %}
       </ol>

--- a/tasks/models/workflow.py
+++ b/tasks/models/workflow.py
@@ -42,8 +42,9 @@ class TaskWorkflow(TaskWorkflowBase):
 
     def get_tasks(self) -> models.QuerySet:
         """Get a QuerySet of the Tasks associated through their TaskItem
-        instances to this TaskWorkflow."""
-        return Task.objects.filter(taskitem__queue=self)
+        instances to this TaskWorkflow, ordered by the position of the
+        TaskItem."""
+        return Task.objects.filter(taskitem__queue=self).order_by("taskitem__position")
 
 
 class TaskItem(QueueItem):
@@ -72,8 +73,11 @@ class TaskWorkflowTemplate(TaskWorkflowBase):
 
     def get_task_templates(self) -> models.QuerySet:
         """Get a QuerySet of the TaskTemplates associated through their
-        TaskItemTemplate instances to this TaskWorkflowTemplate."""
-        return TaskTemplate.objects.filter(taskitemtemplate__queue=self)
+        TaskItemTemplate instances to this TaskWorkflowTemplate, ordered by the
+        position of the TaskItemTemplate."""
+        return TaskTemplate.objects.filter(taskitemtemplate__queue=self).order_by(
+            "taskitemtemplate__position",
+        )
 
     @atomic
     def create_task_workflow(self) -> "TaskWorkflow":

--- a/tasks/static/tasks/scss/_tasks.scss
+++ b/tasks/static/tasks/scss/_tasks.scss
@@ -36,11 +36,3 @@
   margin-top: govuk-spacing(1);
   color: $govuk-secondary-text-colour;
 }
-
-.task-list__reorder-item-actions {
-  display: table-cell;
-  padding-left: govuk-spacing(2);
-  text-align: right;
-  vertical-align: top;
-  @include govuk-text-colour;
-}

--- a/tasks/static/tasks/scss/_tasks.scss
+++ b/tasks/static/tasks/scss/_tasks.scss
@@ -32,18 +32,15 @@
   @include govuk-text-colour;
 }
 
-.govuk-task-list__link::after {
-  content: "";
-  display: block;
-  position: absolute;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  left: 0;
-}
-
 .govuk-task-list__hint {
   margin-top: govuk-spacing(1);
   color: $govuk-secondary-text-colour;
 }
 
+.task-list__reorder-actions {
+  display: table-cell;
+  padding-left: govuk-spacing(2);
+  text-align: right;
+  vertical-align: top;
+  @include govuk-text-colour;
+}

--- a/tasks/static/tasks/scss/_tasks.scss
+++ b/tasks/static/tasks/scss/_tasks.scss
@@ -37,7 +37,7 @@
   color: $govuk-secondary-text-colour;
 }
 
-.task-list__reorder-actions {
+.task-list__reorder-item-actions {
   display: table-cell;
   padding-left: govuk-spacing(2);
   text-align: right;

--- a/tasks/tests/test_views.py
+++ b/tasks/tests/test_views.py
@@ -62,10 +62,12 @@ def test_workflow_template_detail_view_displays_task_templates(valid_user_client
 @pytest.mark.parametrize(
     ("action", "item_position", "expected_item_order"),
     [
-        ("promote_item", 1, [1, 2, 3]),
-        ("promote_item", 2, [2, 1, 3]),
-        ("demote_item", 2, [1, 3, 2]),
-        ("demote_item", 3, [1, 2, 3]),
+        ("promote", 1, [1, 2, 3]),
+        ("promote", 2, [2, 1, 3]),
+        ("demote", 2, [1, 3, 2]),
+        ("demote", 3, [1, 2, 3]),
+        ("promote_to_first", 3, [3, 1, 2]),
+        ("demote_to_last", 1, [2, 3, 1]),
     ],
 )
 def test_workflow_template_detail_view_reorder_items(

--- a/tasks/tests/test_views.py
+++ b/tasks/tests/test_views.py
@@ -1,3 +1,4 @@
+import pytest
 from bs4 import BeautifulSoup
 from django.urls import reverse
 
@@ -6,6 +7,10 @@ from common.tests.factories import TaskFactory
 from tasks.models import ProgressState
 from tasks.models import TaskLog
 from tasks.tests.test_workflow_models import TaskItemTemplateFactory
+from tasks.tests.test_workflow_models import task_workflow_template  # noqa
+from tasks.tests.test_workflow_models import (  # noqa
+    task_workflow_template_three_task_items,
+)
 
 
 def test_task_update_view_update_progress_state(valid_user_client):
@@ -52,3 +57,48 @@ def test_workflow_template_detail_view_displays_task_templates(valid_user_client
     page = BeautifulSoup(response.content.decode(response.charset), "html.parser")
     assert page.find("h1", text=workflow_template.title)
     assert page.find("a", text=task_template.title)
+
+
+@pytest.mark.parametrize(
+    ("action", "item_position", "expected_item_order"),
+    [
+        ("promote_item", 1, [1, 2, 3]),
+        ("promote_item", 2, [2, 1, 3]),
+        ("demote_item", 2, [1, 3, 2]),
+        ("demote_item", 3, [1, 2, 3]),
+    ],
+)
+def test_workflow_template_detail_view_reorder_items(
+    action,
+    item_position,
+    expected_item_order,
+    valid_user_client,
+    task_workflow_template_three_task_items,
+):
+    """Tests that `TaskWorkflowTemplateDetailView` handles POST requests to
+    promote or demote task templates."""
+
+    def convert_to_index(position: int) -> int:
+        """Converts a 1-based item position to a 0-based index for items array
+        access."""
+        return position - 1
+
+    items = list(task_workflow_template_three_task_items.get_items())
+    item_to_move = items[convert_to_index(item_position)]
+
+    url = reverse(
+        "workflow:task-workflow-template-ui-detail",
+        kwargs={"pk": task_workflow_template_three_task_items.pk},
+    )
+    form_data = {
+        action: item_to_move.id,
+    }
+
+    response = valid_user_client.post(url, form_data)
+    assert response.status_code == 302
+
+    reordered_items = task_workflow_template_three_task_items.get_items()
+    for i, reordered_item in enumerate(reordered_items):
+        expected_position = convert_to_index(expected_item_order[i])
+        expected_item = items[expected_position]
+        assert reordered_item.id == expected_item.id

--- a/tasks/views.py
+++ b/tasks/views.py
@@ -1,4 +1,5 @@
 from django.contrib.auth.mixins import PermissionRequiredMixin
+from django.db import OperationalError
 from django.db import transaction
 from django.http import HttpResponseRedirect
 from django.shortcuts import get_object_or_404
@@ -167,8 +168,14 @@ class TaskWorkflowTemplateDetailView(PermissionRequiredMixin, DetailView):
 
     def promote_item(self, item_id: int) -> None:
         task_item_template = get_object_or_404(TaskItemTemplate, id=item_id)
-        task_item_template.promote()
+        try:
+            task_item_template.promote()
+        except OperationalError:
+            pass
 
     def demote_item(self, item_id: int) -> None:
         task_item_template = get_object_or_404(TaskItemTemplate, id=item_id)
-        task_item_template.demote()
+        try:
+            task_item_template.demote()
+        except OperationalError:
+            pass

--- a/tasks/views.py
+++ b/tasks/views.py
@@ -158,23 +158,25 @@ class TaskWorkflowTemplateDetailView(PermissionRequiredMixin, DetailView):
 
     def get_context_data(self, **kwargs):
         context_data = super().get_context_data(**kwargs)
-        context_data["task_template_items"] = (
-            self.task_workflow_template.get_items().select_related("task_template")
-        )
+        context_data["object_list"] = self.task_workflow_template.get_task_templates()
         return context_data
 
     def post(self, request, *args, **kwargs):
-        if "promote_item" in request.POST:
-            self.promote_item(request.POST.get("promote_item"))
-        elif "demote_item" in request.POST:
-            self.demote_item(request.POST.get("demote_item"))
+        if "promote" in request.POST:
+            self.promote(request.POST.get("promote"))
+        elif "demote" in request.POST:
+            self.demote(request.POST.get("demote"))
+        elif "promote_to_first" in request.POST:
+            self.promote_to_first(request.POST.get("promote_to_first"))
+        elif "demote_to_last" in request.POST:
+            self.demote_to_last(request.POST.get("demote_to_last"))
 
         return HttpResponseRedirect(self.view_url)
 
-    def promote_item(self, item_id: int) -> None:
+    def promote(self, task_template_id: int) -> None:
         task_item_template = get_object_or_404(
             TaskItemTemplate,
-            id=item_id,
+            task_template_id=task_template_id,
             queue=self.task_workflow_template,
         )
         try:
@@ -182,13 +184,35 @@ class TaskWorkflowTemplateDetailView(PermissionRequiredMixin, DetailView):
         except OperationalError:
             pass
 
-    def demote_item(self, item_id: int) -> None:
+    def demote(self, task_template_id: int) -> None:
         task_item_template = get_object_or_404(
             TaskItemTemplate,
-            id=item_id,
+            task_template_id=task_template_id,
             queue=self.task_workflow_template,
         )
         try:
             task_item_template.demote()
+        except OperationalError:
+            pass
+
+    def promote_to_first(self, task_template_id: int) -> None:
+        task_item_template = get_object_or_404(
+            TaskItemTemplate,
+            task_template_id=task_template_id,
+            queue=self.task_workflow_template,
+        )
+        try:
+            task_item_template.promote_to_first()
+        except OperationalError:
+            pass
+
+    def demote_to_last(self, task_template_id: int) -> None:
+        task_item_template = get_object_or_404(
+            TaskItemTemplate,
+            task_template_id=task_template_id,
+            queue=self.task_workflow_template,
+        )
+        try:
+            task_item_template.demote_to_last()
         except OperationalError:
             pass


### PR DESCRIPTION
# TP2000-1545  Add task template reordering capability to workflow template detail view


## Why
Users require the ability to reorder task templates within a workflow template.

## What
- Adds new macro to display move up/down buttons  for reordering task templates
- Overrides `TaskWorkflowTemplateDetailView.post()` to handle template reordering form actions

## Checklist
- Requires migrations? No
- Requires dependency updates? No

## Screenshot
<img width="1220" alt="Screenshot 2024-11-14 at 12 38 29" src="https://github.com/user-attachments/assets/c5636fc2-8d37-4b6a-8b58-136422ebb5f2">

