### PR TITLE
TP2000-1678-Measure-condition-duty-bug

### DIFF
--- a/measures/duty_sentence_parser.py
+++ b/measures/duty_sentence_parser.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from decimal import Decimal
 from typing import Sequence
 
 from django.core.exceptions import ObjectDoesNotExist
@@ -460,7 +461,7 @@ class DutyTransformer(Transformer):
 
     def duty_amount(self, value):
         (value,) = value
-        return ("duty_amount", float(value))
+        return ("duty_amount", Decimal(value))
 
     def monetary_unit(self, value):
         (value,) = value

--- a/measures/forms/mixins.py
+++ b/measures/forms/mixins.py
@@ -252,6 +252,13 @@ class MeasureConditionsFormMixin(forms.ModelForm):
             try:
                 components = parser.transform(price)
                 cleaned_data["duty_amount"] = components[0].get("duty_amount")
+                if (
+                    cleaned_data["duty_amount"]
+                    and len(str(cleaned_data["duty_amount"]).split(".")[-1]) > 3
+                ):
+                    raise ValidationError(
+                        f"The reference price cannot have more than 3 decimal places.",
+                    )
                 cleaned_data["monetary_unit"] = components[0].get("monetary_unit")
                 cleaned_data["condition_measurement"] = (
                     models.Measurement.objects.as_at(date)

--- a/measures/tests/test_lark_parser.py
+++ b/measures/tests/test_lark_parser.py
@@ -1,3 +1,4 @@
+from decimal import Decimal
 from typing import Dict
 from typing import List
 from typing import Tuple
@@ -45,7 +46,7 @@ ECU_CONVERSION_FIXTURE_NAME = "ecu_conversion"
             ["1.230", "EUR", "kg"],
             [
                 {
-                    "duty_amount": 1.23,
+                    "duty_amount": Decimal("1.23"),
                     "duty_expression": PERCENT_OR_AMOUNT_FIXTURE_NAME,
                     "monetary_unit": EURO_FIXTURE_NAME,
                     "measurement_unit": KILOGRAM_FIXTURE_NAME,
@@ -57,16 +58,16 @@ ECU_CONVERSION_FIXTURE_NAME = "ecu_conversion"
             ["9.10", "%", "MAX", "1.00", "%", "+", "0.90", "GBP", "100 kg"],
             [
                 {
-                    "duty_amount": 9.1,
+                    "duty_amount": Decimal("9.1"),
                     "duty_expression": PERCENT_OR_AMOUNT_FIXTURE_NAME,
                 },
                 {
                     "duty_expression_sid": MAXIMUM_CLAUSE_SID[0],
-                    "duty_amount": 1.0,
+                    "duty_amount": Decimal("1.0"),
                 },
                 {
                     "duty_expression_sid": PLUS_PERCENT_OR_AMOUNT_SID[1],
-                    "duty_amount": 0.9,
+                    "duty_amount": Decimal("0.9"),
                     "monetary_unit": BRITISH_POUND_FIXTURE_NAME,
                     "measurement_unit": HECTOKILOGRAM_FIXTURE_NAME,
                 },
@@ -77,7 +78,7 @@ ECU_CONVERSION_FIXTURE_NAME = "ecu_conversion"
             ["0.300", "XEM", "100 kg", "lactic."],
             [
                 {
-                    "duty_amount": 0.3,
+                    "duty_amount": Decimal("0.3"),
                     "duty_expression": PERCENT_OR_AMOUNT_FIXTURE_NAME,
                     "measurement_unit": HECTOKILOGRAM_FIXTURE_NAME,
                     "measurement_unit_qualifier": LACTIC_MATTER_FIXTURE_NAME,
@@ -91,10 +92,10 @@ ECU_CONVERSION_FIXTURE_NAME = "ecu_conversion"
             [
                 {
                     "duty_expression": PERCENT_OR_AMOUNT_FIXTURE_NAME,
-                    "duty_amount": 12.9,
+                    "duty_amount": Decimal("12.9"),
                 },
                 {
-                    "duty_amount": 20.0,
+                    "duty_amount": Decimal("20.0"),
                     "duty_expression_sid": PLUS_PERCENT_OR_AMOUNT_SID[0],
                     "measurement_unit": KILOGRAM_FIXTURE_NAME,
                     "monetary_unit": EURO_FIXTURE_NAME,


### PR DESCRIPTION
# TP2000-1678-Measure-condition-duty-bug
<!---
 * Include the JIRA ticket number, eg TP-123, to automatically link.
 * Use 50 characters maximum.
 * Do not end with a full-stop.
--->

## Why
<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Use as many lines as you like.
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions or deliberately ignored edge-cases.
--->

Currently, the duty sentence parser returns a float value of the inputted number. If the inputted number cannot be accurately stored as a float, this results in it being replaced with a near approximation with many decimal places. This is causing form validation to fail with an unhelpful error message due to too many decimal places, even if the user only inputted a number with 3 decimal places.

For example, 6.5 GBP / kg or 6.75 would be fine but something like 6.667 would get converted to 6.66699999999999981526 (20 decimal places) and then error.

## What
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Explain like I'm 5.
 * Use pictures if you can.
--->

This PR:
- changes the duty sentence parser to return the duty sentence as a Decimal rather than float object
- updates tests to account for it being a decimal now
- adds a check in the form of how many decimal places there are and raises an error - although this was already prevented by it being a `DecimalField` with `max_decimal_places=3`, this repeated validation allows a meaningful error message to be surfaced to the user which wasn't before
- adds a new test to confirm the new error message displays on the reference price field

<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
## Checklist
- Requires migrations?
- Requires dependency updates?
--->

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
