### PR TITLE
Tp2000 1542  workflow template admin support

### DIFF
--- a/tasks/admin.py
+++ b/tasks/admin.py
@@ -139,7 +139,24 @@ class TaskTemplateAdmin(admin.ModelAdmin):
         "id",
         "title",
         "description",
+        "taskworkflowtemplate_id",
     )
+
+    @admin.display(description="Task Workflow Template")
+    def taskworkflowtemplate_id(self, obj):
+        if not obj.taskitemtemplate:
+            return "-"
+        return self.link_to_task_workflow_template(obj.taskitemtemplate)
+
+    def link_to_task_workflow_template(self, task_item_template):
+        workflow_template_pk = task_item_template.workflow_template.pk
+        task_workflow_template_url = reverse(
+            "admin:tasks_taskworkflowtemplate_change",
+            args=(workflow_template_pk,),
+        )
+        return mark_safe(
+            f'<a href="{task_workflow_template_url}">{workflow_template_pk}</a>',
+        )
 
     def has_add_permission(self, request):
         return False

--- a/tasks/admin.py
+++ b/tasks/admin.py
@@ -117,14 +117,7 @@ class TaskLogAdmin(admin.ModelAdmin):
     ]
 
 
-class TaskWorkflowTemplateAdmin(admin.ModelAdmin):
-    list_display = (
-        "id",
-        "title",
-        "description",
-        "creator",
-    )
-
+class ReadOnlyAdminMixin:
     def has_add_permission(self, request):
         return False
 
@@ -135,7 +128,16 @@ class TaskWorkflowTemplateAdmin(admin.ModelAdmin):
         return False
 
 
-class TaskTemplateAdmin(admin.ModelAdmin):
+class TaskWorkflowTemplateAdmin(ReadOnlyAdminMixin, admin.ModelAdmin):
+    list_display = (
+        "id",
+        "title",
+        "description",
+        "creator",
+    )
+
+
+class TaskTemplateAdmin(ReadOnlyAdminMixin, admin.ModelAdmin):
     list_display = (
         "id",
         "title",
@@ -158,15 +160,6 @@ class TaskTemplateAdmin(admin.ModelAdmin):
         return mark_safe(
             f'<a href="{task_workflow_template_url}">{workflow_template_pk}</a>',
         )
-
-    def has_add_permission(self, request):
-        return False
-
-    def has_change_permission(self, request, obj=None):
-        return False
-
-    def has_delete_permission(self, request, obj=None):
-        return False
 
 
 class TaskWorflowAdmin(admin.ModelAdmin):

--- a/tasks/admin.py
+++ b/tasks/admin.py
@@ -7,6 +7,8 @@ from tasks.models import ProgressState
 from tasks.models import Task
 from tasks.models import TaskAssignee
 from tasks.models import TaskLog
+from tasks.models import TaskTemplate
+from tasks.models import TaskWorkflowTemplate
 
 
 class TaskAdminMixin:
@@ -114,6 +116,41 @@ class TaskLogAdmin(admin.ModelAdmin):
     ]
 
 
+class TaskWorkflowTemplateAdmin(admin.ModelAdmin):
+    list_display = (
+        "id",
+        "title",
+        "description",
+        "creator",
+    )
+
+    def has_add_permission(self, request):
+        return False
+
+    def has_change_permission(self, request, obj=None):
+        return False
+
+    def has_delete_permission(self, request, obj=None):
+        return False
+
+
+class TaskTemplateAdmin(admin.ModelAdmin):
+    list_display = (
+        "id",
+        "title",
+        "description",
+    )
+
+    def has_add_permission(self, request):
+        return False
+
+    def has_change_permission(self, request, obj=None):
+        return False
+
+    def has_delete_permission(self, request, obj=None):
+        return False
+
+
 admin.site.register(Task, TaskAdmin)
 
 admin.site.register(Category, CategoryAdmin)
@@ -123,3 +160,7 @@ admin.site.register(ProgressState, ProgressStateAdmin)
 admin.site.register(TaskAssignee, TaskAssigneeAdmin)
 
 admin.site.register(TaskLog, TaskLogAdmin)
+
+admin.site.register(TaskWorkflowTemplate, TaskWorkflowTemplateAdmin)
+
+admin.site.register(TaskTemplate, TaskTemplateAdmin)


### PR DESCRIPTION
# TP2000-1542 Workflow Template Admin Support and TP2000-1547 Task Template Admin Support

## Why
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Adding view-only admin support for Task Workflow Templates and Task Templates provides our users with a straightforward interface for viewing all existing instances of task workflow templates and task templates
 * Simple summary information is provided for both, such as 'title', 'description', and 'creator' for workflow templates and 'title, 'description', and 'task workflow template ID' (if available) for task templates
 * Task templates have a one-to-one relationship with task template items. Task template items are associated with workflow templates, which define the relationship between task templates and associated workflow templates.
 * For greater flexibility, task templates can be created standalone without an associated workflow template and this is reflected in the list view 
 * This will allow users to keep track of which task templates are associated with a specific task workflow template

## What
 * Added two classes - `TaskWorkflowTemplateAdmin` and `TaskTemplateAdmin` to `tasks/admin.py`
 * Added `taskworkflowtemplate_id` method to `TaskTemplateAdmin` which first checks if a TaskTemplate has an associated TaskTemplateItem (via a one-to-one relationship) and either returns "-" for error handling, or returns an associated template item object in order to access its workflow template
 * Added `link_to_task_workflow_template` which expects a task item template object to provide workflow template PK and reverses URL so that users can click through to the workflow template detail view for a task template
 * Created `ReadOnlyAdminMixIn` to be shared between `TaskWorkflowTemplateAdmin` and `TaskTemplateAdmin` to reduce repetition in the code

## Checklist
- Requires migrations? - No
- Requires dependency updates? - No

