### PR TITLE
Updates to QA5 to prevent False positives from deleted associations

### DIFF
--- a/additional_codes/tests/test_business_rules.py
+++ b/additional_codes/tests/test_business_rules.py
@@ -15,7 +15,7 @@ pytestmark = pytest.mark.django_db
 
 # Additional Code Type
 
-
+@pytest.mark.business_rules
 @pytest.mark.xfail(reason="CT1 disabled")
 def test_CT1(assert_handles_duplicates):
     """The additional code type must be unique."""
@@ -26,6 +26,7 @@ def test_CT1(assert_handles_duplicates):
     )
 
 
+@pytest.mark.business_rules
 @requires_meursing_tables
 def test_CT2():
     """The Meursing table plan can only be entered if the additional code type
@@ -34,6 +35,7 @@ def test_CT2():
     assert False
 
 
+@pytest.mark.business_rules
 @requires_meursing_tables
 def test_CT3():
     """The Meursing table plan must exist."""
@@ -41,6 +43,7 @@ def test_CT3():
     assert False
 
 
+@pytest.mark.business_rules
 def test_CT4(date_ranges):
     """The start date must be less than or equal to the end date."""
     with pytest.raises(DataError):
@@ -49,7 +52,7 @@ def test_CT4(date_ranges):
 
 # Additional Code
 
-
+@pytest.mark.business_rules
 def test_ACN1(assert_handles_duplicates):
     """The combination of additional code type + additional code + start date
     must be unique."""
@@ -61,17 +64,19 @@ def test_ACN1(assert_handles_duplicates):
     )
 
 
+@pytest.mark.business_rules
 def test_ACN2_type_must_exist(reference_nonexistent_record):
     """The referenced additional code type must exist."""
 
     with pytest.raises(models.AdditionalCodeType.DoesNotExist):
         with reference_nonexistent_record(
-            factories.AdditionalCodeFactory,
-            "type",
+                factories.AdditionalCodeFactory,
+                "type",
         ) as ac:
             assert ac.type is None
 
 
+@pytest.mark.business_rules
 @pytest.mark.parametrize(
     "app_code, expect_error",
     [
@@ -92,6 +97,7 @@ def test_ACN2_allowed_application_codes(app_code, expect_error):
         business_rules.ACN2(additional_code.transaction).validate(additional_code)
 
 
+@pytest.mark.business_rules
 def test_ACN3(date_ranges):
     """The start date of the additional code must be less than or equal to the
     end date."""
@@ -100,6 +106,7 @@ def test_ACN3(date_ranges):
         factories.AdditionalCodeFactory.create(valid_between=date_ranges.backwards)
 
 
+@pytest.mark.business_rules
 def test_ACN4(date_ranges):
     """The validity period of the additional code must not overlap any other
     additional code with the same additional code type + additional code + start
@@ -119,6 +126,7 @@ def test_ACN4(date_ranges):
         business_rules.ACN4(duplicate.transaction).validate(duplicate)
 
 
+@pytest.mark.business_rules
 @requires_meursing_tables
 def text_ACN12():
     """When the additional code is used to represent an additional code line
@@ -128,6 +136,7 @@ def text_ACN12():
     assert False
 
 
+@pytest.mark.business_rules
 def test_ACN13(assert_spanning_enforced):
     """When an additional code is used in an additional code nomenclature
     measure then the validity period of the additional code must span the
@@ -144,6 +153,7 @@ def test_ACN13(assert_spanning_enforced):
     )
 
 
+@pytest.mark.business_rules
 def test_ACN17(assert_spanning_enforced):
     """The validity period of the additional code type must span the validity
     period of the additional code."""
@@ -160,6 +170,7 @@ def test_ACN17(assert_spanning_enforced):
 footnote_association = pytest.mark.skip(reason="Footnote association is not required.")
 
 
+@pytest.mark.business_rules
 @footnote_association
 def test_ACN6():
     """The footnotes that are referenced must exist."""
@@ -167,6 +178,7 @@ def test_ACN6():
     assert False
 
 
+@pytest.mark.business_rules
 @footnote_association
 def test_ACN7():
     """The start date of the footnote association must be less than or equal to
@@ -175,6 +187,7 @@ def test_ACN7():
     assert False
 
 
+@pytest.mark.business_rules
 @footnote_association
 def test_ACN8():
     """The period of the association with a footnote must be within (inclusive)
@@ -183,6 +196,7 @@ def test_ACN8():
     assert False
 
 
+@pytest.mark.business_rules
 @footnote_association
 def test_ACN9():
     """The period of the association with a footnote must be within (inclusive)
@@ -191,6 +205,7 @@ def test_ACN9():
     assert False
 
 
+@pytest.mark.business_rules
 @footnote_association
 def test_ACN10():
     """When the same footnote is associated more than once with the same
@@ -200,6 +215,7 @@ def test_ACN10():
     assert False
 
 
+@pytest.mark.business_rules
 @footnote_association
 def test_ACN11():
     """The referenced footnote must have a footnote type with application type =
@@ -210,7 +226,7 @@ def test_ACN11():
 
 # Additional Code Description and Description Periods
 
-
+@pytest.mark.business_rules
 def test_ACN5_one_description_mandatory():
     """At least one description is mandatory."""
     additional_code = factories.AdditionalCodeFactory.create()
@@ -219,6 +235,7 @@ def test_ACN5_one_description_mandatory():
             business_rules.ACN5(additional_code.transaction).validate(additional_code)
 
 
+@pytest.mark.business_rules
 def test_ACN5_first_description_must_have_same_start_date(date_ranges):
     """The start date of the first description period must be equal to the start
     date of the additional code."""
@@ -234,6 +251,7 @@ def test_ACN5_first_description_must_have_same_start_date(date_ranges):
             )
 
 
+@pytest.mark.business_rules
 def test_ACN5_start_dates_cannot_match():
     """No two associated description periods may have the same start date."""
 
@@ -249,6 +267,7 @@ def test_ACN5_start_dates_cannot_match():
             )
 
 
+@pytest.mark.business_rules
 def test_ACN5_description_start_before_additional_code_end(date_ranges):
     """The start date must be less than or equal to the end date of the
     additional code."""
@@ -268,6 +287,7 @@ def test_ACN5_description_start_before_additional_code_end(date_ranges):
             )
 
 
+@pytest.mark.business_rules
 def test_ACN14(delete_record):
     """An additional code cannot be deleted if it is used in an additional code
     nomenclature measure."""
@@ -288,6 +308,7 @@ def test_ACN14(delete_record):
         )
 
 
+@pytest.mark.business_rules
 @requires_meursing_tables
 def test_ACN15():
     """An additional code cannot be deleted if it is used in an additional code

--- a/additional_codes/tests/test_business_rules.py
+++ b/additional_codes/tests/test_business_rules.py
@@ -15,6 +15,7 @@ pytestmark = pytest.mark.django_db
 
 # Additional Code Type
 
+
 @pytest.mark.business_rules
 @pytest.mark.xfail(reason="CT1 disabled")
 def test_CT1(assert_handles_duplicates):
@@ -52,6 +53,7 @@ def test_CT4(date_ranges):
 
 # Additional Code
 
+
 @pytest.mark.business_rules
 def test_ACN1(assert_handles_duplicates):
     """The combination of additional code type + additional code + start date
@@ -70,8 +72,8 @@ def test_ACN2_type_must_exist(reference_nonexistent_record):
 
     with pytest.raises(models.AdditionalCodeType.DoesNotExist):
         with reference_nonexistent_record(
-                factories.AdditionalCodeFactory,
-                "type",
+            factories.AdditionalCodeFactory,
+            "type",
         ) as ac:
             assert ac.type is None
 
@@ -225,6 +227,7 @@ def test_ACN11():
 
 
 # Additional Code Description and Description Periods
+
 
 @pytest.mark.business_rules
 def test_ACN5_one_description_mandatory():

--- a/certificates/tests/test_business_rules.py
+++ b/certificates/tests/test_business_rules.py
@@ -9,6 +9,7 @@ from common.tests import factories
 pytestmark = pytest.mark.django_db
 
 
+@pytest.mark.business_rules
 def test_CET1(assert_handles_duplicates):
     """The type of the Certificate must be unique."""
 
@@ -18,6 +19,7 @@ def test_CET1(assert_handles_duplicates):
     )
 
 
+@pytest.mark.business_rules
 def test_CET2(delete_record):
     """The Certificate type cannot be deleted if it is used in a Certificate."""
 
@@ -29,6 +31,7 @@ def test_CET2(delete_record):
         )
 
 
+@pytest.mark.business_rules
 def test_CET3(date_ranges):
     """The start date must be less than or equal to the end date."""
 
@@ -36,6 +39,7 @@ def test_CET3(date_ranges):
         factories.CertificateTypeFactory.create(valid_between=date_ranges.backwards)
 
 
+@pytest.mark.business_rules
 @pytest.mark.xfail(reason="CE2 disabled")
 def test_CE2(assert_handles_duplicates):
     """The combination of certificate type and code must be unique."""
@@ -47,6 +51,7 @@ def test_CE2(assert_handles_duplicates):
     )
 
 
+@pytest.mark.business_rules
 def test_CE3(date_ranges):
     """The start date must be less than or equal to the end date."""
 
@@ -54,6 +59,7 @@ def test_CE3(date_ranges):
         factories.CertificateFactory.create(valid_between=date_ranges.backwards)
 
 
+@pytest.mark.business_rules
 def test_CE4(assert_spanning_enforced):
     """If a certificate is used in a measure condition then the validity period
     of the certificate must span the validity period of the measure."""
@@ -68,6 +74,7 @@ def test_CE4(assert_spanning_enforced):
     )
 
 
+@pytest.mark.business_rules
 def test_CE5(delete_record):
     """The certificate cannot be deleted if it is used in a measure
     condition."""
@@ -80,6 +87,7 @@ def test_CE5(delete_record):
         )
 
 
+@pytest.mark.business_rules
 def test_CE6_one_description_mandatory():
     """At least one description record is mandatory."""
     certificate = factories.CertificateFactory.create(description=None)
@@ -89,6 +97,7 @@ def test_CE6_one_description_mandatory():
             business_rules.CE6(certificate.transaction).validate(certificate)
 
 
+@pytest.mark.business_rules
 def test_CE6_first_description_must_have_same_start_date(date_ranges):
     """The start date of the first description period must be equal to the start
     date of the certificate."""
@@ -104,6 +113,7 @@ def test_CE6_first_description_must_have_same_start_date(date_ranges):
             )
 
 
+@pytest.mark.business_rules
 def test_CE6_start_dates_cannot_match():
     """No two associated description periods for the same certificate and
     language may have the same start date."""
@@ -120,6 +130,7 @@ def test_CE6_start_dates_cannot_match():
             )
 
 
+@pytest.mark.business_rules
 def test_CE6_certificate_validity_period_must_span_description(date_ranges):
     """The validity period of the certificate must span the validity period of
     the certificate description."""
@@ -135,6 +146,7 @@ def test_CE6_certificate_validity_period_must_span_description(date_ranges):
             )
 
 
+@pytest.mark.business_rules
 def test_CE7(assert_spanning_enforced):
     """The validity period of the certificate type must span the validity period
     of the certificate."""

--- a/commodities/tests/business_rules/test_NIG11.py
+++ b/commodities/tests/business_rules/test_NIG11.py
@@ -8,6 +8,7 @@ from common.validators import UpdateType
 pytestmark = pytest.mark.django_db
 
 
+@pytest.mark.business_rules
 def test_NIG11_one_indent_mandatory():
     """At least one indent record is mandatory."""
 
@@ -16,6 +17,7 @@ def test_NIG11_one_indent_mandatory():
         business_rules.NIG11(good.transaction).validate(good)
 
 
+@pytest.mark.business_rules
 def test_NIG11_first_indent_must_have_same_start_date(date_ranges):
     """The start date of the first indentation must be equal to the start date
     of the nomenclature."""
@@ -31,6 +33,7 @@ def test_NIG11_first_indent_must_have_same_start_date(date_ranges):
         )
 
 
+@pytest.mark.business_rules
 def test_NIG11_no_overlapping_indents():
     """No two associated indentations may have the same start date."""
 
@@ -45,6 +48,7 @@ def test_NIG11_no_overlapping_indents():
         )
 
 
+@pytest.mark.business_rules
 def test_NIG11_start_date_less_than_end_date(date_ranges):
     """The start date must be less than or equal to the end date of the
     nomenclature."""
@@ -60,6 +64,7 @@ def test_NIG11_start_date_less_than_end_date(date_ranges):
         )
 
 
+@pytest.mark.business_rules
 def test_NIG11_skips_when_goods_deleted(date_ranges):
     """Example failure,"""
 

--- a/commodities/tests/business_rules/test_NIG5.py
+++ b/commodities/tests/business_rules/test_NIG5.py
@@ -9,6 +9,7 @@ from common.validators import UpdateType
 pytestmark = pytest.mark.django_db
 
 
+@pytest.mark.business_rules
 def test_NIG5(workbasket):
     """
     When creating a goods nomenclature code, an origin must exist.
@@ -36,6 +37,7 @@ def test_NIG5(workbasket):
     business_rules.NIG5(good_good.transaction).validate(good_good)
 
 
+@pytest.mark.business_rules
 def test_NIG5_allow_origin_create():
     """
     When creating a goods nomenclature code, an origin must exist.

--- a/commodities/tests/business_rules/test_NIG5_origin.py
+++ b/commodities/tests/business_rules/test_NIG5_origin.py
@@ -9,6 +9,7 @@ from common.validators import UpdateType
 pytestmark = pytest.mark.django_db
 
 
+@pytest.mark.business_rules
 def test_NIG5_origin_raises_violation_when_only_origin_is_deleted(workbasket):
     """
     When deleting an origin there must still be an origin for the goods,
@@ -68,6 +69,7 @@ def test_NIG5_origin_raises_violation_when_only_origin_is_deleted(workbasket):
         business_rules.NIG5_origin(editable_transaction).validate(origin_delete)
 
 
+@pytest.mark.business_rules
 def test_NIG5_origin_does_not_raise_violation_when_origin_still_exists(workbasket):
     """
     When deleting an origin there must still be an origin for the goods,
@@ -140,6 +142,7 @@ def test_NIG5_origin_does_not_raise_violation_when_origin_still_exists(workbaske
     business_rules.NIG5_origin(editable_transaction).validate(origin_delete)
 
 
+@pytest.mark.business_rules
 def test_NIG5_origin_does_not_raise_violation_when_both_origin_and_goods_nomenclature_are_deleted(
     workbasket,
 ):

--- a/commodities/tests/test_business_rules.py
+++ b/commodities/tests/test_business_rules.py
@@ -13,6 +13,7 @@ from footnotes.validators import ApplicationCode
 pytestmark = pytest.mark.django_db
 
 
+@pytest.mark.business_rules
 @pytest.mark.xfail(reason="NIG1 disabled")
 def test_NIG1(date_ranges):
     """The validity period of the goods nomenclature must not overlap any other
@@ -36,6 +37,7 @@ def test_NIG1(date_ranges):
         business_rules.NIG1(duplicate.transaction).validate(duplicate)
 
 
+@pytest.mark.business_rules
 @pytest.mark.parametrize(
     ("parent_validity", "self_validity", "child_validity", "expect_error"),
     (
@@ -92,6 +94,7 @@ def test_NIG2(
         business_rules.NIG2(type(child.transaction).objects.last()).validate(self)
 
 
+@pytest.mark.business_rules
 def test_NIG2_only_checks_future_dates_of_parent(date_ranges):
     """
     The validity period o f the goods nomenclature must be within the validity
@@ -126,6 +129,7 @@ def test_NIG2_only_checks_future_dates_of_parent(date_ranges):
 # add failing test where a parents parents children > child item id and has an allowable date range but is not considered
 
 
+@pytest.mark.business_rules
 def test_NIG2_is_valid_with_multiple_parents_spanning_child_valid_period(date_ranges):
     grand_parent = factories.GoodsNomenclatureIndentFactory.create(
         indented_goods_nomenclature__valid_between=getattr(
@@ -185,6 +189,7 @@ def test_NIG2_is_valid_with_multiple_parents_spanning_child_valid_period(date_ra
         business_rules.NIG2(type(child.transaction).objects.last()).validate(child)
 
 
+@pytest.mark.business_rules
 @pytest.mark.parametrize(
     ("parent_validities", "child_validity", "expected"),
     (
@@ -278,6 +283,7 @@ def test_NIG2_parents_span_child_valid(
     assert target(parents, child) == expected
 
 
+@pytest.mark.business_rules
 def test_NIG4(date_ranges):
     """The start date of the goods nomenclature must be less than or equal to
     the end date."""
@@ -286,6 +292,7 @@ def test_NIG4(date_ranges):
         factories.GoodsNomenclatureFactory.create(valid_between=date_ranges.backwards)
 
 
+@pytest.mark.business_rules
 @pytest.mark.parametrize(
     "valid_between, expect_error",
     [
@@ -312,6 +319,7 @@ def test_NIG7(date_ranges, valid_between, expect_error):
         business_rules.NIG7(origin.transaction).validate(origin)
 
 
+@pytest.mark.business_rules
 @pytest.mark.parametrize(
     ("valid_between", "expect_error"),
     [
@@ -339,6 +347,7 @@ def test_NIG10(date_ranges, update_type, valid_between, expect_error):
         business_rules.NIG10(successor.transaction).validate(successor)
 
 
+@pytest.mark.business_rules
 def test_NIG12_one_description_mandatory():
     """At least one description record is mandatory."""
     good = factories.GoodsNomenclatureFactory.create(description=None)
@@ -347,6 +356,7 @@ def test_NIG12_one_description_mandatory():
             business_rules.NIG12(good.transaction).validate(good)
 
 
+@pytest.mark.business_rules
 def test_NIG12_first_description_must_have_same_start_date(date_ranges):
     """The start date of the first description period must be equal to the start
     date of the nomenclature."""
@@ -358,6 +368,7 @@ def test_NIG12_first_description_must_have_same_start_date(date_ranges):
             business_rules.NIG12(good.transaction).validate(good)
 
 
+@pytest.mark.business_rules
 def test_NIG12_start_dates_cannot_match():
     """No two associated description periods may have the same start date."""
 
@@ -371,6 +382,7 @@ def test_NIG12_start_dates_cannot_match():
             business_rules.NIG12(duplicate.transaction).validate(goods_nomenclature)
 
 
+@pytest.mark.business_rules
 def test_NIG12_description_start_before_nomenclature_end(
     date_ranges,
     unapproved_transaction,
@@ -394,6 +406,7 @@ def test_NIG12_description_start_before_nomenclature_end(
             )
 
 
+@pytest.mark.business_rules
 def test_NIG12_direct_rule_called_for_goods():
     good = factories.GoodsNomenclatureFactory.create(description=None)
     check_transaction_sync(good.transaction)
@@ -407,6 +420,7 @@ def test_NIG12_direct_rule_called_for_goods():
     )
 
 
+@pytest.mark.business_rules
 @pytest.mark.parametrize(
     ("application_code", "item_id", "error_expected"),
     (
@@ -436,6 +450,7 @@ def test_NIG18_NIG19(application_code, item_id, error_expected):
         business_rules.NIG18(assoc.transaction).validate(assoc)
 
 
+@pytest.mark.business_rules
 def test_NIG21(date_ranges):
     """The start date of the association with a footnote must be less than or
     equal to the end date of the association."""
@@ -446,6 +461,7 @@ def test_NIG21(date_ranges):
         )
 
 
+@pytest.mark.business_rules
 def test_NIG22(date_ranges):
     """The period of the association with a footnote must be within the validity
     period of the nomenclature."""
@@ -457,6 +473,7 @@ def test_NIG22(date_ranges):
         business_rules.NIG22(association.transaction).validate(association)
 
 
+@pytest.mark.business_rules
 def test_NIG23(date_ranges):
     """The period of the association with a footnote must be within the validity
     period of the footnote."""
@@ -468,6 +485,7 @@ def test_NIG23(date_ranges):
         business_rules.NIG23(association.transaction).validate(association)
 
 
+@pytest.mark.business_rules
 @pytest.mark.xfail(reason="NIG24 disabled")
 @pytest.mark.parametrize(
     "valid_between, expect_error",
@@ -493,6 +511,7 @@ def test_NIG24(date_ranges, valid_between, expect_error):
         business_rules.NIG24(association.transaction).validate(association)
 
 
+@pytest.mark.business_rules
 def test_NIG30(assert_spanning_enforced):
     """When a goods nomenclature is used in a goods measure then the validity
     period of the goods nomenclature must span the validity period of the goods
@@ -507,6 +526,7 @@ def test_NIG30(assert_spanning_enforced):
     )
 
 
+@pytest.mark.business_rules
 def test_NIG31(assert_spanning_enforced):
     """When a goods nomenclature is used in an additional nomenclature measure
     then the validity period of the goods nomenclature must span the validity
@@ -521,6 +541,7 @@ def test_NIG31(assert_spanning_enforced):
     )
 
 
+@pytest.mark.business_rules
 def test_NIG34(delete_record):
     """A goods nomenclature cannot be deleted if it is used in a goods
     measure."""
@@ -531,6 +552,7 @@ def test_NIG34(delete_record):
         business_rules.NIG34(deleted_record.transaction).validate(deleted_record)
 
 
+@pytest.mark.business_rules
 def test_NIG35(delete_record):
     """A goods nomenclature cannot be deleted if it is used in an additional
     nomenclature measure."""
@@ -541,6 +563,7 @@ def test_NIG35(delete_record):
         business_rules.NIG35(deleted_record.transaction).validate(deleted_record)
 
 
+@pytest.mark.business_rules
 @pytest.mark.skip(reason="Not using export refunds")
 def test_NIG36():
     """A goods nomenclature cannot be deleted if it is used in an Export refund

--- a/common/tests/test_business_rules.py
+++ b/common/tests/test_business_rules.py
@@ -27,6 +27,7 @@ class TestRule(BusinessRule):
     validate = MagicMock()
 
 
+@pytest.mark.business_rules
 def test_business_rule_violation_message():
     model = MagicMock()
     violation = TestRule(model.transaction).violation(model)
@@ -45,6 +46,7 @@ def test_business_rule_violation_message():
     assert violation.args == ("A different message", model)
 
 
+@pytest.mark.business_rules
 @contextmanager
 def add_business_rules(model, rules=None, indirect=False):
     rules = rules or []
@@ -66,11 +68,13 @@ def rule(request) -> Type[BusinessRule]:
     return request.param
 
 
+@pytest.mark.business_rules
 def test_rule_with_no_other_models(rule):
     model = factories.TestModel1Factory.create()
     rule(model.transaction).validate(model)
 
 
+@pytest.mark.business_rules
 def test_rule_with_no_overlaps(rule):
     model = factories.TestModel1Factory.create()
     other = factories.TestModel1Factory.create()
@@ -78,6 +82,7 @@ def test_rule_with_no_overlaps(rule):
     rule(other.transaction).validate(other)
 
 
+@pytest.mark.business_rules
 def test_rule_with_versions(rule, workbasket):
     version1 = factories.TestModel1Factory.create()
     version2 = version1.new_version(workbasket)
@@ -85,6 +90,7 @@ def test_rule_with_versions(rule, workbasket):
     rule(version2.transaction).validate(version2)
 
 
+@pytest.mark.business_rules
 def test_unique_identifying_fields_with_overlaps():
     model = factories.TestModel1Factory.create()
     other = factories.TestModel1Factory.create(sid=model.sid)
@@ -94,6 +100,7 @@ def test_unique_identifying_fields_with_overlaps():
         UniqueIdentifyingFields(other.transaction).validate(other)
 
 
+@pytest.mark.business_rules
 def test_unique_identifying_fields_with_custom_fields():
     model = factories.TestModel2Factory.create()
     UniqueIdentifyingFields(model.transaction).validate(model)
@@ -103,6 +110,7 @@ def test_unique_identifying_fields_with_custom_fields():
         UniqueIdentifyingFields(other.transaction).validate(other)
 
 
+@pytest.mark.business_rules
 @pytest.mark.parametrize(
     ("description", "error_expected"),
     (
@@ -120,6 +128,7 @@ def test_no_blank_descriptions(description, error_expected):
         NoBlankDescription(description.transaction).validate(description)
 
 
+@pytest.mark.business_rules
 @pytest.mark.parametrize(
     ("description_model"),
     (DescriptionMixin.__subclasses__()),
@@ -145,6 +154,7 @@ class TestInUse(PreventDeleteIfInUse):
     __test__ = False
 
 
+@pytest.mark.business_rules
 def test_prevent_delete_if_in_use(approved_transaction):
     with approved_transaction:
         model = factories.TestModel3Factory.create()
@@ -162,12 +172,14 @@ def test_prevent_delete_if_in_use(approved_transaction):
     assert model.in_use.called
 
 
+@pytest.mark.business_rules
 @skip_when_deleted
 class SkipWhenDeletedRule(BusinessRule):
     def validate():
         pass
 
 
+@pytest.mark.business_rules
 @pytest.mark.s
 def test_skip_when_deleted(capfd):
     model = factories.TestModel1Factory.create(update_type=UpdateType.DELETE)
@@ -176,12 +188,14 @@ def test_skip_when_deleted(capfd):
     assert "Skipping SkipWhenDeletedRule: update_type is 2" in capfd.readouterr().err
 
 
+@pytest.mark.business_rules
 @skip_when_not_deleted
 class SkipWhenNotDeletedRule(BusinessRule):
     def validate():
         pass
 
 
+@pytest.mark.business_rules
 @pytest.mark.s
 @pytest.mark.parametrize("update_type", [UpdateType.CREATE, UpdateType.UPDATE])
 def test_skip_when_not_deleted(capfd, update_type):

--- a/footnotes/tests/test_business_rules.py
+++ b/footnotes/tests/test_business_rules.py
@@ -13,6 +13,7 @@ pytestmark = pytest.mark.django_db
 # Footnote Type
 
 
+@pytest.mark.business_rules
 def test_FOT1(assert_handles_duplicates):
     """The type of the footnote must be unique."""
 
@@ -22,6 +23,7 @@ def test_FOT1(assert_handles_duplicates):
     )
 
 
+@pytest.mark.business_rules
 def test_FOT2(delete_record):
     """The footnote type cannot be deleted if it is used in a footnote."""
 
@@ -32,6 +34,7 @@ def test_FOT2(delete_record):
         business_rules.FOT2(deleted_record.transaction).validate(deleted_record)
 
 
+@pytest.mark.business_rules
 def test_FOT3(date_ranges):
     """The start date must be less than or equal to the end date."""
 
@@ -42,6 +45,7 @@ def test_FOT3(date_ranges):
 # Footnote
 
 
+@pytest.mark.business_rules
 def test_FO2(assert_handles_duplicates):
     """The combination of footnote type and code must be unique."""
 
@@ -51,6 +55,7 @@ def test_FO2(assert_handles_duplicates):
     )
 
 
+@pytest.mark.business_rules
 def test_FO3(date_ranges):
     """The start date must be less than or equal to the end date."""
 
@@ -58,6 +63,7 @@ def test_FO3(date_ranges):
         factories.FootnoteFactory.create(valid_between=date_ranges.backwards)
 
 
+@pytest.mark.business_rules
 def test_FO4_one_description_mandatory():
     """At least one description record is mandatory."""
     footnote = factories.FootnoteFactory.create(description=None)
@@ -66,6 +72,7 @@ def test_FO4_one_description_mandatory():
             business_rules.FO4(footnote.transaction).validate(footnote)
 
 
+@pytest.mark.business_rules
 def test_FO4_first_description_must_have_same_start_date(date_ranges):
     """The start date of the first description period must be equal to the start
     date of the footnote."""
@@ -77,6 +84,7 @@ def test_FO4_first_description_must_have_same_start_date(date_ranges):
             business_rules.FO4(footnote.transaction).validate(footnote)
 
 
+@pytest.mark.business_rules
 def test_FO4_start_dates_cannot_match():
     """No two associated description periods may have the same start date."""
 
@@ -90,6 +98,7 @@ def test_FO4_start_dates_cannot_match():
             business_rules.FO4(duplicate.transaction).validate(footnote)
 
 
+@pytest.mark.business_rules
 def test_FO4_description_start_before_footnote_end(date_ranges):
     """The start date must be less than or equal to the end date of the
     footnote."""
@@ -107,6 +116,7 @@ def test_FO4_description_start_before_footnote_end(date_ranges):
             business_rules.FO4(early_description.transaction).validate(footnote)
 
 
+@pytest.mark.business_rules
 def test_FO5(assert_spanning_enforced):
     """When a footnote is used in a measure the validity period of the footnote
     must span the validity period of the measure."""
@@ -118,6 +128,7 @@ def test_FO5(assert_spanning_enforced):
     )
 
 
+@pytest.mark.business_rules
 def test_FO6(assert_spanning_enforced):
     """When a footnote is used in a goods nomenclature the validity period of
     the footnote must span the validity period of the association with the goods
@@ -130,6 +141,7 @@ def test_FO6(assert_spanning_enforced):
     )
 
 
+@pytest.mark.business_rules
 @pytest.mark.skip(reason="Export Refunds not implemented")
 def test_FO7():
     """When a footnote is used in an export refund nomenclature code the
@@ -139,6 +151,7 @@ def test_FO7():
     assert False
 
 
+@pytest.mark.business_rules
 def test_FO9(assert_spanning_enforced):
     """When a footnote is used in an additional code the validity period of the
     footnote must span the validity period of the association with the
@@ -151,6 +164,7 @@ def test_FO9(assert_spanning_enforced):
     )
 
 
+@pytest.mark.business_rules
 @requires_meursing_tables
 def test_FO10():
     """When a footnote is used in a meursing table heading the validity period
@@ -158,6 +172,7 @@ def test_FO10():
     meursing heading."""
 
 
+@pytest.mark.business_rules
 def test_FO17(assert_spanning_enforced):
     """The validity period of the footnote type must span the validity period of
     the footnote."""
@@ -167,6 +182,7 @@ def test_FO17(assert_spanning_enforced):
     )
 
 
+@pytest.mark.business_rules
 def test_FO11(delete_record):
     """When a footnote is used in a measure then the footnote may not be
     deleted."""
@@ -179,6 +195,7 @@ def test_FO11(delete_record):
         )
 
 
+@pytest.mark.business_rules
 def test_FO12(delete_record):
     """When a footnote is used in a goods nomenclature then the footnote may not
     be deleted."""
@@ -191,6 +208,7 @@ def test_FO12(delete_record):
         )
 
 
+@pytest.mark.business_rules
 @pytest.mark.skip(reason="Export Refunds not implemented")
 def test_FO13():
     """When a footnote is used in an export refund code then the footnote may
@@ -199,6 +217,7 @@ def test_FO13():
     assert False
 
 
+@pytest.mark.business_rules
 def test_FO15(delete_record):
     """When a footnote is used in an additional code then the footnote may not
     be deleted."""
@@ -211,6 +230,7 @@ def test_FO15(delete_record):
         )
 
 
+@pytest.mark.business_rules
 @requires_meursing_tables
 def test_FO16():
     """When a footnote is used in a meursing table heading then the footnote may

--- a/geo_areas/tests/test_business_rules.py
+++ b/geo_areas/tests/test_business_rules.py
@@ -12,6 +12,7 @@ from geo_areas.validators import AreaCode
 pytestmark = pytest.mark.django_db
 
 
+@pytest.mark.business_rules
 @pytest.fixture()
 def child():
     return factories.GeographicalAreaFactory.create(
@@ -20,6 +21,7 @@ def child():
     )
 
 
+@pytest.mark.business_rules
 @pytest.mark.xfail(reason="GA1 disabled")
 def test_GA1(assert_handles_duplicates):
     """The combination of geographical area id + validity start date must be
@@ -32,6 +34,7 @@ def test_GA1(assert_handles_duplicates):
     )
 
 
+@pytest.mark.business_rules
 def test_GA2(date_ranges):
     """The start date must be less than or equal to the end date."""
 
@@ -39,6 +42,7 @@ def test_GA2(date_ranges):
         factories.GeographicalAreaFactory.create(valid_between=date_ranges.backwards)
 
 
+@pytest.mark.business_rules
 @only_applicable_after("1998-02-01")
 def test_description_not_empty():
     """The area must have a description."""
@@ -49,6 +53,7 @@ def test_description_not_empty():
         )
 
 
+@pytest.mark.business_rules
 @pytest.mark.xfail(reason="GA3 disabled")
 def test_GA3_one_description_mandatory():
     """At least one description record is mandatory."""
@@ -57,6 +62,7 @@ def test_GA3_one_description_mandatory():
         business_rules.GA3(area.transaction).validate(area)
 
 
+@pytest.mark.business_rules
 def test_GA3_first_description_must_have_same_start_date(date_ranges):
     """The start date of the first description period must be equal to the start
     date of the geographical_area."""
@@ -68,6 +74,7 @@ def test_GA3_first_description_must_have_same_start_date(date_ranges):
             business_rules.GA3(area.transaction).validate(area)
 
 
+@pytest.mark.business_rules
 def test_GA3_start_dates_cannot_match():
     """No two associated description periods may have the same start date."""
 
@@ -83,6 +90,7 @@ def test_GA3_start_dates_cannot_match():
             )
 
 
+@pytest.mark.business_rules
 def test_GA3_description_start_before_geographical_area_end(date_ranges):
     """The start date must be less than or equal to the end date of the
     geographical_area."""
@@ -98,6 +106,7 @@ def test_GA3_description_start_before_geographical_area_end(date_ranges):
             )
 
 
+@pytest.mark.business_rules
 def test_GA4():
     """A parent geographical area must be a group."""
 
@@ -107,6 +116,7 @@ def test_GA4():
         business_rules.GA4(child.transaction).validate(child)
 
 
+@pytest.mark.business_rules
 def test_GA5(assert_spanning_enforced):
     """A parent geographical areas validity period must span a childs validity
     period."""
@@ -118,6 +128,7 @@ def test_GA5(assert_spanning_enforced):
     )
 
 
+@pytest.mark.business_rules
 def test_GA6():
     """Parent-child relationships cannot loop."""
     g1 = factories.GeoGroupFactory.create()
@@ -130,6 +141,7 @@ def test_GA6():
         business_rules.GA6(g3.transaction).validate(g1)
 
 
+@pytest.mark.business_rules
 @pytest.mark.xfail(reason="GA7 disabled")
 def test_GA7(date_ranges):
     """Geographic Areas with the same area id must not overlap."""
@@ -145,6 +157,7 @@ def test_GA7(date_ranges):
         business_rules.GA7(duplicate.transaction).validate(duplicate)
 
 
+@pytest.mark.business_rules
 def test_GA10(assert_spanning_enforced):
     """If referenced in a measure the geographical area validity range must span
     the measure validity range."""
@@ -159,6 +172,7 @@ def test_GA10(assert_spanning_enforced):
     )
 
 
+@pytest.mark.business_rules
 def test_GA11(assert_spanning_enforced):
     """If an area is excluded in a measure then the areas validity must span the
     measure."""
@@ -173,6 +187,7 @@ def test_GA11(assert_spanning_enforced):
     )
 
 
+@pytest.mark.business_rules
 def test_GA12(reference_nonexistent_record):
     """The referenced geographical area id (member) must exist."""
 
@@ -184,6 +199,7 @@ def test_GA12(reference_nonexistent_record):
             business_rules.GA12(membership.transaction).validate(membership)
 
 
+@pytest.mark.business_rules
 @pytest.mark.parametrize(
     "area_code, expect_error",
     [
@@ -204,6 +220,7 @@ def test_GA13(area_code, expect_error):
         business_rules.GA13(membership.transaction).validate(membership)
 
 
+@pytest.mark.business_rules
 def test_GA14(reference_nonexistent_record):
     """The referenced geographical area group id must exist."""
 
@@ -215,6 +232,7 @@ def test_GA14(reference_nonexistent_record):
             business_rules.GA14(membership.transaction).validate(membership)
 
 
+@pytest.mark.business_rules
 def test_GA15(date_ranges):
     """The membership start date must be less than or equal to the membership
     end date."""
@@ -224,6 +242,7 @@ def test_GA15(date_ranges):
         )
 
 
+@pytest.mark.business_rules
 def test_GA16(assert_spanning_enforced):
     """The validity period of the geographical area group must span all
     membership periods of its members."""
@@ -234,6 +253,7 @@ def test_GA16(assert_spanning_enforced):
     )
 
 
+@pytest.mark.business_rules
 def test_GA17(assert_spanning_enforced):
     """The validity range of the geographical area group must span all
     membership ranges of its members."""
@@ -244,6 +264,7 @@ def test_GA17(assert_spanning_enforced):
     )
 
 
+@pytest.mark.business_rules
 def test_GA18(date_ranges):
     """When a geographical area is more than once member of the same group then
     there may be no overlap in their membership periods."""
@@ -261,6 +282,7 @@ def test_GA18(date_ranges):
 
 
 # https://uktrade.atlassian.net/browse/TP2000-469
+@pytest.mark.business_rules
 def test_GA18_multiple_versions(date_ranges):
     """Test that GA18 fires for overlapping memberships when one membership is
     created with a later version of the member area."""
@@ -277,6 +299,7 @@ def test_GA18_multiple_versions(date_ranges):
         business_rules.GA18(duplicate.transaction).validate(duplicate)
 
 
+@pytest.mark.business_rules
 def test_GA19():
     """If the group has a parent the members must also be members of the
     parent."""
@@ -304,6 +327,7 @@ def test_GA19():
     business_rules.GA19(membership.transaction).validate(membership)
 
 
+@pytest.mark.business_rules
 def test_GA20(date_ranges):
     """If the associated geographical area group has a parent geographical area
     group then the membership period of each member of the parent group must
@@ -328,6 +352,7 @@ def test_GA20(date_ranges):
         )
 
 
+@pytest.mark.business_rules
 def test_GA21(delete_record):
     """If a geographical area is referenced in a measure then it may not be
     deleted."""
@@ -342,6 +367,7 @@ def test_GA21(delete_record):
         )
 
 
+@pytest.mark.business_rules
 def test_GA22(delete_record):
     """A geographical area cannot be deleted if it is referenced as a parent
     geographical area group."""
@@ -352,6 +378,7 @@ def test_GA22(delete_record):
         business_rules.GA22(deleted.transaction).validate(deleted)
 
 
+@pytest.mark.business_rules
 def test_GA23(delete_record):
     """If a geographical area is referenced as an excluded geographical area in
     a measure, the membership association with the measure geographical area

--- a/measures/tests/test_business_rules.py
+++ b/measures/tests/test_business_rules.py
@@ -34,6 +34,7 @@ pytestmark = pytest.mark.django_db
 # 140 - MEASURE TYPE SERIES
 
 
+@pytest.mark.business_rules
 def test_MTS1(assert_handles_duplicates):
     """The measure type series must be unique."""
     assert_handles_duplicates(
@@ -42,6 +43,7 @@ def test_MTS1(assert_handles_duplicates):
     )
 
 
+@pytest.mark.business_rules
 def test_MTS2(delete_record):
     """The measure type series cannot be deleted if it is associated with a
     measure type."""
@@ -53,6 +55,7 @@ def test_MTS2(delete_record):
         business_rules.MTS2(deleted.transaction).validate(deleted)
 
 
+@pytest.mark.business_rules
 def test_MTS3(date_ranges):
     """The start date must be less than or equal to the end date."""
 
@@ -63,6 +66,7 @@ def test_MTS3(date_ranges):
 # 235 - MEASURE TYPE
 
 
+@pytest.mark.business_rules
 def test_MT1(assert_handles_duplicates):
     """The measure type code must be unique."""
     assert_handles_duplicates(
@@ -71,6 +75,7 @@ def test_MT1(assert_handles_duplicates):
     )
 
 
+@pytest.mark.business_rules
 def test_MT2(date_ranges):
     """The start date must be less than or equal to the end date."""
 
@@ -78,6 +83,7 @@ def test_MT2(date_ranges):
         factories.MeasureTypeFactory.create(valid_between=date_ranges.backwards)
 
 
+@pytest.mark.business_rules
 def test_MT3(assert_spanning_enforced):
     """When a measure type is used in a measure then the validity period of the
     measure type must span the validity period of the measure."""
@@ -91,6 +97,7 @@ def test_MT3(assert_spanning_enforced):
     )
 
 
+@pytest.mark.business_rules
 def test_MT4(reference_nonexistent_record):
     """The referenced measure type series must exist."""
 
@@ -102,6 +109,7 @@ def test_MT4(reference_nonexistent_record):
             business_rules.MT4(measure_type.transaction).validate(measure_type)
 
 
+@pytest.mark.business_rules
 def test_MT7(delete_record):
     """A measure type can not be deleted if it is used in a measure."""
 
@@ -111,6 +119,7 @@ def test_MT7(delete_record):
         business_rules.MT7(deleted.transaction).validate(deleted)
 
 
+@pytest.mark.business_rules
 def test_MT10(assert_spanning_enforced):
     """The validity period of the measure type series must span the validity
     period of the measure type."""
@@ -124,6 +133,7 @@ def test_MT10(assert_spanning_enforced):
 # 350 - MEASURE CONDITION CODE
 
 
+@pytest.mark.business_rules
 def test_MC1(assert_handles_duplicates):
     """The code of the measure condition code must be unique."""
     assert_handles_duplicates(
@@ -132,6 +142,7 @@ def test_MC1(assert_handles_duplicates):
     )
 
 
+@pytest.mark.business_rules
 def test_MC2(date_ranges):
     """The start date must be less than or equal to the end date."""
 
@@ -141,6 +152,7 @@ def test_MC2(date_ranges):
         )
 
 
+@pytest.mark.business_rules
 def test_MC3(assert_spanning_enforced):
     """If a measure condition code is used in a measure then the validity period
     of the measure condition code must span the validity period of the
@@ -151,6 +163,7 @@ def test_MC3(assert_spanning_enforced):
     )
 
 
+@pytest.mark.business_rules
 def test_MC4(delete_record):
     """The measure condition code cannot be deleted if it is used in a measure
     condition component."""
@@ -164,6 +177,7 @@ def test_MC4(delete_record):
 # 355 - MEASURE ACTION
 
 
+@pytest.mark.business_rules
 def test_MA1(assert_handles_duplicates):
     """The code of the measure action must be unique."""
     assert_handles_duplicates(
@@ -172,6 +186,7 @@ def test_MA1(assert_handles_duplicates):
     )
 
 
+@pytest.mark.business_rules
 def test_MA2(delete_record):
     """The measure action can not be deleted if it is used in a measure
     condition component."""
@@ -183,6 +198,7 @@ def test_MA2(delete_record):
         business_rules.MA2(deleted.transaction).validate(deleted)
 
 
+@pytest.mark.business_rules
 def test_MA3(date_ranges):
     """The start date must be less than or equal to the end date."""
 
@@ -190,6 +206,7 @@ def test_MA3(date_ranges):
         factories.MeasureActionFactory.create(valid_between=date_ranges.backwards)
 
 
+@pytest.mark.business_rules
 def test_MA4(assert_spanning_enforced):
     """If a measure action is used in a measure then the validity period of the
     measure action must span the validity period of the measure."""
@@ -202,6 +219,7 @@ def test_MA4(assert_spanning_enforced):
 # 430 - MEASURE
 
 
+@pytest.mark.business_rules
 def test_ME1(assert_handles_duplicates):
     """
     The combination of measure type + geographical area + goods nomenclature
@@ -225,6 +243,7 @@ def test_ME1(assert_handles_duplicates):
     )
 
 
+@pytest.mark.business_rules
 def test_ME2(reference_nonexistent_record):
     """The measure type must exist."""
 
@@ -236,6 +255,7 @@ def test_ME2(reference_nonexistent_record):
             business_rules.ME2(measure.transaction).validate(measure)
 
 
+@pytest.mark.business_rules
 def test_ME3(assert_spanning_enforced):
     """The validity period of the measure type must span the validity period of
     the measure."""
@@ -245,6 +265,7 @@ def test_ME3(assert_spanning_enforced):
     )
 
 
+@pytest.mark.business_rules
 def test_ME4(reference_nonexistent_record):
     """The geographical area must exist."""
 
@@ -256,6 +277,7 @@ def test_ME4(reference_nonexistent_record):
             business_rules.ME4(measure.transaction).validate(measure)
 
 
+@pytest.mark.business_rules
 def test_ME5(assert_spanning_enforced):
     """The validity period of the geographical area must span the validity
     period of the measure."""
@@ -265,6 +287,7 @@ def test_ME5(assert_spanning_enforced):
     )
 
 
+@pytest.mark.business_rules
 def test_ME6(reference_nonexistent_record):
     """The goods code must exist."""
 
@@ -285,12 +308,14 @@ def test_ME6(reference_nonexistent_record):
             business_rules.ME6(measure.transaction).validate(measure)
 
 
+@pytest.mark.business_rules
 def test_ME6_happy(reference_nonexistent_record):
     measure = factories.MeasureFactory.create()
 
     assert business_rules.ME6(measure.transaction).validate(measure) is None
 
 
+@pytest.mark.business_rules
 def test_ME6_null_goods(reference_nonexistent_record):
     measure = factories.MeasureFactory.create(
         goods_nomenclature__suffix="00",
@@ -301,6 +326,7 @@ def test_ME6_null_goods(reference_nonexistent_record):
         business_rules.ME6(measure.transaction).validate(measure)
 
 
+@pytest.mark.business_rules
 def test_ME7():
     """The goods nomenclature code must be a product code; that is, it may not
     be an intermediate line."""
@@ -313,6 +339,7 @@ def test_ME7():
     business_rules.ME7(measure.transaction).validate(measure)
 
 
+@pytest.mark.business_rules
 def test_ME8(assert_spanning_enforced):
     """The validity period of the goods code must span the validity period of
     the measure."""
@@ -322,6 +349,7 @@ def test_ME8(assert_spanning_enforced):
     )
 
 
+@pytest.mark.business_rules
 def test_ME88():
     """The level of the goods code, if present, cannot exceed the explosion
     level of the measure type."""
@@ -337,6 +365,7 @@ def test_ME88():
         business_rules.ME88(measure.transaction).validate(measure)
 
 
+@pytest.mark.business_rules
 def test_ME115(assert_spanning_enforced):
     """The validity period of the referenced additional code must span the
     validity period of the measure."""
@@ -346,6 +375,7 @@ def test_ME115(assert_spanning_enforced):
     )
 
 
+@pytest.mark.business_rules
 @pytest.mark.parametrize(
     ("measure_dates", "regulation_dates", "regulation_effective_end", "error_expected"),
     (
@@ -382,6 +412,7 @@ def test_ME25(
         business_rules.ME25(measure.transaction).validate(measure)
 
 
+@pytest.mark.business_rules
 def test_ME10():
     """
     The order number must be specified if the "order number flag" (specified in
@@ -407,6 +438,7 @@ def test_ME10():
         business_rules.ME10(measure.transaction).validate(measure)
 
 
+@pytest.mark.business_rules
 @only_applicable_after("2007-12-31")
 def test_ME116(date_ranges):
     """
@@ -424,6 +456,7 @@ def test_ME116(date_ranges):
         business_rules.ME116(measure.transaction).validate(measure)
 
 
+@pytest.mark.business_rules
 @only_applicable_after("2007-12-31")
 def test_ME117():
     """
@@ -455,6 +488,7 @@ def test_ME117():
     business_rules.ME117(measure.transaction).validate(measure)
 
 
+@pytest.mark.business_rules
 @pytest.mark.skip(reason="Duplicate of ME116")
 def test_ME118():
     """
@@ -467,6 +501,7 @@ def test_ME118():
     assert False
 
 
+@pytest.mark.business_rules
 @only_applicable_after("2007-12-31")
 def test_ME119(date_ranges):
     """
@@ -486,6 +521,7 @@ def test_ME119(date_ranges):
 
 
 # https://uktrade.atlassian.net/browse/TP2000-411
+@pytest.mark.business_rules
 def test_ME119_multiple_valid_origins():
     """Tests that it is possible to create two measures with the same quota
     order number for non-overlapping periods both covered by separate quota
@@ -510,6 +546,7 @@ def test_ME119_multiple_valid_origins():
     business_rules.ME119(later_measure.transaction).validate(later_measure)
 
 
+@pytest.mark.business_rules
 @pytest.mark.s
 def test_ME119_skipped_when_deleted(capfd):
     measure = factories.MeasureFactory.create(update_type=UpdateType.DELETE)
@@ -518,6 +555,7 @@ def test_ME119_skipped_when_deleted(capfd):
     assert "Skipping ME119: update_type is 2" in capfd.readouterr().err
 
 
+@pytest.mark.business_rules
 def test_quota_origin_matching_area():
     origin = factories.QuotaOrderNumberOriginFactory.create(
         geographical_area__sid="666",
@@ -534,6 +572,7 @@ def test_quota_origin_matching_area():
 # -- Relation with additional codes
 
 
+@pytest.mark.business_rules
 @pytest.mark.parametrize(
     "additional_code, goods_nomenclature, expect_error",
     [
@@ -573,6 +612,7 @@ def test_ME9(additional_code, goods_nomenclature, expect_error):
         business_rules.ME9(measure.transaction).validate(measure)
 
 
+@pytest.mark.business_rules
 def test_ME12():
     """If the additional code is specified then the additional code type must
     have a relationship with the measure type."""
@@ -594,6 +634,7 @@ def test_ME12():
     business_rules.ME12(measure.transaction).validate(measure)
 
 
+@pytest.mark.business_rules
 def test_ME12_after_measure_type_updated():
     additional_code = factories.AdditionalCodeFactory.create()
     measure_type = factories.MeasureTypeFactory.create()
@@ -610,6 +651,7 @@ def test_ME12_after_measure_type_updated():
     business_rules.ME12(measure.transaction).validate(measure)
 
 
+@pytest.mark.business_rules
 @requires_meursing_tables
 def test_ME13():
     """If the additional code type is related to a Meursing table plan then only
@@ -618,6 +660,7 @@ def test_ME13():
     assert False
 
 
+@pytest.mark.business_rules
 @requires_meursing_tables
 def test_ME14():
     """If the additional code type is related to a Meursing table plan then the
@@ -625,6 +668,7 @@ def test_ME14():
     assert False
 
 
+@pytest.mark.business_rules
 @requires_meursing_tables
 def test_ME15():
     """If the additional code type is related to a Meursing table plan then the
@@ -633,6 +677,7 @@ def test_ME15():
     assert False
 
 
+@pytest.mark.business_rules
 def test_ME17(reference_nonexistent_record):
     """
     If the additional code type has as application "non-Meursing" then the
@@ -650,6 +695,7 @@ def test_ME17(reference_nonexistent_record):
             business_rules.ME17(measure.transaction).validate(measure)
 
 
+@pytest.mark.business_rules
 @pytest.mark.skip(reason="No meursing, so duplicate of ME115")
 def test_ME18():
     """If the additional code type has as application "non-Meursing" then the
@@ -660,6 +706,7 @@ def test_ME18():
 # -- Export Refund nomenclature measures
 
 
+@pytest.mark.business_rules
 @requires_export_refund_nomenclature
 def test_ME19():
     """If the additional code type has as application "ERN" then the goods code
@@ -667,6 +714,7 @@ def test_ME19():
     assert False
 
 
+@pytest.mark.business_rules
 @requires_export_refund_nomenclature
 def test_ME21():
     """If the additional code type has as application "ERN" then the combination
@@ -678,6 +726,7 @@ def test_ME21():
 # -- Export Refund for Processed Agricultural Goods measures
 
 
+@pytest.mark.business_rules
 @requires_export_refund_nomenclature
 def test_ME112():
     """If the additional code type has as application "Export Refund for
@@ -686,6 +735,7 @@ def test_ME112():
     assert False
 
 
+@pytest.mark.business_rules
 @requires_export_refund_nomenclature
 def test_ME113():
     """If the additional code type has as application "Export Refund for
@@ -694,6 +744,7 @@ def test_ME113():
     assert False
 
 
+@pytest.mark.business_rules
 @requires_export_refund_nomenclature
 def test_ME114():
     """If the additional code type has as application "Export Refund for
@@ -706,6 +757,7 @@ def test_ME114():
 # -- Relation with regulations
 
 
+@pytest.mark.business_rules
 def test_ME24(reference_nonexistent_record):
     """
     The role + regulation id must exist.
@@ -722,6 +774,7 @@ def test_ME24(reference_nonexistent_record):
             business_rules.ME24(measure.transaction).validate(measure)
 
 
+@pytest.mark.business_rules
 @pytest.mark.skip(reason="All UK tariff regulations are Base regulations")
 def test_ME86():
     """The role of the entered regulation must be a Base, a Modification, a
@@ -729,6 +782,7 @@ def test_ME86():
     assert False
 
 
+@pytest.mark.business_rules
 def test_ME87(date_ranges):
     """
     The validity period of the measure (implicit or explicit) must reside within
@@ -771,6 +825,7 @@ def test_ME87(date_ranges):
         business_rules.ME87(measure.transaction).validate(measure)
 
 
+@pytest.mark.business_rules
 @pytest.mark.skip(
     reason="Abrogation, modification and replacement regulations are not used",
 )
@@ -778,6 +833,7 @@ def test_ME26():
     """The entered regulation may not be completely abrogated."""
 
 
+@pytest.mark.business_rules
 def test_ME27(spanning_dates):
     """The entered regulation may not be fully replaced."""
     replacement_dates, regulation_dates, fully_spanned = spanning_dates
@@ -793,6 +849,7 @@ def test_ME27(spanning_dates):
         business_rules.ME27(measure.transaction).validate(measure)
 
 
+@pytest.mark.business_rules
 @pytest.mark.skip(
     reason="Abrogation, modification and replacement regulations are not used",
 )
@@ -802,6 +859,7 @@ def test_ME28():
     the measure."""
 
 
+@pytest.mark.business_rules
 @pytest.mark.skip(
     reason="Abrogation, modification and replacement regulations are not used",
 )
@@ -810,6 +868,7 @@ def test_ME29():
     regulation may not be completely abrogated."""
 
 
+@pytest.mark.business_rules
 @pytest.mark.parametrize(
     ("terminating_regulation", "error_expected"),
     (
@@ -840,6 +899,7 @@ def test_ME33(terminating_regulation, date_ranges, error_expected):
         business_rules.ME33(measure.transaction).validate(measure)
 
 
+@pytest.mark.business_rules
 @pytest.mark.parametrize(
     ("terminating_regulation", "error_expected"),
     (
@@ -873,6 +933,7 @@ def test_ME34(terminating_regulation, date_ranges, error_expected):
 # -- Measure component
 
 
+@pytest.mark.business_rules
 @pytest.mark.parametrize(
     ("applicability_code", "component", "condition_component", "error_expected"),
     [
@@ -927,6 +988,7 @@ def test_ME40(applicability_code, component, condition_component, error_expected
         ).validate(measure)
 
 
+@pytest.mark.business_rules
 @pytest.mark.s
 def test_ME40_skipped_when_deleted(capfd):
     measure = factories.MeasureFactory.create(update_type=UpdateType.DELETE)
@@ -935,6 +997,7 @@ def test_ME40_skipped_when_deleted(capfd):
     assert "Skipping ME40: update_type is 2" in capfd.readouterr().err
 
 
+@pytest.mark.business_rules
 def test_ME41(reference_nonexistent_record):
     """The referenced duty expression must exist."""
 
@@ -946,6 +1009,7 @@ def test_ME41(reference_nonexistent_record):
             business_rules.ME41(component.transaction).validate(component)
 
 
+@pytest.mark.business_rules
 def test_ME42(assert_spanning_enforced):
     """The validity period of the duty expression must span the validity period
     of the measure."""
@@ -955,6 +1019,7 @@ def test_ME42(assert_spanning_enforced):
     )
 
 
+@pytest.mark.business_rules
 def test_ME43():
     """
     The same duty expression can only be used once with the same measure.
@@ -974,6 +1039,7 @@ def test_ME43():
         business_rules.ME43(component.transaction).validate(component)
 
 
+@pytest.mark.business_rules
 @pytest.mark.parametrize(
     "applicability_code, amount",
     [
@@ -1000,6 +1066,7 @@ def test_ME45(applicability_code, amount):
         business_rules.ME45(component.transaction).validate(measure)
 
 
+@pytest.mark.business_rules
 @pytest.mark.parametrize(
     "applicability_code, monetary_unit",
     [
@@ -1029,6 +1096,7 @@ def test_ME46(applicability_code, monetary_unit):
         business_rules.ME46(component.transaction).validate(measure)
 
 
+@pytest.mark.business_rules
 @pytest.mark.parametrize(
     "applicability_code, measurement",
     [
@@ -1058,6 +1126,7 @@ def test_ME47(applicability_code, measurement):
         business_rules.ME47(component.transaction).validate(measure)
 
 
+@pytest.mark.business_rules
 def test_ME48(reference_nonexistent_record):
     """The referenced monetary unit must exist."""
 
@@ -1069,6 +1138,7 @@ def test_ME48(reference_nonexistent_record):
             business_rules.ME48(component.transaction).validate(component)
 
 
+@pytest.mark.business_rules
 def test_ME49(assert_spanning_enforced):
     """The validity period of the referenced monetary unit must span the
     validity period of the measure."""
@@ -1078,6 +1148,7 @@ def test_ME49(assert_spanning_enforced):
     )
 
 
+@pytest.mark.business_rules
 def test_ME50(reference_nonexistent_record):
     """The combination of measurement unit and measurement unit qualifier must
     exist."""
@@ -1090,6 +1161,7 @@ def test_ME50(reference_nonexistent_record):
             business_rules.ME50(component.transaction).validate(component)
 
 
+@pytest.mark.business_rules
 def test_ME51(assert_spanning_enforced):
     """The validity period of the measurement unit must span the validity period
     of the measure."""
@@ -1099,6 +1171,7 @@ def test_ME51(assert_spanning_enforced):
     )
 
 
+@pytest.mark.business_rules
 def test_ME52(assert_spanning_enforced):
     """The validity period of the measurement unit qualifier must span the
     validity period of the measure."""
@@ -1111,6 +1184,7 @@ def test_ME52(assert_spanning_enforced):
 # -- Measure condition and Measure condition component
 
 
+@pytest.mark.business_rules
 def test_ME53(reference_nonexistent_record):
     """The referenced measure condition must exist."""
 
@@ -1122,6 +1196,7 @@ def test_ME53(reference_nonexistent_record):
             business_rules.ME53(component.transaction).validate(component)
 
 
+@pytest.mark.business_rules
 @pytest.mark.skip(reason="Erroneous business rule")
 def test_ME54():
     """
@@ -1136,6 +1211,7 @@ def test_ME54():
     """
 
 
+@pytest.mark.business_rules
 @pytest.mark.skip(reason="Erroneous business rule")
 def test_ME55():
     """
@@ -1147,6 +1223,7 @@ def test_ME55():
     """
 
 
+@pytest.mark.business_rules
 def test_ME56(reference_nonexistent_record):
     """The referenced certificate must exist."""
 
@@ -1164,6 +1241,7 @@ def test_ME56(reference_nonexistent_record):
             business_rules.ME56(condition.transaction).validate(condition)
 
 
+@pytest.mark.business_rules
 def test_ME57(assert_spanning_enforced):
     """The validity period of the referenced certificate must span the validity
     period of the measure."""
@@ -1173,6 +1251,7 @@ def test_ME57(assert_spanning_enforced):
     )
 
 
+@pytest.mark.business_rules
 @pytest.mark.parametrize("existing_cert", (True, False))
 @pytest.mark.parametrize("existing_volume", (True, False))
 @pytest.mark.parametrize("existing_unit", (True, False))
@@ -1240,6 +1319,7 @@ def test_ME58(
         business_rules.ME58(duplicate.transaction).validate(duplicate)
 
 
+@pytest.mark.business_rules
 def test_ME59(reference_nonexistent_record):
     """The referenced action code must exist."""
 
@@ -1251,6 +1331,7 @@ def test_ME59(reference_nonexistent_record):
             business_rules.ME59(condition.transaction).validate(condition)
 
 
+@pytest.mark.business_rules
 def test_ME60(reference_nonexistent_record):
     """The referenced monetary unit must exist."""
 
@@ -1262,6 +1343,7 @@ def test_ME60(reference_nonexistent_record):
             business_rules.ME60(condition.transaction).validate(condition)
 
 
+@pytest.mark.business_rules
 def test_ME61(assert_spanning_enforced):
     """The validity period of the referenced monetary unit must span the
     validity period of the measure."""
@@ -1271,6 +1353,7 @@ def test_ME61(assert_spanning_enforced):
     )
 
 
+@pytest.mark.business_rules
 def test_ME62(reference_nonexistent_record):
     """The combination of measurement unit and measurement unit qualifier must
     exist."""
@@ -1283,6 +1366,7 @@ def test_ME62(reference_nonexistent_record):
             business_rules.ME62(condition.transaction).validate(condition)
 
 
+@pytest.mark.business_rules
 def test_ME63(assert_spanning_enforced):
     """The validity period of the measurement unit must span the validity period
     of the measure."""
@@ -1292,6 +1376,7 @@ def test_ME63(assert_spanning_enforced):
     )
 
 
+@pytest.mark.business_rules
 def test_ME64(assert_spanning_enforced):
     """The validity period of the measurement unit qualifier must span the
     validity period of the measure."""
@@ -1301,6 +1386,7 @@ def test_ME64(assert_spanning_enforced):
     )
 
 
+@pytest.mark.business_rules
 def test_ME105(reference_nonexistent_record):
     """The referenced duty expression must exist."""
 
@@ -1312,6 +1398,7 @@ def test_ME105(reference_nonexistent_record):
             business_rules.ME105(component.transaction).validate(component)
 
 
+@pytest.mark.business_rules
 def test_ME106(assert_spanning_enforced):
     """The validity period of the duty expression must span the validity period
     of the measure."""
@@ -1321,6 +1408,7 @@ def test_ME106(assert_spanning_enforced):
     )
 
 
+@pytest.mark.business_rules
 @pytest.mark.parametrize(
     "expression, same_condition, expect_error",
     [
@@ -1359,6 +1447,7 @@ def test_ME108(expression, same_condition, expect_error):
 
 # Even if a ConditionCode can accept either a certificate or a price,
 # a Condition should not be able to accept both at once
+@pytest.mark.business_rules
 @pytest.mark.parametrize(
     "accepts_certificate, accepts_price",
     [
@@ -1388,6 +1477,7 @@ def test_ConditionCodeAcceptance_certificate_and_price(
         )
 
 
+@pytest.mark.business_rules
 @pytest.mark.parametrize(
     "accepts_certificate, accepts_price, expect_error",
     [
@@ -1420,6 +1510,7 @@ def test_ConditionCodeAcceptance_certificate(
         )
 
 
+@pytest.mark.business_rules
 @pytest.mark.parametrize(
     "accepts_certificate, accepts_price, expect_error",
     [
@@ -1450,6 +1541,7 @@ def test_ConditionCodeAcceptance_price(
 
 
 # This is possible for Condition codes (e.g. 'W') that accept neither certificates nor price
+@pytest.mark.business_rules
 def test_ConditionCodeAcceptance_nothing_added():
     code = factories.MeasureConditionCodeFactory.create()
     condition = factories.MeasureConditionFactory.create(
@@ -1459,6 +1551,7 @@ def test_ConditionCodeAcceptance_nothing_added():
     business_rules.ConditionCodeAcceptance(condition.transaction).validate(condition)
 
 
+@pytest.mark.business_rules
 @pytest.mark.parametrize(
     "requires_duty, duty_amount, expect_error",
     [
@@ -1486,6 +1579,7 @@ def test_ActionRequiresDuty(requires_duty, duty_amount, expect_error):
         business_rules.ActionRequiresDuty(condition.transaction).validate(condition)
 
 
+@pytest.mark.business_rules
 def test_ActionRequiresDuty_ignores_outdated_components():
     condition = factories.MeasureConditionFactory.create(action__requires_duty=True)
     component = factories.MeasureConditionComponentFactory.create(
@@ -1504,6 +1598,7 @@ def test_ActionRequiresDuty_ignores_outdated_components():
 
 
 # https://uktrade.atlassian.net/browse/TP2000-369  /PS-IGNORE
+@pytest.mark.business_rules
 def test_ActionRequiresDuty_accepts_0_percent_duty():
     condition = factories.MeasureConditionFactory.create(action__requires_duty=True)
     factories.MeasureConditionComponentFactory.create(
@@ -1515,6 +1610,7 @@ def test_ActionRequiresDuty_accepts_0_percent_duty():
     business_rules.ActionRequiresDuty(condition.transaction).validate(condition)
 
 
+@pytest.mark.business_rules
 @pytest.mark.parametrize(
     ("applicability_code", "amount", "error_expected"),
     [
@@ -1545,6 +1641,7 @@ def test_ME109(applicability_code, amount, error_expected):
         business_rules.ME109(condition.transaction).validate(measure)
 
 
+@pytest.mark.business_rules
 @pytest.mark.parametrize(
     ("applicability_code", "monetary_unit", "error_expected"),
     [
@@ -1577,6 +1674,7 @@ def test_ME110(applicability_code, monetary_unit, error_expected):
         business_rules.ME110(condition.transaction).validate(measure)
 
 
+@pytest.mark.business_rules
 @pytest.mark.parametrize(
     ("applicability_code", "measurement", "error_expected"),
     [
@@ -1613,6 +1711,7 @@ def test_ME111(applicability_code, measurement, error_expected):
 # -- Measure excluded geographical area
 
 
+@pytest.mark.business_rules
 @pytest.mark.parametrize(
     ("area_code", "error_expected"),
     (
@@ -1633,6 +1732,7 @@ def test_ME65(area_code, error_expected):
         business_rules.ME65(exclusion.transaction).validate(exclusion)
 
 
+@pytest.mark.business_rules
 def test_ME66():
     """The excluded geographical area must be a member of the geographical area
     group."""
@@ -1666,6 +1766,7 @@ def test_ME66():
         business_rules.ME66(exclusion.transaction).validate(exclusion)
 
 
+@pytest.mark.business_rules
 def test_ME68():
     """The same geographical area can only be excluded once by the same
     measure."""
@@ -1684,6 +1785,7 @@ def test_ME68():
 # -- Footnote association
 
 
+@pytest.mark.business_rules
 def test_ME69(reference_nonexistent_record):
     """The associated footnote must exist."""
 
@@ -1695,6 +1797,7 @@ def test_ME69(reference_nonexistent_record):
             business_rules.ME69(assoc.transaction).validate(assoc)
 
 
+@pytest.mark.business_rules
 def test_ME70():
     """The same footnote can only be associated once with the same measure."""
 
@@ -1710,6 +1813,7 @@ def test_ME70():
         business_rules.ME70(assoc.transaction).validate(assoc)
 
 
+@pytest.mark.business_rules
 @pytest.mark.parametrize(
     ("application_code", "item_id", "error_expected"),
     (
@@ -1740,6 +1844,7 @@ def test_ME71_ME72(application_code, item_id, error_expected):
         business_rules.ME71(assoc.transaction).validate(assoc)
 
 
+@pytest.mark.business_rules
 def test_ME73(assert_spanning_enforced):
     """The validity period of the associated footnote must span the validity
     period of the measure."""
@@ -1750,6 +1855,7 @@ def test_ME73(assert_spanning_enforced):
 
 
 # -- Partial temporary stop
+@pytest.mark.business_rules
 @requires_partial_temporary_stop
 def test_ME39():
     """The validity period of the measure must span the validity period of all
@@ -1757,12 +1863,14 @@ def test_ME39():
     assert False
 
 
+@pytest.mark.business_rules
 @requires_partial_temporary_stop
 def test_ME74():
     """The start date of the PTS must be less than or equal to the end date."""
     assert False
 
 
+@pytest.mark.business_rules
 @requires_partial_temporary_stop
 def test_ME75():
     """The PTS regulation and abrogation regulation must be the same if the
@@ -1770,6 +1878,7 @@ def test_ME75():
     assert False
 
 
+@pytest.mark.business_rules
 @requires_partial_temporary_stop
 def test_ME76():
     """The abrogation regulation may not be entered if the PTS end date is not
@@ -1777,6 +1886,7 @@ def test_ME76():
     assert False
 
 
+@pytest.mark.business_rules
 @requires_partial_temporary_stop
 def test_ME77():
     """The abrogation regulation must be entered if the PTS end date is filled
@@ -1784,6 +1894,7 @@ def test_ME77():
     assert False
 
 
+@pytest.mark.business_rules
 @requires_partial_temporary_stop
 def test_ME78():
     """The abrogation regulation must be different from the PTS regulation if
@@ -1791,6 +1902,7 @@ def test_ME78():
     assert False
 
 
+@pytest.mark.business_rules
 @requires_partial_temporary_stop
 def test_ME79():
     """There may be no overlap between different PTS periods."""
@@ -1800,6 +1912,7 @@ def test_ME79():
 # -- Justification regulation
 
 
+@pytest.mark.business_rules
 @pytest.mark.xfail(reason="confirm rule is needed")
 def test_ME104(date_ranges, unapproved_transaction):
     """
@@ -1837,12 +1950,14 @@ def test_ME104(date_ranges, unapproved_transaction):
         business_rules.ME104(measure.transaction).validate(measure)
 
 
+@pytest.mark.business_rules
 def test_measurement_unit_qualifier_is_optional():
     """In TARIC measurement unit qualifiers do not have to be used on every
     measure."""
     factories.MeasurementFactory.create(measurement_unit_qualifier=None)
 
 
+@pytest.mark.business_rules
 def test_unique_identifying_fields(assert_handles_duplicates):
     assert_handles_duplicates(
         factories.MeasureFactory,

--- a/measures/tests/test_business_rules/test_ME16.py
+++ b/measures/tests/test_business_rules/test_ME16.py
@@ -107,6 +107,7 @@ def related_measure_dates(request, date_ranges):
     return get_measure_factory_properties(date_ranges), date_overlap
 
 
+@pytest.mark.business_rules
 @pytest.mark.parametrize(
     ("existing_code", "overlapping_code", "error_expected"),
     (
@@ -239,6 +240,7 @@ def related_measure_data(
     return full_data, error_expected
 
 
+@pytest.mark.business_rules
 def test_ME16_part_2(related_measure_data):
     """
     Tests that another measure within the chapter with matching properties :
@@ -255,6 +257,7 @@ def test_ME16_part_2(related_measure_data):
         business_rules.ME16(related.transaction).validate(related)
 
 
+@pytest.mark.business_rules
 def test_ME16_query_similar_measures(measure_instance_for_compile_query):
     """Test that the query_similar_measures method does check against  measure
     type, geo area, order number, additional code and reduction indicator."""
@@ -284,6 +287,7 @@ def test_ME16_query_similar_measures(measure_instance_for_compile_query):
         assert f"'additional_code__isnull', False" in target
 
 
+@pytest.mark.business_rules
 def test_ME16_works_and_ignores_archived_measure_data(
     seed_database_with_indented_goods,
 ):

--- a/measures/tests/test_business_rules/test_ME32.py
+++ b/measures/tests/test_business_rules/test_ME32.py
@@ -194,6 +194,7 @@ def related_measure_data(
     return full_data, error_expected
 
 
+@pytest.mark.business_rules
 def test_ME32(related_measure_data):
     """
     There may be no overlap in time with other measure occurrences with a goods
@@ -212,6 +213,7 @@ def test_ME32(related_measure_data):
         business_rules.ME32(related.transaction).validate(related)
 
 
+@pytest.mark.business_rules
 def test_ME32_compile_query(measure_data_for_compile_query):
     """Test that the compile_query method does check against  measure type, geo
     area, order number, additional code and reduction indicator."""
@@ -246,6 +248,7 @@ def test_ME32_compile_query(measure_data_for_compile_query):
             assert f"'additional_code__isnull', True" in target
 
 
+@pytest.mark.business_rules
 def test_ME32_works_with_wonky_archived_measure(seed_database_with_indented_goods):
     # setup data with archived workbasket and published workbasket
     goods = GoodsNomenclature.objects.all().get(item_id="2903691900")

--- a/measures/tests/test_business_rules/test_ME67.py
+++ b/measures/tests/test_business_rules/test_ME67.py
@@ -12,6 +12,7 @@ from measures import business_rules
 pytestmark = pytest.mark.django_db
 
 
+@pytest.mark.business_rules
 def test_ME67(spanning_dates):
     """The membership period of the excluded geographical area must span the
     validity period of the measure."""
@@ -29,6 +30,7 @@ def test_ME67(spanning_dates):
         business_rules.ME67(exclusion.transaction).validate(exclusion)
 
 
+@pytest.mark.business_rules
 def test_ME67_multiple_member_periods():
     """This test verifies that when a member is added and removed multiple
     times, that the rule performs correctly."""
@@ -183,6 +185,7 @@ def test_ME67_multiple_member_periods():
         assert str(e) == "<ExceptionInfo for raises contextmanager>"
 
 
+@pytest.mark.business_rules
 def test_ME67_with_end_dates_in_range():
     """This test verifies that when queried, null values for end dates are not
     an issue."""
@@ -225,6 +228,7 @@ def test_ME67_with_end_dates_in_range():
     )
 
 
+@pytest.mark.business_rules
 def test_ME67_works_when_measures_are_deleted():
     """
     When checking against exclusions, the rule check historically looked at the
@@ -278,6 +282,7 @@ def test_ME67_works_when_measures_are_deleted():
     )
 
 
+@pytest.mark.business_rules
 def test_ME67_gets_latest_version_of_measure():
     """
     When checking against exclusions, the rule check historically looked at the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,5 +97,6 @@ norecursedirs = [
 ]
 markers = [
     "importer_v2",
-    "reference_documents"
+    "reference_documents",
+    "business_rules"
 ]

--- a/quotas/business_rules.py
+++ b/quotas/business_rules.py
@@ -36,7 +36,7 @@ class PreventDeletingLinkedQuotaDefinitions(BusinessRule):
         if quota_definition.update_type == UpdateType.DELETE:
             kwargs = {f"{self.sid_prefix}sid": quota_definition.sid}
             if related_model.objects.approved_up_to_transaction(
-                    transaction=quota_definition.transaction,
+                transaction=quota_definition.transaction,
             ).filter(**kwargs):
                 raise self.violation(quota_definition)
 
@@ -53,14 +53,14 @@ class ON2(BusinessRule):
 
     def validate(self, order_number):
         if (
-                type(order_number)
-                        .objects.approved_up_to_transaction(order_number.transaction)
-                        .filter(
-                    order_number=order_number.order_number,
-                    valid_between__overlap=order_number.valid_between,
-                )
-                        .exclude(sid=order_number.sid)
-                        .exists()
+            type(order_number)
+            .objects.approved_up_to_transaction(order_number.transaction)
+            .filter(
+                order_number=order_number.order_number,
+                valid_between__overlap=order_number.valid_between,
+            )
+            .exclude(sid=order_number.sid)
+            .exists()
         ):
             raise self.violation(order_number)
 
@@ -74,10 +74,10 @@ class ON4(BusinessRule):
         origin_exists = False
         for order_number_version in order_number_versions:
             if (
-                    order_number_version.origins.approved_up_to_transaction(
-                        order_number.transaction,
-                    ).count()
-                    > 0
+                order_number_version.origins.approved_up_to_transaction(
+                    order_number.transaction,
+                ).count()
+                > 0
             ):
                 origin_exists = True
                 break
@@ -92,15 +92,15 @@ class ON5(BusinessRule):
 
     def validate(self, origin):
         if (
-                type(origin)
-                        .objects.approved_up_to_transaction(origin.transaction)
-                        .filter(
-                    order_number__sid=origin.order_number.sid,
-                    geographical_area__sid=origin.geographical_area.sid,
-                    valid_between__overlap=origin.valid_between,
-                )
-                        .exclude(sid=origin.sid)
-                        .exists()
+            type(origin)
+            .objects.approved_up_to_transaction(origin.transaction)
+            .filter(
+                order_number__sid=origin.order_number.sid,
+                geographical_area__sid=origin.geographical_area.sid,
+                valid_between__overlap=origin.valid_between,
+            )
+            .exclude(sid=origin.sid)
+            .exists()
         ):
             raise self.violation(
                 model=origin,
@@ -339,8 +339,8 @@ class OverlappingQuotaDefinition(BusinessRule):
         if potential_quota_definition_matches.exists():
             for potential_quota_definition in potential_quota_definition_matches:
                 if (
-                        potential_quota_definition
-                        == potential_quota_definition.current_version
+                    potential_quota_definition
+                    == potential_quota_definition.current_version
                 ):
                     raise self.violation(quota_definition)
 
@@ -359,7 +359,7 @@ class VolumeAndInitialVolumeMustMatch(BusinessRule):
             return True
 
         if quota_definition.sub_quota_associations.approved_up_to_transaction(
-                self.transaction,
+            self.transaction,
         ).exists():
             return True
 
@@ -383,9 +383,9 @@ def check_QA2_dict(sub_definition_valid_between, main_definition_valid_between):
     """Confirms data is compliant with QA2."""
     if main_definition_valid_between.upper:
         return (
-                sub_definition_valid_between.lower >= main_definition_valid_between.lower
+            sub_definition_valid_between.lower >= main_definition_valid_between.lower
         ) and (
-                sub_definition_valid_between.upper <= main_definition_valid_between.upper
+            sub_definition_valid_between.upper <= main_definition_valid_between.upper
         )
     else:
         return sub_definition_valid_between.lower >= main_definition_valid_between.lower
@@ -408,30 +408,30 @@ class QA3(BusinessRule):
         main = association.main_quota
         sub = association.sub_quota
         if not check_QA3_dict(
-                main_definition_unit=main.measurement_unit,
-                sub_definition_unit=sub.measurement_unit,
-                main_definition_volume=main.volume,
-                sub_definition_volume=sub.volume,
-                main_initial_volume=main.initial_volume,
-                sub_initial_volume=sub.initial_volume,
+            main_definition_unit=main.measurement_unit,
+            sub_definition_unit=sub.measurement_unit,
+            main_definition_volume=main.volume,
+            sub_definition_volume=sub.volume,
+            main_initial_volume=main.initial_volume,
+            sub_initial_volume=sub.initial_volume,
         ):
             raise self.violation(association)
 
 
 def check_QA3_dict(
-        main_definition_unit,
-        sub_definition_unit,
-        main_definition_volume,
-        sub_definition_volume,
-        sub_initial_volume,
-        main_initial_volume,
+    main_definition_unit,
+    sub_definition_unit,
+    main_definition_volume,
+    sub_definition_volume,
+    sub_initial_volume,
+    main_initial_volume,
 ):
     """Confirms data is compliant with QA3 See note above about changing the
     unit types."""
     return (
-            main_definition_unit == sub_definition_unit
-            and sub_definition_volume <= main_definition_volume
-            and sub_initial_volume <= main_initial_volume
+        main_definition_unit == sub_definition_unit
+        and sub_definition_volume <= main_definition_volume
+        and sub_initial_volume <= main_initial_volume
     )
 
 
@@ -476,9 +476,7 @@ class QA5(BusinessRule):
 
             quota_associations = QuotaAssociation.objects.approved_up_to_transaction(
                 association.transaction
-            ).filter(
-                main_quota=association.main_quota
-            )
+            ).filter(main_quota=association.main_quota)
             volumes = []
             for association in quota_associations:
                 if association.sub_quota.volume not in volumes:
@@ -531,9 +529,9 @@ class QA6(BusinessRule):
 
     def validate(self, association):
         if not check_QA6_dict(
-                association.main_quota,
-                association.sub_quota_relation_type,
-                association.transaction,
+            association.main_quota,
+            association.sub_quota_relation_type,
+            association.transaction,
         ):
             raise self.violation(association)
 
@@ -577,8 +575,8 @@ class BlockingOnlyOfFCFSQuotas(BusinessRule):
 
     def validate(self, blocking):
         if (
-                blocking.quota_definition.order_number.mechanism
-                != AdministrationMechanism.FCFS
+            blocking.quota_definition.order_number.mechanism
+            != AdministrationMechanism.FCFS
         ):
             raise self.violation(blocking)
 
@@ -598,8 +596,8 @@ class SuspensionsOnlyToFCFSQuotas(BusinessRule):
 
     def validate(self, suspension):
         if (
-                suspension.quota_definition.order_number.mechanism
-                != AdministrationMechanism.FCFS
+            suspension.quota_definition.order_number.mechanism
+            != AdministrationMechanism.FCFS
         ):
             raise self.violation(suspension)
 

--- a/quotas/business_rules.py
+++ b/quotas/business_rules.py
@@ -36,7 +36,7 @@ class PreventDeletingLinkedQuotaDefinitions(BusinessRule):
         if quota_definition.update_type == UpdateType.DELETE:
             kwargs = {f"{self.sid_prefix}sid": quota_definition.sid}
             if related_model.objects.approved_up_to_transaction(
-                transaction=quota_definition.transaction,
+                    transaction=quota_definition.transaction,
             ).filter(**kwargs):
                 raise self.violation(quota_definition)
 
@@ -53,14 +53,14 @@ class ON2(BusinessRule):
 
     def validate(self, order_number):
         if (
-            type(order_number)
-            .objects.approved_up_to_transaction(order_number.transaction)
-            .filter(
-                order_number=order_number.order_number,
-                valid_between__overlap=order_number.valid_between,
-            )
-            .exclude(sid=order_number.sid)
-            .exists()
+                type(order_number)
+                        .objects.approved_up_to_transaction(order_number.transaction)
+                        .filter(
+                    order_number=order_number.order_number,
+                    valid_between__overlap=order_number.valid_between,
+                )
+                        .exclude(sid=order_number.sid)
+                        .exists()
         ):
             raise self.violation(order_number)
 
@@ -74,10 +74,10 @@ class ON4(BusinessRule):
         origin_exists = False
         for order_number_version in order_number_versions:
             if (
-                order_number_version.origins.approved_up_to_transaction(
-                    order_number.transaction,
-                ).count()
-                > 0
+                    order_number_version.origins.approved_up_to_transaction(
+                        order_number.transaction,
+                    ).count()
+                    > 0
             ):
                 origin_exists = True
                 break
@@ -92,15 +92,15 @@ class ON5(BusinessRule):
 
     def validate(self, origin):
         if (
-            type(origin)
-            .objects.approved_up_to_transaction(origin.transaction)
-            .filter(
-                order_number__sid=origin.order_number.sid,
-                geographical_area__sid=origin.geographical_area.sid,
-                valid_between__overlap=origin.valid_between,
-            )
-            .exclude(sid=origin.sid)
-            .exists()
+                type(origin)
+                        .objects.approved_up_to_transaction(origin.transaction)
+                        .filter(
+                    order_number__sid=origin.order_number.sid,
+                    geographical_area__sid=origin.geographical_area.sid,
+                    valid_between__overlap=origin.valid_between,
+                )
+                        .exclude(sid=origin.sid)
+                        .exists()
         ):
             raise self.violation(
                 model=origin,
@@ -339,8 +339,8 @@ class OverlappingQuotaDefinition(BusinessRule):
         if potential_quota_definition_matches.exists():
             for potential_quota_definition in potential_quota_definition_matches:
                 if (
-                    potential_quota_definition
-                    == potential_quota_definition.current_version
+                        potential_quota_definition
+                        == potential_quota_definition.current_version
                 ):
                     raise self.violation(quota_definition)
 
@@ -359,7 +359,7 @@ class VolumeAndInitialVolumeMustMatch(BusinessRule):
             return True
 
         if quota_definition.sub_quota_associations.approved_up_to_transaction(
-            self.transaction,
+                self.transaction,
         ).exists():
             return True
 
@@ -383,9 +383,9 @@ def check_QA2_dict(sub_definition_valid_between, main_definition_valid_between):
     """Confirms data is compliant with QA2."""
     if main_definition_valid_between.upper:
         return (
-            sub_definition_valid_between.lower >= main_definition_valid_between.lower
+                sub_definition_valid_between.lower >= main_definition_valid_between.lower
         ) and (
-            sub_definition_valid_between.upper <= main_definition_valid_between.upper
+                sub_definition_valid_between.upper <= main_definition_valid_between.upper
         )
     else:
         return sub_definition_valid_between.lower >= main_definition_valid_between.lower
@@ -408,30 +408,30 @@ class QA3(BusinessRule):
         main = association.main_quota
         sub = association.sub_quota
         if not check_QA3_dict(
-            main_definition_unit=main.measurement_unit,
-            sub_definition_unit=sub.measurement_unit,
-            main_definition_volume=main.volume,
-            sub_definition_volume=sub.volume,
-            main_initial_volume=main.initial_volume,
-            sub_initial_volume=sub.initial_volume,
+                main_definition_unit=main.measurement_unit,
+                sub_definition_unit=sub.measurement_unit,
+                main_definition_volume=main.volume,
+                sub_definition_volume=sub.volume,
+                main_initial_volume=main.initial_volume,
+                sub_initial_volume=sub.initial_volume,
         ):
             raise self.violation(association)
 
 
 def check_QA3_dict(
-    main_definition_unit,
-    sub_definition_unit,
-    main_definition_volume,
-    sub_definition_volume,
-    sub_initial_volume,
-    main_initial_volume,
+        main_definition_unit,
+        sub_definition_unit,
+        main_definition_volume,
+        sub_definition_volume,
+        sub_initial_volume,
+        main_initial_volume,
 ):
     """Confirms data is compliant with QA3 See note above about changing the
     unit types."""
     return (
-        main_definition_unit == sub_definition_unit
-        and sub_definition_volume <= main_definition_volume
-        and sub_initial_volume <= main_initial_volume
+            main_definition_unit == sub_definition_unit
+            and sub_definition_volume <= main_definition_volume
+            and sub_initial_volume <= main_initial_volume
     )
 
 
@@ -462,6 +462,8 @@ class QA5(BusinessRule):
     """
 
     def validate(self, association):
+        from quotas.models import QuotaAssociation
+
         if association.sub_quota_relation_type == SubQuotaType.EQUIVALENT:
             if not check_QA5_equivalent_coefficient(association.coefficient):
                 raise self.violation(
@@ -471,13 +473,18 @@ class QA5(BusinessRule):
                         "coefficient not equal to 1"
                     ),
                 )
-            if (
-                association.main_quota.sub_quotas.values("volume")
-                .order_by("volume")
-                .distinct("volume")
-                .count()
-                > 1
-            ):
+
+            quota_associations = QuotaAssociation.objects.approved_up_to_transaction(
+                association.transaction
+            ).filter(
+                main_quota=association.main_quota
+            )
+            volumes = []
+            for association in quota_associations:
+                if association.sub_quota.volume not in volumes:
+                    volumes.append(association.sub_quota.volume)
+
+            if len(volumes) > 1:
                 raise self.violation(
                     model=association,
                     message=(
@@ -524,9 +531,9 @@ class QA6(BusinessRule):
 
     def validate(self, association):
         if not check_QA6_dict(
-            association.main_quota,
-            association.sub_quota_relation_type,
-            association.transaction,
+                association.main_quota,
+                association.sub_quota_relation_type,
+                association.transaction,
         ):
             raise self.violation(association)
 
@@ -570,8 +577,8 @@ class BlockingOnlyOfFCFSQuotas(BusinessRule):
 
     def validate(self, blocking):
         if (
-            blocking.quota_definition.order_number.mechanism
-            != AdministrationMechanism.FCFS
+                blocking.quota_definition.order_number.mechanism
+                != AdministrationMechanism.FCFS
         ):
             raise self.violation(blocking)
 
@@ -591,8 +598,8 @@ class SuspensionsOnlyToFCFSQuotas(BusinessRule):
 
     def validate(self, suspension):
         if (
-            suspension.quota_definition.order_number.mechanism
-            != AdministrationMechanism.FCFS
+                suspension.quota_definition.order_number.mechanism
+                != AdministrationMechanism.FCFS
         ):
             raise self.violation(suspension)
 

--- a/quotas/tests/test_business_rules.py
+++ b/quotas/tests/test_business_rules.py
@@ -19,6 +19,7 @@ from quotas.validators import SubQuotaType
 pytestmark = pytest.mark.django_db
 
 
+@pytest.mark.business_rules
 def test_ON1(assert_handles_duplicates):
     """Quota order number id + start date must be unique."""
 
@@ -29,12 +30,13 @@ def test_ON1(assert_handles_duplicates):
     )
 
 
+@pytest.mark.business_rules
 @pytest.mark.parametrize(
     ("existing_range", "new_range", "ranges_overlap"),
     (
-        ("normal", "overlap_normal", True),
-        ("big", "normal", True),
-        ("normal", "later", False),
+            ("normal", "overlap_normal", True),
+            ("big", "normal", True),
+            ("normal", "later", False),
     ),
 )
 def test_ON2(date_ranges, existing_range, new_range, ranges_overlap):
@@ -54,6 +56,7 @@ def test_ON2(date_ranges, existing_range, new_range, ranges_overlap):
         business_rules.ON2(order_number.transaction).validate(order_number)
 
 
+@pytest.mark.business_rules
 def test_ON5(date_ranges, approved_transaction, unapproved_transaction):
     """There may be no overlap in time of two quota order number origins with
     the same quota order number SID and geographical area id."""
@@ -79,6 +82,7 @@ def test_ON5(date_ranges, approved_transaction, unapproved_transaction):
         business_rules.ON5(origin.transaction).validate(origin)
 
 
+@pytest.mark.business_rules
 @only_applicable_after("2006-12-31")
 def test_ON6(date_ranges):
     """
@@ -105,6 +109,7 @@ def test_ON6(date_ranges):
         business_rules.ON6(origin.transaction).validate(origin)
 
 
+@pytest.mark.business_rules
 def test_ON7(assert_spanning_enforced):
     """The validity period of the quota order number must span the validity
     period of the quota order number origin."""
@@ -115,6 +120,7 @@ def test_ON7(assert_spanning_enforced):
     )
 
 
+@pytest.mark.business_rules
 def test_ON8(assert_spanning_enforced):
     """The validity period of the quota order number must span the validity
     period of the referencing quota definition."""
@@ -125,6 +131,7 @@ def test_ON8(assert_spanning_enforced):
     )
 
 
+@pytest.mark.business_rules
 @only_applicable_after("2007-12-31")
 def test_ON9(date_ranges):
     """
@@ -146,6 +153,7 @@ def test_ON9(date_ranges):
         business_rules.ON9(measure.transaction).validate(order_number)
 
 
+@pytest.mark.business_rules
 @only_applicable_after("2007-12-31")
 def test_ON11(delete_record):
     """
@@ -160,6 +168,7 @@ def test_ON11(delete_record):
         business_rules.ON11(deleted.transaction).validate(deleted)
 
 
+@pytest.mark.business_rules
 @only_applicable_after("2007-12-31")
 def test_ON12(delete_record):
     """
@@ -175,6 +184,7 @@ def test_ON12(delete_record):
         business_rules.ON12(deleted.transaction).validate(deleted)
 
 
+@pytest.mark.business_rules
 def test_ON12_does_not_raise(delete_record):
     """
     The quota order number origin cannot be deleted if it is used in a measure.
@@ -196,6 +206,7 @@ def test_ON12_does_not_raise(delete_record):
     business_rules.ON12(deleted.transaction).validate(deleted)
 
 
+@pytest.mark.business_rules
 @pytest.mark.parametrize(
     "area_code, expect_error",
     [
@@ -217,6 +228,7 @@ def test_ON13(area_code, expect_error):
         business_rules.ON13(exclusion.transaction).validate(exclusion)
 
 
+@pytest.mark.business_rules
 def test_ON14():
     """The excluded geographical area must be a member of the geographical area
     group."""
@@ -249,6 +261,7 @@ def test_ON14():
         business_rules.ON14(deleted.transaction).validate(exclusion)
 
 
+@pytest.mark.business_rules
 def test_CertificatesMustExist():
     """The referenced certificates must exist."""
     quota_order_number = factories.QuotaOrderNumberFactory.create(
@@ -264,6 +277,7 @@ def test_CertificatesMustExist():
         )
 
 
+@pytest.mark.business_rules
 def test_CertificateValidityPeriodMustSpanQuotaOrderNumber(assert_spanning_enforced):
     """The validity period of the required certificates must span the validity
     period of the quota order number."""
@@ -274,6 +288,7 @@ def test_CertificateValidityPeriodMustSpanQuotaOrderNumber(assert_spanning_enfor
     )
 
 
+@pytest.mark.business_rules
 def test_QD1(assert_handles_duplicates):
     """Quota order number id + start date must be unique."""
 
@@ -284,6 +299,7 @@ def test_QD1(assert_handles_duplicates):
     )
 
 
+@pytest.mark.business_rules
 def test_QD2(date_ranges):
     """The start date must be less than or equal to the end date."""
 
@@ -291,6 +307,7 @@ def test_QD2(date_ranges):
         factories.QuotaDefinitionFactory.create(valid_between=date_ranges.backwards)
 
 
+@pytest.mark.business_rules
 def test_QD7(date_ranges):
     """The validity period of the quota definition must be spanned by one of the
     validity periods of the referenced quota order number."""
@@ -305,6 +322,7 @@ def test_QD7(date_ranges):
         business_rules.QD7(definition.transaction).validate(definition)
 
 
+@pytest.mark.business_rules
 def test_QD8(assert_spanning_enforced):
     """The validity period of the monetary unit code must span the validity
     period of the quota definition."""
@@ -317,6 +335,7 @@ def test_QD8(assert_spanning_enforced):
     )
 
 
+@pytest.mark.business_rules
 @pytest.mark.skip(reason="Using GBP, not EUR")
 def test_QD9():
     """The monetary unit code must always be the Euro ISO code (or Ecu for quota
@@ -325,6 +344,7 @@ def test_QD9():
     assert False
 
 
+@pytest.mark.business_rules
 def test_QD10(assert_spanning_enforced):
     """The validity period of the measurement unit code must span the validity
     period of the quota definition."""
@@ -335,6 +355,7 @@ def test_QD10(assert_spanning_enforced):
     )
 
 
+@pytest.mark.business_rules
 def test_QD11(assert_spanning_enforced):
     """The validity period of the measurement unit qualifier code must span the
     validity period of the quota definition."""
@@ -345,24 +366,28 @@ def test_QD11(assert_spanning_enforced):
     )
 
 
+@pytest.mark.business_rules
 @pytest.mark.skip("Quota events are not supported")
 def test_QD12():
     """If quota events exist for a quota definition, the start date of the quota
     definition cannot be brought forward."""
 
 
+@pytest.mark.business_rules
 @pytest.mark.skip("Quota events are not supported")
 def test_QD13():
     """If quota events exist for a quota definition, the start date can only be
     postponed up to the date of the first quota event."""
 
 
+@pytest.mark.business_rules
 @pytest.mark.skip("Quota events are not supported")
 def test_QD14():
     """If quota events exist for a quota definition, the end date of the quota
     definition can be postponed."""
 
 
+@pytest.mark.business_rules
 @pytest.mark.skip("Quota events are not supported")
 def test_QD15():
     """If quota events exist for a quota definition, the end date can only be
@@ -370,26 +395,27 @@ def test_QD15():
     definition."""
 
 
+@pytest.mark.business_rules
 @pytest.mark.parametrize(
     ("date_range", "error_expected"),
     (
-        ("future", False),
-        ("earlier", True),
+            ("future", False),
+            ("earlier", True),
     ),
 )
 @pytest.mark.parametrize(
     ("update_type"),
     (
-        UpdateType.UPDATE,
-        UpdateType.DELETE,
+            UpdateType.UPDATE,
+            UpdateType.DELETE,
     ),
 )
 def test_prevent_quota_definition_deletion(
-    unapproved_transaction,
-    date_ranges,
-    date_range,
-    update_type,
-    error_expected,
+        unapproved_transaction,
+        date_ranges,
+        date_range,
+        update_type,
+        error_expected,
 ):
     """
     QAM does not like handling deletions of active Quota Definitions.
@@ -413,31 +439,32 @@ def test_prevent_quota_definition_deletion(
         )
 
 
+@pytest.mark.business_rules
 @pytest.mark.parametrize(
     "factory,business_rule,quota_attr",
     [
         (
-            factories.QuotaAssociationFactory,
-            business_rules.QuotaAssociationMustReferToANonDeletedSubQuota,
-            "sub_quota",
+                factories.QuotaAssociationFactory,
+                business_rules.QuotaAssociationMustReferToANonDeletedSubQuota,
+                "sub_quota",
         ),
         (
-            factories.QuotaSuspensionFactory,
-            business_rules.QuotaSuspensionMustReferToANonDeletedQuotaDefinition,
-            "quota_definition",
+                factories.QuotaSuspensionFactory,
+                business_rules.QuotaSuspensionMustReferToANonDeletedQuotaDefinition,
+                "quota_definition",
         ),
         (
-            factories.QuotaBlockingFactory,
-            business_rules.QuotaBlockingPeriodMustReferToANonDeletedQuotaDefinition,
-            "quota_definition",
+                factories.QuotaBlockingFactory,
+                business_rules.QuotaBlockingPeriodMustReferToANonDeletedQuotaDefinition,
+                "quota_definition",
         ),
     ],
 )
 def test_linking_models_must_refer_to_a_non_deleted_sub_quota(
-    unapproved_transaction,
-    factory,
-    business_rule,
-    quota_attr,
+        unapproved_transaction,
+        factory,
+        business_rule,
+        quota_attr,
 ):
     """Ensure a Quota Definition cannot be deleted if referred to by another
     linking quota model."""
@@ -463,6 +490,7 @@ def test_linking_models_must_refer_to_a_non_deleted_sub_quota(
     business_rule(deleted.transaction).validate(deleted)
 
 
+@pytest.mark.business_rules
 def test_overlapping_quota_definition(date_ranges):
     order_number = factories.QuotaOrderNumberFactory.create()
     factories.QuotaDefinitionFactory.create(
@@ -480,10 +508,11 @@ def test_overlapping_quota_definition(date_ranges):
         ).validate(overlapping_definition)
 
 
+@pytest.mark.business_rules
 def test_overlapping_quota_definition_on_deleted_records(
-    date_ranges,
-    delete_record,
-    approved_transaction,
+        date_ranges,
+        delete_record,
+        approved_transaction,
 ):
     order_number = factories.QuotaOrderNumberFactory.create()
 
@@ -505,15 +534,16 @@ def test_overlapping_quota_definition_on_deleted_records(
     )
 
     assert (
-        business_rules.OverlappingQuotaDefinition(
-            overlapping_definition.transaction,
-        ).validate(
-            overlapping_definition,
-        )
-        is None
+            business_rules.OverlappingQuotaDefinition(
+                overlapping_definition.transaction,
+            ).validate(
+                overlapping_definition,
+            )
+            is None
     )
 
 
+@pytest.mark.business_rules
 def test_volume_and_initial_volume_must_match(date_ranges):
     """Unless it is the main quota in a quota association, a definition's volume
     and initial_volume values should always be the same."""
@@ -530,13 +560,14 @@ def test_volume_and_initial_volume_must_match(date_ranges):
         )
 
     assert (
-        "Unless it is the main quota in a quota association, a definition's volume and initial_volume values should always be the same."
-        in str(violation)
+            "Unless it is the main quota in a quota association, a definition's volume and initial_volume values should always be the same."
+            in str(violation)
     )
 
 
+@pytest.mark.business_rules
 def test_volume_and_initial_volume_can_differ_if_in_current_or_historical_period(
-    date_ranges,
+        date_ranges,
 ):
     """Unless it is the main quota in a quota association, a definition's volume
     and initial_volume values should always be the same."""
@@ -568,6 +599,7 @@ def test_volume_and_initial_volume_can_differ_if_in_current_or_historical_period
     assert result_current
 
 
+@pytest.mark.business_rules
 def test_volume_and_initial_volume_must_match_main_quota():
     """Test that VolumeAndInitialVolumeMustMatch does not raise a violation when
     definition with different volume and initial_volume values is used as parent
@@ -588,6 +620,7 @@ def test_volume_and_initial_volume_must_match_main_quota():
     )
 
 
+@pytest.mark.business_rules
 def test_volume_and_initial_volume_must_match_sub_quota():
     """Test that VolumeAndInitialVolumeMustMatch raises a violation when
     definition with different volume and initial_volume values is used as child
@@ -611,11 +644,12 @@ def test_volume_and_initial_volume_must_match_sub_quota():
         )
 
     assert (
-        "Unless it is the main quota in a quota association, a definition's volume and initial_volume values should always be the same."
-        in str(violation)
+            "Unless it is the main quota in a quota association, a definition's volume and initial_volume values should always be the same."
+            in str(violation)
     )
 
 
+@pytest.mark.business_rules
 def test_QA1(assert_handles_duplicates):
     """The association between two quota definitions must be unique."""
 
@@ -625,6 +659,7 @@ def test_QA1(assert_handles_duplicates):
     )
 
 
+@pytest.mark.business_rules
 def test_QA2(date_ranges):
     """The sub-quota’s validity period must be entirely enclosed within the
     validity period of the main quota."""
@@ -637,42 +672,44 @@ def test_QA2(date_ranges):
         business_rules.QA2(association.transaction).validate(association)
 
 
+@pytest.mark.business_rules
 @pytest.mark.parametrize(
     "sub_definition_valid_between, main_definition_valid_between, expected_response",
     [
         (
-            TaricDateRange(date(2019, 1, 1), date(2020, 2, 2)),
-            TaricDateRange(date(2021, 1, 1), date(2021, 12, 1)),
-            False,
+                TaricDateRange(date(2019, 1, 1), date(2020, 2, 2)),
+                TaricDateRange(date(2021, 1, 1), date(2021, 12, 1)),
+                False,
         ),
         (
-            TaricDateRange(date(2021, 1, 1), date(2050, 2, 2)),
-            TaricDateRange(date(2021, 1, 1), date(2021, 12, 1)),
-            False,
+                TaricDateRange(date(2021, 1, 1), date(2050, 2, 2)),
+                TaricDateRange(date(2021, 1, 1), date(2021, 12, 1)),
+                False,
         ),
         (
-            TaricDateRange(date(2021, 1, 1), date(2021, 12, 1)),
-            TaricDateRange(date(2020, 1, 1), date(2023, 12, 1)),
-            True,
+                TaricDateRange(date(2021, 1, 1), date(2021, 12, 1)),
+                TaricDateRange(date(2020, 1, 1), date(2023, 12, 1)),
+                True,
         ),
     ],
 )
 def test_QA2_dict(
-    sub_definition_valid_between,
-    main_definition_valid_between,
-    expected_response,
+        sub_definition_valid_between,
+        main_definition_valid_between,
+        expected_response,
 ):
     """As above, but checking between a definition and a dict with date
     ranges."""
     assert (
-        business_rules.check_QA2_dict(
-            sub_definition_valid_between,
-            main_definition_valid_between,
-        )
-        == expected_response
+            business_rules.check_QA2_dict(
+                sub_definition_valid_between,
+                main_definition_valid_between,
+            )
+            == expected_response
     )
 
 
+@pytest.mark.business_rules
 @pytest.mark.parametrize(
     "main_volume, main_unit, sub_volume, sub_unit, main_init_volume, sub_init_volume, expect_error",
     [
@@ -687,13 +724,13 @@ def test_QA2_dict(
     ],
 )
 def test_QA3(
-    main_volume,
-    main_unit,
-    sub_volume,
-    sub_unit,
-    main_init_volume,
-    sub_init_volume,
-    expect_error,
+        main_volume,
+        main_unit,
+        sub_volume,
+        sub_unit,
+        main_init_volume,
+        sub_init_volume,
+        expect_error,
 ):
     """When converted to the measurement unit of the main quota, the volume of a
     sub-quota must always be lower than or equal to the volume of the main
@@ -714,6 +751,7 @@ def test_QA3(
         business_rules.QA3(assoc.transaction).validate(assoc)
 
 
+@pytest.mark.business_rules
 @pytest.mark.parametrize(
     "main_volume, main_unit, sub_volume, sub_unit, main_init_volume, sub_init_volume, expected_response",
     [
@@ -728,29 +766,30 @@ def test_QA3(
     ],
 )
 def test_QA3_dict(
-    main_volume,
-    main_unit,
-    sub_volume,
-    sub_unit,
-    main_init_volume,
-    sub_init_volume,
-    expected_response,
+        main_volume,
+        main_unit,
+        sub_volume,
+        sub_unit,
+        main_init_volume,
+        sub_init_volume,
+        expected_response,
 ):
     """As above, but checking between a definition and a dict."""
 
     assert (
-        business_rules.check_QA3_dict(
-            main_definition_volume=main_volume,
-            main_definition_unit=main_unit,
-            sub_definition_volume=sub_volume,
-            sub_definition_unit=sub_unit,
-            sub_initial_volume=sub_init_volume,
-            main_initial_volume=main_init_volume,
-        )
-        == expected_response
+            business_rules.check_QA3_dict(
+                main_definition_volume=main_volume,
+                main_definition_unit=main_unit,
+                sub_definition_volume=sub_volume,
+                sub_definition_unit=sub_unit,
+                sub_initial_volume=sub_init_volume,
+                main_initial_volume=main_init_volume,
+            )
+            == expected_response
     )
 
 
+@pytest.mark.business_rules
 @pytest.mark.parametrize(
     "coefficient, expect_error",
     [
@@ -779,6 +818,7 @@ def test_QA4(coefficient, expect_error):
         business_rules.QA4(assoc.transaction).validate(assoc)
 
 
+@pytest.mark.business_rules
 @pytest.mark.parametrize(
     "coefficient, expected_response",
     [
@@ -793,15 +833,16 @@ def test_QA4_dict(coefficient, expected_response):
     assert business_rules.check_QA4_dict(coefficient) == expected_response
 
 
+@pytest.mark.business_rules
 @pytest.mark.parametrize(
     ("existing_volume", "new_volume", "coeff", "type", "error_expected"),
     (
-        ("1000.0", "1000.0", "1.200", SubQuotaType.EQUIVALENT, False),
-        ("1000.0", "1000.0", "1.000", SubQuotaType.EQUIVALENT, True),
-        ("1000.0", "2000.0", "1.200", SubQuotaType.EQUIVALENT, True),
-        ("2000.0", "1000.0", "1.000", SubQuotaType.NORMAL, False),
-        ("1000.0", "1000.0", "1.000", SubQuotaType.NORMAL, False),
-        ("2000.0", "1000.0", "1.200", SubQuotaType.NORMAL, True),
+            ("1000.0", "1000.0", "1.200", SubQuotaType.EQUIVALENT, False),
+            ("1000.0", "1000.0", "1.000", SubQuotaType.EQUIVALENT, True),
+            ("1000.0", "2000.0", "1.200", SubQuotaType.EQUIVALENT, True),
+            ("2000.0", "1000.0", "1.000", SubQuotaType.NORMAL, False),
+            ("1000.0", "1000.0", "1.000", SubQuotaType.NORMAL, False),
+            ("2000.0", "1000.0", "1.200", SubQuotaType.NORMAL, True),
     ),
 )
 def test_QA5(existing_volume, new_volume, coeff, type, error_expected):
@@ -831,13 +872,34 @@ def test_QA5(existing_volume, new_volume, coeff, type, error_expected):
         business_rules.QA5(assoc.transaction).validate(assoc)
 
 
+@pytest.mark.business_rules
+def test_QA5_deleted_association():
+
+    existing = factories.QuotaAssociationFactory.create(
+        sub_quota__volume=Decimal("1000"),
+        sub_quota_relation_type=SubQuotaType.EQUIVALENT,
+    )
+
+    assoc = factories.QuotaAssociationFactory.create(
+        main_quota=existing.main_quota,
+        sub_quota__volume=Decimal("2000"),
+        sub_quota_relation_type=SubQuotaType.EQUIVALENT,
+        coefficient=Decimal('1.200'),
+        update_type=UpdateType.DELETE.value
+    )
+
+    with raises_if(BusinessRuleViolation, False):
+        business_rules.QA5(assoc.transaction).validate(assoc)
+
+
+@pytest.mark.business_rules
 @pytest.mark.parametrize(
     ("existing_relation", "new_relation", "error_expected"),
     (
-        (SubQuotaType.NORMAL, SubQuotaType.NORMAL, False),
-        (SubQuotaType.EQUIVALENT, SubQuotaType.EQUIVALENT, False),
-        (SubQuotaType.NORMAL, SubQuotaType.EQUIVALENT, True),
-        (SubQuotaType.EQUIVALENT, SubQuotaType.NORMAL, True),
+            (SubQuotaType.NORMAL, SubQuotaType.NORMAL, False),
+            (SubQuotaType.EQUIVALENT, SubQuotaType.EQUIVALENT, False),
+            (SubQuotaType.NORMAL, SubQuotaType.EQUIVALENT, True),
+            (SubQuotaType.EQUIVALENT, SubQuotaType.NORMAL, True),
     ),
 )
 def test_QA6(existing_relation, new_relation, error_expected):
@@ -857,6 +919,7 @@ def test_QA6(existing_relation, new_relation, error_expected):
 
 
 # https://uktrade.atlassian.net/browse/TP2000-434
+@pytest.mark.business_rules
 def test_QA6_new_association_version():
     """Tests that previous versions of an association are not compared when
     looking for sub-quotas associated with the same main quota."""
@@ -872,6 +935,7 @@ def test_QA6_new_association_version():
     business_rules.QA6(later_version.transaction).validate(later_version)
 
 
+@pytest.mark.business_rules
 def test_same_main_and_sub_quota():
     """A quota association may only exist between two distinct quota
     definitions."""
@@ -888,11 +952,12 @@ def test_same_main_and_sub_quota():
         )
 
 
+@pytest.mark.business_rules
 @pytest.mark.parametrize(
     ("mechanism", "error_expected"),
     (
-        (AdministrationMechanism.LICENSED, True),
-        (AdministrationMechanism.FCFS, False),
+            (AdministrationMechanism.LICENSED, True),
+            (AdministrationMechanism.FCFS, False),
     ),
 )
 def test_blocking_of_fcfs_quotas_only(mechanism, error_expected):
@@ -905,6 +970,7 @@ def test_blocking_of_fcfs_quotas_only(mechanism, error_expected):
         business_rules.BlockingOnlyOfFCFSQuotas(blocking.transaction).validate(blocking)
 
 
+@pytest.mark.business_rules
 def test_QBP2(date_ranges):
     """The start date of the quota blocking period must be later than or equal
     to the start date of the quota validity period."""
@@ -917,6 +983,7 @@ def test_QBP2(date_ranges):
         business_rules.QBP2(blocking.transaction).validate(blocking)
 
 
+@pytest.mark.business_rules
 def test_QBP3(date_ranges):
     """The end date of the quota blocking period must be later than the start
     date of the quota blocking period."""
@@ -925,11 +992,12 @@ def test_QBP3(date_ranges):
         factories.QuotaBlockingFactory.create(valid_between=date_ranges.backwards)
 
 
+@pytest.mark.business_rules
 @pytest.mark.parametrize(
     ("mechanism", "error_expected"),
     (
-        (AdministrationMechanism.LICENSED, True),
-        (AdministrationMechanism.FCFS, False),
+            (AdministrationMechanism.LICENSED, True),
+            (AdministrationMechanism.FCFS, False),
     ),
 )
 def test_suspension_of_fcfs_quotas_only(mechanism, error_expected):
@@ -945,6 +1013,7 @@ def test_suspension_of_fcfs_quotas_only(mechanism, error_expected):
         )
 
 
+@pytest.mark.business_rules
 def test_QSP2(assert_spanning_enforced):
     """The validity period of the quota must span the quota suspension
     period."""

--- a/quotas/tests/test_business_rules.py
+++ b/quotas/tests/test_business_rules.py
@@ -34,9 +34,9 @@ def test_ON1(assert_handles_duplicates):
 @pytest.mark.parametrize(
     ("existing_range", "new_range", "ranges_overlap"),
     (
-            ("normal", "overlap_normal", True),
-            ("big", "normal", True),
-            ("normal", "later", False),
+        ("normal", "overlap_normal", True),
+        ("big", "normal", True),
+        ("normal", "later", False),
     ),
 )
 def test_ON2(date_ranges, existing_range, new_range, ranges_overlap):
@@ -399,23 +399,23 @@ def test_QD15():
 @pytest.mark.parametrize(
     ("date_range", "error_expected"),
     (
-            ("future", False),
-            ("earlier", True),
+        ("future", False),
+        ("earlier", True),
     ),
 )
 @pytest.mark.parametrize(
     ("update_type"),
     (
-            UpdateType.UPDATE,
-            UpdateType.DELETE,
+        UpdateType.UPDATE,
+        UpdateType.DELETE,
     ),
 )
 def test_prevent_quota_definition_deletion(
-        unapproved_transaction,
-        date_ranges,
-        date_range,
-        update_type,
-        error_expected,
+    unapproved_transaction,
+    date_ranges,
+    date_range,
+    update_type,
+    error_expected,
 ):
     """
     QAM does not like handling deletions of active Quota Definitions.
@@ -444,27 +444,27 @@ def test_prevent_quota_definition_deletion(
     "factory,business_rule,quota_attr",
     [
         (
-                factories.QuotaAssociationFactory,
-                business_rules.QuotaAssociationMustReferToANonDeletedSubQuota,
-                "sub_quota",
+            factories.QuotaAssociationFactory,
+            business_rules.QuotaAssociationMustReferToANonDeletedSubQuota,
+            "sub_quota",
         ),
         (
-                factories.QuotaSuspensionFactory,
-                business_rules.QuotaSuspensionMustReferToANonDeletedQuotaDefinition,
-                "quota_definition",
+            factories.QuotaSuspensionFactory,
+            business_rules.QuotaSuspensionMustReferToANonDeletedQuotaDefinition,
+            "quota_definition",
         ),
         (
-                factories.QuotaBlockingFactory,
-                business_rules.QuotaBlockingPeriodMustReferToANonDeletedQuotaDefinition,
-                "quota_definition",
+            factories.QuotaBlockingFactory,
+            business_rules.QuotaBlockingPeriodMustReferToANonDeletedQuotaDefinition,
+            "quota_definition",
         ),
     ],
 )
 def test_linking_models_must_refer_to_a_non_deleted_sub_quota(
-        unapproved_transaction,
-        factory,
-        business_rule,
-        quota_attr,
+    unapproved_transaction,
+    factory,
+    business_rule,
+    quota_attr,
 ):
     """Ensure a Quota Definition cannot be deleted if referred to by another
     linking quota model."""
@@ -510,9 +510,9 @@ def test_overlapping_quota_definition(date_ranges):
 
 @pytest.mark.business_rules
 def test_overlapping_quota_definition_on_deleted_records(
-        date_ranges,
-        delete_record,
-        approved_transaction,
+    date_ranges,
+    delete_record,
+    approved_transaction,
 ):
     order_number = factories.QuotaOrderNumberFactory.create()
 
@@ -534,12 +534,12 @@ def test_overlapping_quota_definition_on_deleted_records(
     )
 
     assert (
-            business_rules.OverlappingQuotaDefinition(
-                overlapping_definition.transaction,
-            ).validate(
-                overlapping_definition,
-            )
-            is None
+        business_rules.OverlappingQuotaDefinition(
+            overlapping_definition.transaction,
+        ).validate(
+            overlapping_definition,
+        )
+        is None
     )
 
 
@@ -560,14 +560,14 @@ def test_volume_and_initial_volume_must_match(date_ranges):
         )
 
     assert (
-            "Unless it is the main quota in a quota association, a definition's volume and initial_volume values should always be the same."
-            in str(violation)
+        "Unless it is the main quota in a quota association, a definition's volume and initial_volume values should always be the same."
+        in str(violation)
     )
 
 
 @pytest.mark.business_rules
 def test_volume_and_initial_volume_can_differ_if_in_current_or_historical_period(
-        date_ranges,
+    date_ranges,
 ):
     """Unless it is the main quota in a quota association, a definition's volume
     and initial_volume values should always be the same."""
@@ -644,8 +644,8 @@ def test_volume_and_initial_volume_must_match_sub_quota():
         )
 
     assert (
-            "Unless it is the main quota in a quota association, a definition's volume and initial_volume values should always be the same."
-            in str(violation)
+        "Unless it is the main quota in a quota association, a definition's volume and initial_volume values should always be the same."
+        in str(violation)
     )
 
 
@@ -677,35 +677,35 @@ def test_QA2(date_ranges):
     "sub_definition_valid_between, main_definition_valid_between, expected_response",
     [
         (
-                TaricDateRange(date(2019, 1, 1), date(2020, 2, 2)),
-                TaricDateRange(date(2021, 1, 1), date(2021, 12, 1)),
-                False,
+            TaricDateRange(date(2019, 1, 1), date(2020, 2, 2)),
+            TaricDateRange(date(2021, 1, 1), date(2021, 12, 1)),
+            False,
         ),
         (
-                TaricDateRange(date(2021, 1, 1), date(2050, 2, 2)),
-                TaricDateRange(date(2021, 1, 1), date(2021, 12, 1)),
-                False,
+            TaricDateRange(date(2021, 1, 1), date(2050, 2, 2)),
+            TaricDateRange(date(2021, 1, 1), date(2021, 12, 1)),
+            False,
         ),
         (
-                TaricDateRange(date(2021, 1, 1), date(2021, 12, 1)),
-                TaricDateRange(date(2020, 1, 1), date(2023, 12, 1)),
-                True,
+            TaricDateRange(date(2021, 1, 1), date(2021, 12, 1)),
+            TaricDateRange(date(2020, 1, 1), date(2023, 12, 1)),
+            True,
         ),
     ],
 )
 def test_QA2_dict(
-        sub_definition_valid_between,
-        main_definition_valid_between,
-        expected_response,
+    sub_definition_valid_between,
+    main_definition_valid_between,
+    expected_response,
 ):
     """As above, but checking between a definition and a dict with date
     ranges."""
     assert (
-            business_rules.check_QA2_dict(
-                sub_definition_valid_between,
-                main_definition_valid_between,
-            )
-            == expected_response
+        business_rules.check_QA2_dict(
+            sub_definition_valid_between,
+            main_definition_valid_between,
+        )
+        == expected_response
     )
 
 
@@ -724,13 +724,13 @@ def test_QA2_dict(
     ],
 )
 def test_QA3(
-        main_volume,
-        main_unit,
-        sub_volume,
-        sub_unit,
-        main_init_volume,
-        sub_init_volume,
-        expect_error,
+    main_volume,
+    main_unit,
+    sub_volume,
+    sub_unit,
+    main_init_volume,
+    sub_init_volume,
+    expect_error,
 ):
     """When converted to the measurement unit of the main quota, the volume of a
     sub-quota must always be lower than or equal to the volume of the main
@@ -766,26 +766,26 @@ def test_QA3(
     ],
 )
 def test_QA3_dict(
-        main_volume,
-        main_unit,
-        sub_volume,
-        sub_unit,
-        main_init_volume,
-        sub_init_volume,
-        expected_response,
+    main_volume,
+    main_unit,
+    sub_volume,
+    sub_unit,
+    main_init_volume,
+    sub_init_volume,
+    expected_response,
 ):
     """As above, but checking between a definition and a dict."""
 
     assert (
-            business_rules.check_QA3_dict(
-                main_definition_volume=main_volume,
-                main_definition_unit=main_unit,
-                sub_definition_volume=sub_volume,
-                sub_definition_unit=sub_unit,
-                sub_initial_volume=sub_init_volume,
-                main_initial_volume=main_init_volume,
-            )
-            == expected_response
+        business_rules.check_QA3_dict(
+            main_definition_volume=main_volume,
+            main_definition_unit=main_unit,
+            sub_definition_volume=sub_volume,
+            sub_definition_unit=sub_unit,
+            sub_initial_volume=sub_init_volume,
+            main_initial_volume=main_init_volume,
+        )
+        == expected_response
     )
 
 
@@ -837,12 +837,12 @@ def test_QA4_dict(coefficient, expected_response):
 @pytest.mark.parametrize(
     ("existing_volume", "new_volume", "coeff", "type", "error_expected"),
     (
-            ("1000.0", "1000.0", "1.200", SubQuotaType.EQUIVALENT, False),
-            ("1000.0", "1000.0", "1.000", SubQuotaType.EQUIVALENT, True),
-            ("1000.0", "2000.0", "1.200", SubQuotaType.EQUIVALENT, True),
-            ("2000.0", "1000.0", "1.000", SubQuotaType.NORMAL, False),
-            ("1000.0", "1000.0", "1.000", SubQuotaType.NORMAL, False),
-            ("2000.0", "1000.0", "1.200", SubQuotaType.NORMAL, True),
+        ("1000.0", "1000.0", "1.200", SubQuotaType.EQUIVALENT, False),
+        ("1000.0", "1000.0", "1.000", SubQuotaType.EQUIVALENT, True),
+        ("1000.0", "2000.0", "1.200", SubQuotaType.EQUIVALENT, True),
+        ("2000.0", "1000.0", "1.000", SubQuotaType.NORMAL, False),
+        ("1000.0", "1000.0", "1.000", SubQuotaType.NORMAL, False),
+        ("2000.0", "1000.0", "1.200", SubQuotaType.NORMAL, True),
     ),
 )
 def test_QA5(existing_volume, new_volume, coeff, type, error_expected):
@@ -884,8 +884,8 @@ def test_QA5_deleted_association():
         main_quota=existing.main_quota,
         sub_quota__volume=Decimal("2000"),
         sub_quota_relation_type=SubQuotaType.EQUIVALENT,
-        coefficient=Decimal('1.200'),
-        update_type=UpdateType.DELETE.value
+        coefficient=Decimal("1.200"),
+        update_type=UpdateType.DELETE.value,
     )
 
     with raises_if(BusinessRuleViolation, False):
@@ -896,10 +896,10 @@ def test_QA5_deleted_association():
 @pytest.mark.parametrize(
     ("existing_relation", "new_relation", "error_expected"),
     (
-            (SubQuotaType.NORMAL, SubQuotaType.NORMAL, False),
-            (SubQuotaType.EQUIVALENT, SubQuotaType.EQUIVALENT, False),
-            (SubQuotaType.NORMAL, SubQuotaType.EQUIVALENT, True),
-            (SubQuotaType.EQUIVALENT, SubQuotaType.NORMAL, True),
+        (SubQuotaType.NORMAL, SubQuotaType.NORMAL, False),
+        (SubQuotaType.EQUIVALENT, SubQuotaType.EQUIVALENT, False),
+        (SubQuotaType.NORMAL, SubQuotaType.EQUIVALENT, True),
+        (SubQuotaType.EQUIVALENT, SubQuotaType.NORMAL, True),
     ),
 )
 def test_QA6(existing_relation, new_relation, error_expected):
@@ -956,8 +956,8 @@ def test_same_main_and_sub_quota():
 @pytest.mark.parametrize(
     ("mechanism", "error_expected"),
     (
-            (AdministrationMechanism.LICENSED, True),
-            (AdministrationMechanism.FCFS, False),
+        (AdministrationMechanism.LICENSED, True),
+        (AdministrationMechanism.FCFS, False),
     ),
 )
 def test_blocking_of_fcfs_quotas_only(mechanism, error_expected):
@@ -996,8 +996,8 @@ def test_QBP3(date_ranges):
 @pytest.mark.parametrize(
     ("mechanism", "error_expected"),
     (
-            (AdministrationMechanism.LICENSED, True),
-            (AdministrationMechanism.FCFS, False),
+        (AdministrationMechanism.LICENSED, True),
+        (AdministrationMechanism.FCFS, False),
     ),
 )
 def test_suspension_of_fcfs_quotas_only(mechanism, error_expected):

--- a/regulations/tests/test_business_rules.py
+++ b/regulations/tests/test_business_rules.py
@@ -11,6 +11,7 @@ from regulations.validators import RoleType
 pytestmark = pytest.mark.django_db
 
 
+@pytest.mark.business_rules
 def test_ROIMB1(assert_handles_duplicates):
     """The (regulation id + role id) must be unique."""
     # Effectively this means that the regulation ID needs to be unique as we are always
@@ -22,6 +23,7 @@ def test_ROIMB1(assert_handles_duplicates):
     )
 
 
+@pytest.mark.business_rules
 def test_ROIMB3(date_ranges):
     """The start date must be less than or equal to the end date."""
     # In the UK, legislation will be rarely end-dated.
@@ -30,6 +32,7 @@ def test_ROIMB3(date_ranges):
         factories.BaseRegulationFactory.create(valid_between=date_ranges.backwards)
 
 
+@pytest.mark.business_rules
 def test_ROIMB4(reference_nonexistent_record):
     """The referenced regulation group must exist."""
 
@@ -41,6 +44,7 @@ def test_ROIMB4(reference_nonexistent_record):
             business_rules.ROIMB4(regulation.transaction).validate(regulation)
 
 
+@pytest.mark.business_rules
 @pytest.mark.skip(reason="Not using regulation replacement functionality")
 def test_ROIMB5():
     """If the regulation is replaced, completely or partially, modification is
@@ -49,6 +53,7 @@ def test_ROIMB5():
     assert False
 
 
+@pytest.mark.business_rules
 @pytest.mark.skip(reason="Not using regulation abrogation functionality")
 def test_ROIMB6():
     """If the regulation is abrogated, completely or explicitly, modification is
@@ -57,6 +62,7 @@ def test_ROIMB6():
     assert False
 
 
+@pytest.mark.business_rules
 @pytest.mark.skip(reason="Not using regulation prorogation functionality")
 def test_ROIMB7():
     """If the regulation is prorogated, modification is allowed only on the
@@ -65,6 +71,7 @@ def test_ROIMB7():
     assert False
 
 
+@pytest.mark.business_rules
 @only_applicable_after("2003-12-31")
 def test_ROIMB8(date_ranges):
     """
@@ -86,6 +93,7 @@ def test_ROIMB8(date_ranges):
         )
 
 
+@pytest.mark.business_rules
 @pytest.mark.skip(reason="Not using effective end date")
 def test_ROIMB48():
     """If the regulation has not been abrogated, the effective end date must be
@@ -93,6 +101,7 @@ def test_ROIMB48():
     assert False
 
 
+@pytest.mark.business_rules
 @pytest.mark.parametrize(
     "id, approved, change_flag, expect_error",
     [
@@ -140,6 +149,7 @@ def test_ROIMB44(id, approved, change_flag, expect_error):
         business_rules.ROIMB44(regulation.transaction).validate(regulation)
 
 
+@pytest.mark.business_rules
 @pytest.mark.parametrize(
     ("regulation_id", "role_type", "expect_error"),
     (
@@ -172,6 +182,7 @@ def test_ROIMB46(regulation_id, role_type, expect_error, delete_record):
         business_rules.ROIMB46(deleted.transaction).validate(deleted)
 
 
+@pytest.mark.business_rules
 def test_ROIMB47(assert_spanning_enforced):
     """The validity period of the regulation group id must span the validity
     period of the base regulation."""

--- a/requirements.txt
+++ b/requirements.txt
@@ -42,7 +42,7 @@ freezegun==1.1.0
 gevent==23.9.1
 govuk-tech-docs-sphinx-theme==1.0.0
 gunicorn==22.0.0
-Jinja2==3.1.4
+Jinja2==3.1.5
 lark==1.1.9
 lxml==5.2.2
 markdown==3.6


### PR DESCRIPTION
# TOPS-1874 
 * Add pytest mark to all business rules for easier testing business rules in isolation 
 * Add test to check deleted associations are not being incorrectly checked
 * Update QA5 

## Why
 * The rule incorrectly raised rule violations 
 * No test checked that deleted associations were not being checked

## What
 * Update QA5 
 * Test to verify the rule is operating correctly

## Checklist
- Requires migrations? No
- Requires dependency updates? No

Links to relevant material
See: [Description](https://uktrade.atlassian.net/browse/TOPS-1874)