### PR TITLE
TP2000-1737 Move assignments and comments into workbaskets

### DIFF
--- a/common/tests/factories.py
+++ b/common/tests/factories.py
@@ -30,7 +30,7 @@ from measures.validators import MeasureTypeCombination
 from measures.validators import OrderNumberCaptureCode
 from publishing.models import ProcessingState
 from quotas.validators import QuotaEventType
-from tasks.models import UserAssignment
+from tasks.models import AssignmentType
 from workbaskets.validators import WorkflowStatus
 
 User = get_user_model()
@@ -1545,7 +1545,7 @@ class TaskFactory(factory.django.DjangoModelFactory):
 class UserAssignmentFactory(factory.django.DjangoModelFactory):
     user = factory.SubFactory(UserFactory)
     assigned_by = factory.SubFactory(UserFactory)
-    assignment_type = FuzzyChoice(UserAssignment.AssignmentType.values)
+    assignment_type = FuzzyChoice(AssignmentType.values)
     task = factory.SubFactory(TaskFactory)
 
     class Meta:
@@ -1562,11 +1562,11 @@ class AssignedWorkBasketFactory(WorkBasketFactory):
 
         task = TaskFactory.create(workbasket=self)
         UserAssignmentFactory.create(
-            assignment_type=UserAssignment.AssignmentType.WORKBASKET_WORKER,
+            assignment_type=AssignmentType.WORKBASKET_WORKER,
             task=task,
         )
         UserAssignmentFactory.create(
-            assignment_type=UserAssignment.AssignmentType.WORKBASKET_REVIEWER,
+            assignment_type=AssignmentType.WORKBASKET_REVIEWER,
             task=task,
         )
 

--- a/common/tests/test_views.py
+++ b/common/tests/test_views.py
@@ -16,7 +16,7 @@ from common.util import xml_fromstring
 from common.views import HealthCheckView
 from common.views import handler403
 from common.views import handler500
-from tasks.models import UserAssignment
+from tasks.models import AssignmentType
 from workbaskets.validators import WorkflowStatus
 
 pytestmark = pytest.mark.django_db
@@ -276,7 +276,7 @@ def test_homepage_card_currently_working_on(status, valid_user, valid_user_clien
     workbasket = factories.WorkBasketFactory.create(status=status, reason=test_reason)
     factories.UserAssignmentFactory.create(
         user=valid_user,
-        assignment_type=UserAssignment.AssignmentType.WORKBASKET_REVIEWER,
+        assignment_type=AssignmentType.WORKBASKET_REVIEWER,
         task__workbasket=workbasket,
     )
     TrackedModelCheckFactory.create(
@@ -378,8 +378,7 @@ def test_resources_view_displays_resources(heading, expected_url, valid_user_cli
 @override_settings(SSO_ENABLED=True)
 def test_admin_login_shows_404_when_sso_enabled(superuser_client):
     """Test to check that when staff SSO is enabled, the login page shows a 404
-    but the rest of the admin site is still available.
-    """
+    but the rest of the admin site is still available."""
     response = superuser_client.get(reverse("admin:login"))
     assert response.status_code == 404
 

--- a/common/views/pages.py
+++ b/common/views/pages.py
@@ -47,6 +47,7 @@ from measures.models import Measure
 from publishing.models import PackagedWorkBasket
 from quotas.models import QuotaOrderNumber
 from regulations.models import Regulation
+from tasks.models import AssignmentType
 from tasks.models import UserAssignment
 from workbaskets.models import WorkBasket
 from workbaskets.models import WorkflowStatus
@@ -75,8 +76,7 @@ class HomeView(LoginRequiredMixin, FormView):
             workbasket = assignment.task.workbasket
             assignment_type = (
                 "Assigned"
-                if assignment.assignment_type
-                == UserAssignment.AssignmentType.WORKBASKET_WORKER
+                if assignment.assignment_type == AssignmentType.WORKBASKET_WORKER
                 else "Reviewing"
             )
             rule_violations_count = workbasket.tracked_model_check_errors.count()

--- a/conftest.py
+++ b/conftest.py
@@ -71,7 +71,7 @@ from measures.models import MeasurementUnitQualifier
 from measures.models import MonetaryUnit
 from measures.parsers import DutySentenceParser
 from publishing.models import PackagedWorkBasket
-from tasks.models import UserAssignment
+from tasks.models import AssignmentType
 from workbaskets.models import WorkBasket
 from workbaskets.models import get_partition_scheme
 from workbaskets.validators import WorkflowStatus
@@ -542,11 +542,11 @@ def workbasket():
 
     task = factories.TaskFactory.create(workbasket=workbasket)
     factories.UserAssignmentFactory.create(
-        assignment_type=UserAssignment.AssignmentType.WORKBASKET_WORKER,
+        assignment_type=AssignmentType.WORKBASKET_WORKER,
         task=task,
     )
     factories.UserAssignmentFactory.create(
-        assignment_type=UserAssignment.AssignmentType.WORKBASKET_REVIEWER,
+        assignment_type=AssignmentType.WORKBASKET_REVIEWER,
         task=task,
     )
     return workbasket

--- a/tasks/models.py
+++ b/tasks/models.py
@@ -30,20 +30,21 @@ class UserAssignmentQueryset(models.QuerySet):
 
     def workbasket_workers(self):
         return self.filter(
-            assignment_type=UserAssignment.AssignmentType.WORKBASKET_WORKER,
+            assignment_type=AssignmentType.WORKBASKET_WORKER,
         )
 
     def workbasket_reviewers(self):
         return self.filter(
-            assignment_type=UserAssignment.AssignmentType.WORKBASKET_REVIEWER,
+            assignment_type=AssignmentType.WORKBASKET_REVIEWER,
         )
 
 
-class UserAssignment(TimestampedMixin):
-    class AssignmentType(models.TextChoices):
-        WORKBASKET_WORKER = "WORKBASKET_WORKER", "Workbasket worker"
-        WORKBASKET_REVIEWER = "WORKBASKET_REVIEWER", "Workbasket reviewer"
+class AssignmentType(models.TextChoices):
+    WORKBASKET_WORKER = "WORKBASKET_WORKER", "Workbasket worker"
+    WORKBASKET_REVIEWER = "WORKBASKET_REVIEWER", "Workbasket reviewer"
 
+
+class UserAssignment(TimestampedMixin):
     user = models.ForeignKey(
         settings.AUTH_USER_MODEL,
         on_delete=models.PROTECT,

--- a/tasks/tests/conftest.py
+++ b/tasks/tests/conftest.py
@@ -2,7 +2,7 @@ import pytest
 
 from common.tests.factories import TaskFactory
 from common.tests.factories import UserAssignmentFactory
-from tasks.models import UserAssignment
+from tasks.models import AssignmentType
 
 
 @pytest.fixture()
@@ -18,12 +18,12 @@ def user_assignment():
 @pytest.fixture()
 def workbasket_worker_assignment():
     return UserAssignmentFactory.create(
-        assignment_type=UserAssignment.AssignmentType.WORKBASKET_WORKER,
+        assignment_type=AssignmentType.WORKBASKET_WORKER,
     )
 
 
 @pytest.fixture()
 def workbasket_reviewer_assignment():
     return UserAssignmentFactory.create(
-        assignment_type=UserAssignment.AssignmentType.WORKBASKET_REVIEWER,
+        assignment_type=AssignmentType.WORKBASKET_REVIEWER,
     )

--- a/workbaskets/forms.py
+++ b/workbaskets/forms.py
@@ -18,6 +18,7 @@ from django.utils.timezone import make_aware
 from common.validators import AlphanumericValidator
 from common.validators import SymbolValidator
 from common.validators import markdown_tags_allowlist
+from tasks.models import AssignmentType
 from tasks.models import Comment
 from tasks.models import Task
 from tasks.models import UserAssignment
@@ -209,7 +210,7 @@ class WorkBasketAssignUsersForm(forms.Form):
         error_messages={"required": "Select one or more users to assign"},
     )
     assignment_type = forms.ChoiceField(
-        choices=UserAssignment.AssignmentType.choices,
+        choices=AssignmentType.choices,
         widget=forms.RadioSelect,
         error_messages={"required": "Select an assignment type"},
     )

--- a/workbaskets/tests/test_forms.py
+++ b/workbaskets/tests/test_forms.py
@@ -1,6 +1,7 @@
 import pytest
 
 from common.tests import factories
+from tasks.models import AssignmentType
 from tasks.models import UserAssignment
 from workbaskets import forms
 from workbaskets.validators import tops_jira_number_validator
@@ -129,7 +130,7 @@ def test_workbasket_assign_users_form_assigns_users(rf, valid_user, user_workbas
     users = factories.UserFactory.create_batch(2, is_superuser=True)
     data = {
         "users": users,
-        "assignment_type": UserAssignment.AssignmentType.WORKBASKET_WORKER,
+        "assignment_type": AssignmentType.WORKBASKET_WORKER,
     }
 
     form = forms.WorkBasketAssignUsersForm(
@@ -168,7 +169,7 @@ def test_workbasket_unassign_users_form_unassigns_users(
     request.user = valid_user
     assignments = factories.UserAssignmentFactory.create_batch(
         2,
-        assignment_type=UserAssignment.AssignmentType.WORKBASKET_REVIEWER,
+        assignment_type=AssignmentType.WORKBASKET_REVIEWER,
         task__workbasket=user_workbasket,
     )
     data = {

--- a/workbaskets/tests/test_models.py
+++ b/workbaskets/tests/test_models.py
@@ -19,6 +19,7 @@ from common.tests.factories import TransactionFactory
 from common.tests.factories import WorkBasketFactory
 from common.tests.util import assert_transaction_order
 from common.validators import UpdateType
+from tasks.models import AssignmentType
 from tasks.models import UserAssignment
 from workbaskets import tasks
 from workbaskets.models import REVISION_ONLY
@@ -368,11 +369,11 @@ def test_queue(valid_user, unapproved_checked_transaction):
     wb = unapproved_checked_transaction.workbasket
     task = factories.TaskFactory.create(workbasket=wb)
     factories.UserAssignmentFactory.create(
-        assignment_type=UserAssignment.AssignmentType.WORKBASKET_WORKER,
+        assignment_type=AssignmentType.WORKBASKET_WORKER,
         task=task,
     )
     factories.UserAssignmentFactory.create(
-        assignment_type=UserAssignment.AssignmentType.WORKBASKET_REVIEWER,
+        assignment_type=AssignmentType.WORKBASKET_REVIEWER,
         task=task,
     )
     wb.queue(valid_user.pk, settings.TRANSACTION_SCHEMA)
@@ -455,11 +456,11 @@ def test_unassigned_workbasket_cannot_be_queued():
 
     factories.UserAssignmentFactory.create(
         user=worker,
-        assignment_type=UserAssignment.AssignmentType.WORKBASKET_WORKER,
+        assignment_type=AssignmentType.WORKBASKET_WORKER,
         task=task,
     )
     factories.UserAssignmentFactory.create(
-        assignment_type=UserAssignment.AssignmentType.WORKBASKET_REVIEWER,
+        assignment_type=AssignmentType.WORKBASKET_REVIEWER,
         task=task,
     )
     assert workbasket.is_fully_assigned()
@@ -471,11 +472,11 @@ def test_unassigned_workbasket_cannot_be_queued():
 def test_workbasket_user_assignments_queryset():
     workbasket = factories.WorkBasketFactory.create()
     worker_assignment = factories.UserAssignmentFactory.create(
-        assignment_type=UserAssignment.AssignmentType.WORKBASKET_WORKER,
+        assignment_type=AssignmentType.WORKBASKET_WORKER,
         task__workbasket=workbasket,
     )
     reviewer_assignment = factories.UserAssignmentFactory.create(
-        assignment_type=UserAssignment.AssignmentType.WORKBASKET_REVIEWER,
+        assignment_type=AssignmentType.WORKBASKET_REVIEWER,
         task__workbasket=workbasket,
     )
     # Inactive assignment

--- a/workbaskets/tests/test_views.py
+++ b/workbaskets/tests/test_views.py
@@ -33,8 +33,8 @@ from exporter.tasks import upload_workbaskets
 from importer.models import ImportBatch
 from importer.models import ImportBatchStatus
 from measures.models import Measure
+from tasks.models import AssignmentType
 from tasks.models import Comment
-from tasks.models import UserAssignment
 from workbaskets import models
 from workbaskets.tasks import call_end_measures
 from workbaskets.tasks import check_workbasket_sync
@@ -301,12 +301,12 @@ def test_workbasket_assignments_appear(valid_user_client):
     task = factories.TaskFactory.create(workbasket=workbasket)
 
     worker_assignment = factories.UserAssignmentFactory.create(
-        assignment_type=UserAssignment.AssignmentType.WORKBASKET_WORKER,
+        assignment_type=AssignmentType.WORKBASKET_WORKER,
         task=task,
         user=worker,
     )
     reviewer_assignment = factories.UserAssignmentFactory.create(
-        assignment_type=UserAssignment.AssignmentType.WORKBASKET_REVIEWER,
+        assignment_type=AssignmentType.WORKBASKET_REVIEWER,
         task=task,
         user=reviewer,
     )
@@ -348,11 +348,11 @@ def test_select_workbasket_filtering(
     task = factories.TaskFactory.create(workbasket=fully_assigned_workbasket)
 
     factories.UserAssignmentFactory.create(
-        assignment_type=UserAssignment.AssignmentType.WORKBASKET_WORKER,
+        assignment_type=AssignmentType.WORKBASKET_WORKER,
         task=task,
     )
     factories.UserAssignmentFactory.create(
-        assignment_type=UserAssignment.AssignmentType.WORKBASKET_REVIEWER,
+        assignment_type=AssignmentType.WORKBASKET_REVIEWER,
         task=task,
     )
     # Create an unassigned workbasket
@@ -363,14 +363,14 @@ def test_select_workbasket_filtering(
         workbasket=reviewer_assigned_workbasket,
     )
     factories.UserAssignmentFactory.create(
-        assignment_type=UserAssignment.AssignmentType.WORKBASKET_REVIEWER,
+        assignment_type=AssignmentType.WORKBASKET_REVIEWER,
         task=reviewer_task,
     )
     # Create a workbasket with only a worker assigned
     worker_assigned_workbasket = factories.WorkBasketFactory.create(id=4)
     worker_task = factories.TaskFactory.create(workbasket=worker_assigned_workbasket)
     factories.UserAssignmentFactory.create(
-        assignment_type=UserAssignment.AssignmentType.WORKBASKET_WORKER,
+        assignment_type=AssignmentType.WORKBASKET_WORKER,
         task=worker_task,
     )
 
@@ -2333,11 +2333,11 @@ def test_disabled_packaging_for_unassigned_workbasket(
     # Assign the workbasket so it can now be packaged
     task = factories.TaskFactory.create(workbasket=user_empty_workbasket)
     factories.UserAssignmentFactory.create(
-        assignment_type=UserAssignment.AssignmentType.WORKBASKET_WORKER,
+        assignment_type=AssignmentType.WORKBASKET_WORKER,
         task=task,
     )
     factories.UserAssignmentFactory.create(
-        assignment_type=UserAssignment.AssignmentType.WORKBASKET_REVIEWER,
+        assignment_type=AssignmentType.WORKBASKET_REVIEWER,
         task=task,
     )
 


### PR DESCRIPTION
# TP2000-1737 Move assignments and comments into workbaskets
<!---
 * Include the JIRA ticket number, eg TP-123, to automatically link.
 * Use 50 characters maximum.
 * Do not end with a full-stop.
--->

## Why
<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Use as many lines as you like.
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions or deliberately ignored edge-cases.
--->
As part of preparing the way for tasks and workflows, the models used for user assignment and comments require moving to the workbaskets module.

## What
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Explain like I'm 5.
 * Use pictures if you can.
--->
This PR:
- Pulls the `AssignmentType` model out from inner class to a module-level class. It simplifies its use and overcomes an intractable data migration problem accessing the inner class via a migrator's `ProjectState` instance.

<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
--->
## Checklist
- Requires migrations? Yes
- Requires dependency updates? No

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
