### PR TITLE
TP2000-1742  Limit step assignment forms to a single assignee

### DIFF
--- a/common/static/common/js/components/TaskUserAssignment/AssignUserForm.js
+++ b/common/static/common/js/components/TaskUserAssignment/AssignUserForm.js
@@ -1,12 +1,12 @@
-/* global CSRF_TOKEN:readonly, assignUsersUrl:readonly */
+/* global CSRF_TOKEN:readonly, assignUserUrl:readonly */
 
 import React, { useEffect } from "react";
 import accessibleAutocomplete from "accessible-autocomplete";
 import PropTypes from "prop-types";
 
 function AssignUserForm({ users }) {
-  const elementId = "users-select";
-  const elementName = "users";
+  const elementId = "user-select";
+  const elementName = "user";
   const label = "Assign user";
   const hint = "Select a user to assign";
 
@@ -25,7 +25,7 @@ function AssignUserForm({ users }) {
   return (
     <>
       <form
-        action={assignUsersUrl}
+        action={assignUserUrl}
         method="POST"
         data-testid={"assign-user-form"}
       >

--- a/common/static/common/js/components/TaskUserAssignment/UnassignUserForm.js
+++ b/common/static/common/js/components/TaskUserAssignment/UnassignUserForm.js
@@ -1,12 +1,12 @@
-/* global CSRF_TOKEN:readonly, unassignUsersUrl:readonly */
+/* global CSRF_TOKEN:readonly, unassignUserUrl:readonly */
 
 import React, { useEffect } from "react";
 import accessibleAutocomplete from "accessible-autocomplete";
 import PropTypes from "prop-types";
 
-function UnassignUserForm({ users }) {
-  const elementId = "assignees-select";
-  const elementName = "assignees";
+function UnassignUserForm({ user }) {
+  const elementId = "assignee-select";
+  const elementName = "assignee";
   const label = "Unassign user";
   const hint = "Select a user to unassign";
 
@@ -24,7 +24,7 @@ function UnassignUserForm({ users }) {
 
   return (
     <form
-      action={unassignUsersUrl}
+      action={unassignUserUrl}
       method="POST"
       data-testid={"unassign-user-form"}
     >
@@ -43,11 +43,9 @@ function UnassignUserForm({ users }) {
           data-testid="unassign-user-select"
         >
           <option value="">Select a user</option>
-          {users.map((user) => (
-            <option key={user.pk} value={user.pk}>
-              {user.name}
-            </option>
-          ))}
+          <option key={user.pk} value={user.pk}>
+            {user.name}
+          </option>
         </select>
       </div>
       <button
@@ -62,12 +60,10 @@ function UnassignUserForm({ users }) {
 }
 
 UnassignUserForm.propTypes = {
-  users: PropTypes.arrayOf(
-    PropTypes.shape({
-      pk: PropTypes.number.isRequired,
-      name: PropTypes.string.isRequired,
-    }),
-  ),
+  user: PropTypes.shape({
+    pk: PropTypes.number.isRequired,
+    name: PropTypes.string.isRequired,
+  }),
 };
 
 export { UnassignUserForm };

--- a/common/static/common/js/components/TaskUserAssignment/index.js
+++ b/common/static/common/js/components/TaskUserAssignment/index.js
@@ -1,4 +1,4 @@
-/* global assignableUsers:readonly, currentAssignees:readonly */
+/* global assignableUsers:readonly, currentAssignee:readonly */
 
 import React, { useState } from "react";
 import { createPortal } from "react-dom";
@@ -15,13 +15,19 @@ import { UnassignUserForm } from "./UnassignUserForm";
  * @param buttonId The button's element ID
  * @param formId The form's element ID
  */
-function TaskUserAssignment({ action, users, buttonId, formId }) {
+function TaskUserAssignment({
+  action,
+  assignableUsers,
+  currentAssignee,
+  buttonId,
+  formId,
+}) {
   const [showForm, setShowForm] = useState(null);
 
   const removeFormDiv = () => {
     const possibleFormDivs = [
-      document.getElementById("assign-users-form"),
-      document.getElementById("unassign-users-form"),
+      document.getElementById("assign-user-form"),
+      document.getElementById("unassign-user-form"),
     ];
     possibleFormDivs.forEach((form) => {
       if (form) {
@@ -38,7 +44,7 @@ function TaskUserAssignment({ action, users, buttonId, formId }) {
     formDiv.className = "govuk-!-margin-top-4";
 
     const assignedUsersContent = document.getElementById(
-      "assigned-users-content",
+      "assigned-user-content",
     );
     assignedUsersContent.classList.add("govuk-summary-list__row--no-border");
     assignedUsersContent.after(formDiv);
@@ -59,9 +65,9 @@ function TaskUserAssignment({ action, users, buttonId, formId }) {
 
   function UserForm({ action }) {
     if (action === "Assign") {
-      return <AssignUserForm users={users} />;
+      return <AssignUserForm users={assignableUsers} />;
     } else {
-      return <UnassignUserForm users={users} />;
+      return <UnassignUserForm user={currentAssignee} />;
     }
   }
 
@@ -84,12 +90,16 @@ function TaskUserAssignment({ action, users, buttonId, formId }) {
 }
 TaskUserAssignment.propTypes = {
   action: PropTypes.string.isRequired,
-  users: PropTypes.arrayOf(
+  assignableUsers: PropTypes.arrayOf(
     PropTypes.shape({
       pk: PropTypes.number.isRequired,
       name: PropTypes.string.isRequired,
     }),
   ),
+  currentAssignee: PropTypes.shape({
+    pk: PropTypes.number.isRequired,
+    name: PropTypes.string.isRequired,
+  }),
   buttonId: PropTypes.string.isRequired,
   formId: PropTypes.string.isRequired,
 };
@@ -99,28 +109,28 @@ TaskUserAssignment.propTypes = {
  * for each assign/unassign link on the Task detail view.
  */
 function init() {
-  const assignUsersLink = document.getElementById("assign-users");
-  if (assignUsersLink) {
-    const assignUsers = createRoot(assignUsersLink);
-    assignUsers.render(
+  const assignUserLink = document.getElementById("assign-user");
+  if (assignUserLink) {
+    const assignUser = createRoot(assignUserLink);
+    assignUser.render(
       <TaskUserAssignment
         action="Assign"
-        users={assignableUsers}
-        buttonId="assign-users"
-        formId="assign-users-form"
+        assignableUsers={assignableUsers}
+        buttonId="assign-user"
+        formId="assign-user-form"
       />,
     );
   }
 
-  const unassignUsersLink = document.getElementById("unassign-users");
-  if (unassignUsersLink) {
-    const unassignUsers = createRoot(unassignUsersLink);
-    unassignUsers.render(
+  const unassignUserLink = document.getElementById("unassign-user");
+  if (unassignUserLink) {
+    const unassignUser = createRoot(unassignUserLink);
+    unassignUser.render(
       <TaskUserAssignment
         action="Unassign"
-        users={currentAssignees}
-        buttonId="unassign-users"
-        formId="unassign-users-form"
+        currentAssignee={currentAssignee}
+        buttonId="unassign-user"
+        formId="unassign-user-form"
       />,
     );
   }

--- a/common/tests/factories.py
+++ b/common/tests/factories.py
@@ -1543,7 +1543,7 @@ class CategoryFactory(factory.django.DjangoModelFactory):
 
 
 class ProgressStateFactory(factory.django.DjangoModelFactory):
-    name = FuzzyChoice(ProgressState.State.values)
+    name = ProgressState.State.TO_DO
 
     class Meta:
         model = "tasks.ProgressState"

--- a/tasks/forms.py
+++ b/tasks/forms.py
@@ -1,5 +1,3 @@
-from datetime import datetime
-
 import bleach
 import markdown
 from crispy_forms_gds.helper import FormHelper
@@ -16,13 +14,10 @@ from django.core.exceptions import ValidationError
 from django.db import transaction
 from django.db.models import TextChoices
 from django.forms import CharField
-from django.forms import CheckboxSelectMultiple
 from django.forms import Form
 from django.forms import ModelChoiceField
 from django.forms import ModelForm
-from django.forms import ModelMultipleChoiceField
 from django.forms import Textarea
-from django.utils.timezone import make_aware
 
 from common.fields import AutoCompleteField
 from common.forms import BindNestedFormMixin
@@ -32,12 +27,12 @@ from common.forms import delete_form_for
 from common.validators import SymbolValidator
 from common.validators import markdown_tags_allowlist
 from tasks.models import Comment
+from tasks.models import ProgressState
 from tasks.models import Task
 from tasks.models import TaskAssignee
 from tasks.models import TaskTemplate
 from tasks.models import TaskWorkflow
 from tasks.models import TaskWorkflowTemplate
-from tasks.signals import set_current_instigator
 from workbaskets.models import WorkBasket
 
 User = get_user_model()
@@ -160,7 +155,7 @@ class AssignUserForm(Form):
         return super().clean()
 
     @transaction.atomic
-    def assign_user(self, task: Task, user_instigator) -> list[TaskAssignee]:
+    def assign_user(self, task: Task, user_instigator) -> TaskAssignee:
         user = self.cleaned_data["user"]
 
         return TaskAssignee.assign_user(
@@ -170,13 +165,11 @@ class AssignUserForm(Form):
         )
 
 
-class UnassignUsersForm(Form):
-    assignees = ModelMultipleChoiceField(
-        label="Users",
-        help_text="Select users to unassign",
-        widget=CheckboxSelectMultiple,
-        queryset=TaskAssignee.objects.all(),
-        error_messages={"required": "Select one or more users to unassign"},
+class UnassignUserForm(Form):
+    assignee = ModelChoiceField(
+        label="Select user",
+        queryset=TaskAssignee.objects.assigned(),
+        error_messages={"required": "Select a user to unassign"},
     )
 
     def __init__(self, *args, **kwargs):
@@ -186,13 +179,9 @@ class UnassignUsersForm(Form):
         self.init_layout()
 
     def init_fields(self):
-        self.fields["assignees"].queryset = self.task.assignees.order_by(
-            "user__first_name",
-            "user__last_name",
-        ).exclude(unassigned_at__isnull=False)
-
-        self.fields["assignees"].label_from_instance = (
-            lambda obj: f"{obj.user.get_full_name()}"
+        self.fields["assignee"].queryset = self.task.assignees.assigned()
+        self.fields["assignee"].label_from_instance = (
+            lambda obj: obj.user.get_displayname()
         )
 
     def init_layout(self):
@@ -200,7 +189,7 @@ class UnassignUsersForm(Form):
         self.helper.label_size = Size.SMALL
         self.helper.legend_size = Size.SMALL
         self.helper.layout = Layout(
-            "assignees",
+            "assignee",
             Submit(
                 "submit",
                 "Save",
@@ -209,19 +198,22 @@ class UnassignUsersForm(Form):
             ),
         )
 
+    def clean(self):
+        if self.task.progress_state.name == ProgressState.State.DONE:
+            raise ValidationError(
+                "The selected user cannot be unassigned because the step has a status of Done.",
+            )
+
+        return super().clean()
+
     @transaction.atomic
-    def unassign_users(self, user_instigator) -> int:
-        """Set assignees as unassigned from their associated task and return the
-        number of assignees that have been updated in this way."""
-        set_current_instigator(user_instigator)
+    def unassign_user(self, user_instigator) -> bool:
+        assignee = self.cleaned_data["assignee"]
 
-        assignees = self.cleaned_data["assignees"]
-        for assignee in assignees:
-            assignee.unassigned_at = make_aware(datetime.now())
-
-        return TaskAssignee.objects.bulk_update(
-            assignees,
-            fields=["unassigned_at"],
+        return TaskAssignee.unassign_user(
+            user=assignee.user,
+            task=self.task,
+            instigator=user_instigator,
         )
 
 

--- a/tasks/forms.py
+++ b/tasks/forms.py
@@ -149,7 +149,9 @@ class AssignUserForm(Form):
     def clean(self):
         if self.task.assignees.assigned().exists():
             raise ValidationError(
-                "The selected user cannot be assigned because this step already has an assignee.",
+                {
+                    "user": "The selected user cannot be assigned because the step already has an assignee.",
+                },
             )
 
         return super().clean()
@@ -201,7 +203,9 @@ class UnassignUserForm(Form):
     def clean(self):
         if self.task.progress_state.name == ProgressState.State.DONE:
             raise ValidationError(
-                "The selected user cannot be unassigned because the step has a status of Done.",
+                {
+                    "assignee": "The selected user cannot be unassigned because the step has a status of Done.",
+                },
             )
 
         return super().clean()

--- a/tasks/jinja2/tasks/assign_users.jinja
+++ b/tasks/jinja2/tasks/assign_users.jinja
@@ -6,9 +6,11 @@
 
 {% block breadcrumb %}
   {{ breadcrumbs(request, [
-      {"text": "Find and view tasks", "href": url("workflow:task-ui-list")},
-      {"text": page_title}
-    ]
+      {"text": "Ticket " ~ ticket.id, "href": ticket.get_url("detail")},
+      {"text": "Step: " ~ step.title, "href": step.get_url("detail")},
+      {"text": page_title},
+    ],
+    with_workbasket=False,
   ) }}
 {% endblock %}
 

--- a/tasks/jinja2/tasks/detail.jinja
+++ b/tasks/jinja2/tasks/detail.jinja
@@ -177,7 +177,7 @@
       Assignee
     </dt>
     <dd class="govuk-summary-list__value">
-      <div id="assigned-users-content">
+      <div id="assigned-user-content">
         <div class="govuk-!-margin-bottom-3">
           {{ current_assignee.name if current_assignee else "None" }}
         </div>
@@ -188,7 +188,7 @@
         {% if not current_assignee %}
         <li class="govuk-summary-list__actions-list-item">
           <a
-            id="assign-users"
+            id="assign-user"
             class="govuk-link"
             href="{{ url('workflow:task-ui-assign-user', kwargs={'pk': object.pk}) }}"
           >Assign<span class="govuk-visually-hidden"> user</span></a>
@@ -196,7 +196,7 @@
         {% elif current_assignee %}
         <li class="govuk-summary-list__actions-list-item">
           <a
-            id="unassign-users"
+            id="unassign-user"
             class="govuk-link"
             href="{{ url('workflow:task-ui-unassign-user', kwargs={'pk': object.pk}) }}"
           >Unassign<span class="govuk-visually-hidden"> user</span></a>
@@ -237,16 +237,16 @@
   {% endif %}
 </div>
 
-{% set assign_users_link = url("workflow:task-ui-assign-user", kwargs={"pk": object.pk}) %}
-{% set unassign_users_link = url("workflow:task-ui-unassign-user", kwargs={"pk": object.pk}) %}
+{% set assign_user_link = url("workflow:task-ui-assign-user", kwargs={"pk": object.pk}) %}
+{% set unassign_user_link = url("workflow:task-ui-unassign-user", kwargs={"pk": object.pk}) %}
 
 <script nonce="{{ request.csp_nonce }}">
   const CSRF_TOKEN = "{{ csrf_token }}";
 
-  const currentAssignees = {{ current_assignees|safe }};
+  const currentAssignee = {{ current_assignee|safe }};
   const assignableUsers = {{ assignable_users|safe }};
 
-  const assignUsersUrl = "{{ assign_users_link }}";
-  const unassignUsersUrl = "{{ unassign_users_link }}";
+  const assignUserUrl = "{{ assign_user_link }}";
+  const unassignUserUrl = "{{ unassign_user_link }}";
 </script>
 {% endblock %}

--- a/tasks/jinja2/tasks/detail.jinja
+++ b/tasks/jinja2/tasks/detail.jinja
@@ -35,20 +35,6 @@
   {% endif -%}
 {% endset %}
 
-{% macro display_assignees(assignees) %}
-  {% if not assignees %}
-    <div class="govuk-!-margin-bottom-3">
-      None
-    </div>
-  {% else %}
-    {% for assignee in assignees %}
-      <div class="govuk-!-margin-bottom-3">
-      {{ assignee.name }}{% if not loop.last %}, {% endif %}
-      </div>
-    {% endfor %}
-  {% endif %}
-{% endmacro %}
-
 {% block breadcrumb %}
   {{ breadcrumbs(request, [
       {"text": "Find and view tasks", "href": url("workflow:task-ui-list")},
@@ -188,29 +174,32 @@
 
   <div class="govuk-summary-list__row">
     <dt class="govuk-summary-list__key">
-      Assignees
+      Assignee
     </dt>
     <dd class="govuk-summary-list__value">
       <div id="assigned-users-content">
-        {{ display_assignees(current_assignees) }}
+        <div class="govuk-!-margin-bottom-3">
+          {{ current_assignee.name if current_assignee else "None" }}
+        </div>
       </div>
     </dd>
     <dd class="govuk-summary-list__actions">
       <ul class="govuk-summary-list__actions-list">
+        {% if not current_assignee %}
         <li class="govuk-summary-list__actions-list-item">
           <a
             id="assign-users"
             class="govuk-link"
             href="{{ url('workflow:task-ui-assign-user', kwargs={'pk': object.pk}) }}"
-          >Assign<span class="govuk-visually-hidden"> users</span></a>
+          >Assign<span class="govuk-visually-hidden"> user</span></a>
         </li>
-        {% if current_assignees %}
+        {% elif current_assignee %}
         <li class="govuk-summary-list__actions-list-item">
           <a
             id="unassign-users"
             class="govuk-link"
             href="{{ url('workflow:task-ui-unassign-user', kwargs={'pk': object.pk}) }}"
-          >Unassign<span class="govuk-visually-hidden"> users</span></a>
+          >Unassign<span class="govuk-visually-hidden"> user</span></a>
         </li>
         {% endif %}
       </ul>

--- a/tasks/jinja2/tasks/detail.jinja
+++ b/tasks/jinja2/tasks/detail.jinja
@@ -209,7 +209,7 @@
           <a
             id="unassign-users"
             class="govuk-link"
-            href="{{ url('workflow:task-ui-unassign-users', kwargs={'pk': object.pk}) }}"
+            href="{{ url('workflow:task-ui-unassign-user', kwargs={'pk': object.pk}) }}"
           >Unassign<span class="govuk-visually-hidden"> users</span></a>
         </li>
         {% endif %}
@@ -249,7 +249,7 @@
 </div>
 
 {% set assign_users_link = url("workflow:task-ui-assign-user", kwargs={"pk": object.pk}) %}
-{% set unassign_users_link = url("workflow:task-ui-unassign-users", kwargs={"pk": object.pk}) %}
+{% set unassign_users_link = url("workflow:task-ui-unassign-user", kwargs={"pk": object.pk}) %}
 
 <script nonce="{{ request.csp_nonce }}">
   const CSRF_TOKEN = "{{ csrf_token }}";

--- a/tasks/jinja2/tasks/detail.jinja
+++ b/tasks/jinja2/tasks/detail.jinja
@@ -201,7 +201,7 @@
           <a
             id="assign-users"
             class="govuk-link"
-            href="{{ url('workflow:task-ui-assign-users', kwargs={'pk': object.pk}) }}"
+            href="{{ url('workflow:task-ui-assign-user', kwargs={'pk': object.pk}) }}"
           >Assign<span class="govuk-visually-hidden"> users</span></a>
         </li>
         {% if current_assignees %}
@@ -248,7 +248,7 @@
   {% endif %}
 </div>
 
-{% set assign_users_link = url("workflow:task-ui-assign-users", kwargs={"pk": object.pk}) %}
+{% set assign_users_link = url("workflow:task-ui-assign-user", kwargs={"pk": object.pk}) %}
 {% set unassign_users_link = url("workflow:task-ui-unassign-users", kwargs={"pk": object.pk}) %}
 
 <script nonce="{{ request.csp_nonce }}">

--- a/tasks/mixins.py
+++ b/tasks/mixins.py
@@ -1,0 +1,104 @@
+from django.db import OperationalError
+from django.shortcuts import get_object_or_404
+from django.urls import reverse
+from django.utils.functional import cached_property
+
+from tasks.models import Queue
+from tasks.models import QueueItem
+from tasks.models import Task
+
+
+class QueuedItemManagementMixin:
+    """A view mixin providing helper functions to manage queued items."""
+
+    queued_item_model: type[QueueItem] = None
+    """The model responsible for managing members of a queue."""
+
+    item_lookup_field: str = ""
+    """The lookup field of the instance managed by a queued item."""
+
+    queue_field: str = ""
+    """The name of the ForeignKey field relating a queued item to a queue."""
+
+    @cached_property
+    def queue(self) -> type[Queue]:
+        """The queue instance that is the object of the view."""
+        return self.get_object()
+
+    def promote(self, lookup_id: int) -> None:
+        queued_item = get_object_or_404(
+            self.queued_item_model,
+            **{
+                self.item_lookup_field: lookup_id,
+                self.queue_field: self.queue,
+            },
+        )
+        try:
+            queued_item.promote()
+        except OperationalError:
+            pass
+
+    def demote(self, lookup_id: int) -> None:
+        queued_item = get_object_or_404(
+            self.queued_item_model,
+            **{
+                self.item_lookup_field: lookup_id,
+                self.queue_field: self.queue,
+            },
+        )
+        try:
+            queued_item.demote()
+        except OperationalError:
+            pass
+
+    def promote_to_first(self, lookup_id: int) -> None:
+        queued_item = get_object_or_404(
+            self.queued_item_model,
+            **{
+                self.item_lookup_field: lookup_id,
+                self.queue_field: self.queue,
+            },
+        )
+        try:
+            queued_item.promote_to_first()
+        except OperationalError:
+            pass
+
+    def demote_to_last(self, lookup_id: int) -> None:
+        queued_item = get_object_or_404(
+            self.queued_item_model,
+            **{
+                self.item_lookup_field: lookup_id,
+                self.queue_field: self.queue,
+            },
+        )
+        try:
+            queued_item.demote_to_last()
+        except OperationalError:
+            pass
+
+
+class TaskAssignmentMixin:
+    template_name = template_name = "tasks/assign_users.jinja"
+
+    @cached_property
+    def task(self):
+        return Task.objects.get(pk=self.kwargs["pk"])
+
+    def get_form_kwargs(self):
+        kwargs = super().get_form_kwargs()
+        kwargs["task"] = self.task
+        return kwargs
+
+    def get_context_data(self, *args, **kwargs):
+        context = super().get_context_data(*args, **kwargs)
+        context["page_title"] = "Assign user to step"
+        context["ticket"] = self.task.taskitem.workflow
+        context["step"] = self.task
+        return context
+
+    def get_success_url(self):
+        return reverse(
+            "workflow:task-ui-detail",
+            kwargs={"pk": self.kwargs["pk"]},
+        )

--- a/tasks/models/task.py
+++ b/tasks/models/task.py
@@ -158,6 +158,14 @@ class Task(TaskBase):
     def is_summary_task(self) -> bool:
         return hasattr(self, "taskworkflow")
 
+    def get_current_assignee(self) -> "TaskAssignee":
+        """Returns the currently active`TaskAssignee` instance associated to
+        this `Task` instance."""
+        try:
+            return self.assignees.assigned().get()
+        except TaskAssignee.DoesNotExist:
+            return TaskAssignee.objects.none()
+
     def __str__(self):
         return self.title
 
@@ -338,17 +346,14 @@ class TaskAssignee(TimestampedMixin):
 
         set_current_instigator(instigator)
 
-        try:
-            current_assignee = task.assignees.assigned().get().user
-        except cls.DoesNotExist:
-            current_assignee = None
+        current_assignee = task.get_current_assignee()
 
         if current_assignee:
-            if current_assignee == user:
+            if current_assignee.user == user:
                 return TaskAssignee.objects.none()
 
             cls.unassign_user(
-                user=current_assignee,
+                user=current_assignee.user,
                 task=task,
                 instigator=instigator,
             )

--- a/tasks/tests/conftest.py
+++ b/tasks/tests/conftest.py
@@ -5,6 +5,7 @@ from common.tests.factories import ProgressStateFactory
 from common.tests.factories import SubTaskFactory
 from common.tests.factories import TaskAssigneeFactory
 from common.tests.factories import TaskFactory
+from tasks.models import ProgressState
 from tasks.models import Task
 from tasks.models import TaskAssignee
 from tasks.models import TaskItem
@@ -18,6 +19,12 @@ from tasks.tests import factories
 @pytest.fixture()
 def task():
     return TaskFactory.create()
+
+
+@pytest.fixture()
+def done_task():
+    done_state = ProgressStateFactory.create(name=ProgressState.State.DONE)
+    return TaskFactory.create(progress_state=done_state)
 
 
 @pytest.fixture()

--- a/tasks/urls.py
+++ b/tasks/urls.py
@@ -28,9 +28,9 @@ task_ui_patterns = [
         name="task-ui-confirm-delete",
     ),
     path(
-        "<int:pk>/assign-users/",
-        views.TaskAssignUsersView.as_view(),
-        name="task-ui-assign-users",
+        "<int:pk>/assign-user/",
+        views.TaskAssignUserView.as_view(),
+        name="task-ui-assign-user",
     ),
     path(
         f"<int:pk>/unassign-users/",

--- a/tasks/urls.py
+++ b/tasks/urls.py
@@ -33,9 +33,9 @@ task_ui_patterns = [
         name="task-ui-assign-user",
     ),
     path(
-        f"<int:pk>/unassign-users/",
-        views.TaskUnassignUsersView.as_view(),
-        name="task-ui-unassign-users",
+        f"<int:pk>/unassign-user/",
+        views.TaskUnassignUserView.as_view(),
+        name="task-ui-unassign-user",
     ),
     # Subtask urls
     path(

--- a/tasks/views.py
+++ b/tasks/views.py
@@ -24,7 +24,7 @@ from tasks.filters import TaskAndWorkflowFilter
 from tasks.filters import TaskFilter
 from tasks.filters import TaskWorkflowFilter
 from tasks.filters import WorkflowTemplateFilter
-from tasks.forms import AssignUsersForm
+from tasks.forms import AssignUserForm
 from tasks.forms import SubTaskCreateForm
 from tasks.forms import TaskCreateForm
 from tasks.forms import TaskDeleteForm
@@ -207,10 +207,10 @@ class TaskConfirmDeleteView(PermissionRequiredMixin, TemplateView):
         return context_data
 
 
-class TaskAssignUsersView(PermissionRequiredMixin, FormView):
+class TaskAssignUserView(PermissionRequiredMixin, FormView):
     permission_required = "tasks.add_taskassignee"
     template_name = "tasks/assign_users.jinja"
-    form_class = AssignUsersForm
+    form_class = AssignUserForm
 
     @property
     def task(self):
@@ -218,11 +218,18 @@ class TaskAssignUsersView(PermissionRequiredMixin, FormView):
 
     def get_context_data(self, *args, **kwargs):
         context = super().get_context_data(*args, **kwargs)
-        context["page_title"] = "Assign users to task"
+        context["page_title"] = "Assign user to step"
+        context["ticket"] = self.task.taskitem.workflow
+        context["step"] = self.task
         return context
 
+    def get_form_kwargs(self):
+        kwargs = super().get_form_kwargs()
+        kwargs["task"] = self.task
+        return kwargs
+
     def form_valid(self, form):
-        form.assign_users(task=self.task, user_instigator=self.request.user)
+        form.assign_user(task=self.task, user_instigator=self.request.user)
         return HttpResponseRedirect(self.get_success_url())
 
     def get_success_url(self):


### PR DESCRIPTION
# TP2000-1742  Limit step assignment forms to a single assignee

## Why
A step (task) may currently be assigned to many users at once. Step assignment should be constrained to a single assignee at a time, like tickets (workflows).

## What
- Updates TaskAssignment React components and fall back forms to support single user assignment
- Adds view and form unit tests for step (task) assignment and unassignment
- Moves task-related view mixins to mixins.py

## Checklist
- Requires migrations? No
- Requires dependency updates? No

## Screenshots
<details><summary>Step detail view</summary>
<p>
<img width="500" alt="Screenshot 2025-03-17 at 12 26 41" src="https://github.com/user-attachments/assets/510115db-a14e-4916-9593-d323f3125cea" />

<img width="500" alt="Screenshot 2025-03-17 at 12 26 31" src="https://github.com/user-attachments/assets/c0e41c72-230d-4d9d-ab94-ba2773d70c7d" />
</p>
</details> 

<details><summary>Assign user to step fallback form</summary>
<p>
<img width="250" alt="Screenshot 2025-03-17 at 12 27 02" src="https://github.com/user-attachments/assets/e6a58ba3-1539-4927-91ab-60813bcbfd88" />
</p>
</details> 

<details><summary>Unassign user from step fallback form</summary>
<p>
<img width="250" alt="Screenshot 2025-03-17 at 12 27 24" src="https://github.com/user-attachments/assets/675bf151-0d32-448b-868a-180d179bbbf1" />
</p>
</details> 

