### PR TITLE
Tp2000 1726  delete ticket view

### DIFF
--- a/tasks/jinja2/tasks/workflows/delete.jinja
+++ b/tasks/jinja2/tasks/workflows/delete.jinja
@@ -10,9 +10,9 @@
   {{ breadcrumbs(
     request,
     [
-      {"text": "Find and view "~ object_name ~ "s", "href": object.get_url("list")},
+      {"text": "Find and view "~ verbose_name ~ "s", "href": object.get_url("list")},
       {
-        "text": object_name|capitalize ~ ": " ~ object.title,
+        "text": verbose_name|capitalize ~ ": " ~ object.title,
         "href": object.get_url("detail"),
       },
       {"text": page_title}

--- a/tasks/jinja2/tasks/workflows/delete.jinja
+++ b/tasks/jinja2/tasks/workflows/delete.jinja
@@ -4,8 +4,9 @@
 {% from "components/warning-text/macro.njk" import govukWarningText %}
 {% from "components/button/macro.njk" import govukButton %}
 
-{% set object_name = object._meta.verbose_name %}
-{% set page_title = "Delete " ~ object_name ~ ": " ~ object.title %}
+{# {% set object_name = object._meta.verbose_name %}
+{% set page_title = "Delete " ~ object_name ~ ": " ~ object.title %} #}
+{% set page_title = "Delete " ~ verbose_name ~ ": " ~ object.title %}
 
 {% block breadcrumb %}
   {{ breadcrumbs(
@@ -24,7 +25,7 @@
 
 {% block form %}
   {{ govukWarningText({
-    "text": "Are you sure you want to delete this " ~ object_name ~ "?",
+    "text": "Are you sure you want to delete this " ~ verbose_name ~ "?",
   }) }}
 
   {% call django_form(action=object.get_url("delete")) %}

--- a/tasks/jinja2/tasks/workflows/delete.jinja
+++ b/tasks/jinja2/tasks/workflows/delete.jinja
@@ -4,8 +4,6 @@
 {% from "components/warning-text/macro.njk" import govukWarningText %}
 {% from "components/button/macro.njk" import govukButton %}
 
-{# {% set object_name = object._meta.verbose_name %}
-{% set page_title = "Delete " ~ object_name ~ ": " ~ object.title %} #}
 {% set page_title = "Delete " ~ verbose_name ~ ": " ~ object.title %}
 
 {% block breadcrumb %}

--- a/tasks/tests/test_views.py
+++ b/tasks/tests/test_views.py
@@ -783,7 +783,7 @@ def test_workflow_delete_view(
     assert confirmation_response.status_code == 200
 
     soup = BeautifulSoup(str(confirmation_response.content), "html.parser")
-    assert f"Workflow ID: {workflow_pk}" in soup.select(".govuk-panel__title")[0].text
+    assert f"Ticket ID: {workflow_pk}" in soup.select(".govuk-panel__title")[0].text
 
 
 def test_workflow_list_view(valid_user_client, task_workflow):
@@ -891,5 +891,5 @@ def test_workflow_delete_view_deletes_related_tasks(
 
     soup = BeautifulSoup(str(confirmation_response.content), "html.parser")
     assert (
-        f"Workflow ID: {task_workflow_pk}" in soup.select(".govuk-panel__title")[0].text
+        f"Ticket ID: {task_workflow_pk}" in soup.select(".govuk-panel__title")[0].text
     )

--- a/tasks/views.py
+++ b/tasks/views.py
@@ -659,10 +659,10 @@ class TaskWorkflowConfirmDeleteView(PermissionRequiredMixin, TemplateView):
         context_data = super().get_context_data(**kwargs)
         context_data.update(
             {
-                "verbose_name": "workflow",
+                "verbose_name": "ticket",
                 "deleted_pk": self.kwargs["pk"],
                 "create_url": reverse("workflow:task-workflow-ui-create"),
-                "list_url": "#NOT-IMPLEMENTED",
+                "list_url": reverse("workflow:task-workflow-ui-list"),
             },
         )
         return context_data

--- a/tasks/views.py
+++ b/tasks/views.py
@@ -630,6 +630,11 @@ class TaskWorkflowDeleteView(PermissionRequiredMixin, DeleteView):
         kwargs["instance"] = self.object
         return kwargs
 
+    def get_context_data(self, **kwargs):
+        context_data = super().get_context_data(**kwargs)
+        context_data["verbose_name"] = "ticket"
+        return context_data
+
     @transaction.atomic
     def form_valid(self, form):
         summary_task = self.object.summary_task


### PR DESCRIPTION
# TP2000-1726 - Delete Ticket View

## Why

* New UI design changes have renamed 'workflows' to 'tickets', and this PR reflects this change in the delete view

## What
 * UI references to 'Workflows' have been changed to 'Tickets' in 'Delete' and 'Confirm Delete' templates
 * Updates delete view unit tests
 
## Screenshots
 
<details>
<summary>Ticket Delete View</summary>
<br>
<img width="939" alt="Screenshot 2025-02-27 at 17 03 05" src="https://github.com/user-attachments/assets/33d65a14-94f1-4aa8-aa09-6d108520f8ad" />
</details>

<details>
<summary>Ticket Confirm Delete View</summary>
<br>
<img width="782" alt="Screenshot 2025-02-27 at 17 03 20" src="https://github.com/user-attachments/assets/96abc9c5-c8c2-47ed-b781-6faadbf28659" />
</details>


## Checklist
- Requires migrations? - No
- Requires dependency updates? - No

