### PR TITLE
TP-2000-1647 Correcting measurement_unit_qualifier fields

### DIFF
--- a/quotas/forms/wizards.py
+++ b/quotas/forms/wizards.py
@@ -292,6 +292,12 @@ class QuotaDefinitionBulkCreateDefinitionInformation(
         self.fields["measurement_unit"].label_from_instance = (
             lambda obj: f"{obj.code} - {obj.description}"
         )
+        self.fields["measurement_unit_qualifier"].queryset = self.fields[
+            "measurement_unit_qualifier"
+        ].queryset.order_by("code")
+        self.fields["measurement_unit_qualifier"].label_from_instance = (
+            lambda obj: f"{obj.code} - {obj.description}"
+        )
         self.fields["measurement_unit_qualifier"].help_text = (
             "A measurement unit qualifier is not always required"
         )
@@ -559,6 +565,15 @@ class BulkDefinitionUpdateData(
         if "description" in definition_data:
             fields["description"].initial = definition_data["description"]
 
+        self.fields["measurement_unit_qualifier"].help_text = (
+            "A measurement unit qualifier is not always required"
+        )
+        self.fields["measurement_unit_qualifier"].queryset = self.fields[
+            "measurement_unit_qualifier"
+        ].queryset.order_by("code")
+        self.fields["measurement_unit_qualifier"].label_from_instance = (
+            lambda obj: f"{obj.code} - {obj.description}"
+        )
         if (
             "measurement_unit_qualifier" in definition_data
             and definition_data["measurement_unit_qualifier"] != "None"
@@ -576,9 +591,6 @@ class BulkDefinitionUpdateData(
             definition_data["threshold"],
         )
         fields["quota_critical"].initial = definition_data["quota_critical"]
-        self.fields["measurement_unit_qualifier"].help_text = (
-            "A measurement unit qualifier is not always required"
-        )
 
     def update_definition_data_in_session(self, cleaned_data):
         cleaned_data.update(


### PR DESCRIPTION
# TP-2000-1647 Correcting measurement unit qualifier fields

## Why
Missed correcting the display for the measurement unit qualifier on the previous PR.

## What
Corrects the display for the measurement unit qualifier to be `Code - Description` as per the screenshot below on the Bulk Quota definition create wizard (initial information and edit pages)

<img width="895" alt="image" src="https://github.com/user-attachments/assets/d0238ded-38a0-4f37-86d9-ac7530cd8415" />
