### PR TITLE
TP2000-1668: Add override functionality for superusers

### DIFF
--- a/checks/models.py
+++ b/checks/models.py
@@ -1,5 +1,6 @@
 from django.db import models
 from django.db.models import fields
+from django.db.transaction import atomic
 
 from checks.querysets import TransactionCheckQueryset
 from common.models.mixins import TimestampedMixin
@@ -181,6 +182,7 @@ class MissingMeasuresCheck(TimestampedMixin):
 
     successful = fields.BooleanField(null=True)
 
+    @atomic
     def override(self):
         self.model_checks.all().delete()
         self.successful = True

--- a/checks/models.py
+++ b/checks/models.py
@@ -181,6 +181,11 @@ class MissingMeasuresCheck(TimestampedMixin):
 
     successful = fields.BooleanField(null=True)
 
+    def override(self):
+        self.model_checks.all().delete()
+        self.successful = True
+        self.save()
+
 
 class MissingMeasureCommCode(models.Model):
     """Links a GoodsNomenclature to a MissingMeasuresCheck when the commodity

--- a/workbaskets/jinja2/workbaskets/checks/missing_measures.jinja
+++ b/workbaskets/jinja2/workbaskets/checks/missing_measures.jinja
@@ -105,6 +105,21 @@
 
           {# check was not successful #}
           {% else %}
+            {% if request.user.is_superuser %}
+              <form method="post">
+                <input type="hidden" name="csrfmiddlewaretoken" value="{{ csrf_token }}">
+                <input type="hidden" name="workbasket_id" value="{{ workbasket.id }}">
+                {{ govukWarningText({
+                  "text": "Be sure that you understand the implications of this violation before choosing to override it."
+                }) }}
+                {{ govukButton({
+                  "text": "Override measures check",
+                  "classes": "govuk-button--warning",
+                  "name": "form-action",
+                  "value": "override"
+                }) }}
+              </form>
+            {% endif %}
             <p class="govuk-body">Missing measures check finished.</p>
             <div class="govuk-error-summary">
               <div class="govuk-grid-row">

--- a/workbaskets/jinja2/workbaskets/checks/missing_measures.jinja
+++ b/workbaskets/jinja2/workbaskets/checks/missing_measures.jinja
@@ -105,21 +105,6 @@
 
           {# check was not successful #}
           {% else %}
-            {% if request.user.is_superuser %}
-              <form method="post">
-                <input type="hidden" name="csrfmiddlewaretoken" value="{{ csrf_token }}">
-                <input type="hidden" name="workbasket_id" value="{{ workbasket.id }}">
-                {{ govukWarningText({
-                  "text": "Be sure that you understand the implications of this violation before choosing to override it."
-                }) }}
-                {{ govukButton({
-                  "text": "Override measures check",
-                  "classes": "govuk-button--warning",
-                  "name": "form-action",
-                  "value": "override"
-                }) }}
-              </form>
-            {% endif %}
             <p class="govuk-body">Missing measures check finished.</p>
             <div class="govuk-error-summary">
               <div class="govuk-grid-row">
@@ -163,6 +148,28 @@
             }) }}
 
             {{ run_button(text="Re-run") }}
+
+            {% if request.user.is_superuser %}
+            <details class="govuk-details">
+              <summary class="govuk-details__summary">
+                <span class="govuk-details__summary-text">Override missing measures check</span>
+              </summary>
+              <form method="post">
+                <input type="hidden" name="csrfmiddlewaretoken" value="{{ csrf_token }}">
+                <input type="hidden" name="workbasket_id" value="{{ workbasket.id }}">
+                {{ govukWarningText({
+                  "text": "Be sure that you understand the implications of this violation before choosing to override it.",
+                  "classes": "govuk-!-margin-top-5"
+                }) }}
+                {{ govukButton({
+                  "text": "Override",
+                  "classes": "govuk-button--warning",
+                  "name": "form-action",
+                  "value": "override"
+                }) }}
+              </form>
+            </details>
+            {% endif %}
 
           {% endif %}
         {% endif %}

--- a/workbaskets/models.py
+++ b/workbaskets/models.py
@@ -23,6 +23,7 @@ from django_fsm import FSMField
 from django_fsm import transition
 
 from checks.models import MissingMeasureCommCode
+from checks.models import MissingMeasuresCheck
 from checks.models import TrackedModelCheck
 from checks.models import TransactionCheck
 from common.models.mixins import TimestampedMixin
@@ -725,6 +726,9 @@ class WorkBasket(TimestampedMixin):
         """Delete all MissingMeasureCommCode instances related to the
         WorkBasket."""
         self.missing_measure_comm_codes.delete()
+
+    def override_missing_measures_check(self):
+        MissingMeasuresCheck.objects.get(workbasket=self).override()
 
     @property
     def unchecked_or_errored_transactions(self):

--- a/workbaskets/views/ui.py
+++ b/workbaskets/views/ui.py
@@ -1122,6 +1122,8 @@ class WorkBasketCommCodeChecks(SortingMixin, ListView, FormView):
             self.run_missing_measures_check(comm_code_pks)
         if form_action == "stop-check":
             self.workbasket.terminate_missing_measures_check()
+        if form_action == "override":
+            self.workbasket.override_missing_measures_check()
         return super().form_valid(form)
 
     def get_context_data(self, **kwargs):


### PR DESCRIPTION
# TP2000-1668: Add override functionality for superusers
<!---
 * Include the JIRA ticket number, eg TP-123, to automatically link.
 * Use 50 characters maximum.
 * Do not end with a full-stop.
--->

## Why
<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Use as many lines as you like.
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions or deliberately ignored edge-cases.
--->
* We already have an override for business rule checks for superusers. This brings the new missing measures check in line with that

## What
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Explain like I'm 5.
 * Use pictures if you can.
--->
* Adds an override button to the missing measures check page that is only visible to superusers. This deletes all associated `MissingMeasureCommCode`s and sets the `MissingMeasuresCheck.successful` to `True`

<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
## Checklist
- Requires migrations?
- Requires dependency updates?
--->

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
<img width="1217" alt="Screenshot 2025-02-19 at 11 57 05" src="https://github.com/user-attachments/assets/6bc5715f-7583-4705-8eac-c91d36377a49" />
<img width="1204" alt="Screenshot 2025-02-19 at 11 57 14" src="https://github.com/user-attachments/assets/f33bf81a-e039-416c-9b70-6956896e4372" />

