### PR TITLE
TP2000-1652  Enhance workflow, workflow template admin views

### DIFF
--- a/tasks/admin.py
+++ b/tasks/admin.py
@@ -143,7 +143,10 @@ class TaskTemplateAdmin(ReadOnlyAdminMixin, admin.ModelAdmin):
         "title",
         "description",
         "taskworkflowtemplate_id",
+        "created_at",
     )
+    search_fields = ["id", "title", "description"]
+    list_filter = ["category"]
 
     @admin.display(description="Task Workflow Template")
     def taskworkflowtemplate_id(self, obj):
@@ -185,4 +188,5 @@ admin.site.register(TaskLog, TaskLogAdmin)
 admin.site.register(TaskWorkflowTemplate, TaskWorkflowTemplateAdmin)
 
 admin.site.register(TaskTemplate, TaskTemplateAdmin)
+
 admin.site.register(TaskWorkflow, TaskWorflowAdmin)


### PR DESCRIPTION
# TP2000-1652  Enhance workflow, workflow template admin views

## Why
It would be useful to see at a glance the associated items of workflows and workflow templates in the admin view.

## What
- Adds task and task template counts for both workflow and workflow templates on their admin list views
- Displays associated items inline for both workflow and workflow templates on their admin detail views

## Checklist
- Requires migrations? No
- Requires dependency updates? No

## Screenshots
<details><summary>Count added to admin list view</summary>
<p>
<img width="1000" alt="Screenshot 2025-01-10 at 12 02 08" src="https://github.com/user-attachments/assets/eadc33b9-02f9-4b6f-9de0-44ef8438546a" />
</p>
</details> 

<details><summary>Inline items displayed on admin detail view</summary>
<p>
<img width="1000" alt="Screenshot 2025-01-10 at 11 54 49" src="https://github.com/user-attachments/assets/5410dc50-c984-44a0-82a0-75d7d41029c2" />
</p>
</details> 
