### PR TITLE
TP2000-1584  Fix duty sentence parser error with MAX expression

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1777,15 +1777,15 @@ def percent_or_amount() -> DutyExpression:
 
 
 @pytest.fixture
-def plus_percent_or_amount() -> DutyExpression:
-    return factories.DutyExpressionFactory(
-        sid=4,
-        prefix="+",
-        description=f"+ % or amount",
-        duty_amount_applicability_code=ApplicabilityCode.MANDATORY,
-        measurement_unit_applicability_code=ApplicabilityCode.PERMITTED,
-        monetary_unit_applicability_code=ApplicabilityCode.PERMITTED,
-    )
+def plus_percent_or_amount() -> list[DutyExpression]:
+    kwargs = {
+        "prefix": "+",
+        "description": f"+ % or amount",
+        "duty_amount_applicability_code": ApplicabilityCode.MANDATORY,
+        "measurement_unit_applicability_code": ApplicabilityCode.PERMITTED,
+        "monetary_unit_applicability_code": ApplicabilityCode.PERMITTED,
+    }
+    return [factories.DutyExpressionFactory(sid=sid, **kwargs) for sid in [4, 19, 20]]
 
 
 @pytest.fixture
@@ -1798,6 +1798,18 @@ def plus_agri_component() -> DutyExpression:
         measurement_unit_applicability_code=ApplicabilityCode.PERMITTED,
         monetary_unit_applicability_code=ApplicabilityCode.PERMITTED,
     )
+
+
+@pytest.fixture
+def maximum() -> list[DutyExpression]:
+    kwargs = {
+        "prefix": "MAX",
+        "description": "Maximum",
+        "duty_amount_applicability_code": ApplicabilityCode.MANDATORY,
+        "measurement_unit_applicability_code": ApplicabilityCode.PERMITTED,
+        "monetary_unit_applicability_code": ApplicabilityCode.PERMITTED,
+    }
+    return [factories.DutyExpressionFactory(sid=sid, **kwargs) for sid in [17, 35]]
 
 
 @pytest.fixture
@@ -1838,39 +1850,26 @@ def supplementary_unit() -> DutyExpression:
 
 @pytest.fixture
 def duty_expressions(
-    percent_or_amount: DutyExpression,
-    plus_percent_or_amount: DutyExpression,
-    plus_agri_component: DutyExpression,
-    plus_amount_only: DutyExpression,
-    supplementary_unit: DutyExpression,
-    nothing: DutyExpression,
+    duty_expressions_list: list[DutyExpression],
 ) -> Dict[int, DutyExpression]:
-    return {
-        d.sid: d
-        for d in [
-            percent_or_amount,
-            plus_percent_or_amount,
-            plus_agri_component,
-            plus_amount_only,
-            supplementary_unit,
-            nothing,
-        ]
-    }
+    return {d.sid: d for d in duty_expressions_list}
 
 
 @pytest.fixture
 def duty_expressions_list(
     percent_or_amount: DutyExpression,
-    plus_percent_or_amount: DutyExpression,
+    plus_percent_or_amount: list[DutyExpression],
     plus_agri_component: DutyExpression,
+    maximum: list[DutyExpression],
     plus_amount_only: DutyExpression,
     supplementary_unit: DutyExpression,
     nothing: DutyExpression,
 ) -> Sequence[DutyExpression]:
     return [
         percent_or_amount,
-        plus_percent_or_amount,
+        *plus_percent_or_amount,
         plus_agri_component,
+        *maximum,
         plus_amount_only,
         supplementary_unit,
         nothing,

--- a/conftest.py
+++ b/conftest.py
@@ -1801,7 +1801,7 @@ def plus_agri_component() -> DutyExpression:
 
 
 @pytest.fixture
-def maximum() -> list[DutyExpression]:
+def maximum_clause_expression() -> list[DutyExpression]:
     kwargs = {
         "prefix": "MAX",
         "description": "Maximum",
@@ -1860,7 +1860,7 @@ def duty_expressions_list(
     percent_or_amount: DutyExpression,
     plus_percent_or_amount: list[DutyExpression],
     plus_agri_component: DutyExpression,
-    maximum: list[DutyExpression],
+    maximum_clause_expression: list[DutyExpression],
     plus_amount_only: DutyExpression,
     supplementary_unit: DutyExpression,
     nothing: DutyExpression,
@@ -1869,7 +1869,7 @@ def duty_expressions_list(
         percent_or_amount,
         *plus_percent_or_amount,
         plus_agri_component,
-        *maximum,
+        *maximum_clause_expression,
         plus_amount_only,
         supplementary_unit,
         nothing,

--- a/measures/duty_sentence_parser.py
+++ b/measures/duty_sentence_parser.py
@@ -302,14 +302,15 @@ class DutyTransformer(Transformer):
 
             # Each duty expression can only be used once in a sentence and in order of increasing
             # SID so once we have a match, remove it from the list of duty expression sids
-            duty_expression_sids.remove(match.sid)
+            duty_expression_sids[:] = [
+                sid for sid in duty_expression_sids if sid > match.sid
+            ]
             # Update with the matching DutyExpression we found
             phrase["duty_expression"] = match
 
         transformed_duty_expression_sids = [
             phrase["duty_expression"].sid for phrase in transformed
         ]
-
         if transformed_duty_expression_sids != sorted(transformed_duty_expression_sids):
             raise ValidationError(
                 "Duty expressions must be used in the duty sentence in ascending order of SID.",

--- a/measures/duty_sentence_parser.py
+++ b/measures/duty_sentence_parser.py
@@ -8,6 +8,7 @@ from lark import Lark
 from lark import Transformer
 from lark import UnexpectedInput
 
+from common.models import TrackedModel
 from measures import models
 from measures.validators import ApplicabilityCode
 
@@ -347,7 +348,7 @@ class DutyTransformer(Transformer):
                 f"Duty expression {duty_expression.description} ({duty_expression.prefix}) requires a {item_name}.",
             )
         if code == ApplicabilityCode.NOT_PERMITTED and item:
-            if isinstance(item, object):
+            if isinstance(item, TrackedModel):
                 message = f"{item_name.capitalize()} {item.abbreviation} ({item.code}) cannot be used with duty expression {duty_expression.description} ({duty_expression.prefix})."
             else:
                 message = f"{item_name.capitalize()} cannot be used with duty expression {duty_expression.description} ({duty_expression.prefix})."

--- a/measures/duty_sentence_parser.py
+++ b/measures/duty_sentence_parser.py
@@ -288,6 +288,17 @@ class DutyTransformer(Transformer):
                 .order_by("sid")
                 .first()
             )
+
+            # A duty amount will be mistakenly matched by prefix as a supplementary unit
+            # if all possible duty amount expression SIDs have already been applied
+            if (
+                match
+                and match == supplementary_unit
+                and "duty_amount" in phrase
+                and "measurement_unit" not in phrase
+            ):
+                match = None
+
             if match is None:
                 potential_match = (
                     models.DutyExpression.objects.as_at(self.date)

--- a/measures/tests/test_lark_parser.py
+++ b/measures/tests/test_lark_parser.py
@@ -22,7 +22,7 @@ PERCENT_OR_AMOUNT_FIXTURE_NAME = "percent_or_amount"
 PLUS_PERCENT_OR_AMOUNT_SID = (4, 19, 20)
 SUPPLEMENTARY_UNIT_FIXTURE_NAME = "supplementary_unit"
 PLUS_AGRI_COMPONENT_FIXTURE_NAME = "plus_agri_component"
-MAXIMUM_SID = (17, 35)
+MAXIMUM_CLAUSE_SID = (17, 35)
 NOTHING_FIXTURE_NAME = "nothing"
 BRITISH_POUND_FIXTURE_NAME = "british_pound"
 EURO_FIXTURE_NAME = "euro"
@@ -61,7 +61,7 @@ ECU_CONVERSION_FIXTURE_NAME = "ecu_conversion"
                     "duty_expression": PERCENT_OR_AMOUNT_FIXTURE_NAME,
                 },
                 {
-                    "duty_expression_sid": MAXIMUM_SID[0],
+                    "duty_expression_sid": MAXIMUM_CLAUSE_SID[0],
                     "duty_amount": 1.0,
                 },
                 {

--- a/measures/tests/test_util.py
+++ b/measures/tests/test_util.py
@@ -70,7 +70,7 @@ def test_diff_components_update_multiple(
     component_2 = factories.MeasureComponentFactory.create(
         component_measure=component_1.component_measure,
         duty_amount=253.000,
-        duty_expression=plus_percent_or_amount,
+        duty_expression=plus_percent_or_amount[0],
         monetary_unit=monetary_units["GBP"],
         component_measurement__measurement_unit=measurement_units[1],
     )


### PR DESCRIPTION
# TP2000-1584  Fix duty sentence parser error with MAX expression

## Why
Entering the duty sentence `9.10% MAX 1.00% + 0.90 GBP / 100 kg`  in the Commodities & Duties step of the Create Measures journey raises the following form error: `Duty expressions must be used in the duty sentence in ascending order of SID`. 

## What
- Removes the matched duty expression SID in addition to SIDs of a lower order when tracking applicable duty expressions, ensuring expressions are applied in ascending SID order:
    - For example, the duty expression SID order for the above parsed duty sentence was showing as 1, 17, 4; 
    - The new SID order would be applied as 1, 17, 19

- Refactors duty sentence parser related fixtures and tests catering for duty expression SID ordering
    - Modifies both `plus_percent_or_amount` and `maximum` fixtures to return a list of objects for each possible SID
    - Factors out a helper function, `replace_with_component_instances`, that turns test param data defining expected duty components into their corresponding object instances
    - Fixes tests that were giving false positives as a result of `with pytest.raises()` returning early once an exception was raised
    - Separates duty expression applicability code validation from duty expression validation test

Links to relevant material
See: [Duty expressions - Tariff data manual](https://uktrade.github.io/tariff-data-manual/documentation/data-structures/measure-components.html#duty-expressions)