### PR TITLE
TP2000-1655 Hide application info page

### DIFF
--- a/common/jinja2/common/app_info.jinja
+++ b/common/jinja2/common/app_info.jinja
@@ -29,7 +29,6 @@
   </h1>
 
 
-  {% if request.user.is_superuser %}
   <div class="govuk-grid-row govuk-!-margin-bottom-6 info-section">
     <div class="govuk-grid-column-full">
       <h2 class="govuk-heading-m">Deployment information</h2>
@@ -75,7 +74,6 @@
       }) }}
     </div>
   </div>
-  {% endif %}
 
 
   <div class="govuk-grid-row govuk-!-margin-bottom-6 info-section">
@@ -172,7 +170,7 @@
   </div>
 
 
-  {%- if request.user.is_superuser and SQLITE_DUMP_LIST %}
+  {%- if SQLITE_DUMP_LIST %}
   <div class="govuk-grid-row govuk-!-margin-bottom-6 info-section">
     <div class="govuk-grid-column-full">
       <h2 class="govuk-heading-m">Sqlite dumps (past {{ SQLITE_DUMP_DAYS }} days)</h2>

--- a/common/jinja2/common/homepage.jinja
+++ b/common/jinja2/common/homepage.jinja
@@ -150,10 +150,10 @@
         We have a range of resources you can use with the Tariff Application Platform.
       </p>
       <ul id="homepage-tap-resources" class="govuk-list govuk-list--spaced">
+      {% if request.user.is_superuser %}
         <li>
           <a href="{{ url('app-info') }}" class="govuk-link">Application information</a>
         </li>
-        {% if request.user.is_superuser %}
           <li>
             <a href="{{ url('import_batch-ui-list') }}" class="govuk-link">Importer V1</a>
           </li>

--- a/common/tests/test_views.py
+++ b/common/tests/test_views.py
@@ -89,18 +89,11 @@ def test_health_check_view_response(
 
 
 def test_app_info_non_superuser(valid_user_client):
-    """Users without the superuser permission have a restricted view of
-    application information."""
+    """Users without the superuser permission cannot view the application
+    information page."""
     response = valid_user_client.get(reverse("app-info"))
 
-    assert response.status_code == 200
-
-    page = BeautifulSoup(str(response.content), "html.parser")
-    h2_elements = page.select(".info-section h2")
-
-    assert len(h2_elements) == 2
-    assert "Active business rule checks" in h2_elements[0].text
-    assert "Active envelope generation tasks" in h2_elements[1].text
+    assert response.status_code == 403
 
 
 def test_app_info_superuser(superuser_client, new_workbasket):

--- a/common/views/pages.py
+++ b/common/views/pages.py
@@ -39,6 +39,7 @@ from common.celery import app as celery_app
 from common.forms import HomeSearchForm
 from common.models import Transaction
 from common.util import is_cloud_foundry
+from common.views.mixins import RequiresSuperuserMixin
 from exporter.sqlite.util import sqlite_dumps
 from footnotes.models import Footnote
 from geo_areas.models import GeographicalArea
@@ -356,6 +357,7 @@ def get_uptime() -> str:
 
 class AppInfoView(
     LoginRequiredMixin,
+    RequiresSuperuserMixin,
     TemplateView,
 ):
     template_name = "common/app_info.jinja"


### PR DESCRIPTION
# TP2000-1655 Hide application info page
<!---
 * Include the JIRA ticket number, eg TP-123, to automatically link.
 * Use 50 characters maximum.
 * Do not end with a full-stop.
--->

## Why
<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Use as many lines as you like.
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions or deliberately ignored edge-cases.
--->

Application information is a useful tool for us as a product team to check on a number of processes and build information. 

We provided user access as rule checks running weren’t visible, now that we have a rule check queue, we can return this to original settings

## What
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Explain like I'm 5.
 * Use pictures if you can.
--->

This PR makes being a superuser a requirement to view the Application Info page.

<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
## Checklist
- Requires migrations?
- Requires dependency updates?
--->

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
