### PR TITLE
TP2000-1596 Quotas - small fixes

### DIFF
--- a/quotas/jinja2/includes/quotas/tabs/sub_quotas.jinja
+++ b/quotas/jinja2/includes/quotas/tabs/sub_quotas.jinja
@@ -17,7 +17,7 @@
   {% set actions_html %}
       <a class="govuk-link" href="{{ object.sub_quota.get_association_edit_url() }}">Edit</a>
       <br/>
-      <a class="govuk-link" href="{{ url('quota_association-ui-delete', args=[object.pk]) }}">Delete</a>
+      <a class="govuk-link" href="{{ object.get_url('delete') }}">Delete</a>
   {% endset %}
   {{ table_rows.append([
     {"html": sub_quota_link},

--- a/quotas/jinja2/quota-associations/delete.jinja
+++ b/quotas/jinja2/quota-associations/delete.jinja
@@ -21,10 +21,4 @@
   {% call django_form(action="") %}
     {{ crispy(form) }}
   {% endcall %}
-
-  {{ govukButton({
-    "text": "Cancel",
-    "href": object.get_url(),
-    "classes": "govuk-button--secondary"
-  }) }}
 {% endblock %}

--- a/quotas/models.py
+++ b/quotas/models.py
@@ -465,6 +465,33 @@ class QuotaAssociation(TrackedModel):
         business_rules.SameMainAndSubQuota,
     )
 
+    def get_url(self, action: str = "detail") -> Optional[str]:
+        """
+        Generate a URL to a representation of the model in the webapp.
+
+        Custom for quota associations as they do not have a detail view or
+        typical list/edit views.
+        """
+        if action == "edit":
+            url = self.sub_quota.get_association_edit_url()
+            return url
+        try:
+            if action == "create":
+                url = reverse("sub_quota_definitions-ui-create")
+            elif action == "delete":
+                url = reverse("quota_association-ui-delete", kwargs={"pk": self.pk})
+            else:
+                url = reverse(
+                    "quota_definition-ui-list-filter",
+                    kwargs={
+                        "sid": self.main_quota.order_number.sid,
+                        "quota_type": "quota_associations",
+                    },
+                )
+            return url
+        except NoReverseMatch:
+            return None
+
 
 class QuotaSuspension(TrackedModel, ValidityMixin):
     """Defines a suspension period for a quota."""

--- a/quotas/views/base.py
+++ b/quotas/views/base.py
@@ -239,7 +239,7 @@ class QuotaDetail(QuotaOrderNumberMixin, TrackedModelDetailView, SortingMixin):
             order = "goods_nomenclature"
 
         context["measures"] = (
-            Measure.objects.latest_approved()
+            Measure.objects.current()
             .filter(order_number=self.object)
             .as_at(date.today())
             .order_by(order)

--- a/quotas/views/base.py
+++ b/quotas/views/base.py
@@ -241,7 +241,7 @@ class QuotaDetail(QuotaOrderNumberMixin, TrackedModelDetailView, SortingMixin):
         context["measures"] = (
             Measure.objects.current()
             .filter(order_number=self.object)
-            .as_at(date.today())
+            .as_at_today_and_beyond()
             .order_by(order)
         )
         url_params = urlencode({"order_number": self.object.pk})


### PR DESCRIPTION
# TP2000-1596 Quotas - small fixes
<!---
 * Include the JIRA ticket number, eg TP-123, to automatically link.
 * Use 50 characters maximum.
 * Do not end with a full-stop.
--->

## Why
<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Use as many lines as you like.
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions or deliberately ignored edge-cases.
--->

Issues identified:
- When viewing the measures tab on a quota order number details view. The user should be able to see newly created measures. This normally involves using the .current method, rather than latest approved transaction.
- There are 2 cancel buttons on the delete association page and one doesn't work


## What
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Explain like I'm 5.
 * Use pictures if you can.
--->

This PR:
- update the measures tab on quotas to include draft measures (.current()) as well are future measures (.as_at_today_and_beyond())
- Removes the second cancel button from the association edit page
- Overrides get_url() for QuotaAssociation objects to ensure the cancel button redirects to the right page (previously it was going nowhere)

<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
## Checklist
- Requires migrations?
- Requires dependency updates?
--->

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
