### PR TITLE
TP2000-1775  Amend breadcrumbs on ticket and step pages

### DIFF
--- a/common/jinja2/includes/common/pagination-list-summary.jinja
+++ b/common/jinja2/includes/common/pagination-list-summary.jinja
@@ -5,9 +5,11 @@
 <p class="govuk-body">
   {{ objects_count }}
   {# Polymorphic TrackedModelsQuerySet instances don't have a valid `model`. #}
-  {% if object_list.model %}
+  {% if items_name %}
+    {{ items_name }}{{ paginator.count|pluralize }}
+  {% elif object_list.model %}
     {{ object_list.model._meta.verbose_name_plural if paginator.count > 1 else object_list.model._meta.verbose_name }}
   {% else %}
-    {{ items_name if items_name else "items" }}
+    items
   {% endif %}
 </p>

--- a/tasks/jinja2/tasks/confirm_delete.jinja
+++ b/tasks/jinja2/tasks/confirm_delete.jinja
@@ -4,38 +4,37 @@
 {% from "components/panel/macro.njk" import govukPanel %}
 {% from "components/button/macro.njk" import govukButton %}
 
-{% set page_title = "Task deleted" %}
+{% set page_title = "Step deleted" %}
 
 {% block breadcrumb %}
-  {{ govukBreadcrumbs({
-    "items": [
-      {"text": "Find and view tasks", "href": url("workflow:task-ui-list")},
+  {{ breadcrumbs(
+    request,
+    [
+      {"text": "Ticket " ~ ticket.prefixed_id, "href": ticket.get_url("detail")},
       {"text": page_title}
-    ]
-  }) }}
+    ],
+    False,
+  ) }}
 {% endblock %}
 
 {% block panel %}
   {{ govukPanel({
-    "titleText": "Task ID: " ~ deleted_pk,
-    "text": verbose_name|capitalize ~ " has been deleted",
+    "titleText": "Step ID: " ~ deleted_pk,
+    "text": "Step has been deleted",
     "classes": "govuk-!-margin-bottom-7"
   }) }}
 {% endblock %}
 
 {% block button_group %}
   {{ govukButton({
-    "text": "Find and view tasks",
-    "href": url("workflow:task-ui-list"),
-    "classes": "govuk-button"
+    "text": "Return to ticket",
+    "href": ticket.get_url("detail"),
   }) }}
   {{ govukButton({
-    "text": "Return to homepage",
-    "href": url("home"),
+    "text": "View all tickets",
+    "href": ticket.get_url("list"),
     "classes": "govuk-button--secondary"
   }) }}
 {% endblock %}
 
-{% block actions %}
-  <li><a href="{{ url("workflow:task-ui-create") }}">Create a task</a></li>
-{% endblock %}
+{% block actions %}{% endblock %}

--- a/tasks/jinja2/tasks/confirm_update.jinja
+++ b/tasks/jinja2/tasks/confirm_update.jinja
@@ -1,41 +1,42 @@
-{% extends "common/confirm_update.jinja" %}
+{% extends "layouts/confirm.jinja" %}
 
 {% from "components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
 {% from "components/panel/macro.njk" import govukPanel %}
 {% from "components/button/macro.njk" import govukButton %}
 
-{% set page_title = page_title %}
+{% set page_title = "Step updated" %}
+
+{% set ticket = object.taskitem.workflow %}
 
 {% block breadcrumb %}
-  {{ govukBreadcrumbs({
-    "items": [
-      {"text": object_type ~ ": " ~ object.title, "href": url("workflow:task-ui-detail", kwargs={"pk": object.pk})},
+  {{ breadcrumbs(request, [
+      {"text": "Ticket " ~ ticket.prefixed_id, "href": ticket.get_url("detail")},
+      {"text": "Step: " ~ object.title, "href": url("workflow:task-ui-detail", kwargs={"pk": object.pk})},
       {"text": page_title}
-    ]
-  }) }}
+    ],
+    with_workbasket=False,
+  ) }}
 {% endblock %}
 
 {% block panel %}
   {{ govukPanel({
-    "titleText": object_type ~ ": " ~ object.title,
-    "text": object_type ~ " has been updated",
+    "titleText": "Step: " ~ object.title,
+    "text": "Step has been updated",
     "classes": "govuk-!-margin-bottom-7"
   }) }}
 {% endblock %}
 
 {% block button_group %}
   {{ govukButton({
-    "text": "View " ~ object_type,
+    "text": "View step",
     "href": url('workflow:task-ui-detail', kwargs={"pk": object.pk}),
     "classes": "govuk-button"
   }) }}
   {{ govukButton({
-    "text": "Return to homepage",
-    "href": url("home"),
+    "text": "Return to ticket",
+    "href": ticket.get_url("detail"),
     "classes": "govuk-button--secondary"
   }) }}
 {% endblock %}
 
-{% block actions %}
-  <li><a href="{{ url("workflow:task-ui-list") }}">Find and view tasks</a></li>
-{% endblock %}
+{% block actions %}{% endblock %}

--- a/tasks/jinja2/tasks/delete.jinja
+++ b/tasks/jinja2/tasks/delete.jinja
@@ -8,7 +8,7 @@
 {% block breadcrumb %}
   {% if ticket_number %}
     {{ breadcrumbs(request, [
-      {"text": "Ticket " ~ object.taskitem.workflow.pk, "href": url('workflow:task-workflow-ui-detail', kwargs={'pk': object.taskitem.workflow.pk})},
+      {"text": "Ticket " ~ object.taskitem.workflow.prefixed_id, "href": url('workflow:task-workflow-ui-detail', kwargs={'pk': object.taskitem.workflow.pk})},
       {"text": "Step: " ~ object.title, "href": url("workflow:task-ui-detail", kwargs={"pk": object.pk}) },
       {"text": "Delete step: " ~ object.title},
     ],

--- a/tasks/jinja2/tasks/detail.jinja
+++ b/tasks/jinja2/tasks/detail.jinja
@@ -12,7 +12,7 @@
 {% block breadcrumb %}
   {% if ticket_number %}
     {{ breadcrumbs(request, [
-        {"text": ticket_number, "href": url('workflow:task-workflow-ui-detail', kwargs={'pk': ticket_number})},
+        {"text": "Ticket " ~ ticket_prefixed_id, "href": url('workflow:task-workflow-ui-detail', kwargs={'pk': ticket_number})},
         {"text": page_title}
       ],
       with_workbasket=False,
@@ -40,18 +40,18 @@
 {% block content %}
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    {{ ticket_title }}
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-three-quarters">
         <h1 class="govuk-heading-xl govuk-!-margin-bottom-4">
-            {{ page_title }}
+          <span class="govuk-caption-xl">{{ ticket_title }}</span>
+          {{ page_title }}
         </h1>
       </div>
       <div class="govuk-grid-column-one-quarter">
         {{ govukButton({
         "text": "Delete step",
         "href": url("workflow:task-ui-delete", kwargs={"pk": object.pk}),
-        "classes": "govuk-button--warning govuk-!-margin-top-2 delete_step_button"
+        "classes": "govuk-button--warning govuk-!-margin-top-2 float-elements-right"
         }) }}
       </div>
     </div>
@@ -79,13 +79,11 @@
 
   <div class="govuk-summary-list__row">
     <dt class="govuk-summary-list__key">
-      Assignees
+      Assignee
     </dt>
     <dd class="govuk-summary-list__value">
       <div id="assigned-user-content">
-        <div class="govuk-!-margin-bottom-3">
-          {{ current_assignee.name if current_assignee else "None" }}
-        </div>
+        {{ current_assignee.name if current_assignee else "None" }}
       </div>
     </dd>
     <dd class="govuk-summary-list__actions">

--- a/tasks/jinja2/tasks/detail.jinja
+++ b/tasks/jinja2/tasks/detail.jinja
@@ -5,6 +5,7 @@
 
 {% set page_title = "Step: " ~ object.title %}
 
+{% set edit_url = url("workflow:task-ui-update", kwargs={"pk": object.pk}) %}
 {% set assign_user_link = url("workflow:task-ui-assign-user", kwargs={"pk": object.pk}) %}
 {% set unassign_user_link = url("workflow:task-ui-unassign-user", kwargs={"pk": object.pk}) %}
 
@@ -16,7 +17,7 @@
       ],
       with_workbasket=False,
     ) }}
-  {%else %}
+  {% else %}
     {{ breadcrumbs(request, [
         {"text": page_title}
       ],
@@ -39,7 +40,7 @@
 {% block content %}
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    {{ticket_title}}
+    {{ ticket_title }}
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-three-quarters">
         <h1 class="govuk-heading-xl govuk-!-margin-bottom-4">

--- a/tasks/jinja2/tasks/edit.jinja
+++ b/tasks/jinja2/tasks/edit.jinja
@@ -1,11 +1,14 @@
 {% extends "layouts/form.jinja" %}
 {% from "components/breadcrumbs.jinja" import breadcrumbs %}
 
+{% set page_title = "Edit step details" %}
+
+{% set ticket = object.taskitem.workflow %}
 
 {% block breadcrumb %}
   {{ breadcrumbs(request, [
-      {"text": "Find and view tasks", "href": url("workflow:task-ui-list")},
-      {"text": "Task: " ~ object.title, "href": url("workflow:task-ui-detail", kwargs={"pk": object.pk})},
+      {"text": "Ticket " ~ ticket.prefixed_id, "href": ticket.get_url("detail")},
+      {"text": "Step: " ~ object.title, "href": url("workflow:task-ui-detail", kwargs={"pk": object.pk})},
       {"text": page_title}
     ],
     with_workbasket=False,

--- a/tasks/jinja2/tasks/workflows/confirm_create.jinja
+++ b/tasks/jinja2/tasks/workflows/confirm_create.jinja
@@ -1,21 +1,17 @@
-{% extends "common/confirm_create.jinja" %}
+{% extends "layouts/confirm.jinja" %}
 
 {% from "components/breadcrumbs.jinja" import breadcrumbs %}
 {% from "components/panel/macro.njk" import govukPanel %}
 {% from "components/button/macro.njk" import govukButton %}
 
-{% set object_name = object._meta.verbose_name %}
-{% set page_title = object_name ~ " created" %}
+{% set page_title = verbose_name|capitalize ~ " created" %}
 
 {% block breadcrumb %}
   {{ breadcrumbs(
     request,
     [
       {
-        "text": "Find and view workflow templates",
-        "href": object.get_url("list")},
-      {
-        "text": "Create a " ~ object_name,
+        "text": "Create a " ~ verbose_name,
         "href": object.get_url("create"),
       },
       {"text": page_title}
@@ -26,28 +22,22 @@
 
 {% block panel %}
   {{ govukPanel({
-    "titleText": object_name|capitalize ~ ": " ~ object,
-    "text": "You have created a new " ~ object_name,
+    "titleText": verbose_name|capitalize ~ ": " ~ object,
+    "text": "You have created a new " ~ verbose_name,
     "classes": "govuk-!-margin-bottom-7"
   }) }}
 {% endblock %}
 
 {% block button_group %}
   {{ govukButton({
-    "text": "View " ~ object_name,
+    "text": "View " ~ verbose_name,
     "href": object.get_url("detail"),
     "classes": "govuk-button"
   }) }}
 
-  {% if object_name == "workflow" %}
+  {% if verbose_name == "ticket template" %}
     {{ govukButton({
-      "text": "Create a task",
-      "href": "#TODO",
-      "classes": "govuk-button--secondary"
-    }) }}
-  {% elif object_name == "workflow template" %}
-    {{ govukButton({
-      "text": "Create a task template",
+      "text": "Add a step template",
       "href": url("workflow:task-template-ui-create", kwargs={"workflow_template_pk": object.pk}),
       "classes": "govuk-button--secondary"
     }) }}
@@ -56,6 +46,6 @@
 
 {% block actions %}
   <li>
-    <a href={{ object.get_url("list") }} class="govuk-link">Find and view {{object_name}}s</a>
+    <a href={{ object.get_url("list") }} class="govuk-link">View all {{verbose_name}}s</a>
   </li>
 {% endblock %}

--- a/tasks/jinja2/tasks/workflows/confirm_delete.jinja
+++ b/tasks/jinja2/tasks/workflows/confirm_delete.jinja
@@ -10,7 +10,7 @@
   {{ breadcrumbs(
     request,
     [
-      {"text": "Find and view "~ verbose_name ~ "s", "href": list_url},
+      {"text": "View all "~ verbose_name ~ "s", "href": list_url},
       {"text": page_title}
     ],
     False,
@@ -27,12 +27,12 @@
 
 {% block button_group %}
   {{ govukButton({
-    "text": "Find and view " ~ verbose_name ~ "s",
+    "text": "View all " ~ verbose_name ~ "s",
     "href": list_url,
     "classes": "govuk-button"
   }) }}
   {{ govukButton({
-    "text": "Create a " ~ verbose_name,
+    "text": "Create a new " ~ verbose_name,
     "href": create_url,
     "classes": "govuk-button--secondary"
   }) }}

--- a/tasks/jinja2/tasks/workflows/confirm_update.jinja
+++ b/tasks/jinja2/tasks/workflows/confirm_update.jinja
@@ -4,7 +4,7 @@
 {% from "components/panel/macro.njk" import govukPanel %}
 {% from "components/button/macro.njk" import govukButton %}
 
-{% set object_id = object.prefixed_id if object.prefixed_id else object.id%}
+{% set object_id = object.prefixed_id if object.prefixed_id else object.id %}
 
 {% set page_title = verbose_name|capitalize ~ " " ~ object_id ~ " updated" %}
 
@@ -12,7 +12,6 @@
   {{ breadcrumbs(
     request,
     [
-      {"text": "Find and view " ~ verbose_name ~ "s", "href": object.get_url("list")},
       {"text": verbose_name|capitalize ~ " " ~ object_id, "href": object.get_url("detail")},
       {"text": page_title}
     ],
@@ -30,19 +29,15 @@
 
 {% block button_group %}
   {{ govukButton({
-    "text": "View " ~ verbose_name,
+    "text": "Return to " ~ verbose_name,
     "href": object.get_url("detail"),
     "classes": "govuk-button"
   }) }}
-  {% if verbose_name == "ticket template" %}
-    {{ govukButton({
-      "text": "Add a step",
-      "href": url("workflow:task-template-ui-create", kwargs={"workflow_template_pk": object.pk}),
-      "classes": "govuk-button--secondary"
-    }) }}
-  {% endif %}
+  {{ govukButton({
+    "text": "View all " ~ verbose_name ~ "s",
+    "href": object.get_url("list"),
+    "classes": "govuk-button--secondary"
+  }) }}
 {% endblock %}
 
-{% block actions %}
-  <a href={{ object.get_url("list") }} class="govuk-link">Find and view {{verbose_name}}s</a>
-{% endblock %}
+{% block actions %}{% endblock %}

--- a/tasks/jinja2/tasks/workflows/create.jinja
+++ b/tasks/jinja2/tasks/workflows/create.jinja
@@ -8,8 +8,7 @@
   {{ breadcrumbs(
     request,
     [
-      {"text": "Find and view "~ verbose_name ~ "s", "href": list_url},
-      {"text": page_title}
+      {"text": page_title},
     ],
     False,
   ) }}

--- a/tasks/jinja2/tasks/workflows/delete.jinja
+++ b/tasks/jinja2/tasks/workflows/delete.jinja
@@ -4,15 +4,17 @@
 {% from "components/warning-text/macro.njk" import govukWarningText %}
 {% from "components/button/macro.njk" import govukButton %}
 
-{% set page_title = "Delete " ~ verbose_name ~ ": " ~ object.title %}
+
+{% set object_id = object.prefixed_id if object.prefixed_id else object.id %}
+{% set object_name = verbose_name|capitalize ~ " " ~  object_id %}
+{% set page_title = "Delete " ~ object_name %}
 
 {% block breadcrumb %}
   {{ breadcrumbs(
     request,
     [
-      {"text": "Find and view "~ verbose_name ~ "s", "href": object.get_url("list")},
       {
-        "text": verbose_name|capitalize ~ ": " ~ object.prefixed_id,
+        "text": object_name,
         "href": object.get_url("detail"),
       },
       {"text": page_title}
@@ -23,7 +25,7 @@
 
 {% block form %}
   {{ govukWarningText({
-    "text": "Are you sure you want to delete ticket " ~ object.prefixed_id ~ "?",
+    "text": "Are you sure you want to delete " ~ object_name ~ "?",
   }) }}
 
   {% call django_form(action=object.get_url("delete")) %}

--- a/tasks/jinja2/tasks/workflows/detail.jinja
+++ b/tasks/jinja2/tasks/workflows/detail.jinja
@@ -10,7 +10,6 @@
 
 {% block breadcrumb %}
   {{ breadcrumbs(request, [
-      {"text": "Find and view " ~ verbose_name ~ "s", "href": object.get_url("list")},
       {"text": page_title}
     ],
     with_workbasket=False,
@@ -76,6 +75,7 @@
           {{ govukButton({
             "text": "Add a step",
             "href": url("workflow:task-template-ui-create", kwargs={"workflow_template_pk": object.pk}),
+            "classes": "govuk-button--secondary"
           }) }}
           {{ govukButton({
             "text": "Delete " ~ verbose_name,

--- a/tasks/jinja2/tasks/workflows/edit.jinja
+++ b/tasks/jinja2/tasks/workflows/edit.jinja
@@ -1,12 +1,15 @@
 {% extends "layouts/form.jinja" %}
 {% from "components/breadcrumbs.jinja" import breadcrumbs %}
 
-{% set page_title = verbose_name|capitalize ~ " " ~ object.prefixed_id if object.prefixed_id else verbose_name|capitalize ~ " " ~ object.id%}
+
+{% set object_id = object.prefixed_id if object.prefixed_id else object.id %}
+{% set object_name = verbose_name|capitalize ~ " " ~  object_id %}
+
+{% set page_title = "Edit " ~ object_name %}
 
 {% block breadcrumb %}
   {{ breadcrumbs(request, [
-      {"text": "Find and view " ~ verbose_name ~ "s", "href": object.get_url("list")},
-      {"text": verbose_name|capitalize ~ " " ~ object.prefixed_id, "href": object.get_url("detail")},
+      {"text": object_name, "href": object.get_url("detail")},
       {"text": page_title}
     ],
     with_workbasket=False,

--- a/tasks/jinja2/tasks/workflows/list.jinja
+++ b/tasks/jinja2/tasks/workflows/list.jinja
@@ -5,7 +5,7 @@
 {% from "tasks/macros/display_details.jinja" import display_status %}
 {% from "tasks/macros/display_details.jinja" import display_assignees %}
 
-{% set page_title = "Find and view tickets" %}
+{% set page_title = "View all tickets" %}
 
 {% block breadcrumb %}
   {{ breadcrumbs(request, [

--- a/tasks/jinja2/tasks/workflows/list.jinja
+++ b/tasks/jinja2/tasks/workflows/list.jinja
@@ -32,6 +32,7 @@
     </div>
 
     <div class="filter-layout__content">
+      {% set items_name = "ticket" %}
       {% if paginator.count > 0 %}
         {% include "includes/common/pagination-list-summary.jinja" %}
       {% endif %}

--- a/tasks/jinja2/tasks/workflows/task_template_confirm_create.jinja
+++ b/tasks/jinja2/tasks/workflows/task_template_confirm_create.jinja
@@ -1,22 +1,17 @@
-{% extends "common/confirm_create.jinja" %}
+{% extends "layouts/confirm.jinja" %}
 
 {% from "components/breadcrumbs.jinja" import breadcrumbs %}
 {% from "components/panel/macro.njk" import govukPanel %}
 {% from "components/button/macro.njk" import govukButton %}
 
-{% set page_title = "Task template created" %}
-
+{% set page_title = "Step template created" %}
 
 {% block breadcrumb %}
   {{ breadcrumbs(
     request,
     [
       {
-        "text": "Find and view workflow templates",
-        "href": url("workflow:task-workflow-template-ui-list"),
-      },
-      {
-        "text": "Workflow template: " ~ task_workflow_template.title,
+        "text": "Ticket template: " ~ task_workflow_template.title,
         "href": url(
           "workflow:task-workflow-template-ui-detail",
           kwargs={"pk": task_workflow_template.pk}),
@@ -29,25 +24,25 @@
 
 {% block panel %}
   {{ govukPanel({
-    "titleText": "Task template: " ~ object.title,
-    "text": "You have created a new task template",
+    "titleText": "Step template: " ~ object.title,
+    "text": "You have created a new step template",
     "classes": "govuk-!-margin-bottom-7"
   }) }}
 {% endblock %}
 
 {% block button_group %}
   {{ govukButton({
-    "text": "View task template",
+    "text": "View step template",
     "href": url("workflow:task-template-ui-detail", kwargs={"pk": object.pk}),
     "classes": "govuk-button"
   }) }}
   {{ govukButton({
-    "text": "Return to workflow template",
+    "text": "Return to ticket template",
     "href": url("workflow:task-workflow-template-ui-detail", kwargs={"pk": task_workflow_template.pk}),
     "classes": "govuk-button--secondary"
   }) }}
 {% endblock %}
 
 {% block actions %}
-  <li><a href="{{ url('workflow:task-workflow-template-ui-list') }}" class="govuk-link">Find and edit workflow templates</a></li>
+  <li><a href="{{ url('workflow:task-workflow-template-ui-list') }}" class="govuk-link">View all ticket templates</a></li>
 {% endblock %}

--- a/tasks/jinja2/tasks/workflows/task_template_confirm_delete.jinja
+++ b/tasks/jinja2/tasks/workflows/task_template_confirm_delete.jinja
@@ -4,19 +4,14 @@
 {% from "components/panel/macro.njk" import govukPanel %}
 {% from "components/button/macro.njk" import govukButton %}
 
-{% set page_title = "Task template deleted" %}
-
+{% set page_title = "Step template deleted" %}
 
 {% block breadcrumb %}
   {{ breadcrumbs(
     request,
     [
       {
-        "text": "Find and view workflow templates",
-        "href": url("workflow:task-workflow-template-ui-list"),
-      },
-      {
-        "text": "Workflow template: " ~ task_workflow_template.title,
+        "text": "Ticket template: " ~ task_workflow_template.title,
         "href": url(
           "workflow:task-workflow-template-ui-detail",
           kwargs={"pk": task_workflow_template.pk},
@@ -30,15 +25,15 @@
 
 {% block panel %}
   {{ govukPanel({
-    "titleText": "Task template ID: " ~ deleted_pk,
-    "text": "Task template has been deleted",
+    "titleText": "Step template ID: " ~ deleted_pk,
+    "text": "Step template has been deleted",
     "classes": "govuk-!-margin-bottom-7"
   }) }}
 {% endblock %}
 
 {% block button_group %}
   {{ govukButton({
-    "text": "View workflow template",
+    "text": "Return to ticket template",
     "href": url(
       "workflow:task-workflow-template-ui-detail",
       kwargs={"pk": task_workflow_template.pk},
@@ -46,16 +41,10 @@
     "classes": "govuk-button"
   }) }}
   {{ govukButton({
-    "text": "Return to homepage",
-    "href": url("home"),
+    "text": "View all ticket templates",
+    "href": task_workflow_template.get_url("list"),
     "classes": "govuk-button--secondary"
   }) }}
 {% endblock %}
 
-{% block actions %}
-  <li>
-    <a class="govuk-link"
-      href="{{ url('workflow:task-template-ui-create', kwargs={'workflow_template_pk': task_workflow_template.pk}) }}"
-    >Create a task template</a>
-  </li>
-{% endblock %}
+{% block actions %}{% endblock %}

--- a/tasks/jinja2/tasks/workflows/task_template_confirm_update.jinja
+++ b/tasks/jinja2/tasks/workflows/task_template_confirm_update.jinja
@@ -1,24 +1,25 @@
-{% extends "common/confirm_update.jinja" %}
+{% extends "layouts/confirm.jinja" %}
 
 {% from "components/breadcrumbs.jinja" import breadcrumbs %}
 {% from "components/panel/macro.njk" import govukPanel %}
 {% from "components/button/macro.njk" import govukButton %}
 
+{% set page_title = "Step template updated" %}
+
+{% set step_template_url = object.get_url("detail") %}
+{% set ticket_template_url = task_workflow_template.get_url("detail") %}
 
 {% block breadcrumb %}
   {{ breadcrumbs(
     request,
     [
       {
-        "text": "Find and view workflow templates",
-        "href": url("workflow:task-workflow-template-ui-list"),
+        "text": "Ticket template: " ~ task_workflow_template.title,
+        "href": ticket_template_url,
       },
       {
-        "text": "Workflow template: " ~ task_workflow_template.title,
-        "href": url(
-          "workflow:task-workflow-template-ui-detail",
-          kwargs={"pk": task_workflow_template.pk},
-        ),
+        "text": "Step template: " ~ object.title,
+        "href": step_template_url,
       },
       {"text": page_title}
     ],
@@ -28,25 +29,24 @@
 
 {% block panel %}
   {{ govukPanel({
-    "titleText": "Task template: " ~ object.title,
-    "text": "Task template has been updated",
+    "titleText": "Step template: " ~ object.title,
+    "text": "Step template has been updated",
     "classes": "govuk-!-margin-bottom-7"
   }) }}
 {% endblock %}
 
 {% block button_group %}
   {{ govukButton({
-    "text": "View task template",
-    "href": url("workflow:task-template-ui-detail", kwargs={"pk": object.pk}),
-    "classes": "govuk-button"
+    "text": "View step template",
+    "href": step_template_url,
   }) }}
   {{ govukButton({
-    "text": "Return to homepage",
-    "href": url("home"),
+    "text": "Return to ticket template",
+    "href": ticket_template_url,
     "classes": "govuk-button--secondary"
   }) }}
 {% endblock %}
 
 {% block actions %}
-  <li><a href="{{ url('workflow:task-workflow-template-ui-list') }}" class="govuk-link">Find and edit workflow templates</a></li>
+  <li><a href="{{ task_workflow_template.get_url("list") }}" class="govuk-link">View all ticket templates</a></li>
 {% endblock %}

--- a/tasks/jinja2/tasks/workflows/task_template_delete.jinja
+++ b/tasks/jinja2/tasks/workflows/task_template_delete.jinja
@@ -1,22 +1,17 @@
-{% extends "common/delete.jinja" %}
+{% extends "layouts/form.jinja" %}
 
 {% from "components/breadcrumbs.jinja" import breadcrumbs %}
 {% from "components/warning-text/macro.njk" import govukWarningText %}
 {% from "components/button/macro.njk" import govukButton %}
 
-{% set page_title = "Delete task template:" ~ object.title %}
-
+{% set page_title = "Delete step template: " ~ object.title %}
 
 {% block breadcrumb %}
   {{ breadcrumbs(
     request,
     [
       {
-        "text": "Find and view workflow templates",
-        "href": url("workflow:task-workflow-template-ui-list"),
-      },
-      {
-        "text": "Workflow template: " ~ task_workflow_template.title,
+        "text": "Ticket template: " ~ task_workflow_template.title,
         "href": url("workflow:task-workflow-template-ui-detail", kwargs={"pk": task_workflow_template.pk}),
       },
       {"text": page_title}
@@ -27,7 +22,7 @@
 
 {% block form %}
   {{ govukWarningText({
-    "text": "Are you sure you want to delete this task template?"
+    "text": "Are you sure you want to delete this step template?"
   }) }}
 
   {% call django_form(

--- a/tasks/jinja2/tasks/workflows/task_template_detail.jinja
+++ b/tasks/jinja2/tasks/workflows/task_template_detail.jinja
@@ -3,22 +3,17 @@
 {% from "components/breadcrumbs.jinja" import breadcrumbs %}
 {% from "components/button/macro.njk" import govukButton %}
 
-{% set page_title = "Task template: " ~ object.title %}
+{% set page_title = "Step template: " ~ object.title %}
 
+{% set ticket_template_url = task_workflow_template.get_url("detail") %}
 
 {% block breadcrumb %}
   {{ breadcrumbs(
     request,
     [
       {
-        "text": "Find and view workflow templates",
-        "href": url("workflow:task-workflow-template-ui-list"),
-      },
-      {
-        "text": "Workflow template: " ~ task_workflow_template.title,
-        "href": url(
-          "workflow:task-workflow-template-ui-detail",
-          kwargs={"pk": task_workflow_template.pk}),
+        "text": "Ticket template: " ~ task_workflow_template.title,
+        "href": ticket_template_url,
       },
       {"text": page_title}
     ],
@@ -27,7 +22,25 @@
 {% endblock %}
 
 {% block content %}
-  <h1 class="govuk-heading-xl">{{ page_title }}</h1>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-three-quarters">
+      <h1 class="govuk-heading-xl govuk-!-margin-bottom-0">
+        <span class="govuk-caption-xl">{{ task_workflow_template.title }}</span>
+        {{ page_title }}
+      </h1>
+    </div>
+
+    <div class="govuk-grid-column-one-quarter govuk-!-margin-top-7">
+      {{ govukButton({
+        "text": "Delete step template",
+        "href": object.get_url("delete"),
+        "classes": "govuk-button--warning align-right",
+      }) }}
+    </div>
+
+    <a href="{{ ticket_template_url }}" class="govuk-link govuk-back-link govuk-!-margin-bottom-8">Back to ticket template</a>
+  </div>
 
   <h2 class="govuk-heading-m">Details</h2>
 
@@ -54,24 +67,4 @@
       </dd>
     </div>
   </dl>
-
-  <div class="govuk-button-group govuk-!-margin-top-6">
-  {{ govukButton({
-      "text": "Delete task template",
-      "href": url(
-        "workflow:task-template-ui-delete",
-        kwargs={
-          "workflow_template_pk": task_workflow_template.pk,
-          "pk": object.pk,
-        },
-      ),
-
-      "classes": "govuk-button--warning"
-  }) }}
-  {{ govukButton({
-    "text": "Return to workflow template",
-    "href": url("workflow:task-workflow-template-ui-detail", kwargs={"pk": task_workflow_template.pk}),
-    "classes": "govuk-button--secondary"
-  }) }}
-  </div>
 {% endblock %}

--- a/tasks/jinja2/tasks/workflows/task_template_save.jinja
+++ b/tasks/jinja2/tasks/workflows/task_template_save.jinja
@@ -2,17 +2,12 @@
 
 {% from "components/breadcrumbs.jinja" import breadcrumbs %}
 
-
 {% block breadcrumb %}
   {{ breadcrumbs(
     request,
     [
       {
-        "text": "Find and view workflow templates",
-        "href": url("workflow:task-workflow-template-ui-list"),
-      },
-      {
-        "text": "Workflow template: " ~ task_workflow_template.title,
+        "text": "Ticket template: " ~ task_workflow_template.title,
         "href": url("workflow:task-workflow-template-ui-detail", kwargs={"pk": task_workflow_template.pk}),
       },
       {"text": page_title}

--- a/tasks/jinja2/tasks/workflows/template_list.jinja
+++ b/tasks/jinja2/tasks/workflows/template_list.jinja
@@ -29,6 +29,7 @@
     </div>
 
   <div class="filter-layout__content">
+    {% set items_name = "ticket template" %}
     {% if paginator.count > 0 %}
       {% include "includes/common/pagination-list-summary.jinja" %}
     {% endif %}

--- a/tasks/jinja2/tasks/workflows/template_list.jinja
+++ b/tasks/jinja2/tasks/workflows/template_list.jinja
@@ -3,7 +3,7 @@
 {% from "components/table/macro.njk" import govukTable %}
 {% from "components/create_sortable_anchor.jinja" import create_sortable_anchor %}
 
-{% set page_title = "Find and view workflow templates" %}
+{% set page_title = "View all ticket templates" %}
 
 {% block breadcrumb %}
   {{ breadcrumbs(request, [
@@ -16,8 +16,8 @@
 {% block content %}
   <h1 class="govuk-heading-xl">{{ page_title }}</h1>
   <p class="govuk-body">
-    Search for workflow templates.
-    Alternatively, <a class="govuk-link" href="{{ url("workflow:task-workflow-template-ui-create") }}">create a new workflow template</a>.
+    Search for ticket templates.
+    Alternatively, <a class="govuk-link" href="{{ url("workflow:task-workflow-template-ui-create") }}">create a new ticket template</a>.
   </p>
 
   <div class="filter-layout">

--- a/tasks/static/tasks/scss/_tasks.scss
+++ b/tasks/static/tasks/scss/_tasks.scss
@@ -36,7 +36,3 @@
   margin-top: govuk-spacing(1);
   color: $govuk-secondary-text-colour;
 }
-
-.delete_step_button {
-  float: right;
-}

--- a/tasks/tests/test_views.py
+++ b/tasks/tests/test_views.py
@@ -371,7 +371,7 @@ def test_workflow_template_delete_view(
 
     soup = BeautifulSoup(str(confirmation_response.content), "html.parser")
     assert (
-        f"Workflow template ID: {task_workflow_template_pk}"
+        f"Ticket template ID: {task_workflow_template_pk}"
         in soup.select(".govuk-panel__title")[0].text
     )
 

--- a/tasks/tests/test_views.py
+++ b/tasks/tests/test_views.py
@@ -532,7 +532,7 @@ def test_delete_task_template_view(
 
     assert confirmation_response.status_code == 200
     assert (
-        f"Task template ID: {task_template_pk}"
+        f"Step template ID: {task_template_pk}"
         in soup.select(".govuk-panel__title")[0].text
     )
 

--- a/tasks/urls.py
+++ b/tasks/urls.py
@@ -23,7 +23,7 @@ task_ui_patterns = [
     ),
     path("<int:pk>/delete/", views.TaskDeleteView.as_view(), name="task-ui-delete"),
     path(
-        "<int:pk>/confirm-delete/",
+        "<int:pk>/workflow/<int:workflow_pk>/confirm-delete/",
         views.TaskConfirmDeleteView.as_view(),
         name="task-ui-confirm-delete",
     ),

--- a/tasks/views.py
+++ b/tasks/views.py
@@ -628,6 +628,11 @@ class TaskWorkflowConfirmCreateView(PermissionRequiredMixin, DetailView):
     template_name = "tasks/workflows/confirm_create.jinja"
     permission_required = "tasks.add_taskworkflow"
 
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["verbose_name"] = "ticket"
+        return context
+
 
 class TaskWorkflowUpdateView(PermissionRequiredMixin, UpdateView):
     model = TaskWorkflow
@@ -852,6 +857,11 @@ class TaskWorkflowTemplateConfirmCreateView(PermissionRequiredMixin, DetailView)
     model = TaskWorkflowTemplate
     template_name = "tasks/workflows/confirm_create.jinja"
     permission_required = "tasks.add_taskworkflowtemplate"
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["verbose_name"] = "ticket template"
+        return context
 
 
 class TaskWorkflowTemplateUpdateView(PermissionRequiredMixin, UpdateView):

--- a/tasks/views.py
+++ b/tasks/views.py
@@ -196,6 +196,7 @@ class TaskDeleteView(PermissionRequiredMixin, DeleteView):
         return context_data
 
     def get_success_url(self):
+        self.request.session["ticket_pk"] = self.object.taskitem.workflow.pk
         return reverse("workflow:task-ui-confirm-delete", kwargs={"pk": self.object.pk})
 
 
@@ -207,7 +208,10 @@ class TaskConfirmDeleteView(PermissionRequiredMixin, TemplateView):
     def get_context_data(self, **kwargs):
         context_data = super().get_context_data(**kwargs)
         context_data["deleted_pk"] = self.kwargs["pk"]
-        context_data["verbose_name"] = "task"
+        context_data["ticket"] = TaskWorkflow.objects.get(
+            pk=self.request.session["ticket_pk"],
+        )
+        del self.request.session["ticket_pk"]
         return context_data
 
 

--- a/tasks/views.py
+++ b/tasks/views.py
@@ -100,9 +100,13 @@ class TaskDetailView(PermissionRequiredMixin, DetailView):
         context["assignable_users"] = [
             {"pk": user.pk, "name": user.get_full_name()} for user in assignable_users
         ]
+
         if context["object"].taskitem.workflow:
             context["ticket_title"] = context["object"].taskitem.workflow.title
-            context["ticket_number"] = context["object"].taskitem.workflow.pk
+            context["ticket_prefixed_id"] = context[
+                "object"
+            ].taskitem.workflow.prefixed_id
+            context["ticket_number"] = context["object"].taskitem.workflow.id
 
         return context
 

--- a/tasks/views.py
+++ b/tasks/views.py
@@ -470,13 +470,6 @@ class TaskWorkflowDetailView(
     def paginator(self):
         return Paginator(self.comments, per_page=10)
 
-    @property
-    def view_url(self) -> str:
-        return reverse(
-            "workflow:task-workflow-ui-detail",
-            kwargs={"pk": self.queue.pk},
-        )
-
     def form_valid(self, form):
         form.save(user=self.request.user, task=self.summary_task)
         return redirect(self.get_success_url())

--- a/tasks/views.py
+++ b/tasks/views.py
@@ -185,8 +185,13 @@ class TaskDeleteView(PermissionRequiredMixin, DeleteView):
         return context_data
 
     def get_success_url(self):
-        self.request.session["ticket_pk"] = self.object.taskitem.workflow.pk
-        return reverse("workflow:task-ui-confirm-delete", kwargs={"pk": self.object.pk})
+        return reverse(
+            "workflow:task-ui-confirm-delete",
+            kwargs={
+                "pk": self.object.pk,
+                "workflow_pk": self.object.taskitem.workflow.pk,
+            },
+        )
 
 
 class TaskConfirmDeleteView(PermissionRequiredMixin, TemplateView):
@@ -198,9 +203,8 @@ class TaskConfirmDeleteView(PermissionRequiredMixin, TemplateView):
         context_data = super().get_context_data(**kwargs)
         context_data["deleted_pk"] = self.kwargs["pk"]
         context_data["ticket"] = TaskWorkflow.objects.get(
-            pk=self.request.session["ticket_pk"],
+            pk=self.kwargs["workflow_pk"],
         )
-        del self.request.session["ticket_pk"]
         return context_data
 
 

--- a/tasks/views.py
+++ b/tasks/views.py
@@ -568,7 +568,6 @@ class TaskWorkflowCreateView(PermissionRequiredMixin, FormView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context["verbose_name"] = "ticket"
-        context["list_url"] = reverse("workflow:task-workflow-ui-list")
         return context
 
     @transaction.atomic

--- a/tasks/views.py
+++ b/tasks/views.py
@@ -894,6 +894,11 @@ class TaskWorkflowTemplateDeleteView(PermissionRequiredMixin, DeleteView):
         kwargs["instance"] = self.object
         return kwargs
 
+    def get_context_data(self, **kwargs):
+        context_data = super().get_context_data(**kwargs)
+        context_data["verbose_name"] = "ticket template"
+        return context_data
+
     @transaction.atomic
     def form_valid(self, form):
         self.object.get_task_templates().delete()

--- a/tasks/views.py
+++ b/tasks/views.py
@@ -834,8 +834,7 @@ class TaskWorkflowTemplateCreateView(PermissionRequiredMixin, CreateView):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        context["verbose_name"] = "workflow template"
-        context["list_url"] = reverse("workflow:task-workflow-template-ui-list")
+        context["verbose_name"] = "ticket template"
         return context
 
     def form_valid(self, form):

--- a/tasks/views.py
+++ b/tasks/views.py
@@ -955,8 +955,7 @@ class TaskTemplateCreateView(PermissionRequiredMixin, CreateView):
 
     def get_context_data(self, **kwargs) -> dict:
         context = super().get_context_data(**kwargs)
-
-        context["page_title"] = "Create a task template"
+        context["page_title"] = "Add a step template"
         context["task_workflow_template"] = self.get_task_workflow_template()
 
         return context
@@ -1002,7 +1001,7 @@ class TaskTemplateUpdateView(PermissionRequiredMixin, UpdateView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
 
-        context["page_title"] = f"Update task template: {self.get_object().title}"
+        context["page_title"] = f"Edit step template: {self.get_object().title}"
         context["task_workflow_template"] = (
             self.get_object().taskitemtemplate.workflow_template
         )

--- a/tasks/views.py
+++ b/tasks/views.py
@@ -162,12 +162,6 @@ class TaskConfirmUpdateView(PermissionRequiredMixin, DetailView):
     template_name = "tasks/confirm_update.jinja"
     permission_required = "tasks.change_task"
 
-    def get_context_data(self, **kwargs):
-        context = super().get_context_data(**kwargs)
-        context["page_title"] = "Task updated"
-        context["object_type"] = "Task"
-        return context
-
 
 class TaskDeleteView(PermissionRequiredMixin, DeleteView):
     model = Task

--- a/tasks/views.py
+++ b/tasks/views.py
@@ -147,11 +147,6 @@ class TaskUpdateView(PermissionRequiredMixin, UpdateView):
     permission_required = "tasks.change_task"
     form_class = TaskUpdateForm
 
-    def get_context_data(self, **kwargs):
-        context = super().get_context_data(**kwargs)
-        context["page_title"] = "Edit task details"
-        return context
-
     def form_valid(self, form):
         set_current_instigator(self.request.user)
         with transaction.atomic():

--- a/tasks/views.py
+++ b/tasks/views.py
@@ -920,7 +920,7 @@ class TaskWorkflowTemplateConfirmDeleteView(PermissionRequiredMixin, TemplateVie
         context_data = super().get_context_data(**kwargs)
         context_data.update(
             {
-                "verbose_name": "workflow template",
+                "verbose_name": "ticket template",
                 "deleted_pk": self.kwargs["pk"],
                 "create_url": reverse("workflow:task-workflow-template-ui-create"),
                 "list_url": reverse("workflow:task-workflow-template-ui-list"),


### PR DESCRIPTION
# TP2000-1775  Amend breadcrumbs on ticket and step pages

## Why
A coherent page hierarchy and user navigation experience is required on ticket and step pages.

## What
- Amends the breadcumbs on all ticket, ticket template, step and step template pages
- Updates button text and links on confirmation pages
- Renames old references to workflows and tasks on pages

## Checklist
- Requires migrations? No
- Requires dependency updates? No
