### PR TITLE
TP2000-1573  Implement workflow template delete view

### DIFF
--- a/tasks/forms.py
+++ b/tasks/forms.py
@@ -124,6 +124,9 @@ class TaskWorkflowTemplateUpdateForm(TaskWorkflowTemplateBaseForm):
         super().__init__(*args, submit_title="Update", **kwargs)
 
 
+TaskWorkflowTemplateDeleteForm = delete_form_for(TaskWorkflowTemplate)
+
+
 class TaskTemplateFormBase(ModelForm):
     class Meta:
         model = TaskTemplate

--- a/tasks/jinja2/tasks/workflows/template_confirm_delete.jinja
+++ b/tasks/jinja2/tasks/workflows/template_confirm_delete.jinja
@@ -1,0 +1,42 @@
+{% extends "layouts/confirm.jinja" %}
+
+{% from "components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
+{% from "components/panel/macro.njk" import govukPanel %}
+{% from "components/button/macro.njk" import govukButton %}
+
+{% set page_title = "Workflow template deleted" %}
+
+{% block breadcrumb %}
+  {{ breadcrumbs(
+    request,
+    [
+      {"text": "Find and view workflow templates", "href": "#TODO"},
+      {"text": page_title}
+    ],
+    False,
+  ) }}
+{% endblock %}
+
+{% block panel %}
+  {{ govukPanel({
+    "titleText": "Workflow template ID: " ~ deleted_pk,
+    "text": "Workflow template has been deleted",
+    "classes": "govuk-!-margin-bottom-7"
+  }) }}
+{% endblock %}
+
+{% block button_group %}
+  {{ govukButton({
+    "text": "Find and view workflow templates",
+    "href": "#TODO",
+    "classes": "govuk-button"
+  }) }}
+  {{ govukButton({
+    "text": "Create a workflow template",
+    "href": url("workflow:task-workflow-template-ui-create"),
+    "classes": "govuk-button--secondary"
+  }) }}
+{% endblock %}
+
+{% block actions %}
+{% endblock %}

--- a/tasks/jinja2/tasks/workflows/template_delete.jinja
+++ b/tasks/jinja2/tasks/workflows/template_delete.jinja
@@ -1,0 +1,56 @@
+{% extends "layouts/form.jinja" %}
+
+{% from "components/breadcrumbs.jinja" import breadcrumbs %}
+{% from "components/warning-text/macro.njk" import govukWarningText %}
+{% from "components/button/macro.njk" import govukButton %}
+
+{% set page_title = "Delete workflow template: " ~ object.title %}
+
+{% block breadcrumb %}
+  {{ breadcrumbs(
+    request,
+    [
+      {"text": "Find and view workflow templates", "href": "#TODO"},
+      {
+        "text": "Workflow template: " ~ object.title,
+        "href": object.get_url("detail"),
+      },
+      {"text": page_title}
+    ],
+    False,
+  ) }}
+{% endblock %}
+
+{% block form %}
+  {% if task_templates %}
+    <p class="govuk-body">The workflow template contains the following task templates which will not be deleted:</p>
+    <ol class="govuk-task-list">
+      {% for task_template in task_templates %}
+        <li class="govuk-task-list__item govuk-task-list__item--with-link">
+        <div class="govuk-task-list__name-and-hint">
+            <a
+              class="govuk-link govuk-task-list__link"
+              href={{ task_template.get_url("detail") }}
+              rel="noreferrer noopener" target="_blank"
+            >
+              {{- task_template.title -}} <span class="govuk-visually-hidden"> (opens in new tab)</span>
+            </a>
+            {% if task_template.description %}
+              <div class="govuk-task-list__hint">
+                {{ task_template.description|truncate(50) }}
+              </div>
+            {% endif %}
+        </div>
+        </li>
+      {% endfor %}
+    </ol>
+  {% endif %}
+
+  {{ govukWarningText({
+    "text": "Are you sure you want to delete this workflow template?"
+  }) }}
+
+  {% call django_form(action=object.get_url("delete")) %}
+    {{ crispy(form) }}
+  {% endcall %}
+{% endblock %}

--- a/tasks/jinja2/tasks/workflows/template_detail.jinja
+++ b/tasks/jinja2/tasks/workflows/template_detail.jinja
@@ -84,7 +84,7 @@
   <div class="govuk-button-group govuk-!-margin-top-6">
     {{ govukButton({
       "text": "Delete workflow template",
-      "href": "#TODO",
+      "href": object.get_url("delete"),
       "classes": "govuk-button--warning"
     }) }}
     {{ govukButton({

--- a/tasks/models/workflow.py
+++ b/tasks/models/workflow.py
@@ -123,6 +123,11 @@ class TaskWorkflowTemplate(TaskWorkflowBase):
                 "workflow:task-workflow-template-ui-update",
                 kwargs={"pk": self.pk},
             )
+        elif action == "delete":
+            return reverse(
+                "workflow:task-workflow-template-ui-delete",
+                kwargs={"pk": self.pk},
+            )
 
         return "#NOT-IMPLEMENTED"
 

--- a/tasks/tests/test_views.py
+++ b/tasks/tests/test_views.py
@@ -278,6 +278,46 @@ def test_workflow_template_update_view(
     assert task_workflow_template.title in soup.select("h1.govuk-panel__title")[0].text
 
 
+def test_workflow_template_delete_view(
+    valid_user_client,
+    task_workflow_template_single_task_template_item,
+):
+    """Tests that a workflow template can be deleted and that the corresponding
+    confirmation view returns a HTTP 200 response."""
+
+    task_workflow_template_pk = task_workflow_template_single_task_template_item.pk
+    task_template_pk = (
+        task_workflow_template_single_task_template_item.get_task_templates().get().pk
+    )
+
+    delete_url = task_workflow_template_single_task_template_item.get_url("delete")
+    delete_response = valid_user_client.post(delete_url)
+    assert delete_response.status_code == 302
+
+    assert not TaskWorkflowTemplate.objects.filter(
+        pk=task_workflow_template_pk,
+    ).exists()
+    assert not TaskItemTemplate.objects.filter(
+        queue_id=task_workflow_template_pk,
+    ).exists()
+    assert TaskTemplate.objects.filter(pk=task_template_pk).exists()
+
+    confirmation_url = reverse(
+        "workflow:task-workflow-template-ui-confirm-delete",
+        kwargs={"pk": task_workflow_template_pk},
+    )
+    assert delete_response.url == confirmation_url
+
+    confirmation_response = valid_user_client.get(confirmation_url)
+    assert confirmation_response.status_code == 200
+
+    soup = BeautifulSoup(str(confirmation_response.content), "html.parser")
+    assert (
+        f"Workflow template ID: {task_workflow_template_pk}"
+        in soup.select(".govuk-panel__title")[0].text
+    )
+
+
 def test_create_task_template_view(valid_user_client, task_workflow_template):
     """Test the view for creating new TaskTemplates and the confirmation view
     that a successful creation redirects to."""

--- a/tasks/urls.py
+++ b/tasks/urls.py
@@ -69,6 +69,16 @@ workflow_template_ui_patterns = [
         name="task-workflow-template-ui-confirm-update",
     ),
     path(
+        "<int:pk>/delete/",
+        views.TaskWorkflowTemplateDeleteView.as_view(),
+        name="task-workflow-template-ui-delete",
+    ),
+    path(
+        "<int:pk>/confirm-delete/",
+        views.TaskWorkflowTemplateConfirmDeleteView.as_view(),
+        name="task-workflow-template-ui-confirm-delete",
+    ),
+    path(
         "task-templates/<int:pk>/",
         views.TaskTemplateDetailView.as_view(),
         name="task-template-ui-detail",

--- a/tasks/views.py
+++ b/tasks/views.py
@@ -22,6 +22,7 @@ from tasks.forms import TaskTemplateDeleteForm
 from tasks.forms import TaskTemplateUpdateForm
 from tasks.forms import TaskUpdateForm
 from tasks.forms import TaskWorkflowTemplateCreateForm
+from tasks.forms import TaskWorkflowTemplateDeleteForm
 from tasks.forms import TaskWorkflowTemplateUpdateForm
 from tasks.models import Task
 from tasks.models import TaskItemTemplate
@@ -285,6 +286,40 @@ class TaskWorkflowTemplateConfirmUpdateView(PermissionRequiredMixin, DetailView)
     model = TaskWorkflowTemplate
     template_name = "tasks/workflows/template_confirm_update.jinja"
     permission_required = "tasks.change_taskworkflowtemplate"
+
+
+class TaskWorkflowTemplateDeleteView(PermissionRequiredMixin, DeleteView):
+    model = TaskWorkflowTemplate
+    template_name = "tasks/workflows/template_delete.jinja"
+    permission_required = "tasks.delete_taskworkflowtemplate"
+    form_class = TaskWorkflowTemplateDeleteForm
+
+    def get_context_data(self, **kwargs):
+        context_data = super().get_context_data(**kwargs)
+        context_data["task_templates"] = self.object.get_task_templates()
+        return context_data
+
+    def get_form_kwargs(self):
+        kwargs = super().get_form_kwargs()
+        kwargs["instance"] = self.object
+        return kwargs
+
+    def get_success_url(self):
+        return reverse(
+            "workflow:task-workflow-template-ui-confirm-delete",
+            kwargs={"pk": self.object.pk},
+        )
+
+
+class TaskWorkflowTemplateConfirmDeleteView(PermissionRequiredMixin, TemplateView):
+    model = TaskWorkflowTemplate
+    template_name = "tasks/workflows/template_confirm_delete.jinja"
+    permission_required = "tasks.change_taskworkflowtemplate"
+
+    def get_context_data(self, **kwargs):
+        context_data = super().get_context_data(**kwargs)
+        context_data["deleted_pk"] = self.kwargs["pk"]
+        return context_data
 
 
 class TaskTemplateDetailView(PermissionRequiredMixin, DetailView):


### PR DESCRIPTION
# TP2000-1573  Implement workflow template delete view

## Why
A task workflow template delete view is required as part of workflow template management.

## What
- Adds a new view and form to support workflow template deletion
- Adds accompanying delete view unit test

## Checklist
- Requires migrations? No
- Requires dependency updates? No

## Screenshot
<img width="1066" alt="Screenshot 2024-11-18 at 14 09 26" src="https://github.com/user-attachments/assets/f16e99d4-7670-476f-8056-6b667c7878c0">

