### PR TITLE
TP-2000-1784 annual volume changes for recurring QuotaDefinitionPeriods

### DIFF
--- a/common/static/common/scss/_quota-definitions.scss
+++ b/common/static/common/scss/_quota-definitions.scss
@@ -35,3 +35,9 @@
         height: 420px !important;
     }
 }
+
+#id_definition_period_info-volume_change_type_radio{ 
+    .govuk-form-group {
+        margin-bottom: 10px;
+    }
+}

--- a/common/templates/common/widgets/radio_conditional_commodities.html
+++ b/common/templates/common/widgets/radio_conditional_commodities.html
@@ -53,9 +53,6 @@
                     {% include "django/forms/widgets/attrs.html" %} />
                 {% endif %}
               </div>
-              <p id="input-error" class="govuk-error-message">
-                <span class="govuk-visually-hidden">Error:</span> This field cannot be left empty
-              </p>
           </div>
         </div>
         {% endif %}

--- a/common/templates/common/widgets/radio_conditional_commodities.html
+++ b/common/templates/common/widgets/radio_conditional_commodities.html
@@ -1,0 +1,64 @@
+<div class="govuk-form-group">
+    <fieldset class="govuk-fieldset">
+      <div class="govuk-radios" data-module="govuk-radios">
+        {% if option.value == 'divider' %}
+          <div class="govuk-radios__divider">{{option.label}}</div>
+        {% elif option.value == 'no_change' %}
+        <div class="govuk-radios__item">
+          <input class="govuk-radios__input" 
+            id="volume-change-{{option.value}}"
+            name="volume-change" 
+            type="radio" 
+            value={{option.value}}
+            checked data-aria-controls="conditional-volume-{{option.value}}"
+        >
+          <label class="govuk-label govuk-radios__label" for="volume-change">
+            {{option.label.label}}
+            <div class="govuk-hint">
+              {{option.label.help_text}}
+            </div>
+          </label>
+        </div>
+        {% else %}
+        <div class="govuk-radios__item">
+          <input class="govuk-radios__input" 
+            id="volume-change-{{option.value}}"
+            name="volume-change" 
+            type="radio" 
+            value={{option.value}}
+            checked data-aria-controls="conditional-volume-{{option.value}}"
+        >
+          <label class="govuk-label govuk-radios__label" for="volume-change">
+            {{option.label.label}}
+          </label>
+        </div>
+        <div class="govuk-radios__conditional" id="conditional-volume-{{option.value}}">
+          <div class="govuk-form-group">
+            <div class="govuk-input__wrapper govuk-form-group--error">
+              {% if widget.label.suffix %}
+              <input 
+                    class="numberinput govuk-input govuk-input govuk-input--width-3" 
+                    type="text"
+                    id="{{option.value}}"
+                    name="{{ option.value }}"
+                    {% include "django/forms/widgets/attrs.html" %} />
+                <div class="govuk-input__suffix" aria-hidden="true">{{widget.label.suffix}}</div>
+              {% else %}
+                <input 
+                    class="numberinput govuk-input govuk-input govuk-input--width-5" 
+                    type="text"
+                    id="{{option.value}}"
+                    name="{{ option.value }}"
+                    aria-describedby="input-error"
+                    {% include "django/forms/widgets/attrs.html" %} />
+                {% endif %}
+              </div>
+              <p id="input-error" class="govuk-error-message">
+                <span class="govuk-visually-hidden">Error:</span> This field cannot be left empty
+              </p>
+          </div>
+        </div>
+        {% endif %}
+      </div>
+    </fieldset>
+  </div>

--- a/common/templates/common/widgets/radio_conditional_commodities.html
+++ b/common/templates/common/widgets/radio_conditional_commodities.html
@@ -34,7 +34,7 @@
         </div>
         <div class="govuk-radios__conditional" id="conditional-volume-{{option.value}}">
           <div class="govuk-form-group">
-            <div class="govuk-input__wrapper govuk-form-group--error">
+            <div class="govuk-input__wrapper">
               {% if widget.label.suffix %}
               <input 
                     class="numberinput govuk-input govuk-input govuk-input--width-3" 

--- a/common/widgets.py
+++ b/common/widgets.py
@@ -27,6 +27,17 @@ class RadioNestedWidget(RadioSelect):
         self.nested_forms = forms
 
 
+class CommodityVolumeRadioSelect(RadioSelect):
+    option_template_name = "common/widgets/radio_conditional_commodities.html"
+
+    def get_context(self, name, value, attrs):
+        ctx = super().get_context(name, value, attrs)
+
+        ctx.update({"optgroups": self.choices})
+
+        return ctx
+
+
 class FormSetFieldWidget(widgets.Widget):
     template_name = "common/widgets/formset_field.html"
     input_type = ""

--- a/common/widgets.py
+++ b/common/widgets.py
@@ -31,11 +31,11 @@ class CommodityVolumeRadioSelect(RadioSelect):
     option_template_name = "common/widgets/radio_conditional_commodities.html"
 
     def get_context(self, name, value, attrs):
-        ctx = super().get_context(name, value, attrs)
+        context = super().get_context(name, value, attrs)
 
-        ctx.update({"optgroups": self.choices})
+        context.update({"optgroups": self.choices})
 
-        return ctx
+        return context
 
 
 class FormSetFieldWidget(widgets.Widget):

--- a/quotas/forms/wizards.py
+++ b/quotas/forms/wizards.py
@@ -499,7 +499,7 @@ class QuotaDefinitionBulkCreateDefinitionInformation(
                 )
                 if self.cleaned_data["volume_change_value"] is None:
                     raise ValidationError(
-                        "A value must be provided for the option you have selected",
+                        "A value must be provided for the volume change option you have selected",
                     )
 
             self.save_definition_data_to_session(cleaned_data)

--- a/quotas/forms/wizards.py
+++ b/quotas/forms/wizards.py
@@ -360,7 +360,10 @@ class QuotaDefinitionBulkCreateDefinitionInformation(
         frequency = decimal.Decimal(cleaned_data["frequency"])
         volume = decimal.Decimal(cleaned_data["volume"])
         volume_change_type = cleaned_data["volume_change_type"]
-        if "volume_change_value" in cleaned_data:
+        if (
+            "volume_change_value" in cleaned_data
+            and cleaned_data["volume_change_value"] is not None
+        ):
             volume_change_value = decimal.Decimal(cleaned_data["volume_change_value"])
 
         definition_data = {

--- a/quotas/forms/wizards.py
+++ b/quotas/forms/wizards.py
@@ -241,6 +241,7 @@ class QuotaDefinitionBulkCreateDefinitionInformation(
             "required": "Enter the initial volume",
         },
     )
+    # required=False is passed twice here so the nested input is not required.
     volume_change_type_radio = forms.ChoiceField(
         label="How will the volume change between definition periods?",
         widget=CommodityVolumeRadioSelect(attrs={"required": False}),

--- a/quotas/forms/wizards.py
+++ b/quotas/forms/wizards.py
@@ -412,14 +412,15 @@ class QuotaDefinitionBulkCreateDefinitionInformation(
                     {"valid_between": new_date_range},
                 )
 
-            if change_type == 1:
-                volume += volume * (change_amount / decimal.Decimal(100))
-            elif change_type == 2:
-                volume -= volume * (change_amount / decimal.Decimal(100))
-            elif change_type == 3:
-                volume += change_amount
-            elif change_type == 4:
-                volume -= change_amount
+            if frequency == 1:
+                if change_type == 1:
+                    volume += volume * (change_amount / decimal.Decimal(100))
+                elif change_type == 2:
+                    volume -= volume * (change_amount / decimal.Decimal(100))
+                elif change_type == 3:
+                    volume += change_amount
+                elif change_type == 4:
+                    volume -= change_amount
 
             definition_data.update({"volume": round(volume, 2)})
 

--- a/quotas/forms/wizards.py
+++ b/quotas/forms/wizards.py
@@ -462,7 +462,7 @@ class QuotaDefinitionBulkCreateDefinitionInformation(
                 elif volume_change_type == "decrease_quantity":
                     volume -= volume_change_value
                 elif volume_change_type == "no_change":
-                    volume = volume
+                    volume
 
             definition_data.update({"volume": round(volume, 2)})
 
@@ -473,35 +473,35 @@ class QuotaDefinitionBulkCreateDefinitionInformation(
 
     def clean(self):
         cleaned_data = super().clean()
-        if (
-            cleaned_data["frequency"] != "1"
-            and self.data["volume-change"] != "no_change"
-        ):
-            raise ValidationError(
-                "Automatically increasing or decreasing the volume between definition periods is only available for definition periods that span the entire year or if there is only one definition period in the year.",
-            )
-
-        self.cleaned_data["volume_change_type"] = self.data["volume-change"]
-        if self.data["volume-change"] != "no_change":
-            self.cleaned_data["volume_change_value"] = next(
-                (
-                    v
-                    for v in [
-                        self.data["increase_percentage"],
-                        self.data["decrease_percentage"],
-                        self.data["increase_quantity"],
-                        self.data["decrease_quantity"],
-                    ]
-                    if v
-                ),
-                None,
-            )
-            if self.cleaned_data["volume_change_value"] is None:
+        if self.is_valid():
+            if (
+                cleaned_data["frequency"] != "1"
+                and self.data["volume-change"] != "no_change"
+            ):
                 raise ValidationError(
-                    "A value must be provided for the option you have selected",
+                    "Automatically increasing or decreasing the volume between definition periods is only available for definition periods that span the entire year or if there is only one definition period in the year.",
                 )
 
-        if self.is_valid():
+            self.cleaned_data["volume_change_type"] = self.data["volume-change"]
+            if self.data["volume-change"] != "no_change":
+                self.cleaned_data["volume_change_value"] = next(
+                    (
+                        v
+                        for v in [
+                            self.data["increase_percentage"],
+                            self.data["decrease_percentage"],
+                            self.data["increase_quantity"],
+                            self.data["decrease_quantity"],
+                        ]
+                        if v
+                    ),
+                    None,
+                )
+                if self.cleaned_data["volume_change_value"] is None:
+                    raise ValidationError(
+                        "A value must be provided for the option you have selected",
+                    )
+
             self.save_definition_data_to_session(cleaned_data)
         return cleaned_data
 

--- a/quotas/tests/test_forms.py
+++ b/quotas/tests/test_forms.py
@@ -1169,6 +1169,9 @@ def test_quota_definition_bulk_create_definition_info_frequencies(
         ),
         "volume": 600.000,
         "initial_volume": 500.000,
+        "volume-change": "no_change",
+        "volume_change_type": "no_change",
+        "volume_change_value": None,
         "measurement_unit": measurement_unit,
         "quota_critical_threshold": 90,
         "quota_critical": "False",
@@ -1277,8 +1280,8 @@ def test_quota_definition_bulk_create_definition_increment_decriment(
         ),
         "volume": 100.000,
         "initial_volume": 100.000,
-        "volume_change_type": 0,
-        "volume_change_amount": None,
+        "volume_change_type": "no_change",
+        "volume_change_value": None,
         "measurement_unit": measurement_unit,
         "quota_critical_threshold": 90,
         "quota_critical": "False",
@@ -1302,8 +1305,8 @@ def test_quota_definition_bulk_create_definition_increment_decriment(
         )
 
     # increment by percentage
-    form_data["volume_change_type"] = 1
-    form_data["volume_change_amount"] = 4.5
+    form_data["volume_change_type"] = "increase_percentage"
+    form_data["volume_change_value"] = 4.5
     with override_current_transaction(Transaction.objects.last()):
         bulk_create_definition_form.save_definition_data_to_session(form_data)
         # check that the length staged_definitions still matches the initial_info['instance_count']
@@ -1319,8 +1322,8 @@ def test_quota_definition_bulk_create_definition_increment_decriment(
         )
 
     # decrement by percentage
-    form_data["volume_change_type"] = 2
-    form_data["volume_change_amount"] = 7.7
+    form_data["volume_change_type"] = "decrease_percentage"
+    form_data["volume_change_value"] = 7.7
     with override_current_transaction(Transaction.objects.last()):
         bulk_create_definition_form.save_definition_data_to_session(form_data)
         # check that the length staged_definitions still matches the initial_info['instance_count']
@@ -1332,8 +1335,8 @@ def test_quota_definition_bulk_create_definition_increment_decriment(
         assert session_request.session["staged_definition_data"][2]["volume"] == "85.19"
 
     # increment by value
-    form_data["volume_change_type"] = 3
-    form_data["volume_change_amount"] = 10
+    form_data["volume_change_type"] = "increase_quantity"
+    form_data["volume_change_value"] = 10
     with override_current_transaction(Transaction.objects.last()):
         bulk_create_definition_form.save_definition_data_to_session(form_data)
         # check that the length staged_definitions still matches the initial_info['instance_count']
@@ -1349,8 +1352,8 @@ def test_quota_definition_bulk_create_definition_increment_decriment(
         )
 
     # decrement by value
-    form_data["volume_change_type"] = 4
-    form_data["volume_change_amount"] = 10
+    form_data["volume_change_type"] = "decrease_quantity"
+    form_data["volume_change_value"] = 10
     with override_current_transaction(Transaction.objects.last()):
         bulk_create_definition_form.save_definition_data_to_session(form_data)
         # check that the length staged_definitions still matches the initial_info['instance_count']
@@ -1384,6 +1387,8 @@ def test_bulk_create_update_definition_data_populates_parent_data(
         ),
         "volume": "600.000",
         "initial_volume": "500.000",
+        "volume_change_type": "no_change",
+        "volume_change_value": None,
         "measurement_unit": measurement_unit,
         "quota_critical_threshold": "90",
         "quota_critical": "False",
@@ -1432,6 +1437,8 @@ def test_bulk_create_update_definition_data_updates_data(
         ),
         "volume": 600.000,
         "initial_volume": 500.000,
+        "volume_change_type": "no_change",
+        "volume_change_value": None,
         "measurement_unit": measurement_unit,
         "quota_critical_threshold": 90,
         "quota_critical": "False",
@@ -1498,6 +1505,12 @@ def test_quota_definition_bulk_create_definition_is_valid(
         "end_date_2": date_ranges.normal.upper.year,
         "volume": "600.000",
         "initial_volume": "500.000",
+        "volume-change": "no_change",
+        "volume_change_type": "no_change",
+        "increase_percentage": None,
+        "decrease_percentage": None,
+        "increase_quantity": None,
+        "decrease_quantity": None,
         "measurement_unit": measurement_unit,
         "measurement_unit_qualifier": measurement_unit_qualifier,
         "quota_critical_threshold": "90",

--- a/quotas/tests/test_views.py
+++ b/quotas/tests/test_views.py
@@ -2878,16 +2878,6 @@ def test_bulk_create_creates_definition(
         assert len(models.QuotaDefinition.objects.all()) == 1
 
 
-# @pytest.mark.parametrize(
-#     "change_type, change_value, result_1, result_2",
-#     [
-#         ("no_change", None, "100.00", "100.00"),
-#         ("increase_percentage", 4.5, "104.50", "109.20"),
-#         ("decrease_percentage", 7.7, "92.30", "85.19"),
-#         ("increase_quantity", 10, "110.00", "120.00"),
-#         ("decrease_quantity", 5, "95.00", "90.00"),
-#     ],
-# )
 def test_bulk_create_creates_definition_with_changing_volumes(
     session_request_with_workbasket,
     date_ranges,

--- a/quotas/tests/test_views.py
+++ b/quotas/tests/test_views.py
@@ -1,3 +1,5 @@
+import datetime
+from decimal import Decimal
 from typing import OrderedDict
 from unittest import mock
 
@@ -16,6 +18,7 @@ from common.tests.util import assert_read_only_model_view_returns_list
 from common.tests.util import get_class_based_view_urls_matching_url
 from common.tests.util import view_is_subclass
 from common.tests.util import view_urlpattern_ids
+from common.util import TaricDateRange
 from common.validators import UpdateType
 from common.views import TamatoListView
 from common.views import TrackedModelDetailMixin
@@ -23,6 +26,7 @@ from geo_areas.validators import AreaCode
 from quotas import models
 from quotas import validators
 from quotas.forms.base import QuotaSuspensionType
+from quotas.forms.wizards import QuotaDefinitionBulkCreateDefinitionInformation
 from quotas.views import DuplicateDefinitionsWizard
 from quotas.views import QuotaList
 from quotas.views.wizards import QuotaDefinitionBulkCreatorUpdateDefinitionData
@@ -2872,6 +2876,77 @@ def test_bulk_create_creates_definition(
             definition=staged_data,
         )
         assert len(models.QuotaDefinition.objects.all()) == 1
+
+
+# @pytest.mark.parametrize(
+#     "change_type, change_value, result_1, result_2",
+#     [
+#         ("no_change", None, "100.00", "100.00"),
+#         ("increase_percentage", 4.5, "104.50", "109.20"),
+#         ("decrease_percentage", 7.7, "92.30", "85.19"),
+#         ("increase_quantity", 10, "110.00", "120.00"),
+#         ("decrease_quantity", 5, "95.00", "90.00"),
+#     ],
+# )
+def test_bulk_create_creates_definition_with_changing_volumes(
+    session_request_with_workbasket,
+    date_ranges,
+):
+    quota_order_number = factories.QuotaOrderNumberFactory.create()
+    measurement_unit = factories.MeasurementUnitFactory.create()
+    factories.MeasurementUnitQualifierFactory.create()
+    storage = QuotaDefinitionBulkCreatorSessionStorage(
+        request=session_request_with_workbasket,
+        prefix="",
+    )
+    wizard = QuotaDefinitionBulkCreatorWizard(
+        request=session_request_with_workbasket,
+        storage=storage,
+    )
+    wizard.form_list = OrderedDict(wizard.form_list)
+    form_data = {
+        "maximum_precision": 3,
+        "valid_between": TaricDateRange(
+            datetime.date(2025, 1, 1),
+            datetime.date(2025, 12, 31),
+        ),
+        "start_date": str(date_ranges.normal.lower),
+        "end_date": str(date_ranges.normal.upper),
+        "volume": 100.00,
+        "initial_volume": 100.00,
+        "volume_change_type": "increase_percentage",
+        "volume_change_value": "4.5",
+        "increase_percentage": 4.5,
+        "measurement_unit": measurement_unit,
+        "measurement_unit_code": measurement_unit.code,
+        "quota_critical_threshold": 90,
+        "quota_critical": "False",
+        "instance_count": 3,
+        "frequency": 1,
+        "description": "This is a description",
+    }
+    # use the form method to duplicate staged_definition data with
+    # calculated volumes for subsequent definitions
+    form = QuotaDefinitionBulkCreateDefinitionInformation(
+        request=session_request_with_workbasket,
+        prefix="definition_period_info",
+    )
+
+    form.save_definition_data_to_session(form_data)
+    session_data = session_request_with_workbasket.session["staged_definition_data"]
+
+    assert len(models.QuotaDefinition.objects.all()) == 0
+    with override_current_transaction(Transaction.objects.last()):
+        for definition in session_data:
+            wizard.create_definition(
+                order_number=quota_order_number.pk,
+                definition=definition,
+            )
+        definitions_created = models.QuotaDefinition.objects.all()
+        assert len(definitions_created) == 3
+        assert definitions_created[0].volume == form_data["volume"]
+        assert definitions_created[1].volume == Decimal("104.500")
+        assert definitions_created[2].volume == Decimal("109.200")
 
 
 def test_bulk_create_done(


### PR DESCRIPTION
# TP-2000-1784 Incremental volume increase for annually recurring QuotaDefinitionPeriods

## Why
Annually recurring QuotaDefinitionPeriods can increase or decrease by a numerical or percentage value from the previous year.

## What
This feature calculates the value of a QuotaDefinitionPeriod volume based on the value of the previous year's volume and a provided figure, either as a percentage or an amount.
The widget used is a custom RadioSelect widget that uses elements of two GDS radio select widgets, the radio select with text divider and the radio select with conditionally revealed inputs. Documentation on these can be found [here](https://design-system.service.gov.uk/components/radios/)

The user is presented with five options, no change or for the figure to increase or decrease by amount or percentage. Choosing an option that changes the volume opens an input field for a value, either amount or percentage.
<img width="729" alt="image" src="https://github.com/user-attachments/assets/4207b51a-47e1-4b4a-9fa1-ca8803323ac6" />

Choosing a change option but not entering a value triggers a validation error.

Calculated amounts are then displayed on the summary page
<img width="1237" alt="image" src="https://github.com/user-attachments/assets/b376bafd-445b-4041-b809-3acb7c7cbb72" />

Note 1: the widget has required false set twice because not all of the options have a secondary input and submitting this option resulted in a false failure. The validation for this widget runs on form submission.

Note 2: I would like to have made this a generic widget that could be re-used and have built with this in mind. At the moment, it's custom to the bulk create process and so the template is bespoke. The criteria for generalisation I believe are as follows:
1. can pass through a divider class (ie. or)
2. can pass through **optional** secondary inputs
3. can pass through a suffix for the secondary inputs, e.g. `%` 
This is quite low priority as it works for the current scenario and I don't know of anywhere else it would be used at present.