### PR TITLE
UI text changes for new 'tickets' tile on homepage

### DIFF
--- a/common/jinja2/common/homepage.jinja
+++ b/common/jinja2/common/homepage.jinja
@@ -144,29 +144,24 @@
       </article>
     {% endif %}
 
+
+    {% if request.user.groups.filter(name='Tariff Managers').exists() or request.user.is_superuser %}
       <article class="masonry-card">
-        <h3 class="govuk-heading-m">Tasks and Workflows - TEST ONLY</h3>
-        <p class="govuk-body">
-          <a href="{{ url('workflow:task-ui-list') }}"
-            class="govuk-link"
-          >Tasks</a>
-        </p>
-        <p class="govuk-body"></p>
+        <h3 class="govuk-heading-m">Tickets</h3>
+          <p class="govuk-body"></p>
           <a href="{{ url('workflow:task-workflow-ui-list') }}"
             class="govuk-link"
-          >Workflows</a>
-        </p>
-        <p class="govuk-body"></p>
-          <a href="{{ url('workflow:task-and-workflow-ui-list') }}"
-            class="govuk-link"
-          >Tasks and Workflows</a>
-        </p>
-        <p class="govuk-body"></p>
+          >Tickets</a>
+          </p>
+        {% if request.user.is_superuser %}
+          <p class="govuk-body"></p>
           <a href="{{ url('workflow:task-workflow-template-ui-list') }}"
             class="govuk-link"
-          >Workflow templates</a>
-        </p>
+          >Ticket templates</a>
+          </p>
+        {% endif %}
       </article>
+    {% endif %}
 
     <article class="masonry-card">
       <h3 class="govuk-heading-m">Resources</h3>


### PR DESCRIPTION
# TP2000-1718 Apply UI changes to home ticket page card

## Why
 * Users need to be able to access our new Tickets task management functionality
 * Providing a 'Tickets' tile for TMs and Superusers navigation

## What
 * Modifying text of previous 'Tasks and Workflows' tile to reflect new terminology changes 
 * 'Workflows' --> 'Tickets', 'Workflow Templates' --> 'Ticket Templates'
 * Conditional rendering based on permissions - the Tickets tile is only visible to TMs and Superusers and 'Ticket Templates' link is only visible to Superusers
 * URLs remain unchanged and redirect to 'workflow' related pages
 * Parametrized unit test to check that 'Tickets' tile is only visible to TMs and Superusers
 * Parametrized unit test to check that 'Ticket Templates' link on 'Tickets' tile only visible to superusers, not TMs

Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
## Checklist
- Requires migrations? - No
- Requires dependency updates? - No

<img width="994" alt="Screenshot 2025-02-18 at 14 57 21" src="https://github.com/user-attachments/assets/ab0d0c2e-0a48-4947-867b-d1f442ab308b" />
Homepage viewed as a superuser