### PR TITLE
Update TaskWorkflowTemplate.create_task_workflow() method and unit test

### DIFF
--- a/tasks/migrations/0012_taskworkflow_assign_summary_task.py
+++ b/tasks/migrations/0012_taskworkflow_assign_summary_task.py
@@ -12,7 +12,7 @@ def assign_new_summary_task_on_workflow(apps, schema_editor):
             title="Workflow summarising task",
             description="Workflow summarising task.",
         )
-        TaskWorkflow.save()
+        task_workflow.save()
 
 
 class Migration(migrations.Migration):

--- a/tasks/models/workflow.py
+++ b/tasks/models/workflow.py
@@ -91,13 +91,17 @@ class TaskWorkflowTemplate(Queue):
         )
 
     @atomic
-    def create_task_workflow(self) -> "TaskWorkflow":
-        """Create a workflow and it subtasks, using values from this template
-        workflow and its task templates."""
+    def create_task_workflow(self, summary_data: dict) -> "TaskWorkflow":
+        """
+        Create a workflow and it subtasks, using values from this template
+        workflow and its task templates.
 
+        The `summary_data` param is used to populate the details of the `TaskWorkflow.summary_task` instance.
+        """
+
+        summary_task = Task.objects.create(**summary_data)
         task_workflow = TaskWorkflow.objects.create(
-            title=self.title,
-            description=self.description,
+            summary_task=summary_task,
             creator_template=self,
         )
 

--- a/tasks/models/workflow.py
+++ b/tasks/models/workflow.py
@@ -91,15 +91,11 @@ class TaskWorkflowTemplate(Queue):
         )
 
     @atomic
-    def create_task_workflow(self, summary_data: dict) -> "TaskWorkflow":
-        """
-        Create a workflow and it subtasks, using values from this template
-        workflow and its task templates.
+    def create_task_workflow(self, title: str, description: str) -> "TaskWorkflow":
+        """Create a workflow and it subtasks, using values from this template
+        workflow and its task templates."""
 
-        The `summary_data` param is used to populate the details of the `TaskWorkflow.summary_task` instance.
-        """
-
-        summary_task = Task.objects.create(**summary_data)
+        summary_task = Task.objects.create(title=title, description=description)
         task_workflow = TaskWorkflow.objects.create(
             summary_task=summary_task,
             creator_template=self,

--- a/tasks/tests/test_workflow_models.py
+++ b/tasks/tests/test_workflow_models.py
@@ -13,13 +13,12 @@ def test_create_task_workflow_from_task_workflow_template(
 ):
     """Test creation of TaskWorkflow instances from TaskWorkflowTemplates using
     its `create_task_workflow()` method."""
-    summary_data = {
-        "title": "Workflow title",
-        "description": "Workflow description",
-    }
+    title = "Workflow title"
+    description = "Workflow description"
     task_workflow = (
         task_workflow_template_three_task_template_items.create_task_workflow(
-            summary_data,
+            title=title,
+            description=description,
         )
     )
 
@@ -28,8 +27,8 @@ def test_create_task_workflow_from_task_workflow_template(
         task_workflow.creator_template
         == task_workflow_template_three_task_template_items
     )
-    assert task_workflow.summary_task.title == summary_data["title"]
-    assert task_workflow.summary_task.description == summary_data["description"]
+    assert task_workflow.summary_task.title == title
+    assert task_workflow.summary_task.description == description
     assert task_workflow.get_items().count() == 3
 
     # Validate that item positions are equivalent.

--- a/tasks/tests/test_workflow_models.py
+++ b/tasks/tests/test_workflow_models.py
@@ -13,8 +13,14 @@ def test_create_task_workflow_from_task_workflow_template(
 ):
     """Test creation of TaskWorkflow instances from TaskWorkflowTemplates using
     its `create_task_workflow()` method."""
+    summary_data = {
+        "title": "Workflow title",
+        "description": "Workflow description",
+    }
     task_workflow = (
-        task_workflow_template_three_task_template_items.create_task_workflow()
+        task_workflow_template_three_task_template_items.create_task_workflow(
+            summary_data,
+        )
     )
 
     # Test that workflow values are valid.
@@ -22,11 +28,8 @@ def test_create_task_workflow_from_task_workflow_template(
         task_workflow.creator_template
         == task_workflow_template_three_task_template_items
     )
-    assert task_workflow.title == task_workflow_template_three_task_template_items.title
-    assert (
-        task_workflow.description
-        == task_workflow_template_three_task_template_items.description
-    )
+    assert task_workflow.summary_task.title == summary_data["title"]
+    assert task_workflow.summary_task.description == summary_data["description"]
     assert task_workflow.get_items().count() == 3
 
     # Validate that item positions are equivalent.


### PR DESCRIPTION
# Update TaskWorkflowTemplate.create_task_workflow() method

## Why
The [task-workflow megabranch](https://github.com/uktrade/tamato/pull/1298) has a failing test following changes to `TaskWorkflow` model: `tasks/tests/test_workflow_models.py::test_create_task_workflow_from_task_workflow_template`

## What
- Adds `summary_data` param to `TaskWorkflowTemplate.create_task_workflow()` to populate the details of the `TaskWorkflow.summary_task` instance (since it has become a required field), replacing the old way of using the workflow template's title and description
- Updates unit test based on the above change
- Fixes application of `tasks/migrations/0012_taskworkflow_assign_summary_task.py` by saving the modified object instances in the forward migration operation

## Checklist
- Requires migrations? Yes
- Requires dependency updates? No

