### PR TITLE
TP2000-1565 Create an association update object when definition updated

### DIFF
--- a/quotas/forms/definitions.py
+++ b/quotas/forms/definitions.py
@@ -48,7 +48,11 @@ class QuotaDefinitionUpdateForm(
             "quota_critical",
         ]
 
-    description = forms.CharField(label="", widget=forms.Textarea(), required=False)
+    description = forms.CharField(
+        label="Description",
+        widget=forms.Textarea(),
+        required=False,
+    )
     volume = forms.DecimalField(
         label="Current volume",
         widget=forms.TextInput(),
@@ -116,33 +120,15 @@ class QuotaDefinitionUpdateForm(
         self.helper.legend_size = Size.SMALL
 
         self.helper.layout = Layout(
-            Accordion(
-                AccordionSection(
-                    "Description",
-                    "description",
-                ),
-                AccordionSection(
-                    "Validity period",
-                    "start_date",
-                    "end_date",
-                ),
-                AccordionSection(
-                    "Measurements",
-                    Field("measurement_unit", css_class="govuk-!-width-full"),
-                    Field("measurement_unit_qualifier", css_class="govuk-!-width-full"),
-                ),
-                AccordionSection(
-                    "Volume",
-                    "initial_volume",
-                    "volume",
-                ),
-                AccordionSection(
-                    "Criticality",
-                    "quota_critical_threshold",
-                    "quota_critical",
-                ),
-                css_class="govuk-!-width-two-thirds",
-            ),
+            "description",
+            "start_date",
+            "end_date",
+            Field("measurement_unit", css_class="govuk-!-width-full"),
+            Field("measurement_unit_qualifier", css_class="govuk-!-width-full"),
+            "initial_volume",
+            "volume",
+            "quota_critical_threshold",
+            "quota_critical",
             Submit(
                 "submit",
                 "Save",

--- a/quotas/jinja2/includes/quotas/tabs/sub_quotas.jinja
+++ b/quotas/jinja2/includes/quotas/tabs/sub_quotas.jinja
@@ -15,7 +15,7 @@
     </a>
   {% endset %}
   {% set actions_html %}
-      <a class="govuk-link" href="{{ object.sub_quota.version_at(request.user.current_workbasket.transactions.last()).get_association_edit_url() }}">Edit</a>
+      <a class="govuk-link" href="{{ object.sub_quota.get_association_edit_url() }}">Edit</a>
       <br/>
       <a class="govuk-link" href="{{ url('quota_association-ui-delete', args=[object.pk]) }}">Delete</a>
   {% endset %}
@@ -33,11 +33,6 @@
       href="{{ url('quota-ui-detail', args=[object.main_quota.order_number.sid]) }}">
       {{ object.main_quota.order_number }}
     </a>
-  {% endset %}
-  {% set actions_html %}
-      <a class="govuk-link" href="{{ object.sub_quota.version_at(request.user.current_workbasket.transactions.last()).get_association_edit_url() }}">Edit</a>
-      <br/>
-      <a class="govuk-link" href="{{ url('quota_association-ui-delete', args=[object.pk]) }}">Delete</a>
   {% endset %}
 
   {{ table_rows.append([

--- a/quotas/jinja2/quotas/tables/sub_quotas.jinja
+++ b/quotas/jinja2/quotas/tables/sub_quotas.jinja
@@ -20,8 +20,8 @@
     {{ table_rows.append([
       {"text": definition_link },
       {"text": sub_quota_link },
-      {"text": "{:%d %b %Y}".format(object.sub_quota.version_at(request.user.current_workbasket.transactions.last()).valid_between.lower) },
-      {"text": "{:%d %b %Y}".format(object.sub_quota.version_at(request.user.current_workbasket.transactions.last()).valid_between.upper) if object.sub_quota.valid_between.upper else "-"},
+      {"text": "{:%d %b %Y}".format(object.sub_quota.valid_between.lower) },
+      {"text": "{:%d %b %Y}".format(object.sub_quota.valid_between.upper) if object.sub_quota.valid_between.upper else "-"},
       {"text": object.get_sub_quota_relation_type_display() },
       {"text": object.coefficient },
       {"text": actions_html },
@@ -53,8 +53,8 @@
     {{ table_rows.append([
       {"text": definition_link },
       {"text": main_quota_link },
-      {"text": "{:%d %b %Y}".format(object.main_quota.version_at(request.user.current_workbasket.transactions.last()).valid_between.lower) },
-      {"text": "{:%d %b %Y}".format(object.main_quota.version_at(request.user.current_workbasket.transactions.last()).valid_between.upper) if object.main_quota.valid_between.upper else "-"},
+      {"text": "{:%d %b %Y}".format(object.main_quota.valid_between.lower) },
+      {"text": "{:%d %b %Y}".format(object.main_quota.valid_between.upper) if object.main_quota.valid_between.upper else "-"},
       {"text": object.get_sub_quota_relation_type_display() },
       {"text": object.coefficient },
     ]) or "" }}

--- a/quotas/views/definitions.py
+++ b/quotas/views/definitions.py
@@ -314,7 +314,8 @@ class SubQuotaDefinitionAssociationMixin:
 
 class SubQuotaDefinitionAssociationUpdate(
     SubQuotaDefinitionAssociationMixin,
-    QuotaDefinitionUpdate,
+    QuotaDefinitionUpdateMixin,
+    CreateTaricUpdateView,
 ):
 
     @transaction.atomic


### PR DESCRIPTION
# TP2000-1565 Create an association update object when definition updated
<!---
 * Include the JIRA ticket number, eg TP-123, to automatically link.
 * Use 50 characters maximum.
 * Do not end with a full-stop.
--->

## Why
<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Use as many lines as you like.
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions or deliberately ignored edge-cases.
--->

At the moment, a current workbasket is required to view the quota definition data page. This is because the association list view needs to check current updates in order to display the latest data if a quota definition was updated.

This is not ideal as detail views should not mandate a workbasket. Some stakeholders like HMRC may want to view this page and won't have one.

This ticket solves that issue by ensuring that whenever a quota definition is updated, an updated association object is created too. This ensures that associations listed all point to updated quota definitions and show the latest data rather than previously when unedited associations were pointing to old instances of quota definitions.

## What
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Explain like I'm 5.
 * Use pictures if you can.
--->

This PR:
- removes the current workbasket requirement for the quota definition list page
- creates a new association object for any related associations when a definition is updated
- removes the accordion layout for the edit quota definition page

<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
## Checklist
- Requires migrations?
- Requires dependency updates?
--->

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
