### PR TITLE
TP2000-1636 Fix date-related failing unit tests

### DIFF
--- a/measures/forms/mixins.py
+++ b/measures/forms/mixins.py
@@ -247,7 +247,7 @@ class MeasureConditionsFormMixin(forms.ModelForm):
             )
 
         if price:
-            date = measure_start_date or make_aware(datetime.now())
+            date = measure_start_date or make_aware(datetime.datetime.now())
             parser = LarkDutySentenceParser(compound_duties=False, date=date)
             try:
                 components = parser.transform(price)

--- a/measures/tests/conftest.py
+++ b/measures/tests/conftest.py
@@ -425,7 +425,7 @@ def measure_conditions_form_data(
         },
         "kwargs": {
             "form_kwargs": {
-                "measure_start_date": datetime.date(2025, 1, 1),
+                "measure_start_date": date_ranges.normal,
                 "measure_type": factories.MeasureTypeFactory.create(
                     valid_between=date_ranges.normal,
                 ),
@@ -451,7 +451,7 @@ def measure_footnotes_form_data():
 
 
 @pytest.fixture()
-def measure_commodities_and_duties_form_data():
+def measure_commodities_and_duties_form_data(date_ranges):
     commodity_1 = factories.GoodsNomenclatureFactory.create()
     commodity_2 = factories.GoodsNomenclatureFactory.create()
 
@@ -464,7 +464,7 @@ def measure_commodities_and_duties_form_data():
         },
         "kwargs": {
             "min_commodity_count": 1,
-            "measure_start_date": datetime.date(2025, 1, 1),
+            "measure_start_date": date_ranges.normal,
             "form_kwargs": {
                 "measure_type": None,
             },

--- a/measures/tests/conftest.py
+++ b/measures/tests/conftest.py
@@ -425,7 +425,7 @@ def measure_conditions_form_data(
         },
         "kwargs": {
             "form_kwargs": {
-                "measure_start_date": date_ranges.normal,
+                "measure_start_date": date_ranges.normal.lower,
                 "measure_type": factories.MeasureTypeFactory.create(
                     valid_between=date_ranges.normal,
                 ),
@@ -464,7 +464,7 @@ def measure_commodities_and_duties_form_data(date_ranges):
         },
         "kwargs": {
             "min_commodity_count": 1,
-            "measure_start_date": date_ranges.normal,
+            "measure_start_date": date_ranges.normal.lower,
             "form_kwargs": {
                 "measure_type": None,
             },

--- a/reference_documents/tests/test_ref_quota_definition_range_forms.py
+++ b/reference_documents/tests/test_ref_quota_definition_range_forms.py
@@ -67,16 +67,16 @@ class TestRefQuotaDefinitionRangeCreateUpdateForm:
             ("zz", "Enter a whole number."),
             (
                 0,
-                "Start year is not valid, it must be a 4 digit year greater than 2010 and less than 2124",
+                f"Start year is not valid, it must be a 4 digit year greater than 2010 and less than {date.today().year + 100}",
             ),
             (
                 1980,
-                "Start year is not valid, it must be a 4 digit year greater than 2010 and less than 2124",
+                f"Start year is not valid, it must be a 4 digit year greater than 2010 and less than {date.today().year + 100}",
             ),
             (date.today().year + 2, None),
             (
                 date.today().year + 101,
-                "Start year is not valid, it must be a 4 digit year greater than 2010 and less than 2124",
+                f"Start year is not valid, it must be a 4 digit year greater than 2010 and less than {date.today().year + 100}",
             ),
         ],
     )
@@ -139,17 +139,17 @@ class TestRefQuotaDefinitionRangeCreateUpdateForm:
             (
                 0,
                 "start_year",
-                "Start year is not valid, it must be a 4 digit year greater than 2010 and less than 2124",
+                f"Start year is not valid, it must be a 4 digit year greater than 2010 and less than {date.today().year + 100}",
             ),
             (
                 1980,
                 "start_year",
-                "Start year is not valid, it must be a 4 digit year greater than 2010 and less than 2124",
+                f"Start year is not valid, it must be a 4 digit year greater than 2010 and less than {date.today().year + 100}",
             ),
             (
                 date.today().year + 101,
                 "start_year",
-                "Start year is not valid, it must be a 4 digit year greater than 2010 and less than 2124",
+                f"Start year is not valid, it must be a 4 digit year greater than 2010 and less than {date.today().year + 100}",
             ),
             (date.today().year + 2, "start_year", None),
             # end year

--- a/reference_documents/tests/test_ref_quota_definition_ranges_model.py
+++ b/reference_documents/tests/test_ref_quota_definition_ranges_model.py
@@ -92,7 +92,8 @@ class TestRefQuotaDefinitionRange:
 
         rqdr_date_ranges = target.date_ranges()
 
-        assert len(rqdr_date_ranges) == 8
+        # date_ranges() adds three years to the current date to calculate target.end_year if None
+        assert len(rqdr_date_ranges) == (date.today().year + 4) - target.start_year
         assert rqdr_date_ranges[0] == TaricDateRange(
             date(2020, 1, 1),
             date(2020, 12, 31),


### PR DESCRIPTION
# TP2000-1636 Fix date-related failing unit tests

## Why
A few unit tests have begun to fail because of hardcoded dates.

<details><summary>Examples</summary>
<p>

```
FAILED measures/tests/test_forms.py::test_formset_measure_forms_serialize_deserialize[conditions_form] - AttributeError: 'NoneType' object has no attribute 'filter'
FAILED measures/tests/test_forms.py::test_formset_measure_forms_serialize_deserialize[commodities] - AttributeError: 'NoneType' object has no attribute 'filter'
FAILED reference_documents/tests/test_ref_quota_definition_range_forms.py::TestRefQuotaDefinitionRangeCreateUpdateForm::test_clean_start_year[0-Start year is not valid, it must be a 4 digit year greater than 2010 and less than 2124] - AssertionError: assert ['Start year ...ss than 2125'] == ['Start year ...ss than 2124']
  At index 0 diff: 'Start year is not valid, it must be a 4 digit year greater than 2010 and less than 2125' != 'Start year is not valid, it must be a 4 digit year greater than 2010 and less than 2124'
  Full diff:
    [
  -  'Start year is not valid, it must be a 4 digit year greater than 2010 and '
  +  'Start year is not valid, it must be a 4 digit year greater than 2010 and less than 2125',
  ?                                                                            ++++++++++++++ +
  -  'less than 2124',
    ]
FAILED reference_documents/tests/test_ref_quota_definition_range_forms.py::TestRefQuotaDefinitionRangeCreateUpdateForm::test_clean_start_year[1980-Start year is not valid, it must be a 4 digit year greater than 2010 and less than 2124] - AssertionError: assert ['Start year ...ss than 2125'] == ['Start year ...ss than 2124']
  At index 0 diff: 'Start year is not valid, it must be a 4 digit year greater than 2010 and less than 2125' != 'Start year is not valid, it must be a 4 digit year greater than 2010 and less than 2124'
  Full diff:
    [
  -  'Start year is not valid, it must be a 4 digit year greater than 2010 and '
  +  'Start year is not valid, it must be a 4 digit year greater than 2010 and less than 2125',
  ?                                                                            ++++++++++++++ +
  -  'less than 2124',
    ]
FAILED reference_documents/tests/test_ref_quota_definition_range_forms.py::TestRefQuotaDefinitionRangeCreateUpdateForm::test_clean_start_year[2126-Start year is not valid, it must be a 4 digit year greater than 2010 and less than 2124] - AssertionError: assert ['Start year ...ss than 2125'] == ['Start year ...ss than 2124']
  At index 0 diff: 'Start year is not valid, it must be a 4 digit year greater than 2010 and less than 2125' != 'Start year is not valid, it must be a 4 digit year greater than 2010 and less than 2124'
  Full diff:
    [
  -  'Start year is not valid, it must be a 4 digit year greater than 2010 and '
  +  'Start year is not valid, it must be a 4 digit year greater than 2010 and less than 2125',
  ?                                                                            ++++++++++++++ +
  -  'less than 2124',
    ]
FAILED reference_documents/tests/test_ref_quota_definition_range_forms.py::TestRefQuotaDefinitionRangeCreateUpdateForm::test_clean_fields[0-start_year-Start year is not valid, it must be a 4 digit year greater than 2010 and less than 2124] - AssertionError: assert ['Start year ...ss than 2125'] == ['Start year ...ss than 2124']
  At index 0 diff: 'Start year is not valid, it must be a 4 digit year greater than 2010 and less than 2125' != 'Start year is not valid, it must be a 4 digit year greater than 2010 and less than 2124'
  Full diff:
    [
  -  'Start year is not valid, it must be a 4 digit year greater than 2010 and '
  +  'Start year is not valid, it must be a 4 digit year greater than 2010 and less than 2125',
  ?                                                                            ++++++++++++++ +
  -  'less than 2124',
    ]
FAILED reference_documents/tests/test_ref_quota_definition_range_forms.py::TestRefQuotaDefinitionRangeCreateUpdateForm::test_clean_fields[1980-start_year-Start year is not valid, it must be a 4 digit year greater than 2010 and less than 2124] - AssertionError: assert ['Start year ...ss than 2125'] == ['Start year ...ss than 2124']
  At index 0 diff: 'Start year is not valid, it must be a 4 digit year greater than 2010 and less than 2125' != 'Start year is not valid, it must be a 4 digit year greater than 2010 and less than 2124'
  Full diff:
    [
  -  'Start year is not valid, it must be a 4 digit year greater than 2010 and '
  +  'Start year is not valid, it must be a 4 digit year greater than 2010 and less than 2125',
  ?                                                                            ++++++++++++++ +
  -  'less than 2124',
    ]
FAILED reference_documents/tests/test_ref_quota_definition_range_forms.py::TestRefQuotaDefinitionRangeCreateUpdateForm::test_clean_fields[2126-start_year-Start year is not valid, it must be a 4 digit year greater than 2010 and less than 2124] - AssertionError: assert ['Start year ...ss than 2125'] == ['Start year ...ss than 2124']
  At index 0 diff: 'Start year is not valid, it must be a 4 digit year greater than 2010 and less than 2125' != 'Start year is not valid, it must be a 4 digit year greater than 2010 and less than 2124'
  Full diff:
    [
  -  'Start year is not valid, it must be a 4 digit year greater than 2010 and '
  +  'Start year is not valid, it must be a 4 digit year greater than 2010 and less than 2125',
  ?                                                                            ++++++++++++++ +
  -  'less than 2124',
    ]
FAILED reference_documents/tests/test_ref_quota_definition_ranges_model.py::TestRefQuotaDefinitionRange::test_date_ranges_no_end_date - AssertionError: assert 9 == 8
 +  where 9 = len([TaricDateRange(datetime.date(2020, 1, 1), datetime.date(2020, 12, 31), '[]'), TaricDateRange(datetime.date(2021, 1, 1... datetime.date(2024, 12, 31), '[]'), TaricDateRange(datetime.date(2025, 1, 1), datetime.date(2025, 12, 31), '[]'), ...])
= 9 failed, 5830 passed, 85 skipped, 2 xfailed, 10 xpassed, 24519 warnings in 704.33s (0:11:44) =
``` 

</p>
</details> 

## What
- Replaces hardcoded dates with dynamic date generation

## Checklist
- Requires migrations? No
- Requires dependency updates? No

