### PR TITLE
TP2000-1126 Increase rule checks speed with threading support

### DIFF
--- a/common/util.py
+++ b/common/util.py
@@ -712,8 +712,10 @@ def log_timing(logger_function: typing.Callable):
         elapsed_time = end_time - start_time
         logger_function(
             f"Exited the function {wrapped.__name__}() on "
-            f"process pid={os.getpid()} at {end_time.isoformat()} after "
-            f"an elapsed time of {elapsed_time}.",
+            f"process pid={os.getpid()} at {end_time.isoformat()}",
+        )
+        logger_function(
+            f"\033[1mTotal elapsed time {elapsed_time}.\033[0m",
         )
 
         return result

--- a/settings/common.py
+++ b/settings/common.py
@@ -945,3 +945,13 @@ DATA_MIGRATION_BATCH_SIZE = int(os.environ.get("DATA_MIGRATION_BATCH_SIZE", "100
 # Asynchronous / background (bulk) object creation and editing config.
 MEASURES_ASYNC_CREATION = is_truthy(os.environ.get("MEASURES_ASYNC_CREATION", "true"))
 MEASURES_ASYNC_EDIT = is_truthy(os.environ.get("MEASURES_ASYNC_EDIT", "true"))
+
+
+# BUSINESS_RULE_CHECKS_CONCURRENCY is used to set the concurrency model used by
+# the business rule checks system and should take one of the string values,
+# "SERIAL" or "THREADED". (No "ASYNC" option is currently available as Tamato
+# is not provisioned to support Python async Django database calls.)
+BUSINESS_RULE_CHECKS_CONCURRENCY = os.environ.get(
+    "BUSINESS_RULE_CHECKS_CONCURRENCY",
+    "THREADED",
+)


### PR DESCRIPTION
# TP2000-1126 Increase rule checks speed with threading support
<!---
 * Include the JIRA ticket number, eg TP-123, to automatically link.
 * Use 50 characters maximum.
 * Do not end with a full-stop.
--->

## Why
<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Use as many lines as you like.
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions or deliberately ignored edge-cases.
--->

Because business rule checks can take some time, they are sometimes a bottleneck to publishing tariff changes.

## What
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Explain like I'm 5.
 * Use pictures if you can.
--->
This PR:
- Introduces the option of splitting transaction checks across multiple CPU threads using Python threading.
- Retains the option of reverting to the current, non-threaded (serial) approach to transaction checks via the setting `BUSINESS_RULE_CHECKS_CONCURRENCY`, which defaults to `"THREADED"` but can be set to `"SERIAL"` to get the old behaviour.

<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
--->
## Checklist
- Requires migrations? No
- Requires dependency updates? No

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
