### PR TITLE
TP2000-1765-Fix-measures-search-conditions-bug

### DIFF
--- a/measures/jinja2/includes/measures/conditions.jinja
+++ b/measures/jinja2/includes/measures/conditions.jinja
@@ -1,7 +1,7 @@
 {% macro conditions_list(measure, workbasket) -%}
   {% set latest_approved_transaction = workbasket.transactions.last() if workbasket else None %}
   <ol class="govuk-list">
-    {% for condition in measure.conditions.approved_up_to_transaction(transaction).with_reference_price_string() -%}
+    {% for condition in measure.conditions.approved_up_to_transaction(latest_approved_transaction).with_reference_price_string() -%}
       <li title="{{ condition.description }}">
 
         <span class="condition_code">

--- a/measures/jinja2/includes/measures/conditions.jinja
+++ b/measures/jinja2/includes/measures/conditions.jinja
@@ -1,6 +1,7 @@
 {% macro conditions_list(measure, workbasket) -%}
+  {% set latest_approved_transaction = workbasket.transactions.last() if workbasket else None %}
   <ol class="govuk-list">
-    {% for condition in measure.conditions.approved_up_to_transaction(workbasket.transactions.last()).with_reference_price_string() -%}
+    {% for condition in measure.conditions.approved_up_to_transaction(transaction).with_reference_price_string() -%}
       <li title="{{ condition.description }}">
 
         <span class="condition_code">


### PR DESCRIPTION
# TP2000-1765-Fix-measures-search-conditions-bug
<!---
 * Include the JIRA ticket number, eg TP-123, to automatically link.
 * Use 50 characters maximum.
 * Do not end with a full-stop.
--->

## Why
<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Use as many lines as you like.
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions or deliberately ignored edge-cases.
--->

HMRC have reported a bug when searching for measures gives a 500 response. This is because the conditions macro looks for the latest transaction in the workbasket to determine the conditions to show and HMRC users do not have a workbasket.

## What
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Explain like I'm 5.
 * Use pictures if you can.
--->

This PR updates the conditions macro to only check for the latest transaction if a workbasket is present. If not it will set the latest transaction to None which makes the `approved_up_to_transaction` default to the latest approved.

<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
## Checklist
- Requires migrations?
- Requires dependency updates?
--->

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
