### PR TITLE
TP2000-1724  Redesign ticket edit view

### DIFF
--- a/common/static/common/scss/_components.scss
+++ b/common/static/common/scss/_components.scss
@@ -175,15 +175,15 @@
   @extend .govuk-summary-list__key;
   display: block;
   width: 100%;
-  padding: 0;
-  margin: 0;
+  padding: 0 !important;
+  margin: 0 !important;
 }
 
 .govuk-summary-list__value__stacked {
   @extend .govuk-summary-list__value;
   display: block;
   padding: 0;
-  margin: 0;
+  margin-bottom: govuk-spacing(2) !important;
 }
 
 .govuk-summary-list__value__stacked:last-child {

--- a/common/util.py
+++ b/common/util.py
@@ -690,16 +690,16 @@ def format_date_string(date_string: str, short_format=False) -> str:
         return ""
 
 
-def format_date(value: datetime) -> str:
-    """Formats a datetime object using `settings.DATE_FORMAT`."""
-    if isinstance(value, datetime):
+def format_date(value: datetime | date) -> str:
+    """Formats a datetime or date object using `settings.DATE_FORMAT`."""
+    if isinstance(value, (datetime, date)):
         return value.strftime(settings.DATE_FORMAT)
     return value
 
 
-def format_short_date(value: datetime) -> str:
-    """Formats a datetime object using `settings.SHORT_DATE_FORMAT`."""
-    if isinstance(value, datetime):
+def format_short_date(value: datetime | date) -> str:
+    """Formats a datetime or date object using `settings.SHORT_DATE_FORMAT`."""
+    if isinstance(value, (datetime, date)):
         return value.strftime(settings.SHORT_DATE_FORMAT)
     return value
 

--- a/tasks/forms.py
+++ b/tasks/forms.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 
 from crispy_forms_gds.helper import FormHelper
+from crispy_forms_gds.layout import HTML
 from crispy_forms_gds.layout import Fieldset
 from crispy_forms_gds.layout import Layout
 from crispy_forms_gds.layout import Size
@@ -361,6 +362,10 @@ class TaskWorkflowUpdateForm(ModelForm):
                 "Save",
                 data_module="govuk-button",
                 data_prevent_double_click="true",
+                css_class="govuk-!-margin-right-2",
+            ),
+            HTML(
+                f'<a class="govuk-link govuk-!-display-inline-block govuk-!-margin-top-2" href="{self.instance.get_url("detail")}">Back</a>',
             ),
         )
 

--- a/tasks/forms.py
+++ b/tasks/forms.py
@@ -312,23 +312,31 @@ TaskWorkflowDeleteForm = delete_form_for(TaskWorkflow)
 
 class TaskWorkflowUpdateForm(ModelForm):
     title = CharField(
+        label="Ticket name",
         max_length=255,
         validators=[SymbolValidator],
         error_messages={
-            "required": "Enter a title",
+            "required": "Enter a ticket name",
         },
     )
     description = CharField(
         validators=[SymbolValidator],
         widget=Textarea(),
-        error_messages={
-            "required": "Enter a description",
-        },
+        required=False,
+    )
+    eif_date = DateInputFieldFixed(
+        label="Entry into force date",
+        required=False,
+    )
+    policy_contact = CharField(
+        required=False,
+        max_length=40,
+        validators=[SymbolValidator],
     )
 
     class Meta:
         model = TaskWorkflow
-        fields = []
+        fields = ["eif_date", "policy_contact"]
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -346,9 +354,11 @@ class TaskWorkflowUpdateForm(ModelForm):
         self.helper.layout = Layout(
             "title",
             "description",
+            "eif_date",
+            "policy_contact",
             Submit(
                 "submit",
-                "Update",
+                "Save",
                 data_module="govuk-button",
                 data_prevent_double_click="true",
             ),
@@ -356,12 +366,16 @@ class TaskWorkflowUpdateForm(ModelForm):
 
     @transaction.atomic
     def save(self, commit=True):
-        summary_task = self.instance.summary_task
+        instance = super().save(commit)
+
+        summary_task = instance.summary_task
         summary_task.title = self.cleaned_data["title"]
         summary_task.description = self.cleaned_data["description"]
+
         if commit:
             summary_task.save()
-        return self.instance
+
+        return instance
 
 
 class TaskWorkflowTemplateBaseForm(ModelForm):

--- a/tasks/jinja2/tasks/includes/task_list.jinja
+++ b/tasks/jinja2/tasks/includes/task_list.jinja
@@ -16,8 +16,8 @@
 
 {{ govukTable({
   "head": [
-    {"text": "Name"},
-    {"text": "Status"},
+    {"text": "Name", "classes": "govuk-visually-hidden"},
+    {"text": "Status", "classes": "govuk-visually-hidden"},
   ],
   "rows": table_rows
 }) }}

--- a/tasks/jinja2/tasks/includes/task_list.jinja
+++ b/tasks/jinja2/tasks/includes/task_list.jinja
@@ -1,5 +1,4 @@
 {% from "components/table/macro.njk" import govukTable %}
-{% from "tasks/macros/display_details.jinja" import display_assignees %}
 {% from "tasks/macros/display_details.jinja" import display_status %}
 
 {% set table_rows = [] %}
@@ -11,7 +10,6 @@
 
   {{ table_rows.append([
     {"html": object_link},
-    {"text": display_assignees(object.assignees.assigned())},
     {"text": display_status(object.progress_state.__str__())},
   ]) or "" }}
 {% endfor %}
@@ -19,7 +17,6 @@
 {{ govukTable({
   "head": [
     {"text": "Name"},
-    {"text": "Assignee"},
     {"text": "Status"},
   ],
   "rows": table_rows

--- a/tasks/jinja2/tasks/workflows/confirm_update.jinja
+++ b/tasks/jinja2/tasks/workflows/confirm_update.jinja
@@ -4,15 +4,14 @@
 {% from "components/panel/macro.njk" import govukPanel %}
 {% from "components/button/macro.njk" import govukButton %}
 
-{% set object_name = object._meta.verbose_name %}
-{% set page_title = object_name|capitalize ~ " updated" %}
+{% set page_title = verbose_name|capitalize ~ " updated" %}
 
 {% block breadcrumb %}
   {{ breadcrumbs(
     request,
     [
-      {"text": "Find and view " ~ object_name ~ "s", "href": object.get_url("list")},
-      {"text": object_name|capitalize ~ ": " ~ object.title, "href": object.get_url("detail")},
+      {"text": "Find and view " ~ verbose_name ~ "s", "href": object.get_url("list")},
+      {"text": verbose_name|capitalize ~ " " ~ object.id, "href": object.get_url("detail")},
       {"text": page_title}
     ],
     with_workbasket=False,
@@ -21,27 +20,21 @@
 
 {% block panel %}
   {{ govukPanel({
-    "titleText": object_name|capitalize ~ ": " ~ object,
-    "text": "You have updated the " ~ object_name,
+    "titleText": verbose_name|capitalize ~ " " ~ object.id,
+    "text": "You have updated the " ~ verbose_name,
     "classes": "govuk-!-margin-bottom-7"
   }) }}
 {% endblock %}
 
 {% block button_group %}
   {{ govukButton({
-    "text": "View " ~ object_name,
+    "text": "View " ~ verbose_name,
     "href": object.get_url("detail"),
     "classes": "govuk-button"
   }) }}
-  {% if object_name == "workflow" %}
+  {% if verbose_name == "ticket template" %}
     {{ govukButton({
-      "text": "Create a task",
-      "href": "#TODO",
-      "classes": "govuk-button--secondary"
-    }) }}
-  {% elif object_name == "workflow template" %}
-    {{ govukButton({
-      "text": "Create a task template",
+      "text": "Add a step",
       "href": url("workflow:task-template-ui-create", kwargs={"workflow_template_pk": object.pk}),
       "classes": "govuk-button--secondary"
     }) }}
@@ -49,5 +42,5 @@
 {% endblock %}
 
 {% block actions %}
-  <a href={{ object.get_url("list") }} class="govuk-link">Find and view {{object_name}}s</a>
+  <a href={{ object.get_url("list") }} class="govuk-link">Find and view {{verbose_name}}s</a>
 {% endblock %}

--- a/tasks/jinja2/tasks/workflows/detail.jinja
+++ b/tasks/jinja2/tasks/workflows/detail.jinja
@@ -59,8 +59,8 @@
           {{ display_summary_row_stacked("Assignee", display_assignees(object.summary_task.assignees.assigned())) }}
           {{ display_summary_row_stacked("Work type", object.creator_template.title) }}
           {{ display_summary_row_stacked("Created date", object.summary_task.created_at|format_date) }}
-          {{ display_summary_row_stacked("Entry into force date", "None") }}
-          {{ display_summary_row_stacked("Policy contact", "None") }}
+          {{ display_summary_row_stacked("Entry into force date", object.eif_date|format_date) }}
+          {{ display_summary_row_stacked("Policy contact", object.policy_contact or "None") }}
         {% elif verbose_name == "ticket template" %}
           {{ display_summary_row_stacked("Created by", object.creator.get_displayname()) }}
           {{ display_summary_row_stacked("Created date", object.created_at|format_date) }}

--- a/tasks/jinja2/tasks/workflows/edit.jinja
+++ b/tasks/jinja2/tasks/workflows/edit.jinja
@@ -1,14 +1,12 @@
 {% extends "layouts/form.jinja" %}
 {% from "components/breadcrumbs.jinja" import breadcrumbs %}
 
-{% set object_name = object._meta.verbose_name %}
-
-{% set page_title = "Edit " ~ object_name ~ " details" %}
+{% set page_title = "Edit " ~ verbose_name ~ " " ~ object.id %}
 
 {% block breadcrumb %}
   {{ breadcrumbs(request, [
-      {"text": "Find and view " ~ object_name ~ "s", "href": object.get_url("list")},
-      {"text": object_name|capitalize ~ ": " ~ object.title, "href": object.get_url("detail")},
+      {"text": "Find and view " ~ verbose_name ~ "s", "href": object.get_url("list")},
+      {"text": verbose_name|capitalize ~ " " ~ object.id, "href": object.get_url("detail")},
       {"text": page_title}
     ],
     with_workbasket=False,

--- a/tasks/tests/test_forms.py
+++ b/tasks/tests/test_forms.py
@@ -1,3 +1,5 @@
+from datetime import date
+
 import pytest
 
 from common.tests.factories import ProgressStateFactory
@@ -80,13 +82,19 @@ def test_workflow_update_form_save(task_workflow):
     """Tests that the details of `TaskWorkflow.summary_task` are updated when
     calling form.save()."""
     form_data = {
-        "title": "Updated workflow title",
-        "description": "Updated workflow description",
+        "title": "Updated title",
+        "description": "Updated description",
+        "eif_date_0": date.today().day,
+        "eif_date_1": date.today().month,
+        "eif_date_2": date.today().year,
+        "policy_contact": "Policy contact",
     }
 
     form = forms.TaskWorkflowUpdateForm(data=form_data, instance=task_workflow)
     assert form.is_valid()
 
     workflow = form.save()
+    assert workflow.eif_date == date.today()
+    assert workflow.policy_contact == form_data["policy_contact"]
     assert workflow.summary_task.title == form_data["title"]
     assert workflow.summary_task.description == form_data["description"]

--- a/tasks/views.py
+++ b/tasks/views.py
@@ -607,6 +607,11 @@ class TaskWorkflowConfirmUpdateView(PermissionRequiredMixin, DetailView):
     template_name = "tasks/workflows/confirm_update.jinja"
     permission_required = "tasks.change_taskworkflow"
 
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["verbose_name"] = "ticket"
+        return context
+
 
 class TaskWorkflowDeleteView(PermissionRequiredMixin, DeleteView):
     model = TaskWorkflow
@@ -796,6 +801,11 @@ class TaskWorkflowTemplateConfirmUpdateView(PermissionRequiredMixin, DetailView)
     model = TaskWorkflowTemplate
     template_name = "tasks/workflows/confirm_update.jinja"
     permission_required = "tasks.change_taskworkflowtemplate"
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["verbose_name"] = "ticket template"
+        return context
 
 
 class TaskWorkflowTemplateDeleteView(PermissionRequiredMixin, DeleteView):

--- a/tasks/views.py
+++ b/tasks/views.py
@@ -590,6 +590,11 @@ class TaskWorkflowUpdateView(PermissionRequiredMixin, UpdateView):
     permission_required = "tasks.change_taskworkflow"
     form_class = TaskWorkflowUpdateForm
 
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["verbose_name"] = "ticket"
+        return context
+
     def get_success_url(self):
         return reverse(
             "workflow:task-workflow-ui-confirm-update",
@@ -774,6 +779,11 @@ class TaskWorkflowTemplateUpdateView(PermissionRequiredMixin, UpdateView):
     template_name = "tasks/workflows/edit.jinja"
     permission_required = "tasks.change_taskworkflowtemplate"
     form_class = TaskWorkflowTemplateUpdateForm
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["verbose_name"] = "ticket template"
+        return context
 
     def get_success_url(self):
         return reverse(


### PR DESCRIPTION
# TP2000-1724  Redesign ticket edit view

## Why
Users need to be able to edit the new fields that have recently been added to the `TaskWorkflow` (Ticket) model.

## What
- Adds EIF date and policy contact as editable fields to the update form
- Renames "workflow" as "ticket" in UI
- Adds back link on form per design
- Updates related view and form unit tests
- Updates detail view template to display EIF date and policy contact values
- Removes step column headers on ticket detail view following design iteration

### Screenshots
<details><summary>Ticket edit view</summary>
<p>
<img width="500" alt="Screenshot 2025-03-03 at 17 27 03" src="https://github.com/user-attachments/assets/7a7ac284-ccbf-4b0f-8e15-7362a4103c58" />
</p>
</details> 

<details><summary>Ticket detail view (displaying new field values)</summary>
<p>
<img width="500" alt="Screenshot 2025-03-05 at 12 21 51" src="https://github.com/user-attachments/assets/9b8fd6bc-3dbf-4d80-acc8-01a134b546b8" />
</p>
</details> 