### PR TITLE
TP2000-1644 Strengthen Content Security Policy configuration

### DIFF
--- a/common/static/common/js/application.js
+++ b/common/static/common/js/application.js
@@ -9,6 +9,7 @@ const imagePath = (name) => images(name, true);
 
 require.context("govuk-frontend/govuk/assets");
 
+import "./trustedTypes";
 import { initAll } from "govuk-frontend";
 
 import showHideCheckboxes from "./showHideCheckboxes";

--- a/common/static/common/js/trustedTypes.js
+++ b/common/static/common/js/trustedTypes.js
@@ -1,0 +1,12 @@
+import DOMPurify from "dompurify";
+
+/**
+ * Creates a default Trusted Types policy that serves as a fallback policy
+ * to sanitise direct sink usage in third-party dependencies.
+ */
+if (typeof window.trustedTypes !== "undefined") {
+  window.trustedTypes.createPolicy("default", {
+    createHTML: (to_escape) =>
+      DOMPurify.sanitize(to_escape, { RETURN_TRUSTED_TYPE: true }),
+  });
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "chart.js": "^3.9.1",
         "chartjs-adapter-moment": "^1.0.0",
         "css-loader": "^5.2.6",
+        "dompurify": "^3.2.3",
         "file-loader": "^6.2.0",
         "govuk-frontend": "^3.15.0",
         "govuk-react": "^0.10.6",
@@ -4160,6 +4161,13 @@
       "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
       "dev": true
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@types/unist": {
       "version": "2.0.10",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.10.tgz",
@@ -6295,6 +6303,15 @@
       },
       "funding": {
         "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.3.tgz",
+      "integrity": "sha512-U1U5Hzc2MO0oW3DF+G9qYN0aT7atAou4AgI0XjWz061nyBPbdxkfdhfy5uMgGn6+oLFCfn44ZGbdDqCzVmlOWA==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/domutils": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "chart.js": "^3.9.1",
     "chartjs-adapter-moment": "^1.0.0",
     "css-loader": "^5.2.6",
+    "dompurify": "^3.2.3",
     "file-loader": "^6.2.0",
     "govuk-frontend": "^3.15.0",
     "govuk-react": "^0.10.6",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
 -r requirements.txt
 
-django_debug_toolbar
+django_debug_toolbar==5.0.1
 pre-commit

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ defusedxml==0.7.*
 dj-database-url==0.5.0
 django-chunk-upload-handlers==0.0.13
 django-crispy-forms==1.14.0
-django-csp==3.6
+django-csp==3.8
 django-cte==1.3.1
 django-extensions==3.2.3
 django-filter==23.5

--- a/settings/common.py
+++ b/settings/common.py
@@ -223,6 +223,7 @@ CSP_STYLE_SRC = (
     "https://tagmanager.google.com/",
 )
 CSP_SCRIPT_SRC = (
+    "'strict-dynamic'",
     "'self'",
     "'unsafe-eval'",
     "'unsafe-inline'",

--- a/settings/common.py
+++ b/settings/common.py
@@ -233,6 +233,8 @@ CSP_SCRIPT_SRC = (
 CSP_FONT_SRC = ("'self'", "'unsafe-inline'")
 CSP_OBJECT_SRC = ("'none'",)
 CSP_BASE_URI = ("'none'",)
+CSP_REQUIRE_TRUSTED_TYPES_FOR = ("'script'",)
+CSP_TRUSTED_TYPES = ("tap#webpack",)
 CSP_INCLUDE_NONCE_IN = ("script-src",)
 CSP_REPORT_ONLY = False
 

--- a/settings/common.py
+++ b/settings/common.py
@@ -232,6 +232,7 @@ CSP_SCRIPT_SRC = (
 )
 CSP_FONT_SRC = ("'self'", "'unsafe-inline'")
 CSP_OBJECT_SRC = ("'none'",)
+CSP_BASE_URI = ("'none'",)
 CSP_INCLUDE_NONCE_IN = ("script-src",)
 CSP_REPORT_ONLY = False
 

--- a/settings/common.py
+++ b/settings/common.py
@@ -231,6 +231,7 @@ CSP_SCRIPT_SRC = (
     "ajax.googleapis.com/",
 )
 CSP_FONT_SRC = ("'self'", "'unsafe-inline'")
+CSP_OBJECT_SRC = ("'none'",)
 CSP_INCLUDE_NONCE_IN = ("script-src",)
 CSP_REPORT_ONLY = False
 

--- a/settings/common.py
+++ b/settings/common.py
@@ -235,7 +235,7 @@ CSP_FONT_SRC = ("'self'", "'unsafe-inline'")
 CSP_OBJECT_SRC = ("'none'",)
 CSP_BASE_URI = ("'none'",)
 CSP_REQUIRE_TRUSTED_TYPES_FOR = ("'script'",)
-CSP_TRUSTED_TYPES = ("tap#webpack",)
+CSP_TRUSTED_TYPES = ("tap#webpack", "dompurify", "default")
 CSP_INCLUDE_NONCE_IN = ("script-src",)
 CSP_REPORT_ONLY = False
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -18,6 +18,9 @@ module.exports = {
     // (they are picked up by `collectstatic`)
     publicPath: "/assets/webpack_bundles/",
     filename: "[name]-[hash].js",
+    trustedTypes: {
+      policyName: "tap#webpack",
+    },
   },
 
   plugins: [


### PR DESCRIPTION
# TP2000-1644 Strengthen Content Security Policy configuration

## Why
Recommendations have been made to improve the Content Security Policy (CSP) header.

## What
- Bumps the version of `django-csp` to 3.8 which adds support for Trusted Types
- Adds `object-src`, `base-uri`, `strict-dynamic` and `trusted-types` directives to the CSP header
- Creates a default Trusted Types policy that acts as a fallback for third-party libraries that don't adhere to Trusted Types (e.g `accessible-autocomplete`)
- Adds `dompurify` JS package for use in default Trusted Types policy
- Bumps the version of `django-debug-toolbar` to 5.0.1 for compatibility with the newly added 'strict-dynamic' CSP directive

## Checklist
- Requires migrations?
- Requires dependency updates? **Yes**

#### Links to relevant material
- [Mozilla CSP overview](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP)
- [w3c Trusted Types default policy](https://w3c.github.io/trusted-types/dist/spec/#default-policy-hdr)
- [web.dev Trusted Types](https://web.dev/articles/trusted-types)
- [Configuring django-csp](https://django-csp.readthedocs.io/en/3.8/configuration.html)
