### PR TITLE
TP2000-1679-105: Add type 105 to missing measure check

### DIFF
--- a/workbaskets/jinja2/workbaskets/checks/missing_measures.jinja
+++ b/workbaskets/jinja2/workbaskets/checks/missing_measures.jinja
@@ -94,7 +94,7 @@
             <div class="success-summary govuk-!-margin-bottom-5">
               <div class="govuk-grid-row">
                 <div class="govuk-grid-column-two-thirds">
-                  <p class="govuk-body govuk-!-font-weight-bold govuk-!-margin-bottom-0">There are no missing 103 measures.</p>
+                  <p class="govuk-body govuk-!-font-weight-bold govuk-!-margin-bottom-0">There are no missing 103 or 105 measures.</p>
                 </div>
                 <div class="govuk-grid-column-one-third">
                 <p class="govuk-body govuk-!-font-weight-bold text-align-right govuk-!-margin-bottom-0">Last run: {{ "{:%d %b %Y %H:%M}".format(missing_measures_check.updated_at) }}</p>
@@ -110,7 +110,7 @@
               <div class="govuk-grid-row">
                 <div class="govuk-grid-column-two-thirds">
                   {{ govukWarningText({
-                    "text": "The following commodity codes are missing a 103 measure type:",
+                    "text": "The following commodity codes are missing a 103 or 105 measure type:",
                     "iconFallbackText": "Warning",
                     "classes": "govuk-!-margin-bottom-0",
                   }) }}

--- a/workbaskets/jinja2/workbaskets/checks/missing_measures.jinja
+++ b/workbaskets/jinja2/workbaskets/checks/missing_measures.jinja
@@ -135,7 +135,7 @@
               {{ table_rows.append([
                 {"html": link},
                 {"text": check.commodity.get_description().description if check.commodity.get_description().description else "—"},
-                {"text": "Measure type 103 missing"},
+                {"text": "Measure type 103/105 missing"},
               ]) or "" }}
             {% endfor %}
             {{ govukTable({

--- a/workbaskets/tasks.py
+++ b/workbaskets/tasks.py
@@ -198,14 +198,15 @@ def check_comm_code_for_missing_measures(
             successful=False,
         )
 
+    # check for 103 and 105 measure types
     filtered_measures = applicable_measures.filter(
-        measure_type__sid=103,
+        measure_type__sid__in=[103, 105],
         geographical_area=GeographicalArea.objects.erga_omnes().first(),
     )
 
     if not filtered_measures:
         logger.info(
-            f"Commodity {code.item_id} has no applicable measures of type 103!",
+            f"Commodity {code.item_id} has no applicable measures of type 103 or 105!",
         )
         return MissingMeasureCommCode.objects.create(
             commodity=code,
@@ -214,7 +215,7 @@ def check_comm_code_for_missing_measures(
         )
 
     logger.info(
-        f"Commodity {code.item_id} has {filtered_measures.count()} applicable type 103 measure(s)",
+        f"Commodity {code.item_id} has {filtered_measures.count()} applicable type 103 and/or 105 measure(s)",
     )
     return MissingMeasureCommCode.objects.create(
         commodity=code,

--- a/workbaskets/tests/test_checks_views.py
+++ b/workbaskets/tests/test_checks_views.py
@@ -38,7 +38,7 @@ def test_check_missing_measures_fail_list(valid_user_client, user_workbasket):
     response = valid_user_client.get(url)
     soup = BeautifulSoup(str(response.content), "html.parser")
     assert (
-        "The following commodity codes are missing a 103 measure type:"
+        "The following commodity codes are missing a 103 or 105 measure type:"
         in soup.select_one(".govuk-tabs__panel").text
     )
     assert len(soup.select("tbody .govuk-table__row")) == 3
@@ -58,7 +58,7 @@ def test_check_missing_measures_success(valid_user_client, user_workbasket):
     response = valid_user_client.get(url)
     soup = BeautifulSoup(str(response.content), "html.parser")
     assert (
-        "There are no missing 103 measures."
+        "There are no missing 103 or 105 measures."
         in soup.select_one(".govuk-tabs__panel").text
     )
 

--- a/workbaskets/tests/test_tasks.py
+++ b/workbaskets/tests/test_tasks.py
@@ -14,6 +14,11 @@ def measure_type103():
     return factories.MeasureTypeFactory.create(sid=103)
 
 
+@pytest.fixture
+def measure_type142():
+    return factories.MeasureTypeFactory.create(sid=142)
+
+
 def test_create_missing_measure_comm_codes_new_comm_code_fail(
     erga_omnes,
     date_ranges,
@@ -38,8 +43,10 @@ def test_create_missing_measure_comm_codes_new_comm_code_fail(
     assert new_commodity in [m.commodity for m in failed_comm_codes]
 
 
-def test_create_missing_measure_comm_codes_new_comm_code_142_fail(erga_omnes):
-    measure_type142 = factories.MeasureTypeFactory.create(sid=103)
+def test_create_missing_measure_comm_codes_new_comm_code_142_fail(
+    erga_omnes,
+    measure_type142,
+):
     workbasket = factories.WorkBasketFactory.create()
     new_commodity = factories.GoodsNomenclatureFactory.create(
         transaction=workbasket.new_transaction(),
@@ -89,16 +96,15 @@ def test_create_missing_measure_comm_codes_new_comm_code_99_pass(
     assert not failed_comm_codes
 
 
-def test_create_missing_measure_comm_codes_new_comm_code_103_pass(
-    erga_omnes,
-    measure_type103,
-):
+@pytest.mark.parametrize("sid", [(103), (105)])
+def test_create_missing_measure_comm_codes_new_comm_code_pass(sid, erga_omnes):
+    measure_type = factories.MeasureTypeFactory.create(sid=sid)
     workbasket = factories.WorkBasketFactory.create()
     new_commodity = factories.GoodsNomenclatureFactory.create(
         transaction=workbasket.new_transaction(),
     )
-    mfn = factories.MeasureFactory.create(
-        measure_type=measure_type103,
+    factories.MeasureFactory.create(
+        measure_type=measure_type,
         goods_nomenclature=new_commodity,
         geographical_area=erga_omnes,
         transaction=workbasket.new_transaction(),
@@ -121,8 +127,8 @@ def test_create_missing_measure_comm_codes_new_comm_code_103_pass(
 def test_create_missing_measure_comm_codes_ended_comm_code_pass(
     erga_omnes,
     date_ranges,
+    measure_type142,
 ):
-    measure_type142 = factories.MeasureTypeFactory.create(sid=103)
     workbasket = factories.WorkBasketFactory.create()
     new_commodity = factories.GoodsNomenclatureFactory.create(
         transaction=workbasket.new_transaction(),


### PR DESCRIPTION
# TP2000-1679-105: Add type 105 to missing measure check
<!---
 * Include the JIRA ticket number, eg TP-123, to automatically link.
 * Use 50 characters maximum.
 * Do not end with a full-stop.
--->

## Why
<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Use as many lines as you like.
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions or deliberately ignored edge-cases.
--->
* Some measures that would normally use a measure type 103 instead use a 105 for policy reasons

## What
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Explain like I'm 5.
 * Use pictures if you can.
--->
* Adds measure type 105 to missing measures check. If a comm code has only a measure type 105 the check will now pass

<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
## Checklist
- Requires migrations?
- Requires dependency updates?
--->

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
<img width="1203" alt="Screenshot 2025-02-14 at 12 11 37" src="https://github.com/user-attachments/assets/a9d7eb12-23f6-4651-bed1-f0103669aaee" />
