### PR TITLE
TP2000-1456: Fix logic that displays packaging queue button on rule check page

### DIFF
--- a/workbaskets/jinja2/includes/workbaskets/workbasket-business-rules.jinja
+++ b/workbaskets/jinja2/includes/workbaskets/workbasket-business-rules.jinja
@@ -80,7 +80,7 @@ govuk-button{% if workbasket.tracked_model_checks.exists() %} govuk-button--seco
   {% endset %}
   {% set rule_check_button = terminate_rule_check_form %}
   {% set rule_check_block %}{% endset %}
-{% elif workbasket.tracked_model_checks.exists() and not workbasket.unchecked_or_errored_transactions.exists() and not missing_measures_check_successful %}
+{% elif workbasket.tracked_model_checks.exists() and not workbasket.unchecked_or_errored_transactions.exists() %}
   {% set live_rule_check_status = "Business rule check passed. No business rule violations" %}
   {% set rule_check_button = run_business_rules_form %}
   {% set rule_check_block %}
@@ -98,6 +98,13 @@ govuk-button{% if workbasket.tracked_model_checks.exists() %} govuk-button--seco
         {% elif unsent_notification %}
           <div class="govuk-hint"> 
             For commodity code imports, a notification to the Channel Islands must be sent from the commodities tab on the workbasket review page before packaging.
+          </div>
+          <a href="{{ url('publishing:packaged-workbasket-queue-ui-create')}}" disabled class="govuk-button govuk-button--primary">
+            Send to packaging queue
+          </a>
+        {% elif not missing_measures_check_successful %}
+          <div class="govuk-hint"> 
+            Missing measures check must be run before packaging.
           </div>
           <a href="{{ url('publishing:packaged-workbasket-queue-ui-create')}}" disabled class="govuk-button govuk-button--primary">
             Send to packaging queue


### PR DESCRIPTION
# TP2000-1456: Fix logic that displays packaging queue button on rule check page
<!---
 * Include the JIRA ticket number, eg TP-123, to automatically link.
 * Use 50 characters maximum.
 * Do not end with a full-stop.
--->

## Why
<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Use as many lines as you like.
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions or deliberately ignored edge-cases.
--->
* When rule check and measures check were both successful it looked as if the rule check reset to not having been run

## What
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Explain like I'm 5.
 * Use pictures if you can.
--->
* Moves logic for measures check in template

<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
## Checklist
- Requires migrations?
- Requires dependency updates?
--->

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
<img width="1211" alt="Screenshot 2025-01-23 at 11 33 04" src="https://github.com/user-attachments/assets/c607780d-0dae-4489-947a-6eabfd4e0b16" />
