### PR TITLE
TP2000-1678 Measure condition duty bug update

### DIFF
--- a/measures/duty_sentence_parser.py
+++ b/measures/duty_sentence_parser.py
@@ -379,6 +379,12 @@ class DutyTransformer(Transformer):
                 f"Measurement unit qualifier {qualifier.abbreviation} cannot be used with measurement unit {unit.abbreviation}.",
             )
 
+    def validate_duty_amount(self, duty_amount):
+        if len(str(duty_amount).split(".")[-1]) > 3:
+            raise ValidationError(
+                f"The reference price cannot have more than 3 decimal places.",
+            )
+
     def validate_phrase(self, phrase):
         # Each measure component can have an amount, monetary unit and measurement.
         # Which expression elements are allowed in a component is controlled by
@@ -392,6 +398,9 @@ class DutyTransformer(Transformer):
         monetary_unit = phrase.get("monetary_unit", None)
         measurement_unit = phrase.get("measurement_unit", None)
         measurement_unit_qualifier = phrase.get("measurement_unit_qualifier", None)
+
+        if duty_amount:
+            self.validate_duty_amount(duty_amount)
 
         self.validate_according_to_applicability_code(
             amount_code,

--- a/measures/duty_sentence_parser.py
+++ b/measures/duty_sentence_parser.py
@@ -380,7 +380,7 @@ class DutyTransformer(Transformer):
             )
 
     def validate_duty_amount(self, duty_amount):
-        if len(str(duty_amount).split(".")[-1]) > 3:
+        if duty_amount.as_tuple().exponent < -3:
             raise ValidationError(
                 f"The reference price cannot have more than 3 decimal places.",
             )

--- a/measures/duty_sentence_parser.py
+++ b/measures/duty_sentence_parser.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from decimal import Decimal
 from typing import Sequence
 
 from django.core.exceptions import ObjectDoesNotExist
@@ -460,7 +461,7 @@ class DutyTransformer(Transformer):
 
     def duty_amount(self, value):
         (value,) = value
-        return ("duty_amount", float(value))
+        return ("duty_amount", Decimal(value))
 
     def monetary_unit(self, value):
         (value,) = value

--- a/measures/forms/mixins.py
+++ b/measures/forms/mixins.py
@@ -252,6 +252,13 @@ class MeasureConditionsFormMixin(forms.ModelForm):
             try:
                 components = parser.transform(price)
                 cleaned_data["duty_amount"] = components[0].get("duty_amount")
+                if (
+                    cleaned_data["duty_amount"]
+                    and len(str(cleaned_data["duty_amount"]).split(".")[-1]) > 3
+                ):
+                    raise ValidationError(
+                        f"The reference price cannot have more than 3 decimal places.",
+                    )
                 cleaned_data["monetary_unit"] = components[0].get("monetary_unit")
                 cleaned_data["condition_measurement"] = (
                     models.Measurement.objects.as_at(date)

--- a/measures/forms/mixins.py
+++ b/measures/forms/mixins.py
@@ -252,13 +252,6 @@ class MeasureConditionsFormMixin(forms.ModelForm):
             try:
                 components = parser.transform(price)
                 cleaned_data["duty_amount"] = components[0].get("duty_amount")
-                if (
-                    cleaned_data["duty_amount"]
-                    and len(str(cleaned_data["duty_amount"]).split(".")[-1]) > 3
-                ):
-                    raise ValidationError(
-                        f"The reference price cannot have more than 3 decimal places.",
-                    )
                 cleaned_data["monetary_unit"] = components[0].get("monetary_unit")
                 cleaned_data["condition_measurement"] = (
                     models.Measurement.objects.as_at(date)

--- a/measures/tests/test_forms.py
+++ b/measures/tests/test_forms.py
@@ -21,7 +21,6 @@ from measures.forms import MeasureEndDateForm
 from measures.forms import MeasureForm
 from measures.forms import MeasureStartDateForm
 from measures.models import Measure
-from measures.models.tracked_models import DutyExpression
 from measures.validators import MeasureExplosionLevel
 
 pytestmark = pytest.mark.django_db
@@ -1026,6 +1025,10 @@ def test_measure_forms_conditions_invalid_duty(
             "3.5 % + 11 GBP / 100 kg",
             "A compound duty expression was found at character 7. \n\nCheck that you are entering a single duty amount or a duty amount together with a measurement unit (and measurement unit qualifier if required). ",
         ),
+        (
+            "1.2345 GBP / kg",
+            "The reference price cannot have more than 3 decimal places.",
+        ),
     ],
 )
 def test_measure_forms_conditions_wizard_invalid_duty(
@@ -1219,38 +1222,6 @@ def test_measure_forms_conditions_wizard_clears_unneeded_certificate(date_ranges
         )
         assert form_expects_no_certificate.is_valid()
         assert form_expects_no_certificate.cleaned_data["required_certificate"] is None
-
-
-def test_measure_forms_conditions_wizard_form_invalid_duty(date_ranges):
-    """Tests that MeasureConditionsWizardStepForm is invalid when the duty has
-    more than 3 decimal places."""
-    condition_code = factories.MeasureConditionCodeFactory.create()
-    monetary_unit = factories.MonetaryUnitFactory.create()
-    factories.MeasurementUnitFactory.create()
-    factories.MeasurementUnitQualifierFactory.create()
-    factories.MeasureConditionComponentFactory.create()
-    action = factories.MeasureActionFactory.create()
-    if not DutyExpression.objects.filter(sid=99):
-        factories.DutyExpressionFactory.create(sid=99)
-
-    data = {
-        "reference_price": f"1.2345 {monetary_unit.code}",
-        "action": action.pk,
-        "condition_code": condition_code.pk,
-    }
-    # MeasureConditionsForm.__init__ expects prefix kwarg for instantiating crispy forms `Layout` object
-    form = forms.MeasureConditionsWizardStepForm(
-        data,
-        prefix="",
-        measure_start_date=date_ranges.normal,
-    )
-
-    with override_current_transaction(action.transaction):
-        assert not form.is_valid()
-        assert (
-            "The reference price cannot have more than 3 decimal places."
-            in form.errors["reference_price"]
-        )
 
 
 def test_measure_form_valid_data(erga_omnes, session_request_with_workbasket):

--- a/measures/tests/test_forms.py
+++ b/measures/tests/test_forms.py
@@ -21,6 +21,7 @@ from measures.forms import MeasureEndDateForm
 from measures.forms import MeasureForm
 from measures.forms import MeasureStartDateForm
 from measures.models import Measure
+from measures.models.tracked_models import DutyExpression
 from measures.validators import MeasureExplosionLevel
 
 pytestmark = pytest.mark.django_db
@@ -1228,8 +1229,9 @@ def test_measure_forms_conditions_wizard_form_invalid_duty(date_ranges):
     factories.MeasurementUnitFactory.create()
     factories.MeasurementUnitQualifierFactory.create()
     factories.MeasureConditionComponentFactory.create()
-    factories.DutyExpressionFactory.create(sid=99)
     action = factories.MeasureActionFactory.create()
+    if not DutyExpression.objects.filter(sid=99):
+        factories.DutyExpressionFactory.create(sid=99)
 
     data = {
         "reference_price": f"1.2345 {monetary_unit.code}",

--- a/measures/tests/test_lark_parser.py
+++ b/measures/tests/test_lark_parser.py
@@ -1,3 +1,4 @@
+from decimal import Decimal
 from typing import Dict
 from typing import List
 from typing import Tuple
@@ -45,7 +46,7 @@ ECU_CONVERSION_FIXTURE_NAME = "ecu_conversion"
             ["1.230", "EUR", "kg"],
             [
                 {
-                    "duty_amount": 1.23,
+                    "duty_amount": Decimal("1.23"),
                     "duty_expression": PERCENT_OR_AMOUNT_FIXTURE_NAME,
                     "monetary_unit": EURO_FIXTURE_NAME,
                     "measurement_unit": KILOGRAM_FIXTURE_NAME,
@@ -57,16 +58,16 @@ ECU_CONVERSION_FIXTURE_NAME = "ecu_conversion"
             ["9.10", "%", "MAX", "1.00", "%", "+", "0.90", "GBP", "100 kg"],
             [
                 {
-                    "duty_amount": 9.1,
+                    "duty_amount": Decimal("9.1"),
                     "duty_expression": PERCENT_OR_AMOUNT_FIXTURE_NAME,
                 },
                 {
                     "duty_expression_sid": MAXIMUM_CLAUSE_SID[0],
-                    "duty_amount": 1.0,
+                    "duty_amount": Decimal("1.0"),
                 },
                 {
                     "duty_expression_sid": PLUS_PERCENT_OR_AMOUNT_SID[1],
-                    "duty_amount": 0.9,
+                    "duty_amount": Decimal("0.9"),
                     "monetary_unit": BRITISH_POUND_FIXTURE_NAME,
                     "measurement_unit": HECTOKILOGRAM_FIXTURE_NAME,
                 },
@@ -77,7 +78,7 @@ ECU_CONVERSION_FIXTURE_NAME = "ecu_conversion"
             ["0.300", "XEM", "100 kg", "lactic."],
             [
                 {
-                    "duty_amount": 0.3,
+                    "duty_amount": Decimal("0.3"),
                     "duty_expression": PERCENT_OR_AMOUNT_FIXTURE_NAME,
                     "measurement_unit": HECTOKILOGRAM_FIXTURE_NAME,
                     "measurement_unit_qualifier": LACTIC_MATTER_FIXTURE_NAME,
@@ -91,10 +92,10 @@ ECU_CONVERSION_FIXTURE_NAME = "ecu_conversion"
             [
                 {
                     "duty_expression": PERCENT_OR_AMOUNT_FIXTURE_NAME,
-                    "duty_amount": 12.9,
+                    "duty_amount": Decimal("12.9"),
                 },
                 {
-                    "duty_amount": 20.0,
+                    "duty_amount": Decimal("20.0"),
                     "duty_expression_sid": PLUS_PERCENT_OR_AMOUNT_SID[0],
                     "measurement_unit": KILOGRAM_FIXTURE_NAME,
                     "monetary_unit": EURO_FIXTURE_NAME,


### PR DESCRIPTION
# TP2000-1678 Measure condition duty bug update
<!---
 * Include the JIRA ticket number, eg TP-123, to automatically link.
 * Use 50 characters maximum.
 * Do not end with a full-stop.
--->

## Why
<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Use as many lines as you like.
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions or deliberately ignored edge-cases.
--->

The validation applied to the `applicable_duty` field in the measure condition form could be applied to all duty sentence fields.

Also the test I previously wrote could be consolidated into an existing test as a new parameter.

## What
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Explain like I'm 5.
 * Use pictures if you can.
--->

This PR:
- moves the check for no more than 3 decimal places from the MeasureCondition form to the Duty Sentence Parser so it can be applied to all duty sentence fields
- moves a test to be a parameter of an existing test

<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
## Checklist
- Requires migrations?
- Requires dependency updates?
--->

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
