### PR TITLE
TP2000-1767 Add required param to create_bucket()

### DIFF
--- a/workbaskets/tests/test_views.py
+++ b/workbaskets/tests/test_views.py
@@ -150,7 +150,12 @@ def test_download(
     bucket = "hmrc"
     settings.HMRC_STORAGE_BUCKET_NAME = bucket
     try:
-        s3_resource.create_bucket(Bucket="hmrc")
+        s3_resource.create_bucket(
+            Bucket="hmrc",
+            CreateBucketConfiguration={
+                "LocationConstraint": "eu-west-2",
+            },
+        )
     except s3.exceptions.BucketAlreadyOwnedByYou:
         pass
     with patch(


### PR DESCRIPTION
# TP2000-1767 Add required param to create_bucket()
<!---
 * Include the JIRA ticket number, eg TP-123, to automatically link.
 * Use 50 characters maximum.
 * Do not end with a full-stop.
--->

## Why
<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Use as many lines as you like.
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions or deliberately ignored edge-cases.
--->
The unit `test workbaskets/tests/test_views.py::test_download` has started to fail or failing intermittently because of a missing mandatory parameter to a Boto3 API call, `create_bucket()`.


## What
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Explain like I'm 5.
 * Use pictures if you can.
--->
Provides the mandatory parameter to fix the failing unit test.


<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
--->
## Checklist
- Requires migrations? No
- Requires dependency updates? No

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
