### PR TITLE
TP2000-1741  Add ticket assignment to ticket create & edit forms

### DIFF
--- a/tasks/forms.py
+++ b/tasks/forms.py
@@ -345,7 +345,7 @@ class TaskWorkflowCreateForm(BindNestedFormMixin, Form):
 TaskWorkflowDeleteForm = delete_form_for(TaskWorkflow)
 
 
-class TaskWorkflowUpdateForm(ModelForm):
+class TaskWorkflowUpdateForm(TaskWorkflowAssigneeForm, ModelForm):
     title = CharField(
         label="Ticket name",
         max_length=255,
@@ -382,6 +382,14 @@ class TaskWorkflowUpdateForm(ModelForm):
         self.fields["title"].initial = self.instance.summary_task.title
         self.fields["description"].initial = self.instance.summary_task.description
 
+        self.fields["assignee"].help_text = ""
+        try:
+            self.fields["assignee"].initial = (
+                self.instance.summary_task.assignees.assigned().get().user
+            )
+        except TaskAssignee.DoesNotExist:
+            pass
+
     def init_layout(self):
         self.helper = FormHelper(self)
         self.helper.label_size = Size.SMALL
@@ -389,6 +397,7 @@ class TaskWorkflowUpdateForm(ModelForm):
         self.helper.layout = Layout(
             "title",
             "description",
+            "assignee",
             "eif_date",
             "policy_contact",
             Submit(

--- a/tasks/forms.py
+++ b/tasks/forms.py
@@ -251,7 +251,7 @@ class TaskWorkflowAssigneeForm(Form):
         queryset=User.objects.active_tms(),
         help_text="Choose assignee",
         error_messages={
-            "required": "Select someone to assign",
+            "required": "Select an assignee",
         },
     )
 

--- a/tasks/forms.py
+++ b/tasks/forms.py
@@ -8,6 +8,7 @@ from crispy_forms_gds.layout import Size
 from crispy_forms_gds.layout import Submit
 from django.contrib.auth import get_user_model
 from django.db import transaction
+from django.db.models import TextChoices
 from django.forms import CharField
 from django.forms import CheckboxSelectMultiple
 from django.forms import Form
@@ -20,6 +21,7 @@ from django.utils.timezone import make_aware
 from common.fields import AutoCompleteField
 from common.forms import BindNestedFormMixin
 from common.forms import DateInputFieldFixed
+from common.forms import RadioNested
 from common.forms import delete_form_for
 from common.validators import SymbolValidator
 from tasks.models import Task
@@ -244,7 +246,25 @@ class TaskWorkflowTemplateForm(Form):
     )
 
 
+class TaskWorkflowAssigneeForm(Form):
+    assignee = ModelChoiceField(
+        queryset=User.objects.active_tms(),
+        help_text="Choose assignee",
+        error_messages={
+            "required": "Select someone to assign",
+        },
+    )
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.fields["assignee"].label_from_instance = lambda obj: obj.get_displayname()
+
+
 class TaskWorkflowCreateForm(BindNestedFormMixin, Form):
+    class AssignType(TextChoices):
+        SELF = "SELF", "Assign ticket to me"
+        OTHER_USER = "OTHER_USER", "Assign ticket to someone else"
+        NO_USER = "NO_USER", "Do not assign ticket to anyone"
 
     ticket_name = CharField(
         required=True,
@@ -257,10 +277,23 @@ class TaskWorkflowCreateForm(BindNestedFormMixin, Form):
 
     work_type = ModelChoiceField(
         required=True,
-        help_text="Choose the most appropriate category, this will generate a pre-defined set of steps to complete the work",
+        help_text="Choose the most appropriate category. This will generate a pre-defined set of steps to complete the work",
         queryset=TaskWorkflowTemplate.objects.all(),
         error_messages={
             "required": "Choose a work type",
+        },
+    )
+
+    assignment = RadioNested(
+        label="Assignee",
+        choices=AssignType.choices,
+        nested_forms={
+            AssignType.SELF.value: [],
+            AssignType.OTHER_USER: [TaskWorkflowAssigneeForm],
+            AssignType.NO_USER.value: [],
+        },
+        error_messages={
+            "required": "Select an assignee option",
         },
     )
 
@@ -295,6 +328,7 @@ class TaskWorkflowCreateForm(BindNestedFormMixin, Form):
             Fieldset(
                 "ticket_name",
                 "work_type",
+                "assignment",
                 "description",
                 "entry_into_force_date",
                 "policy_contact",

--- a/tasks/jinja2/tasks/includes/task_list.jinja
+++ b/tasks/jinja2/tasks/includes/task_list.jinja
@@ -1,4 +1,5 @@
 {% from "components/table/macro.njk" import govukTable %}
+{% from "tasks/macros/display_details.jinja" import display_assignees %}
 {% from "tasks/macros/display_details.jinja" import display_status %}
 
 {% set table_rows = [] %}
@@ -10,6 +11,7 @@
 
   {{ table_rows.append([
     {"html": object_link},
+    {"text": display_assignees(object.assignees.assigned())},
     {"text": display_status(object.progress_state.__str__())},
   ]) or "" }}
 {% endfor %}
@@ -17,6 +19,7 @@
 {{ govukTable({
   "head": [
     {"text": "Name", "classes": "govuk-visually-hidden"},
+    {"text": "Assignee", "classes": "govuk-visually-hidden"},
     {"text": "Status", "classes": "govuk-visually-hidden"},
   ],
   "rows": table_rows

--- a/tasks/tests/conftest.py
+++ b/tasks/tests/conftest.py
@@ -118,12 +118,11 @@ def task_workflow() -> TaskWorkflow:
 
 
 @pytest.fixture()
-def assigned_task_workflow() -> TaskWorkflow:
+def assigned_task_workflow(valid_user) -> TaskWorkflow:
     """Return an empty TaskWorkflow instance whose `summary_task` has an
     assignee."""
     workflow = factories.TaskWorkflowFactory.create()
-    assignee = workflow.summary_task.creator
-    TaskAssigneeFactory.create(task=workflow.summary_task, user=assignee)
+    TaskAssigneeFactory.create(task=workflow.summary_task, user=valid_user)
     return workflow
 
 

--- a/tasks/tests/conftest.py
+++ b/tasks/tests/conftest.py
@@ -118,6 +118,16 @@ def task_workflow() -> TaskWorkflow:
 
 
 @pytest.fixture()
+def assigned_task_workflow() -> TaskWorkflow:
+    """Return an empty TaskWorkflow instance whose `summary_task` has an
+    assignee."""
+    workflow = factories.TaskWorkflowFactory.create()
+    assignee = workflow.summary_task.creator
+    TaskAssigneeFactory.create(task=workflow.summary_task, user=assignee)
+    return workflow
+
+
+@pytest.fixture()
 def task_workflow_single_task_item(task_workflow) -> TaskWorkflow:
     """Return a TaskWorkflow instance containing a single TaskItem instance with
     associated Task instance."""

--- a/tasks/tests/test_forms.py
+++ b/tasks/tests/test_forms.py
@@ -36,6 +36,7 @@ def test_workflow_create_form_valid_data(task_workflow_template):
         "ticket_name": "Test ticket 1",
         "description": "Ticket created with all fields",
         "work_type": task_workflow_template,
+        "assignment": forms.TaskWorkflowCreateForm.AssignType.SELF,
         "entry_into_force_date_0": 12,
         "entry_into_force_date_1": 12,
         "entry_into_force_date_2": 2026,
@@ -62,11 +63,26 @@ def test_workflow_create_form_valid_data(task_workflow_template):
             "work_type",
             "Choose a work type",
         ),
+        (
+            {"assignment": ""},
+            "assignment",
+            "Select an assignee option",
+        ),
+        (
+            {
+                "assignment": forms.TaskWorkflowCreateForm.AssignType.OTHER_USER.value,
+                "assignee": "",
+            },
+            "assignment",
+            "Select someone to assign",
+        ),
     ],
     ids=(
         "missing_title",
         "missing_work_type",
         "invalid_work_type",
+        "missing_assignment",
+        "invalid_assignee",
     ),
 )
 def test_workflow_create_form_invalid_data(form_data, field, error_message):

--- a/tasks/tests/test_forms.py
+++ b/tasks/tests/test_forms.py
@@ -74,7 +74,7 @@ def test_workflow_create_form_valid_data(task_workflow_template):
                 "assignee": "",
             },
             "assignment",
-            "Select someone to assign",
+            "Select an assignee",
         ),
     ],
     ids=(
@@ -94,19 +94,20 @@ def test_workflow_create_form_invalid_data(form_data, field, error_message):
     assert error_message in form.errors[field]
 
 
-def test_workflow_update_form_save(task_workflow):
+def test_workflow_update_form_save(assigned_task_workflow):
     """Tests that the details of `TaskWorkflow.summary_task` are updated when
     calling form.save()."""
     form_data = {
         "title": "Updated title",
         "description": "Updated description",
+        "assignee": assigned_task_workflow.summary_task.assignees.get().user,
         "eif_date_0": date.today().day,
         "eif_date_1": date.today().month,
         "eif_date_2": date.today().year,
         "policy_contact": "Policy contact",
     }
 
-    form = forms.TaskWorkflowUpdateForm(data=form_data, instance=task_workflow)
+    form = forms.TaskWorkflowUpdateForm(data=form_data, instance=assigned_task_workflow)
     assert form.is_valid()
 
     workflow = form.save()

--- a/tasks/tests/test_models.py
+++ b/tasks/tests/test_models.py
@@ -81,6 +81,17 @@ def test_task_assignee_workbasket_reviewers_queryset(
     assert workbasket_reviewer_assignee in workbasket_reviewers
 
 
+def test_task_incomplete_queryset(task):
+    """Tests that `TaskQueryset.incomplete()` excludes `Task` instances that are
+    marked as done."""
+    done_task = TaskFactory.create(progress_state__name=ProgressState.State.DONE)
+    incomplete_tasks = Task.objects.incomplete()
+
+    assert Task.objects.count() == 2
+    assert task in incomplete_tasks
+    assert done_task not in incomplete_tasks
+
+
 def test_non_workflow_queryset(task, task_workflow_single_task_item):
     """Test correct behaviour of TaskQueryset.non_workflow()."""
 

--- a/tasks/tests/test_models.py
+++ b/tasks/tests/test_models.py
@@ -37,6 +37,21 @@ def test_task_assignee_unassign_user_classmethod(task_assignee):
     assert not TaskAssignee.unassign_user(user=user, task=task, instigator=user)
 
 
+def test_task_assignee_assign_user_classmethod(task_assignee, valid_user):
+    """Tests that `TaskAssignee.assign_user()` assigns the new user to the task
+    and unassigns the existing assignee."""
+    old_assignee = task_assignee.user
+    task = task_assignee.task
+
+    new_assignee = TaskAssignee.assign_user(
+        user=valid_user,
+        task=task,
+        instigator=valid_user,
+    )
+    assert task.assignees.assigned().get() == new_assignee
+    assert TaskAssignee.objects.unassigned().get(user=old_assignee, task=task)
+
+
 def test_task_assignee_assigned_queryset(
     task_assignee,
 ):
@@ -81,10 +96,17 @@ def test_task_assignee_workbasket_reviewers_queryset(
     assert workbasket_reviewer_assignee in workbasket_reviewers
 
 
-def test_task_incomplete_queryset(task):
+def test_task_incomplete_queryset():
     """Tests that `TaskQueryset.incomplete()` excludes `Task` instances that are
     marked as done."""
-    done_task = TaskFactory.create(progress_state__name=ProgressState.State.DONE)
+    task = TaskFactory.create(
+        progress_state=ProgressStateFactory.create(
+            name=ProgressState.State.IN_PROGRESS,
+        ),
+    )
+    done_task = TaskFactory.create(
+        progress_state=ProgressStateFactory.create(name=ProgressState.State.DONE),
+    )
     incomplete_tasks = Task.objects.incomplete()
 
     assert Task.objects.count() == 2

--- a/tasks/tests/test_views.py
+++ b/tasks/tests/test_views.py
@@ -735,11 +735,17 @@ def test_workflow_update_view_reassigns_tasks(
     """Tests that when a workflow is updated with a new assignee, all associated
     tasks are assigned to that user except for those marked as done."""
 
-    TaskItemFactory.create_batch(2, workflow=assigned_task_workflow)
-    done_state = ProgressStateFactory.create(name=ProgressState.State.DONE)
+    TaskItemFactory.create_batch(
+        2,
+        workflow=assigned_task_workflow,
+        task__progress_state=ProgressStateFactory.create(
+            name=ProgressState.State.TO_DO,
+        ),
+    )
+
     done_task = TaskItemFactory.create(
         workflow=assigned_task_workflow,
-        task__progress_state=done_state,
+        task__progress_state=ProgressStateFactory.create(name=ProgressState.State.DONE),
     ).task
 
     form_data = {

--- a/tasks/views.py
+++ b/tasks/views.py
@@ -555,7 +555,7 @@ class TaskWorkflowCreateView(PermissionRequiredMixin, FormView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context["verbose_name"] = "ticket"
-        context["list_url"] = "#NOT-IMPLEMENTED"
+        context["list_url"] = reverse("workflow:task-workflow-ui-list")
         return context
 
     def form_valid(self, form):


### PR DESCRIPTION
# TP2000-1741  Add ticket assignment to ticket create & edit forms

## Why
Users need the capabilities to add an assignee when creating a new ticket and to edit an assignee of an existing ticket.

## What
- Handles user assignment on ticket create form & view
    -  Creates an assignee for the (ticket) summary task in addition to all other associated task instances (steps)
 
- Handles user assignment on ticket edit form & form
    - Same as creation, except task instances (steps) marked as done are not reassigned

- Updates view and form unit tests

- Adds a new queryset method to filter out task instances (steps) that are marked as done

## Screenshots
<details><summary>Ticket create form</summary>
<p>
<img width="553" alt="Screenshot 2025-03-07 at 11 05 04" src="https://github.com/user-attachments/assets/99c0dca0-e6dd-4528-82be-65e0b328156e" />
</p>
</details> 

<details><summary>Ticket edit form</summary>
<p>
<img width="553" alt="Screenshot 2025-03-07 at 11 05 40" src="https://github.com/user-attachments/assets/35a35720-c6f4-4aec-866b-c65ffc29a70f" />
</p>
</details> 
