### PR TITLE
TP2000-1503-speed-up-auto-end-measures

### DIFF
--- a/workbaskets/models.py
+++ b/workbaskets/models.py
@@ -710,12 +710,8 @@ class WorkBasket(TimestampedMixin):
             commodity.sid: commodity.valid_between
             for commodity in end_dated_commodities
         }
-        measures_on_commodities = (
-            Measure.objects.current()
-            .with_effective_valid_between()
-            .filter(
-                goods_nomenclature__sid__in=commodity_dict.keys(),
-            )
+        measures_on_commodities = Measure.objects.current().filter(
+            goods_nomenclature__sid__in=commodity_dict.keys(),
         )
         conditions = [
             When(
@@ -731,7 +727,7 @@ class WorkBasket(TimestampedMixin):
             ),
         )
 
-        return measures.exclude(
+        return measures.with_effective_valid_between().exclude(
             db_effective_valid_between__not_gt=F("commodity_valid_between"),
         )
 


### PR DESCRIPTION
# TP2000-1503-speed-up-auto-end-measures
<!---
 * Include the JIRA ticket number, eg TP-123, to automatically link.
 * Use 50 characters maximum.
 * Do not end with a full-stop.
--->

## Why
<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Use as many lines as you like.
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions or deliberately ignored edge-cases.
--->

User testing of the auto end-dating measures in UAT found that the page times out with a 504 error. This does not happen locally but it can take about 15 seconds to load.

## What
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Explain like I'm 5.
 * Use pictures if you can.
--->

This PR moves the .effective_valid_between() part of the function to the end so that it is applied on the final smallest queryset. As this is the most time consuming bit of the query it reduces the time to load the page.

<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
## Checklist
- Requires migrations?
- Requires dependency updates?
--->

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
