### PR TITLE
TP2000-1744 Support configurable ticket ID prefix

### DIFF
--- a/settings/common.py
+++ b/settings/common.py
@@ -948,4 +948,4 @@ MEASURES_ASYNC_EDIT = is_truthy(os.environ.get("MEASURES_ASYNC_EDIT", "true"))
 
 
 # Ticket naming prefix
-TICKET_PREFIX = "TC-"
+os.environ.get("TICKET_PREFIX", "TC-")

--- a/settings/common.py
+++ b/settings/common.py
@@ -948,4 +948,4 @@ MEASURES_ASYNC_EDIT = is_truthy(os.environ.get("MEASURES_ASYNC_EDIT", "true"))
 
 
 # Ticket naming prefix
-os.environ.get("TICKET_PREFIX", "TC-")
+TICKET_PREFIX = os.environ.get("TICKET_PREFIX", "TC-")

--- a/settings/common.py
+++ b/settings/common.py
@@ -945,3 +945,7 @@ DATA_MIGRATION_BATCH_SIZE = int(os.environ.get("DATA_MIGRATION_BATCH_SIZE", "100
 # Asynchronous / background (bulk) object creation and editing config.
 MEASURES_ASYNC_CREATION = is_truthy(os.environ.get("MEASURES_ASYNC_CREATION", "true"))
 MEASURES_ASYNC_EDIT = is_truthy(os.environ.get("MEASURES_ASYNC_EDIT", "true"))
+
+
+# Ticket naming prefix
+TICKET_PREFIX = "TC-"

--- a/tasks/filters.py
+++ b/tasks/filters.py
@@ -50,7 +50,7 @@ class TaskWorkflowFilter(TamatoFilter):
         "description",
     )
     if settings.TICKET_PREFIX:
-        search_regex = re.compile(rf"(?i)({settings.TICKET_PREFIX}?)(\d+)")
+        id_search_regex = re.compile(rf"(?i)({settings.TICKET_PREFIX}?)(\d+)")
 
     clear_url = reverse_lazy("workflow:task-workflow-ui-list")
 
@@ -78,8 +78,8 @@ class TaskWorkflowFilter(TamatoFilter):
         """Looks for a pattern matching a ticket ID with prefix and removes the
         ticket_prefix from the search groups."""
         value = value.strip()
-        if self.search_regex:
-            match = self.search_regex.search(value)
+        if self.id_search_regex:
+            match = self.id_search_regex.search(value)
             if match:
                 terms = list(match.groups())
                 terms = [term for term in terms if term != settings.TICKET_PREFIX]

--- a/tasks/filters.py
+++ b/tasks/filters.py
@@ -75,8 +75,8 @@ class TaskWorkflowFilter(TamatoFilter):
     )
 
     def get_search_term(self, value):
-        """Looks for a pattern matching a ticket ID and removes any TC- prefix
-        so only the number is searched."""
+        """Looks for a pattern matching a ticket ID and removes any non
+        numerical prefix so only the number is searched."""
         value = value.strip()
         if self.search_regex:
             match = self.search_regex.search(value)

--- a/tasks/filters.py
+++ b/tasks/filters.py
@@ -49,8 +49,6 @@ class TaskWorkflowFilter(TamatoFilter):
         "title",
         "description",
     )
-    if settings.TICKET_PREFIX:
-        id_search_regex = re.compile(rf"(?i)({settings.TICKET_PREFIX}?)(\d+)")
 
     clear_url = reverse_lazy("workflow:task-workflow-ui-list")
 
@@ -78,14 +76,24 @@ class TaskWorkflowFilter(TamatoFilter):
         """Looks for a pattern matching a ticket ID with prefix and removes the
         ticket_prefix from the search groups."""
         value = value.strip()
-        if self.id_search_regex:
-            match = self.id_search_regex.search(value)
+        ticket_prefix = settings.TICKET_PREFIX
+        import pdb
+
+        pdb.set_trace()
+        if ticket_prefix:
+            cleaned_prefix = re.sub("-", "", ticket_prefix)
+            cleaned_search_value = re.sub("-", "", value)
+            prefixed_id_pattern = re.compile(rf"(?i)({cleaned_prefix})(\d+)")
+            match = prefixed_id_pattern.search(cleaned_search_value)
             if match:
-                prefix_pattern = re.compile(rf"(?i){settings.TICKET_PREFIX}?")
+                prefix_pattern = re.compile(rf"(?i){cleaned_prefix}")
                 terms = list(match.groups())
                 terms = [term for term in terms if not prefix_pattern.search(term)]
                 terms.extend(
-                    [value[: match.start()].strip(), value[match.end() :].strip()],
+                    [
+                        cleaned_search_value[: match.start()].strip(),
+                        cleaned_search_value[match.end() :].strip(),
+                    ],
                 )
                 return " ".join(terms)
         return value

--- a/tasks/filters.py
+++ b/tasks/filters.py
@@ -81,8 +81,9 @@ class TaskWorkflowFilter(TamatoFilter):
         if self.id_search_regex:
             match = self.id_search_regex.search(value)
             if match:
+                prefix_pattern = re.compile(rf"(?i){settings.TICKET_PREFIX}?")
                 terms = list(match.groups())
-                terms = [term for term in terms if term != settings.TICKET_PREFIX]
+                terms = [term for term in terms if not prefix_pattern.search(term)]
                 terms.extend(
                     [value[: match.start()].strip(), value[match.end() :].strip()],
                 )

--- a/tasks/filters.py
+++ b/tasks/filters.py
@@ -77,9 +77,7 @@ class TaskWorkflowFilter(TamatoFilter):
         ticket_prefix from the search groups."""
         value = value.strip()
         ticket_prefix = settings.TICKET_PREFIX
-        import pdb
 
-        pdb.set_trace()
         if ticket_prefix:
             cleaned_prefix = re.sub("-", "", ticket_prefix)
             cleaned_search_value = re.sub("-", "", value)

--- a/tasks/filters.py
+++ b/tasks/filters.py
@@ -73,8 +73,6 @@ class TaskWorkflowFilter(TamatoFilter):
     )
 
     def get_search_term(self, value):
-        """Looks for a pattern matching a ticket ID with prefix and removes the
-        ticket_prefix from the search groups."""
         return self.normalise_prefixed_ticket_ids(value)
 
     def normalise_prefixed_ticket_ids(self, search_sentence: str) -> str:

--- a/tasks/jinja2/tasks/workflows/confirm_update.jinja
+++ b/tasks/jinja2/tasks/workflows/confirm_update.jinja
@@ -4,14 +4,14 @@
 {% from "components/panel/macro.njk" import govukPanel %}
 {% from "components/button/macro.njk" import govukButton %}
 
-{% set page_title = verbose_name|capitalize ~ " updated" %}
+{% set page_title = "Ticket " ~ object.prefixed_id ~ " updated" %}
 
 {% block breadcrumb %}
   {{ breadcrumbs(
     request,
     [
       {"text": "Find and view " ~ verbose_name ~ "s", "href": object.get_url("list")},
-      {"text": verbose_name|capitalize ~ " " ~ object.id, "href": object.get_url("detail")},
+      {"text": verbose_name|capitalize ~ " " ~ object.prefixed_id, "href": object.get_url("detail")},
       {"text": page_title}
     ],
     with_workbasket=False,
@@ -20,7 +20,7 @@
 
 {% block panel %}
   {{ govukPanel({
-    "titleText": verbose_name|capitalize ~ " " ~ object.id,
+    "titleText": verbose_name|capitalize ~ " " ~ object.prefixed_id,
     "text": "You have updated the " ~ verbose_name,
     "classes": "govuk-!-margin-bottom-7"
   }) }}

--- a/tasks/jinja2/tasks/workflows/delete.jinja
+++ b/tasks/jinja2/tasks/workflows/delete.jinja
@@ -12,7 +12,7 @@
     [
       {"text": "Find and view "~ verbose_name ~ "s", "href": object.get_url("list")},
       {
-        "text": verbose_name|capitalize ~ ": " ~ object.title,
+        "text": verbose_name|capitalize ~ ": " ~ object.prefixed_id,
         "href": object.get_url("detail"),
       },
       {"text": page_title}
@@ -23,7 +23,7 @@
 
 {% block form %}
   {{ govukWarningText({
-    "text": "Are you sure you want to delete this " ~ verbose_name ~ "?",
+    "text": "Are you sure you want to delete ticket " ~ object.prefixed_id ~ "?",
   }) }}
 
   {% call django_form(action=object.get_url("delete")) %}

--- a/tasks/jinja2/tasks/workflows/detail.jinja
+++ b/tasks/jinja2/tasks/workflows/detail.jinja
@@ -6,7 +6,7 @@
 {% from "tasks/macros/display_details.jinja" import display_summary_row_stacked %}
 {% from "tasks/macros/display_details.jinja" import display_status %}
 
-{% set page_title = verbose_name|capitalize ~ " " ~ object.id %}
+{% set page_title = verbose_name|capitalize ~ " " ~ object.prefixed_id %}
 
 {% block breadcrumb %}
   {{ breadcrumbs(request, [

--- a/tasks/jinja2/tasks/workflows/edit.jinja
+++ b/tasks/jinja2/tasks/workflows/edit.jinja
@@ -1,12 +1,12 @@
 {% extends "layouts/form.jinja" %}
 {% from "components/breadcrumbs.jinja" import breadcrumbs %}
 
-{% set page_title = "Edit " ~ verbose_name ~ " " ~ object.id %}
+{% set page_title = "Edit " ~ verbose_name ~ " " ~ object.prefixed_id %}
 
 {% block breadcrumb %}
   {{ breadcrumbs(request, [
       {"text": "Find and view " ~ verbose_name ~ "s", "href": object.get_url("list")},
-      {"text": verbose_name|capitalize ~ " " ~ object.id, "href": object.get_url("detail")},
+      {"text": verbose_name|capitalize ~ " " ~ object.prefixed_id, "href": object.get_url("detail")},
       {"text": page_title}
     ],
     with_workbasket=False,

--- a/tasks/jinja2/tasks/workflows/list.jinja
+++ b/tasks/jinja2/tasks/workflows/list.jinja
@@ -44,7 +44,7 @@
             <a
               class="govuk-link"
               href="{{ url('workflow:task-workflow-ui-detail', kwargs={'pk':  object.taskworkflow.pk}) }}"
-            >{{ object.taskworkflow.pk }}</a>
+            >{{ object.taskworkflow.prefixed_id }}</a>
           {%- endset -%}
 
           {{ table_rows.append([

--- a/tasks/models/workflow.py
+++ b/tasks/models/workflow.py
@@ -57,7 +57,7 @@ class TaskWorkflow(Queue):
 
     @property
     def prefixed_id(self) -> str:
-        return f"{settings.TICKET_PREFIX}{str(self.id)}"
+        return f"{settings.TICKET_PREFIX}{self.id}"
 
     def get_tasks(self) -> models.QuerySet:
         """Get a QuerySet of the Tasks associated through their TaskItem

--- a/tasks/models/workflow.py
+++ b/tasks/models/workflow.py
@@ -45,7 +45,7 @@ class TaskWorkflow(Queue):
         verbose_name = "workflow"
 
     def __str__(self):
-        return self.title
+        return f"{self.prefixied_id} - {self.title}"
 
     @property
     def title(self) -> str:
@@ -54,6 +54,10 @@ class TaskWorkflow(Queue):
     @property
     def description(self) -> str:
         return self.summary_task.description
+
+    @property
+    def prefixed_id(self) -> str:
+        return f"{settings.TICKET_PREFIX}{str(self.id).zfill(4)}"
 
     def get_tasks(self) -> models.QuerySet:
         """Get a QuerySet of the Tasks associated through their TaskItem

--- a/tasks/models/workflow.py
+++ b/tasks/models/workflow.py
@@ -45,7 +45,7 @@ class TaskWorkflow(Queue):
         verbose_name = "workflow"
 
     def __str__(self):
-        return f"{self.prefixied_id} - {self.title}"
+        return f"{self.prefixed_id} - {self.title}"
 
     @property
     def title(self) -> str:
@@ -57,7 +57,7 @@ class TaskWorkflow(Queue):
 
     @property
     def prefixed_id(self) -> str:
-        return f"{settings.TICKET_PREFIX}{str(self.id).zfill(4)}"
+        return f"{settings.TICKET_PREFIX}{str(self.id)}"
 
     def get_tasks(self) -> models.QuerySet:
         """Get a QuerySet of the Tasks associated through their TaskItem

--- a/tasks/tests/test_filters.py
+++ b/tasks/tests/test_filters.py
@@ -14,7 +14,7 @@ pytestmark = pytest.mark.django_db
     [
         (f"{settings.TICKET_PREFIX}1234", True),
         (f"{settings.TICKET_PREFIX.lower()}1234", True),
-        (f"{settings.TICKET_PREFIX[:-1]}1234", True),
+        (f"{settings.TICKET_PREFIX}-1234", True),
         ("1234", True),
         ("4321", False),
     ],
@@ -22,6 +22,7 @@ pytestmark = pytest.mark.django_db
 def test_ticket_id_filter(search_term, expected_result):
     """Test that a user searching by a prefixed ticket ID correctly returns
     results regardless of case or if the dash is included."""
+
     ticket_filter = TaskWorkflowFilter()
     summary_task = TaskFactory.create()
     TaskWorkflowFactory.create(summary_task=summary_task, id=1234)
@@ -29,3 +30,19 @@ def test_ticket_id_filter(search_term, expected_result):
 
     filtered_steps = ticket_filter.filter_search(queryset, "search", search_term)
     assert (summary_task in filtered_steps) == expected_result
+
+
+# @pytest.mark.parametrize("ticket_prefix", [("TC2025"), ("TC2025-"), ("")])
+# def test_alternative_ticket_prefixes(monkeypatch, ticket_prefix):
+#     """Test that filtering still works with a prefix including numbers or no prefix at all."""
+#     monkeypatch.setenv(settings.TICKET_PREFIX, ticket_prefix)
+#     importlib.reload(common)
+
+#     ticket_filter = TaskWorkflowFilter()
+#     summary_task = TaskFactory.create()
+#     TaskWorkflowFactory.create(summary_task=summary_task, id=1234)
+#     queryset = Task.objects.all()
+
+#     search_term = f"{ticket_prefix}1234"
+#     filtered_steps = ticket_filter.filter_search(queryset, "search", search_term)
+#     assert (summary_task in filtered_steps) == True

--- a/tasks/tests/test_filters.py
+++ b/tasks/tests/test_filters.py
@@ -32,17 +32,17 @@ def test_ticket_id_filter(search_term, expected_result):
     assert (summary_task in filtered_steps) == expected_result
 
 
-# @pytest.mark.parametrize("ticket_prefix", [("TC2025"), ("TC2025-"), ("")])
-# def test_alternative_ticket_prefixes(monkeypatch, ticket_prefix):
-#     """Test that filtering still works with a prefix including numbers or no prefix at all."""
-#     monkeypatch.setenv(settings.TICKET_PREFIX, ticket_prefix)
-#     importlib.reload(common)
+@pytest.mark.parametrize("ticket_prefix", [("TC2025"), ("TC2025-"), ("")])
+def test_alternative_ticket_prefixes(ticket_prefix):
+    """Test that filtering still works with a prefix including numbers or no
+    prefix at all."""
+    settings.TICKET_PREFIX = ticket_prefix
 
-#     ticket_filter = TaskWorkflowFilter()
-#     summary_task = TaskFactory.create()
-#     TaskWorkflowFactory.create(summary_task=summary_task, id=1234)
-#     queryset = Task.objects.all()
+    ticket_filter = TaskWorkflowFilter()
+    summary_task = TaskFactory.create()
+    TaskWorkflowFactory.create(summary_task=summary_task, id=1234)
+    queryset = Task.objects.all()
 
-#     search_term = f"{ticket_prefix}1234"
-#     filtered_steps = ticket_filter.filter_search(queryset, "search", search_term)
-#     assert (summary_task in filtered_steps) == True
+    search_term = f"{ticket_prefix}1234"
+    filtered_steps = ticket_filter.filter_search(queryset, "search", search_term)
+    assert (summary_task in filtered_steps) == True

--- a/tasks/tests/test_filters.py
+++ b/tasks/tests/test_filters.py
@@ -1,0 +1,31 @@
+import pytest
+from django.conf import settings
+
+from common.tests.factories import TaskFactory
+from tasks.filters import TaskWorkflowFilter
+from tasks.models import Task
+from tasks.tests.factories import TaskWorkflowFactory
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.mark.parametrize(
+    "search_term, expected_result",
+    [
+        (f"{settings.TICKET_PREFIX}1234", True),
+        (f"{settings.TICKET_PREFIX.lower()}1234", True),
+        (f"{settings.TICKET_PREFIX[:-1]}1234", True),
+        ("1234", True),
+        ("4321", False),
+    ],
+)
+def test_ticket_id_filter(search_term, expected_result):
+    """Test that a user searching by a prefixed ticket ID correctly returns
+    results regardless of case or if the dash is included."""
+    ticket_filter = TaskWorkflowFilter()
+    summary_task = TaskFactory.create()
+    TaskWorkflowFactory.create(summary_task=summary_task, id=1234)
+    queryset = Task.objects.all()
+
+    filtered_steps = ticket_filter.filter_search(queryset, "search", search_term)
+    assert (summary_task in filtered_steps) == expected_result

--- a/tasks/tests/test_models.py
+++ b/tasks/tests/test_models.py
@@ -263,5 +263,5 @@ def test_task_is_summary_task_property(create_task_fn):
 
 
 def test_prefixed_id(task_workflow):
-    expected_prefixed_id = f"{settings.TICKET_PREFIX}{str(task_workflow.id)}"
+    expected_prefixed_id = f"{settings.TICKET_PREFIX}{task_workflow.id}"
     assert task_workflow.prefixed_id == expected_prefixed_id

--- a/tasks/tests/test_models.py
+++ b/tasks/tests/test_models.py
@@ -1,4 +1,5 @@
 import pytest
+from django.conf import settings
 from django.db.utils import IntegrityError
 
 from common.tests.factories import CategoryFactory
@@ -259,3 +260,8 @@ def test_task_is_subtask_property(task_factory):
 def test_task_is_summary_task_property(create_task_fn):
     task = create_task_fn()
     assert bool(hasattr(task, "taskworkflow")) == task.is_summary_task
+
+
+def test_prefixed_id(task_workflow):
+    expected_prefixed_id = f"{settings.TICKET_PREFIX}{str(task_workflow.id)}"
+    assert task_workflow.prefixed_id == expected_prefixed_id


### PR DESCRIPTION
# TP2000-1744 Support configurable ticket ID prefix
<!---
 * Include the JIRA ticket number, eg TP-123, to automatically link.
 * Use 50 characters maximum.
 * Do not end with a full-stop.
--->

## Why
<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Use as many lines as you like.
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions or deliberately ignored edge-cases.
--->

A ticket naming prefix may be desirable as a way of including contextual information when referring to tickets by their ID. For instance, if a prefix of “TC-” (Tariff Change, or other preferred prefix, including the empty string) is adopted, then by referring to TC-123 it’s clear that ticket 123 is being referenced.

## What
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Explain like I'm 5.
 * Use pictures if you can.
--->

This PR adds a configurable TICKET_PREFIX env variable used as the prefix to a ticket PK to form the prefixed_id which is rendered to users whenever a ticket ID is referenced.

It also updates filtering so correct results are returned regardless of case or whether the prefix is included in search.

![image](https://github.com/user-attachments/assets/3735768d-117b-4ee5-a2ef-b7f0ee28de13)


<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
## Checklist
- Requires migrations?
- Requires dependency updates?
--->

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
