### PR TITLE
added prefixed id back to homepage ticket card

### DIFF
--- a/common/jinja2/common/homepage.jinja
+++ b/common/jinja2/common/homepage.jinja
@@ -29,7 +29,7 @@
             <a
               class="govuk-link"
               href="{{ url('workflow:task-workflow-ui-detail', kwargs={'pk':  ticket.taskworkflow.pk}) }}"
-            >{{ ticket.taskworkflow.pk }}</a>
+            >{{ ticket.taskworkflow.prefixed_id }}</a>
         {%- endset -%}
 
         {{ my_tickets_rows.append([          


### PR DESCRIPTION
# TP2000-1803 - Update Tickets card on home page to use ticket prefix

## Why
 * Implementing TAP ticketing ID prefixes in the UI 

## What
 * Adding in ticket prefix to ticket ID on a user's 'my tickets' card on the homepage

## Checklist
- Requires migrations? - No
- Requires dependency updates? - No

<details open>
<summary>Updated 'Tickets' homepage card</summary>
<br>
<img width="452" alt="Screenshot 2025-04-30 at 14 48 38" src="https://github.com/user-attachments/assets/f91f0b85-bf3b-43ed-87dd-695e50bfd07c" />

</details>