### PR TITLE
TP2000-1672 Measure current version bug

### DIFF
--- a/common/models/transactions.py
+++ b/common/models/transactions.py
@@ -7,6 +7,7 @@ from logging import getLogger
 
 from django.core.serializers.json import DjangoJSONEncoder
 from django.db import models
+from django.db.models import Q
 from django.db.transaction import atomic
 from django_fsm import FSMIntegerField
 from django_fsm import transition
@@ -202,7 +203,10 @@ class TransactionQueryset(models.QuerySet):
             versions = (
                 version_group.versions.has_approved_state()
                 .order_by("-pk")
-                .exclude(pk=obj.pk)
+                .exclude(
+                    Q(pk=obj.pk)
+                    | Q(transaction__workbasket=obj.transaction.workbasket),
+                )
             )
             if versions.count() == 0:
                 version_group.current_version = None

--- a/workbaskets/tests/test_models.py
+++ b/workbaskets/tests/test_models.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 from typing import Iterable
+from unittest.mock import PropertyMock
 from unittest.mock import patch
 
 import pytest

--- a/workbaskets/tests/test_models.py
+++ b/workbaskets/tests/test_models.py
@@ -498,3 +498,43 @@ def test_terminate_missing_measures_check_no_id():
         missing_measures_check_task_id=None,
     )
     assert workbasket.terminate_missing_measures_check() is None
+
+
+def test_dequeue_reverts_current_version(valid_user, user_workbasket):
+    """Test that when dequeueing a workbasket with 2 updates of the same object
+    that the current version is correctly reverted."""
+    measure_create = factories.MeasureFactory.create()
+    measure_update_1 = measure_create.new_version(
+        workbasket=user_workbasket,
+        update_type=UpdateType.UPDATE,
+    )
+    measure_update_2 = measure_create.new_version(
+        workbasket=user_workbasket,
+        update_type=UpdateType.UPDATE,
+    )
+
+    for tx in user_workbasket.transactions.all():
+        TransactionCheckFactory.create(
+            transaction=tx,
+            successful=True,
+            completed=True,
+        )
+
+    assert measure_create.version_group.current_version == measure_create
+
+    with patch(
+        "workbaskets.models.WorkBasket.unchecked_or_errored_transactions",
+        new_callable=PropertyMock,
+    ) as mock_unchecked:
+        mock_unchecked.return_value = Transaction.objects.none()
+        user_workbasket.queue(
+            valid_user.pk,
+            settings.TRANSACTION_SCHEMA,
+        )
+
+    measure_create.refresh_from_db()
+    assert measure_create.version_group.current_version == measure_update_2
+
+    user_workbasket.dequeue()
+    measure_create.refresh_from_db()
+    assert measure_create.version_group.current_version == measure_create

--- a/workbaskets/tests/test_views.py
+++ b/workbaskets/tests/test_views.py
@@ -2,12 +2,14 @@ import datetime
 import os
 import re
 from unittest.mock import MagicMock
+from unittest.mock import PropertyMock
 from unittest.mock import mock_open
 from unittest.mock import patch
 
 import factory
 import pytest
 from bs4 import BeautifulSoup
+from django.conf import settings
 from django.contrib.auth.models import Permission
 from django.db import IntegrityError
 from django.test.client import RequestFactory
@@ -16,6 +18,7 @@ from django.utils.timezone import localtime
 
 from checks.models import TrackedModelCheck
 from checks.tests.factories import TrackedModelCheckFactory
+from checks.tests.factories import TransactionCheckFactory
 from common.inspect_tap_tasks import CeleryTask
 from common.inspect_tap_tasks import TAPTasks
 from common.models.trackedmodel import TrackedModel
@@ -2832,3 +2835,43 @@ def test_reordering_transactions_bug(valid_user_client, user_workbasket):
         pytest.fail(
             "IntegrityError - New trackedmodel cannot be created after reordering then deleting transactions.",
         )
+
+
+def test_dequeue_reverts_current_version(valid_user, user_workbasket):
+    """Test that when dequeueing a workbasket with 2 updates of the same object
+    that the current version is correctly reverted."""
+    measure_create = factories.MeasureFactory.create()
+    measure_update_1 = measure_create.new_version(
+        workbasket=user_workbasket,
+        update_type=UpdateType.UPDATE,
+    )
+    measure_update_2 = measure_create.new_version(
+        workbasket=user_workbasket,
+        update_type=UpdateType.UPDATE,
+    )
+
+    for tx in user_workbasket.transactions.all():
+        TransactionCheckFactory.create(
+            transaction=tx,
+            successful=True,
+            completed=True,
+        )
+
+    assert measure_create.version_group.current_version == measure_create
+
+    with patch(
+        "workbaskets.models.WorkBasket.unchecked_or_errored_transactions",
+        new_callable=PropertyMock,
+    ) as mock_unchecked:
+        mock_unchecked.return_value = Transaction.objects.none()
+        user_workbasket.queue(
+            valid_user.pk,
+            settings.TRANSACTION_SCHEMA,
+        )
+
+    measure_create.refresh_from_db()
+    assert measure_create.version_group.current_version == measure_update_2
+
+    user_workbasket.dequeue()
+    measure_create.refresh_from_db()
+    assert measure_create.version_group.current_version == measure_create


### PR DESCRIPTION
# TP2000-1672 Measure current version bug
<!---
 * Include the JIRA ticket number, eg TP-123, to automatically link.
 * Use 50 characters maximum.
 * Do not end with a full-stop.
--->

## Why
<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Use as many lines as you like.
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions or deliberately ignored edge-cases.
--->

If a workbasket has 2 updates of the same object and it is queued and dequeued, revert_current_version() incorrectly assigns the current version to one of the updates which is about to be turned to draft.

Current version should be either the latest approved version or None.

## What
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Explain like I'm 5.
 * Use pictures if you can.
--->

This PR updates revert_current_version() so when it's querying existing approved versions to revert to, it does not include those in the same workbasket. Also adds a test to confirm the fix works.

<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
## Checklist
- Requires migrations?
- Requires dependency updates?
--->

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
