### PR TITLE
TP2000-1667: Skip checking of comm codes in workbasket that have already ended

### DIFF
--- a/workbaskets/tasks.py
+++ b/workbaskets/tasks.py
@@ -11,14 +11,14 @@ from checks.models import MissingMeasureCommCode
 from checks.models import MissingMeasuresCheck
 from checks.tasks import check_transaction
 from checks.tasks import check_transaction_sync
-from common.util import TaricDateRange
-from common.validators import UpdateType
-from measures.models.tracked_models import Measure
 from commodities.helpers import get_measures_on_declarable_commodities
 from commodities.models.orm import GoodsNomenclature
 from common.celery import app
 from common.models import Transaction
+from common.util import TaricDateRange
+from common.validators import UpdateType
 from geo_areas.models import GeographicalArea
+from measures.models.tracked_models import Measure
 from workbaskets.models import WorkBasket
 from workbaskets.validators import WorkflowStatus
 
@@ -157,6 +157,10 @@ def get_comm_codes_with_missing_measures(tx_pk: int, comm_code_pks: List[int]):
 
         if code.item_id.startswith("99") or code.item_id.startswith("98"):
             logger.info(f"Chapters 98 and 99 are exempt. Skipping.")
+            continue
+
+        if code.valid_between.upper < date.today():
+            logger.info(f"Commodity validity has ended. Skipping.")
             continue
 
         tx = Transaction.objects.get(pk=tx_pk)

--- a/workbaskets/tasks.py
+++ b/workbaskets/tasks.py
@@ -159,7 +159,7 @@ def get_comm_codes_with_missing_measures(tx_pk: int, comm_code_pks: List[int]):
             logger.info(f"Chapters 98 and 99 are exempt. Skipping.")
             continue
 
-        if code.valid_between.upper < date.today():
+        if code.valid_between.upper and code.valid_between.upper < date.today():
             logger.info(f"Commodity validity has ended. Skipping.")
             continue
 

--- a/workbaskets/tests/test_tasks.py
+++ b/workbaskets/tests/test_tasks.py
@@ -93,6 +93,28 @@ def test_get_comm_codes_with_missing_measures_new_comm_code_103_pass(
     assert not comm_codes_with_missing_measures
 
 
+def test_get_comm_codes_with_missing_measures_ended_comm_code_pass(
+    erga_omnes,
+    date_ranges,
+):
+    measure_type142 = factories.MeasureTypeFactory.create(sid=103)
+    workbasket = factories.WorkBasketFactory.create()
+    new_commodity = factories.GoodsNomenclatureFactory.create(
+        transaction=workbasket.new_transaction(),
+        valid_between=date_ranges.earlier,
+    )
+    pref = factories.MeasureFactory.create(
+        measure_type=measure_type142,
+        goods_nomenclature=new_commodity,
+        transaction=workbasket.new_transaction(),
+    )
+    comm_codes_with_missing_measures = get_comm_codes_with_missing_measures(
+        pref.transaction.pk,
+        [new_commodity.pk],
+    )
+    assert not comm_codes_with_missing_measures
+
+
 @patch("workbaskets.tasks.get_comm_codes_with_missing_measures")
 def test_check_workbasket_for_missing_measures(mock_check_comm_codes):
     workbasket = factories.WorkBasketFactory.create()


### PR DESCRIPTION
# TP2000-1667: Skip checking of comm codes in workbasket that have already ended
<!---
 * Include the JIRA ticket number, eg TP-123, to automatically link.
 * Use 50 characters maximum.
 * Do not end with a full-stop.
--->

## Why
<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Use as many lines as you like.
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions or deliberately ignored edge-cases.
--->
* No point checking for missing measures against a comm code that has ended

## What
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Explain like I'm 5.
 * Use pictures if you can.
--->
* Checks comm code validity when checking for missing 103 measures and skips if the end date is in the past

<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
## Checklist
- Requires migrations?
- Requires dependency updates?
--->

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
