### PR TITLE
TP2000-1625 Measure conditions and footnotes not showing on review measures

### DIFF
--- a/measures/jinja2/includes/measures/conditions.jinja
+++ b/measures/jinja2/includes/measures/conditions.jinja
@@ -1,6 +1,6 @@
-{% macro conditions_list(measure) -%}
+{% macro conditions_list(measure, workbasket) -%}
   <ol class="govuk-list">
-    {% for condition in measure.conditions.current().with_reference_price_string() -%}
+    {% for condition in measure.conditions.approved_up_to_transaction(workbasket.transactions.last()).with_reference_price_string() -%}
       <li title="{{ condition.description }}">
 
         <span class="condition_code">

--- a/measures/jinja2/includes/measures/list.jinja
+++ b/measures/jinja2/includes/measures/list.jinja
@@ -68,7 +68,7 @@
                 {"text": create_link(measure.order_number.get_url(), measure.order_number.order_number) if measure.order_number else '-'},
                 {"text": footnotes_display(measure.footnoteassociationmeasure_set.current())},
                 {"text": create_link(url("regulation-ui-detail", kwargs={"role_type": measure.generating_regulation.role_type,"regulation_id": measure.generating_regulation.regulation_id}), measure.generating_regulation.regulation_id) if measure.generating_regulation.regulation_id else '-'},
-                {"text": conditions_list(measure) if measure.conditions.current() else "-", "classes": "govuk-!-width-one-quarter"},
+                {"text": conditions_list(measure, workbasket) if measure.conditions.current() else "-", "classes": "govuk-!-width-one-quarter"},
               ]) or "" }} 
           {% endfor %}
         {{ govukTable({

--- a/measures/jinja2/includes/measures/workbasket-measures.jinja
+++ b/measures/jinja2/includes/measures/workbasket-measures.jinja
@@ -17,8 +17,8 @@
     {"html": create_link(url("additional_code-ui-detail", kwargs={"sid": measure.additional_code.sid}), measure.additional_code.type.sid ~ measure.additional_code.code) if measure.additional_code else '-'},
     {"html": create_link(url("geo_area-ui-detail", kwargs={"sid": measure.geographical_area.sid}), measure.geographical_area.area_id ~ " - " ~ measure.geographical_area.get_description().description) if measure.geographical_area else '-'},
     {"text": create_link(measure.order_number.get_url(), measure.order_number.order_number) if measure.order_number else '-'},
-    {"text": footnotes_display(measure.footnoteassociationmeasure_set.current())},
-    {"text": conditions_list(measure) if measure.conditions.current() else "-"},
+    {"text": footnotes_display(measure.footnoteassociationmeasure_set.approved_up_to_transaction(workbasket.transactions.last()))},
+    {"text": conditions_list(measure, workbasket) if measure.conditions.approved_up_to_transaction(workbasket.transactions.last()) else "-"},
   ]) or "" }}
 {% endfor %}
 

--- a/measures/views/search.py
+++ b/measures/views/search.py
@@ -241,6 +241,7 @@ class MeasureList(
                     page.paginator.num_pages,
                 ),
                 "selected_filter_lists": self.selected_filter_formatter(),
+                "workbasket": self.workbasket,
             },
         )
         if context["has_previous_page"]:

--- a/workbaskets/jinja2/workbaskets/compare.jinja
+++ b/workbaskets/jinja2/workbaskets/compare.jinja
@@ -92,7 +92,7 @@
         {"html": create_link(url("geo_area-ui-detail", kwargs={"sid": measure.geographical_area.sid}), measure.geographical_area.area_id ~ " - " ~ measure.geographical_area.get_description().description) if measure.geographical_area else '-'},
         {"text": create_link(measure.order_number.get_url(), measure.order_number.order_number) if measure.order_number else '-'},
         {"text": footnotes_display(measure.footnoteassociationmeasure_set.current())},
-        {"text": conditions_list(measure) if measure.conditions.current() else "-"},
+        {"text": conditions_list(measure, workbasket) if measure.conditions.current() else "-"},
       ]) or "" }}
     {% endfor %}
 


### PR DESCRIPTION
# TP2000-1625 Measure conditions and footnotes not showing on review measures
<!---
 * Include the JIRA ticket number, eg TP-123, to automatically link.
 * Use 50 characters maximum.
 * Do not end with a full-stop.
--->

## Why
<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Use as many lines as you like.
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions or deliberately ignored edge-cases.
--->

HMRC users noticed they could not see conditions and footnotes on measures in workbasket 2020.

This was because it was filtering current conditions by current workbasket rather than the workbasket they were viewing.

## What
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Explain like I'm 5.
 * Use pictures if you can.
--->

This PR:
- Updates conditions_list macro so that it takes a workbasket argument. This allows specification of whether the current conditions should be queried in the current workbasket or another one (in this case if you're reviewing measures in workbasket X, workbasket X will not necessarily be your current workbasket)
- passes workbasket argument in places conditions_list is used - that is, review measures tab, measures search and worksheet checker

<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
## Checklist
- Requires migrations?
- Requires dependency updates?
--->

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
