### PR TITLE
TP2000-1746: Footnote association real edits

### DIFF
--- a/measures/patterns.py
+++ b/measures/patterns.py
@@ -19,6 +19,7 @@ from common.models.trackedmodel import TrackedModel
 from common.renderers import Counter
 from common.renderers import counter_generator
 from common.util import TaricDateRange
+from common.util import make_real_edit
 from common.util import maybe_max
 from common.util import maybe_min
 from common.validators import UpdateType
@@ -275,11 +276,16 @@ class MeasureCreationPattern:
         footnotes: Sequence[Footnote],
     ) -> Sequence[FootnoteAssociationMeasure]:
         return [
-            FootnoteAssociationMeasure.objects.create(
-                footnoted_measure=measure,
-                associated_footnote=footnote,
+            make_real_edit(
+                tx=measure.transaction,
+                cls=FootnoteAssociationMeasure,
+                obj=None,
+                data={
+                    "footnoted_measure": measure,
+                    "associated_footnote": footnote,
+                },
+                workbasket=self.workbasket,
                 update_type=UpdateType.CREATE,
-                transaction=measure.transaction,
             )
             for footnote in footnotes
         ]

--- a/measures/util.py
+++ b/measures/util.py
@@ -1,19 +1,17 @@
 import decimal
+import logging
 from datetime import date
 from math import floor
+from typing import List
+from typing import Type
 
-from common.models import TrackedModel
 from common.models.transactions import Transaction
+from common.util import make_real_edit
 from common.validators import UpdateType
-
 from geo_areas.models import GeographicalArea
 from geo_areas.utils import get_all_members_of_geo_groups
 from measures import models as measure_models
-from typing import List
-from typing import Type
 from workbaskets import models as workbasket_models
-
-import logging
 
 logger = logging.getLogger(__name__)
 
@@ -125,8 +123,7 @@ def update_measure_condition_components(
     measure: "measure_models.Measure",
     workbasket: "workbasket_models.WorkBasket",
 ):
-    """Updates the measure condition components associated to the
-    measure."""
+    """Updates the measure condition components associated to the measure."""
     conditions = measure.conditions.current()
     for condition in conditions:
         condition.new_version(
@@ -200,7 +197,15 @@ def update_measure_footnote_associations(measure, workbasket):
         )
     )
     for fa in footnote_associations:
-        fa.new_version(
-            footnoted_measure=measure,
+        data = {
+            "footnoted_measure": measure,
+        }
+        new_tx = workbasket.new_transaction()
+        make_real_edit(
+            tx=new_tx,
+            cls=measure_models.FootnoteAssociationMeasure,
+            obj=fa,
+            data=data,
             workbasket=workbasket,
+            update_type=UpdateType.UPDATE,
         )


### PR DESCRIPTION
# TP2000-1746: Footnote association real edits
<!---
 * Include the JIRA ticket number, eg TP-123, to automatically link.
 * Use 50 characters maximum.
 * Do not end with a full-stop.
--->

## Why
<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Use as many lines as you like.
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions or deliberately ignored edge-cases.
--->
* Makes forms smarter so that users don't need to remove previous edits from their workbasket when they make another edit

## What
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Explain like I'm 5.
 * Use pictures if you can.
--->
* Replaces various .new_version()/.create() calls with make_real_edit to make the appropriate update to the workbasket when a footnote association is updated/created/deleted 
* Also splits MeasureForm.save() into separate methods for ease of reading

<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
## Checklist
- Requires migrations?
- Requires dependency updates?
--->

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
