### PR TITLE
TP2000-1692 Upgrade GitHub actions/cache version

### DIFF
--- a/.github/actions/setup-python/action.yml
+++ b/.github/actions/setup-python/action.yml
@@ -17,7 +17,7 @@ runs:
 
     - name: Restore dependencies from cache
       id: cache
-      uses: actions/cache@v1
+      uses: actions/cache@v4
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}


### PR DESCRIPTION
# TP2000-1692 Upgrade GitHub actions/cache version

## Why
GitHub `actions/cache@v1` is soon to be deprecated on 1 March 2025.

<details><summary>CI/CD workflow error</summary>
<p>
<img width="1000" alt="Screenshot 2025-02-05 at 10 47 58" src="https://github.com/user-attachments/assets/325eac43-d2b7-42fb-8ce2-a45bb4840ee1" />
</p>
</details> 

## What
- Upgrades `actions/cache` from `v1` to `v4` in `.github/actions/setup-python/action.yml`

### Links to relevant material
- https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#actions-cache-v1-v2-and-actions-toolkit-cache-package-closing-down
- https://github.com/actions/cache/discussions/1510
