### PR TITLE
TP2000-1488 Edit Subtasks 

### DIFF
--- a/tasks/jinja2/tasks/confirm_update.jinja
+++ b/tasks/jinja2/tasks/confirm_update.jinja
@@ -4,12 +4,12 @@
 {% from "components/panel/macro.njk" import govukPanel %}
 {% from "components/button/macro.njk" import govukButton %}
 
-{% set page_title = "Task updated" %}
+{% set page_title = page_title %}
 
 {% block breadcrumb %}
   {{ govukBreadcrumbs({
     "items": [
-      {"text": "Task: " ~ object.title, "href": url("workflow:task-ui-detail", kwargs={"pk": object.pk})},
+      {"text": object_type ~ ": " ~ object.title, "href": url("workflow:task-ui-detail", kwargs={"pk": object.pk})},
       {"text": page_title}
     ]
   }) }}
@@ -17,15 +17,15 @@
 
 {% block panel %}
   {{ govukPanel({
-    "titleText": "Task: " ~ object.title,
-    "text": "Task has been updated",
+    "titleText": object_type ~ ": " ~ object.title,
+    "text": object_type ~ " has been updated",
     "classes": "govuk-!-margin-bottom-7"
   }) }}
 {% endblock %}
 
 {% block button_group %}
   {{ govukButton({
-    "text": "View task",
+    "text": "View " ~ object_type,
     "href": url('workflow:task-ui-detail', kwargs={"pk": object.pk}),
     "classes": "govuk-button"
   }) }}

--- a/tasks/jinja2/tasks/detail.jinja
+++ b/tasks/jinja2/tasks/detail.jinja
@@ -4,6 +4,7 @@
 
 {% set page_title = "Task: " ~ object.title %}
 
+{# Change this depending on task or subtask #}
 {% set edit_url = url("workflow:task-ui-update", kwargs={"pk": object.pk}) %}
 
 {% block breadcrumb %}
@@ -114,7 +115,7 @@
   {% if not object.parent_task %}
     {{ govukButton({
       "text": "Create subtask",
-      "href": url("workflow:subtask-ui-create", kwargs={"pk": object.pk}),
+      "href": url("workflow:subtask-ui-create", kwargs={"parent_task_pk": object.pk}),
       "classes": "govuk-button--secondary"
     }) }}
   {% endif %}

--- a/tasks/jinja2/tasks/detail.jinja
+++ b/tasks/jinja2/tasks/detail.jinja
@@ -4,8 +4,11 @@
 
 {% set page_title = "Task: " ~ object.title %}
 
-{# Change this depending on task or subtask #}
-{% set edit_url = url("workflow:task-ui-update", kwargs={"pk": object.pk}) %}
+{%if object.parent_task%}
+  {% set edit_url = url("workflow:subtask-ui-update", kwargs={"pk": object.pk}) %}
+{% else %}
+  {% set edit_url = url("workflow:task-ui-update", kwargs={"pk": object.pk}) %}
+{% endif%}
 
 {% block breadcrumb %}
   {{ breadcrumbs(request, [

--- a/tasks/jinja2/tasks/edit.jinja
+++ b/tasks/jinja2/tasks/edit.jinja
@@ -1,7 +1,7 @@
 {% extends "layouts/form.jinja" %}
 {% from "components/breadcrumbs.jinja" import breadcrumbs %}
 
-{% set page_title = "Edit task details" %}
+{% set page_title = page_title %}
 
 {% block breadcrumb %}
   {{ breadcrumbs(request, [

--- a/tasks/tests/test_views.py
+++ b/tasks/tests/test_views.py
@@ -108,9 +108,9 @@ def test_create_subtask_button_shows_only_for_non_parent_tasks(
     page = BeautifulSoup(response.content.decode(response.charset), "html.parser")
 
     if expected_result:
-        assert page.find("a", href=f"/tasks/{task.pk}/subtasks/create")
+        assert page.find("a", href=f"/tasks/{task.pk}/subtasks/create/")
     else:
-        assert not page.find("a", href=f"/tasks/{task.pk}/subtasks/create")
+        assert not page.find("a", href=f"/tasks/{task.pk}/subtasks/create/")
 
 
 def test_create_subtask_form_errors_when_parent_is_subtask(valid_user_client):
@@ -129,7 +129,7 @@ def test_create_subtask_form_errors_when_parent_is_subtask(valid_user_client):
     url = reverse(
         "workflow:subtask-ui-create",
         kwargs={
-            "pk": subtask_parent.pk,
+            "parent_task_pk": subtask_parent.pk,
         },
     )
 

--- a/tasks/tests/test_views.py
+++ b/tasks/tests/test_views.py
@@ -82,6 +82,40 @@ def test_confirm_create_template_shows_task_or_subtask(
 
 
 @pytest.mark.parametrize(
+    ("task_factory", "update_subtask_url"),
+    [
+        (TaskFactory, False),
+        (SubTaskFactory, True),
+    ],
+    ids=("task test", "subtask test"),
+)
+def test_update_link_changes_for_task_and_subtask(
+    superuser_client,
+    task_factory,
+    update_subtask_url,
+):
+    task = task_factory.create()
+
+    url = reverse(
+        "workflow:task-ui-detail",
+        kwargs={
+            "pk": task.pk,
+        },
+    )
+    response = superuser_client.get(url)
+    assert response.status_code == 200
+
+    page = BeautifulSoup(response.content.decode(response.charset), "html.parser")
+
+    if update_subtask_url:
+        assert page.find("a", href=f"/tasks/subtasks/{task.pk}/update/")
+        assert not page.find("a", href=f"/tasks/{task.pk}/update/")
+    else:
+        assert page.find("a", href=f"/tasks/{task.pk}/update/")
+        assert not page.find("a", href=f"/tasks/subtasks/{task.pk}/update/")
+
+
+@pytest.mark.parametrize(
     ("task_factory", "expected_result"),
     [
         (TaskFactory, True),

--- a/tasks/urls.py
+++ b/tasks/urls.py
@@ -6,37 +6,50 @@ from tasks import views
 app_name = "workflow"
 
 task_ui_patterns = [
+    # Task urls
     path("", views.TaskListView.as_view(), name="task-ui-list"),
     path("<int:pk>/", views.TaskDetailView.as_view(), name="task-ui-detail"),
     path("create/", views.TaskCreateView.as_view(), name="task-ui-create"),
     path(
-        "<int:pk>/confirm-create",
+        "<int:pk>/confirm-create/",
         views.TaskConfirmCreateView.as_view(),
         name="task-ui-confirm-create",
     ),
     path("<int:pk>/update/", views.TaskUpdateView.as_view(), name="task-ui-update"),
     path(
-        "<int:pk>/confirm-update",
+        "<int:pk>/confirm-update/",
         views.TaskConfirmUpdateView.as_view(),
         name="task-ui-confirm-update",
     ),
     path("<int:pk>/delete/", views.TaskDeleteView.as_view(), name="task-ui-delete"),
     path(
-        "<int:pk>/confirm-delete",
+        "<int:pk>/confirm-delete/",
         views.TaskConfirmDeleteView.as_view(),
         name="task-ui-confirm-delete",
     ),
+    # Subtask urls
     path(
-        "<int:pk>/subtasks/create",
+        "<int:parent_task_pk>/subtasks/create/",
         views.SubTaskCreateView.as_view(),
         name="subtask-ui-create",
     ),
     path(
-        "subtasks/<int:pk>/confirm-create/",
+        "subtasks/confirm-create/<int:pk>/",
         views.SubTaskConfirmCreateView.as_view(),
         name="subtask-ui-confirm-create",
     ),
+    path(
+        "subtasks/<int:pk>/update/",
+        views.SubTaskUpdateView.as_view(),
+        name="subtask-ui-update",
+    ),
+    path(
+        "subtasks/confirm-update/<int:pk>/",
+        views.SubTaskConfirmUpdateView.as_view(),
+        name="subtask-ui-confirm-update",
+    ),
 ]
+
 
 workflow_ui_patterns = [
     # TODO

--- a/tasks/views.py
+++ b/tasks/views.py
@@ -104,6 +104,12 @@ class TaskConfirmUpdateView(PermissionRequiredMixin, DetailView):
     template_name = "tasks/confirm_update.jinja"
     permission_required = "tasks.change_task"
 
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["page_title"] = "Task updated"
+        context["object_type"] = "Task"
+        return context
+
 
 class TaskDeleteView(PermissionRequiredMixin, DeleteView):
     model = Task
@@ -139,11 +145,13 @@ class SubTaskCreateView(PermissionRequiredMixin, CreateView):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        context["page_title"] = f"Create a subtask for task {self.kwargs['pk']}"
+        context["page_title"] = (
+            f"Create a subtask for task {self.kwargs['parent_task_pk']}"
+        )
         return context
 
     def form_valid(self, form):
-        parent_task = Task.objects.filter(pk=self.kwargs["pk"]).first()
+        parent_task = Task.objects.filter(pk=self.kwargs["parent_task_pk"]).first()
         if parent_task.parent_task:
             form.add_error(
                 None,
@@ -168,6 +176,42 @@ class SubTaskConfirmCreateView(DetailView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context["verbose_name"] = "subtask"
+        return context
+
+
+class SubTaskUpdateView(PermissionRequiredMixin, UpdateView):
+    model = Task
+    template_name = "tasks/edit.jinja"
+    permission_required = "tasks.change_task"
+    form_class = TaskUpdateForm
+
+    def form_valid(self, form):
+        set_current_instigator(self.request.user)
+        with transaction.atomic():
+            self.object = form.save()
+        return HttpResponseRedirect(self.get_success_url())
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["page_title"] = f"Edit subtask {self.object.pk}"
+        return context
+
+    def get_success_url(self):
+        return reverse(
+            "workflow:subtask-ui-confirm-update",
+            kwargs={"pk": self.object.pk},
+        )
+
+
+class SubTaskConfirmUpdateView(PermissionRequiredMixin, DetailView):
+    model = Task
+    template_name = "tasks/confirm_update.jinja"
+    permission_required = "tasks.change_task"
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["page_title"] = "Subtask updated"
+        context["object_type"] = "Subtask"
         return context
 
 


### PR DESCRIPTION
#TP2000-1488 Edit Subtasks 


## Why
As part of the Task work, we need a custom set of urls, views and templates to edit a subtask. A lot of the functionality piggybacks off creating a task. 

## What
- Cleans up urls file to be consistent in it's patterns
- Adds urls for updating and confirm updating
- Adds views for both updating and confirm update. 
- Amends the templates to be dynamic so that both tasks and subtasks can share it. 
- Adds logic to the details template to either go to the subtask update url, or the task update url depending on what type of task it is. 
- Adds tests to check this logic. 

## Checklist
- Requires migrations? - no
- Requires dependency updates? - no


