### PR TITLE
Include user param in form.save() call

### DIFF
--- a/tasks/views.py
+++ b/tasks/views.py
@@ -521,6 +521,10 @@ class TaskWorkflowTemplateCreateView(PermissionRequiredMixin, CreateView):
         context["list_url"] = reverse("workflow:task-workflow-template-ui-list")
         return context
 
+    def form_valid(self, form):
+        self.object = form.save(user=self.request.user)
+        return HttpResponseRedirect(self.get_success_url())
+
     def get_success_url(self):
         return reverse(
             "workflow:task-workflow-template-ui-confirm-create",


### PR DESCRIPTION
# Fix test test_workflow_template_create_view failure
<!---
 * Include the JIRA ticket number, eg TP-123, to automatically link.
 * Use 50 characters maximum.
 * Do not end with a full-stop.
--->

## Why
<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Use as many lines as you like.
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions or deliberately ignored edge-cases.
--->

The unit test `test_workflow_template_create_view` is currently failing.

## What
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Explain like I'm 5.
 * Use pictures if you can.
--->

This PR overrides `TaskWorkflowTemplateCreateView.form_valid()` so that the required `user` parameter can be included in the call to `form.save()`.

<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
--->
## Checklist
- Requires migrations? No
- Requires dependency updates? No

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
